### PR TITLE
Glossary fixes (2)

### DIFF
--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -955,7 +955,7 @@ The slider velocity defines the movement speed of the slider ball. The lower the
 
 ### TAG
 
-A TAG difficulty is a type of beatmap that is designed for more than one person to play at the same time in multiplayer mode, using the Tag Co-Op/Tag Team Co-Op Team Mode.
+A TAG difficulty is a type of beatmap that is designed for more than one person to play at the same time in multiplayer mode, using the Tag Coop/Tag Team Vs Team Mode.
 
 Each player is responsible for one comboset, where each hitobject in that comboset is mapped to be extremely farther apart, making it nearly impossible to play by a single player.
 Therefore it becomes a challenge for elite players in terms of precision of jumping.

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -396,12 +396,9 @@ It accompanies the total score at the result screen and appears in all lists whe
 
 From lowest to highest, the possible grades are D, C, B, A, S, Silver S, SS, and Silver SS.
 
-<!-- TODO where do I go??!?!!?!?! -->
-For a complete explanation, see <!--[](...FAQ?)-->.
-
 ### Grid snapping
 
-Grid snapping refers to a same-named button on the right hand side of the editor screen.
+Grid snapping refers to a button on the right hand side of the editor screen.
 
 Enabling it will force every newly placed (or existing, but moved) object to snap along the intersections of the grid.
 
@@ -526,14 +523,13 @@ This only happens if the beatmapper has placed objects right at or very close at
 
 ### Life bar
 
-The life bar, also known as the _health bar_, _v_, _spirit bar_, or _ki bar_, is a bar at the top left of the playing screen for osu!standard, osu!catch, and osu!taiko.
+The life bar, also known as the _health bar_, _HP bar_, _spirit bar_, or _ki bar_, is a bar at the top left of the playing screen for osu!standard, osu!catch, and osu!taiko.
 For osu!mania, the life bar is rotated 90 degrees counter-clockwise and is placed next to the bottom-right of the stage.
 
 In all modes, expect for osu!mania, there is a symbol moving along it indicating the player's life.
 If the bar is completely empty, the player fails the current beatmap (assuming no special game modifiers are enabled).
 
-The bar drains at a constant rate throughout the course of a beatmap, except during a break.
-For osu!taiko and osu!mania, health drain was disabled.
+osu!standard and osu!catch will have health drain at a constant rate throughout the course of a beatmap, except during breaks.
 
 For osu!standard, the bar is replenished by the player tapping hit circles, following sliders and slider ticks, and spinning spinners.
 The more accurate the tapping, the bigger the boost.
@@ -541,7 +537,7 @@ The player also receives larger boosts if he achieves a katu or an geki at the e
 
 For osu!catch, this can be done by catching fruit and drops.
 
-A sizeable part of the bar is also depleted in case of a miss.
+For all game modes (expect osu!taiko), a sizeable part of the bar is also depleted in case of a miss.
 
 ### Local song offset
 
@@ -561,11 +557,17 @@ You can change your local song offset by pressing:
 
 M4M, or _Mod for Mod_, is a term describing when a modder agrees to mod another modder's map in return for a mod on their own map.
 
+### Mapping Technique
+
+A mapping technique is a method to how objects are placed in any of the four game modes.
+
+For a list of the Mapping Techniques, see [Mapping Techniques](/wiki/Mapping_Techniques/).
+
 ### Marathon
 
 A marathon is a type of beatmap that can only be approved.
 
-Marathon beatmaps are considered to be at least 6 minutes long and can only have one mapped difficulty.
+Marathon beatmaps are considered to be, at least, 6 minutes long and can only have one mapped difficulty.
 However, some marathon mapsets may contain a single osu!taiko variant as well.
 
 Marathon beatmaps are often collaborative efforts, as mapping longer tracks is a draining endeavour when done solo.
@@ -577,7 +579,8 @@ Upon the creation of the marathon beatmap, one should name their beatmap version
 **As of the April 23, 2013, all members of the MAT at that time were promoted as full members of the BAT, with the MAT team decommissioned.**
 
 The MAT, meaning _Modding Assistance Team_, was a group of users experienced in modding.
-MAT members can mark beatmap they approve of with a bubble, noting them as worthy of further consideration by the BAT.
+MAT members were able to mark any beatmap they approve of with a bubble.
+This bubble would note that the beatmap as worthy of further consideration by the BAT.
 
 ### Modder
 
@@ -660,7 +663,7 @@ The following day, peppy rolled back the implementation of osu!coins due to popu
 
 ### osu!dev
 
-The osu!dev team is a group of people, including peppy, that 
+The osu!dev team are the people who updates and improves osu!.
 
 For details about the osu!dev, see [The Team](/wiki/People/The_Team/).
 
@@ -703,11 +706,12 @@ This topic was discussed in an episode of osu!talk ([osu!talk special Over Mappi
 Pass has three meanings:
 
 - the completion of a beatmap with or without the use of mods
-- the player having more than 50% health during a break; where an indicator will display if you passed the section
+- the player having more than 50% health during a break
+  - an indicator will display if you passed the section
 
 ### peppy
 
-peppy, written with a lowercase p, is the online alias of Dean Herbert.
+peppy, written with a lowercase `p`, is the online alias of Dean Herbert.
 He is the creator of the osu! project and its primary developer.
 
 ### Play time
@@ -1053,6 +1057,7 @@ Version has two meanings:
   - they could be called "Easy", "Normal", "Hard", "Insane", and "Expert"
   - however, beatmappers are allowed to give custom names to the difficulty versions of their beatmaps
 - the version of a skin
+  - see [Skinning](/wiki/Skinning/) for more details
 
 ## W
 
@@ -1069,7 +1074,7 @@ There are various reasons to mark a beatmap as WIP:
   - suggestions on the timing,
   - needs feedback
 
-WIPs can be submitted through the BSS to the Beatmap Help forum to get comments, feedback and help from mods and other users.
+WIPs can be submitted through the BSS to the Beatmap Help forum to get comments, feedback, and help from mods and other users.
 
 ## Z
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -277,11 +277,11 @@ Some factors that can affect a version's difficulty are the number of object in 
 Difficulty stars are one way to gauge a version's difficulty level.
 The osu!website sorts difficulty versions into 5 categories:
 
-- Easy,
-- Normal,
-- Hard,
-- Insane, and
-- Expert
+- [![Easy icon](/wiki/shared/Easy-s.png) Easy](/wiki/Difficulties/osu!standard/Easy/)
+- [![Normal icon](/wiki/shared/Normal-s.png) Normal](/wiki/Difficulties/osu!standard/Normal/)
+- [![Hard icon](/wiki/shared/Hard-s.png) Hard](/wiki/Difficulties/osu!standard/Hard/)
+- [![Insane icon](/wiki/shared/Insane-s.png) Insane](/wiki/Difficulties/osu!standard/Insane/)
+- [![Expert icon](/wiki/shared/Expert-s.png) Expert](/wiki/Difficulties/osu!standard/Expert/)
 
 ### Drain time
 
@@ -312,8 +312,10 @@ This term is usually seen during the modding process.
 ### DS games
 
 DS games is a collective term for [Osu! Tatakae! Ouendan!](https://en.wikipedia.org/wiki/Osu!_Tatakae!_Ouendan) (also called "Ouendan" or "Ouendan 1"), [Moero! Nekketsu Rhythm Damashii Osu! Tatakae! Ouendan! 2](https://en.wikipedia.org/wiki/Moero!_Nekketsu_Rhythm_Damashii_Osu!_Tatakae!_Ouendan!_2) (almost always called "Ouendan 2") and [Elite Beat Agents](https://en.wikipedia.org/wiki/Elite_Beat_Agents) (also called "EBA").
+
 A set of rhythm games, developed by [iNiS](https://en.wikipedia.org/wiki/INiS) for the Nintendo DS handheld video game system, which share a lot of gameplay and presentation elements.
-osu! is mostly based on these games.
+
+The osu!standard game mode was is mostly based off of those games.
 
 ## E
 
@@ -337,9 +339,13 @@ For more information about the Extended Chat Console, see [Chat Console](/wiki/C
 
 Fail has three meanings:
 
-- the incompletion of a beatmap due to low health
+- the incompletion of a beatmap due
+  - not filling the healthbar up to 80% when completing a beatmap (osu!taiko)
+  - empty healthbar (osu!standard, osu!catch, and osu!mania)
 - in multiplayer, an indicator underneath the player's name to show they have failed the beatmap
 - the player having less than 50% health during a break; where an indicator will display if you failed the section
+  - a fail indicator will be shown
+  - a failed storyboard animation will be played instead (if available).
 
 ### FC
 
@@ -357,8 +363,7 @@ Because of the combo multiplier effect, full combos will give the most score in 
 
 ### Geki
 
-Geki, or Elite Beat!, is a scoring term used when you complete a combo with the highest accuracy on every note.
-Many geki will happen during the course of a successful play.
+Geki(激), or Elite Beat!, is a scoring term used when you complete a combo with the highest accuracy on every note.
 
 ### Guest difficulty
 
@@ -374,8 +379,8 @@ There are many reasons for guest difficulties to exist:
 
 On the other hand, it may be the creator who wants a few guest difficulties:
 
-- this (usually) is to give the mapset a "community effort" feel
-- or simply because they don't want to create such difficulties by themselves
+- to give the mapset a "community effort" feel
+- simply because they don't want to create such difficulties by themselves
 
 Guest difficulties are often requested by private messages in-game or via forum private messages.
 Guest difficulties can also be requested in the modding queues, especially those who are offering to do them.
@@ -386,14 +391,13 @@ Each guest beatmapper is also allowed to create more than one difficulty to cont
 
 ### Grade
 
-A grade, usually confused with rank is a term created to prevent confusion with other terms sharing that name.
-A grade is a letter-grade that repersents the player's performance when playing a beatmap.
+A grade, usually confused with "rank", is a letter-grade that repersents the player's performance when playing a beatmap.
 It accompanies the total score at the result screen and appears in all lists where scores appear.
+
 From lowest to highest, the possible grades are D, C, B, A, S, Silver S, SS, and Silver SS.
 
-In order to achieve an S, one should not miss when playing the beatmap and have at most a ratio of 1:10 of 100s to 300s.
-In order to achieve an SS, one must only score 300s.
-There are also the Silver S and Silver SS grades, which are, respectively, an S and SS grade achieved when playing with the Hidden and/or Flashlight mod enabled
+<!-- TODO where do I go??!?!!?!?! -->
+For a complete explanation, see <!--[](...FAQ?)-->.
 
 ### Grid snapping
 
@@ -467,9 +471,9 @@ If a jump is too wide, a hyperdash may be used to prevent impossible jumps, thus
 
 ### Katu
 
-Katu, or beat, is when you complete a particular combo without achieving the highest level of accuracy throughout that set.
+Katu(喝), or _Beat!_, is when you complete a particular combo without achieving the highest level of accuracy throughout that set.
 
-This is different than a Geki because the comboset wasn't done perfectly with 300s.
+This is different than a Geki(激) because the comboset wasn't done perfectly with 300s.
 
 ### Keys
 
@@ -522,22 +526,34 @@ This only happens if the beatmapper has placed objects right at or very close at
 
 ### Life bar
 
-The life bar, also known as the health bar, HP bar, spirit bar, or ki bar, is a bar at the top left of the playing screen for osu!standard, osu!catch, and osu!taiko.
-For osu!mania, the life bar is rotated 90 degrees counter-clock-wise and is placed next to the bottom-right of the stage.
+The life bar, also known as the _health bar_, _v_, _spirit bar_, or _ki bar_, is a bar at the top left of the playing screen for osu!standard, osu!catch, and osu!taiko.
+For osu!mania, the life bar is rotated 90 degrees counter-clockwise and is placed next to the bottom-right of the stage.
 
 In all modes, expect for osu!mania, there is a symbol moving along it indicating the player's life.
 If the bar is completely empty, the player fails the current beatmap (assuming no special game modifiers are enabled).
 
 The bar drains at a constant rate throughout the course of a beatmap, except during a break.
-A sizeable part of the bar is also depleted in case of a miss.
-The bar is replenished by the player tapping hit circles, following sliders and slider ticks, and spinning spinners.
+For osu!taiko and osu!mania, health drain was disabled.
+
+For osu!standard, the bar is replenished by the player tapping hit circles, following sliders and slider ticks, and spinning spinners.
 The more accurate the tapping, the bigger the boost.
 The player also receives larger boosts if he achieves a katu or an geki at the end of a combo.
+
+For osu!catch, this can be done by catching fruit and drops.
+
+A sizeable part of the bar is also depleted in case of a miss.
 
 ### Local song offset
 
 The local song offset is an offset set for individual beatmaps, not the entire beatmapset itself.
 This is to offset the beatmap's offset alongside the global offset.
+
+You can change your local song offset by pressing:
+
+- `+` to increase the offset by 5 milliseconds
+- `-` to decrease the offset by 5 milliseconds
+- `Alt` + `+` to increase the offset by 1 milliseconds
+- `Alt` + `-` to decrease the offset by 1 milliseconds
 
 ## M
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -17,7 +17,7 @@ When a thread is "wastelanded", it is moved there.
 
 AFK is an internet acronym that means "Away From Keyboard".
 An example of this is when an active user walks off to do something else while they're still logged on.
-osu! will mark users as "Idle" if they have been inactive for sometime.
+osu! will mark users as "Idle" if they have been inactive for some time.
 
 ### Approach circle
 
@@ -162,7 +162,7 @@ Collab (or collaboration) has two meanings:
    - this is to ensure that the creator has done enough to upload the map under their username
 2. the mapset containing guest difficulties
 
-Collab may sometimes be used in difficulty version names.
+Collab may some times be used in difficulty version names.
 
 ### Combo
 
@@ -606,7 +606,7 @@ osu! has three meanings:
 
 - The rhythm video game for the Microsoft Windows Operating Systems.
   Spelled with a lowercase "o" and an exclamation mark at the end.
-- The game mode (sometimes refered to as _osu!standard_ to prevent ambiguity).
+- The game mode (some times refered to as _osu!standard_ to prevent ambiguity).
 - An informal greeting in the Japanese language, resulting from condensing the phrase "Ohayo gozaimasu!" (Good morning!)
   - Pronounced with a silent u ("OSS").
   - Close English equivalents include "Yo!" or "Hey!".
@@ -655,7 +655,7 @@ Ouendan has three meanings:
 
 - In Japanese culture, a cheer squad which, similar to western cheerleaders, rallies a sports team on using drums, horns, banners and yells of encouragement.
 - The pair of Japanese DS games that osu! was based on.
-  This term may sometimes be used to refer specifically to the first of these games.
+  This term may some times be used to refer specifically to the first of these games.
 - A collective term for the playable characters in the aforementioned games, i.e. "The Ouendan".
 
 ### Overmap
@@ -903,7 +903,7 @@ Steams does not require the hitobjects to be in the same comboset.
 ### SV
 
 SV, meaning slider velocity, is the speed in which the slider moves at in relation to the BPM.
-This term may sometimes be used during the modding process.
+This term may some times be used during the modding process.
 
 ## T
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -149,9 +149,9 @@ To see the changelog, see [Recent Releases](https://osu.ppy.sh/p/changelog).
 
 ### Choke
 
-A choke occurs when the player almosts obtains a full combo while playing a beatmap, but loses it near the end.
+A choke occurs when the player almosts obtains a full combo while playing a beatmap, but combobreaks near the end.
 
-On the contrary, a reverse choke is when the player loses their combo at the beginning but obtains a full combo for the rest of the beatmap.
+On the contrary, a reverse choke is when the player combobreaks at the beginning but obtains a full combo for the rest of the beatmap.
 
 ### Collab
 
@@ -221,7 +221,7 @@ This feature was later disabled on March 5, 2013 due to performance concerns.
 
 ### Combo milestone
 
-A combo milestone is the set of numbers that will shoot stars and display the comboburst after obtaining one of these milestones.
+A combo milestone is a set of numbers that will shoot stars and display the comboburst after obtaining one of these milestones.
 
 The combo milestones for osu!standard and osu!catch are 30, 60, 100, and multiples of 50 after 100.
 For osu!taiko, the combo milestones are multiples of 50.
@@ -559,7 +559,7 @@ You can change your local song offset by pressing:
 
 ### M4M
 
-M4M, or Mod for Mod, is a term describing when a modder agrees to mod another modder's map in return for a mod on their own map.
+M4M, or _Mod for Mod_, is a term describing when a modder agrees to mod another modder's map in return for a mod on their own map.
 
 ### Marathon
 
@@ -576,7 +576,7 @@ Upon the creation of the marathon beatmap, one should name their beatmap version
 
 **As of the April 23, 2013, all members of the MAT at that time were promoted as full members of the BAT, with the MAT team decommissioned.**
 
-The MAT, meaning Modding Assistance Team, was a group of users experienced in modding.
+The MAT, meaning _Modding Assistance Team_, was a group of users experienced in modding.
 MAT members can mark beatmap they approve of with a bubble, noting them as worthy of further consideration by the BAT.
 
 ### Modder
@@ -622,7 +622,7 @@ osu! has three meanings:
 
 - The rhythm video game for the Microsoft Windows Operating Systems.
   Spelled with a lowercase "o" and an exclamation mark at the end.
-- The game mode (some times refered to as _osu!standard_ to prevent ambiguity).
+- The game mode (unofficially called _osu!standard_ to prevent ambiguity).
 - An informal greeting in the Japanese language, resulting from condensing the phrase "Ohayo gozaimasu!" (Good morning!)
   - Pronounced with a silent u ("OSS").
   - Close English equivalents include "Yo!" or "Hey!".
@@ -658,6 +658,12 @@ If the player runs out of osu!coins, they may purchase more—out of their own w
 
 The following day, peppy rolled back the implementation of osu!coins due to popular demand, and ended with [this remark](https://disq.us/p/w2ydos).
 
+### osu!dev
+
+The osu!dev team is a group of people, including peppy, that 
+
+For details about the osu!dev, see [The Team](/wiki/People/The_Team/).
+
 ### osupixel
 
 An osupixel is the representation of one screen pixel when osu! is running in 640x480 resolution.
@@ -674,7 +680,7 @@ Ouendan has three meanings:
   This term may some times be used to refer specifically to the first of these games.
 - A collective term for the playable characters in the aforementioned games, i.e. "The Ouendan".
 
-### Overmap
+### Overmapping
 
 Overmapping is when the beats or placement of beats is placed in a way that makes the difficulty of the map contrast the actual song.
 This can be done by adding unnecessary jumps, slider speed-ups, or by mapping to an unknown beat in the music consistently (ie. adding notes on blue ticks when the song is only using red ticks), in order to add difficulty.
@@ -720,7 +726,9 @@ For more information about puush, see [puush / home](https://puush.me/).
 
 ### QAT
 
-QAT, meaning Quality Assurance Team, members are the ones responsible for ensuring that beatmaps will remain playable and enjoyable.
+QAT, meaning _Quality Assurance Team_, members are the ones responsible for ensuring that beatmaps will remain playable and enjoyable.
+
+To view the list of current QAT memebers, see [QAT](wiki/People/Quality_Assurance_Team).
 
 ## R
 
@@ -728,14 +736,14 @@ QAT, meaning Quality Assurance Team, members are the ones responsible for ensuri
 
 Rank has three meanings:
 
-1. another word for a grade
+1. another word for a letter grade
 2. a player’s standing in the online leaderboard (a.k.a. player ranking)
 3. the verb "to rank", which is when someone second another moderator’s nomination and include a submitted beatmap to the ranked beatmap list, making scores achieved by anyone playing it count towards each player’s ranking.
    Getting their beatmaps ranked is a goal of every beatmapper.
 
 ### Ranking
 
-Ranking, alternatively called "leaderboard", is a list that sorts members of the osu!community according to certain criteria.
+Ranking, alternatively called _leaderboard_, is a list that sorts members of the osu!community according to certain criteria.
 This can also refer to one's position in such a list.
 
 osu! currently has three rankings:
@@ -765,10 +773,17 @@ Usage is suggested when there has been a change in offset and/or BPM, after obje
 This command will automatically reposition all objects on the timeline so that they fall on the closest beat division your snap divisor allows.
 If used, it is important, especially if a large change in BPM and/or offset has been made, to check every object and adjust its position on the timeline manually, where necessary.
 
+### Restricted Mode
+
+Restricted mode is a state automatically applied to accounts that are suspected to breaking the [TOS](/wiki/Legal/TOS/).
+Submitted scores of gameplay are not allowed publically displayed.
+
+For more info, see [What is "restricted" mode, exactly?](http://osu.enchanthq.com/article/6/what-is-restricted-mode-exactly).
+
 ### RSI
 
-RSI, meaning Repetitive Strain Injury, is a type of injury that affects the musculoskeletal and nervous system of the body.
-It can be caused by repetitive tasks in awkward positions which may include playing osu! for an extended amount of time.
+RSI, short for _Repetitive Strain Injury_, is a type of injury that affects the musculoskeletal and nervous system of the body.
+This can be caused by doing repetitive tasks in an awkward position which may include playing osu! for an extended amount of time.
 
 ## S
 
@@ -810,10 +825,13 @@ Silences lasts for 4 weeks before being reset, along with the time that gets add
 
 ### Skin
 
-A skin is a set of graphics and custom sample sets that can be chosen to replace the default ones used by osu! in order to customise one's playing experience.
+A skin is a set of graphics and custom sample sets (audio clips) that can replace the default ones used by osu!.
+This will allow for a more customised user experience.
 Most of what you see and hear in osu! can be skinned.
 
 To see the dedicated sub-forum for skins, see [Skinning](https://osu.ppy.sh/forum/15).
+
+To see the list of skinnable eleemnts, see [Skinning](/wiki/Skinning/) (and its subpages).
 
 ### Skinner
 
@@ -856,8 +874,8 @@ On the other hand, there is the inverse of this, very long spinners that are pla
 
 Before considering this mapping technique, it is very important to note:
 
-- spinners can cause fatigue to the player, since it requires rapid, repetitive, and vigorous motion
-- the circular motion of a spinner will cause the cursor to be placed in random locations after completion.
+- Spinners can cause fatigue to the player, since it requires rapid, repetitive, and vigorous motion.
+- The circular motion of a spinner will cause the cursor to be placed in random locations after completion.
   - This will confuse the player when they are needed to click the next object(s).
 
 ### Stacked

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -21,7 +21,7 @@ osu! will mark users as "Idle" if they have been inactive for sometime.
 
 ### Approach circle
 
-In [osu!standard](/wiki/Game_Modes/osu!/), the approach circle is the outermost circle that will enclose the hitcircle, the start of a slider, or the center of the spinner.
+In [osu!standard](/wiki/Game_Modes/osu!/), the approach circle is the outermost circle that will enclose the hitcircle, the start of a slider, or the center of the spinner (for older skins).
 When the approach circle touches the outer border of the hitcircle or slider you should click.
 For spinners, the approach circle will indicate the duration of that spinner.
 
@@ -34,40 +34,43 @@ Authentic denotes a beatmap that emulates in every aspect of a specific stage fr
 ### Bancho
 
 Bancho is the easily expandable server coded by peppy.
-This replaces the need for a third-party IRC server in the management of all online content in osu!.
-Players automatically connect to Bancho when they start osu!, that is, if the player is connected to the internet.
+Bancho replaces the need for a third-party IRC server in the management of all online content in osu!.
+Logging with an osu! account ingame will automatically attempt to connect to Bancho until done successfully.
 
 ### BAT
 
-**As of February 1, 2015, the BAT was renamed to Beatmap Nomination Group**
+**As of February 1, 2015, the BAT was renamed to _Beatmap Nomination Group_**
 
-BAT&mdash;which was short for the _Beatmap Appreciation Team_&mdash;was a group of users that would rank and approve your beatmaps.
+BAT, short for the _Beatmap Appreciation Team_, was a group of users that would rank and approve your beatmaps.
 
 ### Beat
 
 Beat is a term that applies to the timeline in editor mode.
 Beat is a period of time that songs can be divided into based off of their BPM.
 A correctly timed beatmap will have each beat correspond to the song's rhythm and a whole beat should fall between two white lines on the timeline.
-Depending on the position of your snap divisor, other lines dividing a beat may be visible:
 
-- red lines for half beats,
-- blue lines for quarter beats,
-- yellow lines for eighth beats, and
-- purple lines for third and sixth beats
+For more information about the timeline, see [Beat Snap Divisor](/wiki/Beat_Snap_Divisor).
 
 ### Beatmap pack
 
-Beatmap packs _(if the name isn't clear)_ are packaged beatmaps.
+Beatmap packs (also known as _packs_) are sets of beatmaps packaged as one compressed file.
 Beatmap packs are collections of ranked and/or approved beatmaps that can be downloaded from a file sharing service (on [MediaFire](https://www.mediafire.com/)).
 
-Most beatmap packs are sets of beatmaps that were ranked during the same time period. However, in some packs may contain songs of a similar style or theme.
+Most beatmap packs are sets of beatmaps that were ranked during the same time period.
+Although, some packs are tailored to a similar style or theme.
 
-To see the beatmap packs, see [Beatmap Pack Listing](https://osu.ppy.sh/p/packlist)
+To see the beatmap packs, see [Beatmap Pack Listing](https://osu.ppy.sh/p/packlist).
+
+If you are interested in torrenting the beatmap packs instead, see [HiraOsu! - Torrents](https://osu.hiramiya.me/torrents.htm).
 
 ### Beat spacing
 
 Beat spacing is a principle which states that the spacing of every object (except for spinners) should be either closer, if closely placed on the timeline, or farther, if placed farther apart on the timeline.
-This basically means, close in time = close in space and farther in time = farther in space.
+
+This basically means:
+
+- closer in time = closer in space
+- farther in time = farther in space
 
 Your beat spacing plays a crucial role when the player is playing your beatmap!
 Consistent beat spacing is a basic requirement to rank a beatmap because it provides the player with a more intuitive experience as the player will learn where to move their cursor along the screen, at a constant speed.
@@ -95,13 +98,13 @@ A beatmapper (or mapper) refers to the osu!user who uses the editor to create a 
 
 ### Beatmapset
 
-A beatmapset (or mapset) is the collection of beatmaps that are packaged inside the `OSZ` file, under the same beatmapper.
-Beatmapsets will always have the same music/sound, video, if any.
+A beatmapset (or mapset) is the collection of beatmaps that are packaged inside the `.osz` file, under the same beatmapper.
+Beatmapsets will always have the same music, sounds, and video, if any.
 However, do note that some beatmaps from a beatmapset may specifically contain a certain background image or storyboard that is separate from the others.
 
 ### BG
 
-BG is short for background.
+BG is short for _background_.
 BG refers to the background image and/or video of a beatmap.
 Inside a beatmap folder, "BG" is usually the name for the background image.
 
@@ -122,22 +125,25 @@ A break is when a section of a beatmap has no objects.
 During this time, the drain in the life bar is temporarily halted.
 Breaks usually allow the player to rest their arm for a short while and reposition their input device.
 
-Depending on the settings, when a break is initated, letterboxes (the black horizontal bars on the top and bottom off the screen) may appear.
+Depending on the settings, when a break is initiated, letterboxes (the black horizontal bars on the top and bottom off the screen) may appear.
 In addition to this, a passing or failing graphic and sound will appear and play to indicate if the player is doing well or not, if there is enough time.
 
 ### BSS
 
-BSS is short for Beatmap Submission System.
+BSS is short for _Beatmap Submission System_.
 
-When a beatmapper is finished mapping their beatmap and is ready to share their creation around the world, they must first submit it to the BSS.
+When a beatmapper is finished mapping their beatmap(set) and is ready to share their creation around the world, they must first submit it to the BSS.
 When they do this, the BSS will automatically assign a forum thread and will generate a post with information about your beatmapset.
 The forum thread it generates will help you get feedback from modders and other players who play your map.
+Lastly, your beatmap will be given a beatmapID and can be commented on during replays.
+
+For a complete rundown, check out the [BSS](/wiki/Submission/) page.
 
 ## C
 
 ### Changelog
 
-The changelog is a forum thread where peppy and the osu!dev team details their day-by-day improvements, additions and bug fixes.
+The changelog is a page where peppy and the osu!dev team details their day-by-day improvements, additions and bug fixes.
 
 To see the changelog, see [Recent Releases](https://osu.ppy.sh/p/changelog).
 
@@ -170,9 +176,19 @@ Combo has two meanings:
      - above the fruit catcher in osu!catch
      - centre of the stage in osu!mania (vertical height varies by skin)
 
+### Combobreak
+
+A combobreak is when the player losses their combo during any part of playing a beatmap.
+
 ### Comboburst
 
-The comboburst is a collection of skinned elements/images that will _burst_ out from the left or right of the screen (or the right side of the osu!mania stage) after obtaining a combo of 30, 60, 100, (multiples of 50, after 100).
+A comboburst is a celebration of achieving a combo milestone.
+
+- For osu!standard and osu!catch, a character will _burst_ out from either the left or right side of the window
+- For osu!taiko, a collection of flowers will _burst_ behind pippidon
+- For osu!mania, a character will _burst_ from the right side of the stage (or left side if specified in the skin.ini)
+
+Combobursts can be disabled in the options.
 
 ### Combo colour
 
@@ -196,11 +212,20 @@ However, do note that the skin's defined combo colours is only used when the map
 
 ![R.I.P. combo fire](img/combo-fire.jpg)
 
-The combo fire was a feature in osu! that would display a burning yellow flame after obtaining a combo of 30.
+The combo fire was a background gameplay feature from the ouendan game integrated in osu!.
+This would display a burning yellow flame after obtaining the first combo milestone, 30.
 If the player obtains a combo of 500, the combo fire colour will change from yellow to blue.
 The combo fire will extinguish itself if the combo was broken but would still be reobtainable.
 
-This feature was later disabled due to performance concerns.
+This feature was later disabled on March 5, 2013 due to performance concerns.
+
+### Combo milestone
+
+A combo milestone is the set of numbers that will shoot stars and display the comboburst after obtaining one of these milestones.
+
+The combo milestones for osu!standard and osu!catch are 30, 60, 100, and multiples of 50 after 100.
+For osu!taiko, the combo milestones are multiples of 50.
+For osu!mania, the combo milestones are multiples of 100.
 
 ### Combo multiplier effect
 
@@ -209,8 +234,8 @@ This occurs because said game modes use the player's current combo as a part of 
 Meaning that a player would get a higher score, if they had gotten a full combo, than someone who played the same map with a broken combo.
 
 However, if you obtain a combo of ~10,000, your score will begin to count backwards.
-This is a flaw with the 32-bit signed integer where—in computing—the max integer is 2,147,483,647.
-A fix, scoreV2, for this in still being tested
+This is a flaw with the 32-bit signed integer where (in computing) the max integer is 2,147,483,647.
+A fix, _scoreV2_, for this in still being tested.
 
 ### Cookie
 
@@ -244,7 +269,7 @@ You can see a beatmap's difficulty stars when testing it in the editor, on the s
 
 ### Difficulties
 
-Beatmaps can have multiple difficulties, or diffs for short (or diff for singular), varying from Easy to Expert and above.
+Beatmaps can have multiple difficulties, or _diffs_ for short (or _diff_ for singular), varying from Easy to Expert and above.
 A beatmap should generally have two to five versions of varying difficulty.
 This would allow both novices and experienced players to be able to enjoy playing it.
 
@@ -349,7 +374,7 @@ There are many reasons for guest difficulties to exist:
 
 On the other hand, it may be the creator who wants a few guest difficulties:
 
-- this&mdash;usually&mdash;is to give the mapset a "community effort" feel
+- this (usually) is to give the mapset a "community effort" feel
 - or simply because they don't want to create such difficulties by themselves
 
 Guest difficulties are often requested by private messages in-game or via forum private messages.
@@ -550,7 +575,7 @@ Activities are shown either at [Works In Progress/Help](https://osu.ppy.sh/forum
 
 NC has two meanings:
 
-1. short for new combo, a modding term to suggest that a beat needs to be the start of a new combo
+1. short for _new combo_, a modding term to suggest that a beat needs to be the start of a new combo
 2. an abbreviation for the nightcore mod, a variant of the double time mod that increases the pitch of the music and adds a consistent bass drum beat to the music.
 
 ### Nuke
@@ -579,9 +604,9 @@ The offset is the first half of beatmap timing, where the other half is the BPM.
 
 osu! has three meanings:
 
-- the rhythm video game for the Microsoft Windows Operating Systems.
+- The rhythm video game for the Microsoft Windows Operating Systems.
   Spelled with a lowercase "o" and an exclamation mark at the end.
-- osu!standard, the game mode that osu! was originally based on.
+- The game mode (sometimes refered to as _osu!standard_ to prevent ambiguity).
 - An informal greeting in the Japanese language, resulting from condensing the phrase "Ohayo gozaimasu!" (Good morning!)
   - Pronounced with a silent u ("OSS").
   - Close English equivalents include "Yo!" or "Hey!".
@@ -629,7 +654,8 @@ In contrast, textures are scaled such that one texture pixel ([texel](https://en
 Ouendan has three meanings:
 
 - In Japanese culture, a cheer squad which, similar to western cheerleaders, rallies a sports team on using drums, horns, banners and yells of encouragement.
-- The pair of Japanese DS games that osu! was based on. This term may sometimes be used to refer specifically to the first of these games.
+- The pair of Japanese DS games that osu! was based on.
+  This term may sometimes be used to refer specifically to the first of these games.
 - A collective term for the playable characters in the aforementioned games, i.e. "The Ouendan".
 
 ### Overmap
@@ -688,22 +714,26 @@ Rank has three meanings:
 
 1. another word for a grade
 2. a player’s standing in the online leaderboard (a.k.a. player ranking)
-3. the verb "to rank", which is when someone second another moderator’s nomination and include a submitted beatmap to the ranked beatmap list, making scores achieved by anyone playing it count towards each player’s ranking. Getting their beatmaps ranked is a goal of every beatmapper.
+3. the verb "to rank", which is when someone second another moderator’s nomination and include a submitted beatmap to the ranked beatmap list, making scores achieved by anyone playing it count towards each player’s ranking.
+   Getting their beatmaps ranked is a goal of every beatmapper.
 
 ### Ranking
 
-Ranking&mdash;alternatively called "leaderboard"&mdash;is a list that sorts members of the osu!community according to certain criteria.
+Ranking, alternatively called "leaderboard", is a list that sorts members of the osu!community according to certain criteria.
 This can also refer to one's position in such a list.
 
 osu! currently has three rankings:
 
-- Player rankings: the ranking most commonly referred to, this list sorts players depending on their ranked score. Ranked score is the sum of the highest scores that a player has achieved in every ranked beatmap they had played. Scores achieved from ranked beatmaps are taken into account. Only one score from each beatmapset (the highest) is taken into account, regardless of how many difficulty versions it has.
+- Player rankings: the ranking most commonly referred to, this list sorts players depending on their ranked score.
+  Ranked score is the sum of the highest scores that a player has achieved in every ranked beatmap they had played.
+  Scores achieved from ranked beatmaps are taken into account.
+  Only one score from each beatmapset (the highest) is taken into account, regardless of how many difficulty versions it has.
 - Beatmapper rankings: this list sorts everyone who has created at least one ranked beatmap, depending on the weighted average of all the ratings given to their beatmaps by other players, multiplied by a bonus modifier that increases the more ranked beatmaps they have.
 - Moderator rankings: this list sorts moderators depending on how many posts they have made in the beatmap sub-forums, i.e. how much beatmap modding they are doing.
 
 ### Recalc
 
-Recalc is short for "Recalculate slider lengths".
+Recalc is short for _Recalculate slider lengths_.
 Recalc is a command under the `Timing` header of the editor screen.
 
 Usage of this is suggested after a BPM change is made, if the beatmap already has sliders.
@@ -745,6 +775,16 @@ Inside each categories has these four hitsounds:
 
 However, there are other parts of a sample set that may include the slider tick sounds and the sound made when filling the spinner metre.
 
+### scoreV2
+
+scoreV2 has two meanings:
+
+- The game modifier that is only available for the cuttingedge stream.
+  This allows players using the cuttingedge stream to test out the new algorithm.
+- The successor to scoreV1,
+
+scoreV2 is a new scoring algorithm that will resolve issues with the combo multiplier effect.
+
 ### Silence
 
 A silence is an action taken against an osu!user who spams the osu!chat.
@@ -761,14 +801,17 @@ To see the dedicated sub-forum for skins, see [Skinning](https://osu.ppy.sh/foru
 
 ### Skinner
 
-A skinner refers to the osu!user who releases downloadable skins on the osu!forums. They may have had used an photo editing application such as GIMP or Photoshop.
+A skinner refers to the osu!user who releases downloadable skins on the osu!forums.
+They may have had used an photo editing application such as GIMP or Photoshop.
 
 ### Sliderbreak
 
 Sliderbreak has two meanings:
 
 - In osu!standard, a sliderbreak is when the player loses their combo by not holding a slider long enough.
-  - This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider). This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed. Unlike missing, you can still achieve an "S" rank after sliderbreaking.
+  - This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider).
+    This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed.
+    Unlike missing, you can still achieve an "S" rank after sliderbreaking.
 - The case where the player doesn't obtain the max possible combo without missing an object.
 
 ### Slidertick
@@ -830,7 +873,8 @@ Star priority has two meanings:
    - at least 12 star priority is needed for a map to be bubbled or ranked
 2. a method in determining whether a Feature Request is wanted by the community
    - the higher the star priority, the faster it gets noticed
-   - users that have supporter status active when voting will shoot a pink star (![Kudosu](/wiki/shared/Kudos.png)) that increases Star Priority by 2 each, whilst a user without supporter will shoot a blue star (![Star](/wiki/shared/Star.gif)) that is worth only 1 each. Users may be able to shoot multiple stars depending on how many votes they have left.
+   - users that have supporter status active when voting will shoot a pink star (![Kudosu](/wiki/shared/Kudos.png)) that increases Star Priority by 2 each, whilst a user without supporter will shoot a blue star (![Star](/wiki/shared/Star.gif)) that is worth only 1 each.
+     Users may be able to shoot multiple stars depending on how many votes they have left.
 
 ### Storyboard
 
@@ -873,7 +917,8 @@ Therefore it becomes a challenge for elite players in terms of precision of jump
 TAG difficulties are usually named TAG in a beatmap set.
 TAG2 maps are meant for 2 players while TAG4 maps (the hardest) are meant for 4 players.
 
-Note that tag difficulties are unrankable because they are far too hard to be ranked and are not designed for the single player. However, this hasn't stop pros from trying.
+Note that tag difficulties are unrankable because they are far too hard to be ranked and are not designed for the single player.
+However, this hasn't stop pros from trying.
 
 ### Tablet
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -162,7 +162,7 @@ Collab (or collaboration) has two meanings:
    - this is to ensure that the creator has done enough to upload the map under their username
 2. the mapset containing guest difficulties
 
-Collab may some times be used in difficulty version names.
+Collab may sometimes be used in difficulty version names.
 
 ### Combo
 
@@ -595,11 +595,11 @@ Activities are shown either at [Works In Progress/Help](https://osu.ppy.sh/forum
 NC has two meanings:
 
 1. short for _new combo_, a modding term to suggest that a beat needs to be the start of a new combo
-2. an abbreviation for the nightcore mod, a variant of the double time mod that increases the pitch of the music and adds a consistent bass drum beat to the music.
+2. an abbreviation for the Nightcore [mod](/wiki/Game_Modifiers/), a variant of the double time mod that increases the pitch of the music and adds a consistent bass drum beat to the music.
 
 ### Nuke
 
-Any beatmap that is considered to be disregarding the rules (or the mapper disregarding the Code of Conduct) can be nuked.
+Any beatmap that is considered to be disregarding the rules (or the mapper disregarding the [Code of Conduct](/wiki/Modding_and_Mapping/)) can be nuked.
 Nuked beatmaps are considered "closed" until significant changes are made and the status is manually removed by a member of the team.
 
 Examples include but are not limited to:
@@ -614,7 +614,7 @@ The warning icon that accompanies nuked beatmaps is the symbol for radioactive m
 
 ### Offset
 
-The offset is a period of time between the beginning of a beatmap’s song file and the instant the first beat of the rhythm is heard, from which the position of the first beat is calculated.
+The offset is a period of time between the beginning of a beatmap's song file and the instant the first beat of the rhythm is heard, from which the position of the first beat is calculated.
 This is measured in milliseconds (ms).
 
 The offset is the first half of beatmap timing, where the other half is the BPM.
@@ -680,7 +680,7 @@ Ouendan has three meanings:
 
 - In Japanese culture, a cheer squad which, similar to western cheerleaders, rallies a sports team on using drums, horns, banners and yells of encouragement.
 - The pair of Japanese DS games that osu! was based on.
-  This term may some times be used to refer specifically to the first of these games.
+  This term may sometimes be used to refer specifically to the first of these games.
 - A collective term for the playable characters in the aforementioned games, i.e. "The Ouendan".
 
 ### Overmapping
@@ -741,8 +741,8 @@ To view the list of current QAT memebers, see [QAT](wiki/People/Quality_Assuranc
 Rank has three meanings:
 
 1. another word for a letter grade
-2. a player’s standing in the online leaderboard (a.k.a. player ranking)
-3. the verb "to rank", which is when someone second another moderator’s nomination and include a submitted beatmap to the ranked beatmap list, making scores achieved by anyone playing it count towards each player’s ranking.
+2. a player's standing in the online leaderboard (a.k.a. player ranking)
+3. the verb "to rank", which is when someone second another moderator's nomination and include a submitted beatmap to the ranked beatmap list, making scores achieved by anyone playing it count towards each player's ranking.
    Getting their beatmaps ranked is a goal of every beatmapper.
 
 ### Ranking
@@ -816,9 +816,10 @@ scoreV2 has two meanings:
 
 - The game modifier that is only available for the cuttingedge stream.
   This allows players using the cuttingedge stream to test out the new algorithm.
-- The successor to scoreV1,
+- The successor to scoreV1
 
 scoreV2 is a new scoring algorithm that will resolve issues with the combo multiplier effect.
+This caps the scores for all game modes to 1 million points, like osu!mania, and adjusts a few things within the osu!mania mode.
 
 ### Silence
 
@@ -840,16 +841,16 @@ To see the list of skinnable eleemnts, see [Skinning](/wiki/Skinning/) (and its 
 ### Skinner
 
 A skinner refers to the osu!user who releases downloadable skins on the osu!forums.
-They may have had used an photo editing application such as GIMP or Photoshop.
 
 ### Sliderbreak
 
 Sliderbreak has two meanings:
 
-- In osu!standard, a sliderbreak is when the player loses their combo by not holding a slider long enough.
-  - This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider).
-    This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed.
-    Unlike missing, you can still achieve an "S" rank after sliderbreaking.
+- In osu!standard:
+  - tapping the slider-start too early (this can cause the slider to shake)
+  - not collecting a slidertick (includes the hidden ones underneath the slider-start and slider-end)
+  - releasing the slider ball before it hits the slider-end
+    - this will not cause a miss, rather it will give you a 100 with no combo increment
 - The case where the player doesn't obtain the max possible combo without missing an object.
 
 ### Slidertick
@@ -871,7 +872,7 @@ Spectator aura is a mysterious phenomenon that could cause players to choke thei
 
 ### Spinner spam
 
-Spinner spam is a mapping technique that is heavily discouraged.
+Spinner spam is a **heavily discouraged** mapping technique (in fact, it will probably make your map unrankable).
 
 As the name sugguests, spinner spam occurs when a mapper spams many very short spinners (that last for ~2 sec or less) one after another.
 On the other hand, there is the inverse of this, very long spinners that are placed right after another.
@@ -887,19 +888,24 @@ Before considering this mapping technique, it is very important to note:
 Stacked objects are hitobjects that overlap each other in the playfield.
 The most common object that is stacked are hitcircles.
 
-Stacking hitcircles&mdash;while a clear violation of beat spacing&mdash;is, nevertheless, permitted if the hitcircles are very close to each other in the timeline (half a beat or usually even less).
+Stacking hitcircles (a clear violation of beat spacing) is, nevertheless, permitted if the hitcircles are very close to each other in the timeline (half a beat or usually even less).
 
 ### Star
 
-Star has two meanings:
+Star has four meanings:
 
-1. a stage in a beatmap’s modding process where a moderator judges a beatmap to be on the right track but needing some improvements before he approves of it with a bubble
+1. a stage in a beatmap's modding process where a moderator judges a beatmap to be on the right track but needing some improvements before approve with a bubble
    - examples include adjustments in timing, incorrect beat spacing in some areas, or creating additional difficulty versions
-   - beatmaps receiving a star are denoted by a star graphic next to their thread’s title
-   - a star may be removed by another mod if he judges the beatmap to need a rather larger amount of improvements than expected
-2. another term for "difficulty stars"
+   - beatmaps receiving a star are denoted by a star graphic next to their thread's title
+   - a star may be removed by another mod if the beatmap is thought to be in need of more improvements
+2. another term for "Difficulty Stars"
+   - the symbol that represents the difficulty of a beatmap
+3. another term for "Kudosu!"
+   - these are given to beatmap modders and can be used to raise a beatmap above others
+4. another term for "Stars Priority"
+   - these stars are given to [osu!supporters](/wiki/osu!support) and are used in Feature Requests
 
-### Star priority
+### Star Priority
 
 Star priority has two meanings:
 
@@ -916,9 +922,9 @@ Star priority has two meanings:
 
 ### Storyboard
 
-A storyboard is a set of still and/or animated images and sound effects that tells a story during a beatmap’s course but especially before the beatmap’s beginning, during breaks and after the beatmap’s end.
+A storyboard is a set of still and/or animated images and sound effects that tells a story during a beatmap's course but especially before the beatmap's beginning, during breaks and after the beatmap's end.
 In the DS games, storyboards concern one or more persons facing a difficult challenge or predicament which they then try to overcome whilst being cheered on by the player-controlled characters to the tune of a song.
-Therefore, a storyboard can take various directions depending on the player’s performance.
+Therefore, a storyboard can take various directions depending on the player's performance.
 osu!storyboarding is supported through the use of a scripting language or through the storyboard editor which can be accessed in editor mode under "Design".
 
 There is a sub-forum dedicated to storyboards, see [Storyboarding](https://osu.ppy.sh/forum/20).
@@ -940,23 +946,25 @@ Steams does not require the hitobjects to be in the same comboset.
 
 ### SV
 
-SV, meaning slider velocity, is the speed in which the slider moves at in relation to the BPM.
-This term may some times be used during the modding process.
+SV, meaning _slider velocity_, is the speed in which the slider moves at in relation to the BPM.
+This term may sometimes be used during the modding process.
+
+The slider velocity defines the movement speed of the slider ball. The lower the slider velocity, the slower the slider ball.
 
 ## T
 
 ### TAG
 
-A TAG difficulty is a type of beatmap version that is designed for more than one person to play at the same time in multiplayer mode.
+A TAG difficulty is a type of beatmap that is designed for more than one person to play at the same time in multiplayer mode, using the Tag Co-Op/Tag Team Co-Op Team Mode.
 
 Each player is responsible for one comboset, where each hitobject in that comboset is mapped to be extremely farther apart, making it nearly impossible to play by a single player.
 Therefore it becomes a challenge for elite players in terms of precision of jumping.
 
 TAG difficulties are usually named TAG in a beatmap set.
-TAG2 maps are meant for 2 players while TAG4 maps (the hardest) are meant for 4 players.
+TAG2 maps are meant for 2 players, while TAG4 maps (the hardest) are meant for 4 players.
 
-Note that tag difficulties are unrankable because they are far too hard to be ranked and are not designed for the single player.
-However, this hasn't stop pros from trying.
+Note that TAG difficulties are unrankable because they are intentionally not designed for a single player.
+However, this hasn't stop users from trying.
 
 ### Tablet
 
@@ -968,7 +976,7 @@ The image of the screen does not appear on the tablet, thus making it different 
 ### Tap
 
 In osu!standard, tapping is a term that means "to press a button while the cursor is over a hitobject".
-Tapping hitobjects at the right moment, as indicated by the beatmap’s music and the approach circle, is an essential part of osu! gameplay.
+Tapping hitobjects at the right moment, as indicated by the beatmap's music and the approach circle, is an essential part of osu! gameplay.
 There are a few different buttons one can use to tap:
 
 - the left and right mouse buttons,
@@ -976,16 +984,15 @@ There are a few different buttons one can use to tap:
 - using the buttons on the tablet/touchpad, or
 - directly on a touchscreen/tablet
 
-### Test mode
+### Test Mode
 
 Test mode is a feature of the beatmap editor.
-This allows you to best your beatmap without having to submit anything.
-However, you are required to overwrite and save the beatmap before continuing.
-This creates issues if you need to rollback on your recent changes.
+This allows you to test your beatmap without having to submit anything.
+However, you are required to save the beatmap before continuing to test mode; creating issues if you need to rollback on your recent changes.
 
 ### Time signature
 
-The time signature is a musical term that indicats how many beats are in each measure and what note value constitutes a single beat.
+The time signature is a musical term that indicates how many beats are in each measure and what note value constitutes a single beat.
 osu! offers two alternative time signatures, which can be selected from the Timing menu: 4/4, which is the one most commonly used, and 3/4, which is selected when the rhythm of the song is of, or similar to, a waltz.
 
 ### Timing
@@ -1000,15 +1007,17 @@ The timing process creates the timeline on which objects will be placed.
 One of many reasons as to why your timing of a beatmap is important is because osu! takes the given BPM and offset to determine where the hitobjects should go.
 If your timing is off, even by a little, then it is next to unrankable to map hitobjects on the editor.
 
-### Timing section
+### Timing Section
 
-A timing section is a part of a song which follows a different rhythm than the parts preceding and following it.
-Many songs have a constant tempo and thus a single timing section.
-However, there may be some that have more.
-If this does happen, the beatmapper needs to identify any areas where the song BPM and/or time signature changes and find the timing for each one.
+Good timing of a beatmap is big a requirement for a beatmap to get ranked.
+Timing a beatmap consists of determining the offset and then the BPM of the song it uses.
 
-Timing sections can also be used even if the rhythm of the song remains constant throughout the beatmap, for example in order to allow the beatmapper to assign different sample sets to different parts of the song.
-Those are called "inherited timing sections" and are identified by green lines.
+When the tempo changes, you are required to add a new timing section to accompany the new tempo.
+
+The timing process creates the timeline on which objects will be placed.
+
+One of many reasons as to why your timing of a beatmap is important because osu! takes the given BPM and offset to determine where the hitobjects should go.
+If your timing is off, even by a little, then it is next to unrankable to map hitobjects on the editor.
 
 ### Touchscreen
 
@@ -1021,7 +1030,7 @@ This is different than a tablet because a touchscreen has some kind of display w
 
 A touchpad is a substitute for the computer mouse.
 Touchpads are most commonly found on laptop computers.
-The touchpad usually consists of a small rectangular area which one can drag one’s finger to move the mouse cursor.
+The touchpad usually consists of a small rectangular area which one can drag one's finger to move the mouse cursor.
 Due to the way touchpads are designed, they do not work with a stylus or similar devices.
 
 ## U
@@ -1037,7 +1046,7 @@ The universal offset applies to all songs used in osu! and its value differs acc
 After being determined, it doesn't need to be modified again.
 An incorrectly universal offset will cause timing problems in every beatmap played or edited.
 If everything sounds off to you while playing a few ranked beatmaps, try checking your universal offset.
-The universal offset settings is located in the Options.
+The universal offset settings is located in the [Options](/wiki/Options/).
 
 ### upppy
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -77,7 +77,7 @@ On the otherhand, placing them too far may force the player to move their cursor
 A common exception to beat spacing is stacked hitcircles.
 
 To ensure consistent beat spacing, turn on the `Distance Snap` button on the right-hand side of the editor.
-You can choose a beat spacing value by holding `ALT` and sliding the selector at the top right until you reach the desired value.
+You can choose a beat spacing value by holding `Alt` and sliding the selector at the top right until you reach the desired value.
 Note that the higher the value would allow a more difficult beatmap.
 
 ### Beatmap
@@ -105,9 +105,9 @@ BG is short for background.
 BG refers to the background image and/or video of a beatmap.
 Inside a beatmap folder, "BG" is usually the name for the background image.
 
-## BN
+### BN
 
-BN is short for Beatmap Nominator which is a group of osu!users who nominate pending beatmaps.
+BN is short for Beatmap Nominator which is a group of users who nominate pending beatmaps.
 This group was once called the BAT (Beatmap Appreciation Team).
 
 For details about Beatmap Nominators, see [Beatmap Nominator](/wiki/People/Beatmap_Nomination_Group/).
@@ -202,6 +202,16 @@ The combo fire will extinguish itself if the combo was broken but would still be
 
 This feature was later disabled due to performance concerns.
 
+### Combo multiplier effect
+
+The combo multiplier effect occurs in the osu!standard, osu!taiko, and osu!catch game modes.
+This occurs because said game modes use the player's current combo as a part of the score calculations.
+Meaning that a player would get a higher score, if they had gotten a full combo, than someone who played the same map with a broken combo.
+
+However, if you obtain a combo of ~10,000, your score will begin to count backwards.
+This is a flaw with the 32-bit signed integer where—in computing—the max integer is 2,147,483,647.
+A fix, scoreV2, for this in still being tested
+
 ### Cookie
 
 ![](img/Intro_static.jpg "The cookie is typically used to describe the circular osu!logo which appears at the very start of the game, and refers to its shape.")
@@ -258,14 +268,14 @@ Maps with very long drain times are typically referred to as "marathon" maps and
 ### Drop
 
 A drop is an osu!catch element that gives a score of 100.
-A drop is the equivalent to the osu!standard's slider tick.
+It is the equivalent to the osu!standard's slidertick.
 
 The difference between drops and droplets is that a drop is twice as big as droplets are.
 
 ### Droplet
 
 A droplet is an osu!catch element that gives a score of 10.
-A droplet is the equivalent to the osu!standard's slider track.
+It is the equivalent to the osu!standard's slider track.
 
 The difference between drops and droplets is that a droplet is half as big as drops are.
 
@@ -276,7 +286,7 @@ This term is usually seen during the modding process.
 
 ### DS games
 
-Collective term for [Osu! Tatakae! Ouendan!](https://en.wikipedia.org/wiki/Osu!_Tatakae!_Ouendan) (also called "Ouendan" or "Ouendan 1"), [Moero! Nekketsu Rhythm Damashii Osu! Tatakae! Ouendan! 2](https://en.wikipedia.org/wiki/Moero!_Nekketsu_Rhythm_Damashii_Osu!_Tatakae!_Ouendan!_2) (almost always called "Ouendan 2") and [Elite Beat Agents](https://en.wikipedia.org/wiki/Elite_Beat_Agents) (also called "EBA").
+DS games is a collective term for [Osu! Tatakae! Ouendan!](https://en.wikipedia.org/wiki/Osu!_Tatakae!_Ouendan) (also called "Ouendan" or "Ouendan 1"), [Moero! Nekketsu Rhythm Damashii Osu! Tatakae! Ouendan! 2](https://en.wikipedia.org/wiki/Moero!_Nekketsu_Rhythm_Damashii_Osu!_Tatakae!_Ouendan!_2) (almost always called "Ouendan 2") and [Elite Beat Agents](https://en.wikipedia.org/wiki/Elite_Beat_Agents) (also called "EBA").
 A set of rhythm games, developed by [iNiS](https://en.wikipedia.org/wiki/INiS) for the Nintendo DS handheld video game system, which share a lot of gameplay and presentation elements.
 osu! is mostly based on these games.
 
@@ -318,7 +328,7 @@ Losing your combo halfway through the game could easily lose you half as many po
 FC or, a "full combo", is when a player completes a beatmap while obtaining the maximum combo possible.
 This does not account accuracy as it is often used to mean clearing a beatmap without having any misses or sliderbreaks.
 
-Full combos usually give the most score in the osu!standard and osu!catch modes.
+Because of the combo multiplier effect, full combos will give the most score in the osu!standard, osu!taiko, and osu!catch modes.
 
 ## G
 
@@ -342,7 +352,7 @@ There are many reasons for guest difficulties to exist:
 On the other hand, it may be the creator who wants a few guest difficulties:
 
 - this&mdash;usually&mdash;is to give the mapset a "community effort" feel
-- or, simply, they don't want to create such difficulties by themselves
+- or simply because they don't want to create such difficulties by themselves
 
 Guest difficulties are often requested by private messages in-game or via forum private messages.
 Guest difficulties can also be requested in the modding queues, especially those who are offering to do them.
@@ -759,15 +769,17 @@ A skinner refers to the osu!user who releases downloadable skins on the osu!foru
 
 ### Sliderbreak
 
-In osu!standard, a sliderbreak is when the player loses their combo by not holding a slider long enough.
-This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider).
-This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed.
-Unlike missing, you can still achieve an "S" rank after sliderbreaking.
+Sliderbreak has two meanings:
 
-### Slider tick
+- In osu!standard, a sliderbreak is when the player loses their combo by not holding a slider long enough.
+  This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider).
+  This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed.
+  Unlike missing, you can still achieve an "S" rank after sliderbreaking.
 
-The slider tick is a hitobject that gives out 10 points.
-The amount of slider ticks used in a slider is dependent on the slider velocity, the BPM and the inherited timing.
+### Slidertick
+
+The slidertick is a hitobject that gives out 10 points.
+The amount of sliderticks used in a slider is dependent on the slider velocity, the BPM and the inherited timing.
 
 ### Spectate
 
@@ -790,7 +802,7 @@ On the other hand, there is the inverse of this, very long spinners that are pla
 
 Before considering this mapping technique, it is very important to note:
 
-- apinners can cause fatigue to the player, since it requires rapid, repetitive, and vigorous motion
+- spinners can cause fatigue to the player, since it requires rapid, repetitive, and vigorous motion
 - the circular motion of a spinner will cause the cursor to be placed in random locations after completion.
   - This will confuse the player when they are needed to click the next object(s).
 
@@ -881,10 +893,10 @@ In osu!standard, tapping is a term that means "to press a button while the curso
 Tapping hitobjects at the right moment, as indicated by the beatmap’s music and the approach circle, is an essential part of osu! gameplay.
 There are a few different buttons one can use to tap:
 
--     the left and right mouse buttons,
--     the `Z` and `X` keys on the keyboard,
--     using the buttons on the tablet/touchpad, or
--     directly on a touchscreen/tablet
+- the left and right mouse buttons,
+- the `Z` and `X` keys on the keyboard,
+- using the buttons on the tablet/touchpad, or
+- directly on a touchscreen/tablet
 
 ### Test mode
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -250,7 +250,7 @@ This would allow both novices and experienced players to be able to enjoy playin
 
 Some factors that can affect a version's difficulty are the number of object in the beatmap, whether a main or background (harder to hear) rhythm is followed for object placement, the length of combos, the beat spacing value, the drain rate, the accuracy limit the game requires to register a hit, the size of hitcircle, etc..
 Difficulty stars are one way to gauge a version's difficulty level.
-The osu!website sorts difficulty versions into into 5 categories:
+The osu!website sorts difficulty versions into 5 categories:
 
 - Easy,
 - Normal,
@@ -301,12 +301,10 @@ EBA has two meanings:
 
 ### Extended chat
 
-The Extended chat can be activated by pressing `F9` in osu! where the chat window is expanded with a list of user panels.
-These panels are sortable by various attributes.
-Users that are using the osu!client are displayed, not ones that are participating in chat from using a IRC client.
-The user panels supply lots of information on each user.
-If the mouse cursor is placed on them.
-The colour of the user panels indicates the user's current activity; an explaination for these codes, see [Chat Console](/wiki/Chat_Console/).
+Extended chat is the Chat Console (bottom portion) with the user panels (top portion) of players currently logged-in to the game client.
+Press `F8` to show the chat and/or `F9` to show the user panels (if you press `F9` without the chat opened, this will open both).
+
+For more information about the Extended Chat Console, see [Chat Console](/wiki/Chat_Console/) (under the _Extended Chat Console_ section).
 
 ## F
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -772,9 +772,8 @@ A skinner refers to the osu!user who releases downloadable skins on the osu!foru
 Sliderbreak has two meanings:
 
 - In osu!standard, a sliderbreak is when the player loses their combo by not holding a slider long enough.
-  This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider).
-  This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed.
-  Unlike missing, you can still achieve an "S" rank after sliderbreaking.
+  - This can occur by the player moving their cursor out of the slider circle or not hitting the beginning of the slider (but within the follow circle of the slider). This will give a score of 100 or 50 for the slider, depending on how much slider ticks are missed. Unlike missing, you can still achieve an "S" rank after sliderbreaking.
+- The case where the player doesn't obtain the max possible combo without missing an object.
 
 ### Slidertick
 

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -27,7 +27,7 @@ For spinners, the approach circle will indicate the duration of that spinner.
 
 ### Authentic
 
-Authentic is a word that denotes a beatmap that emulates in every aspect of a specific stage from the DS games (song, settings, object placement, etc.).
+Authentic denotes a beatmap that emulates in every aspect of a specific stage from the DS games (song, settings, object placement, etc.).
 
 ## B
 
@@ -41,7 +41,7 @@ Players automatically connect to Bancho when they start osu!, that is, if the pl
 
 **As of February 1, 2015, the BAT was renamed to Beatmap Nomination Group**
 
-BAT&mdash;which was short for the Beatmap Appreciation Team&mdash;was a group of users that would rank and approve your beatmaps.
+BAT&mdash;which was short for the _Beatmap Appreciation Team_&mdash;was a group of users that would rank and approve your beatmaps.
 
 ### Beat
 
@@ -58,7 +58,7 @@ Depending on the position of your snap divisor, other lines dividing a beat may 
 ### Beatmap pack
 
 Beatmap packs _(if the name isn't clear)_ are packaged beatmaps.
-Beatmap packs are collections of ranked and/or approved beatmaps that can be downloaded from a file sharing service (either on [osu!Mirror](https://osu.yas-online.net/) or [MediaFire](https://www.mediafire.com/)).
+Beatmap packs are collections of ranked and/or approved beatmaps that can be downloaded from a file sharing service (on [MediaFire](https://www.mediafire.com/)).
 
 Most beatmap packs are sets of beatmaps that were ranked during the same time period. However, in some packs may contain songs of a similar style or theme.
 
@@ -417,8 +417,6 @@ osu! provides a wide array of hitsounds (eight in the stable release, since upgr
 Though, mappers can go further add up to 24 more.
 Sliders also have ambient sound effects when they are being performed successfully, including a recurrent ticking sound which matches the beat.
 
-For a list of skinnable hitsounds, see [Skinning Sounds](/wiki/Skinning/Sounds/).
-
 ## I
 
 ### Ignore list
@@ -583,9 +581,13 @@ The offset is the first half of beatmap timing, where the other half is the BPM.
 
 osu! has three meanings:
 
-- the rhythm video game for the Microsoft Windows Operating Systems. Spelled with a lowercase "o" and an exclamation mark at the end.
+- the rhythm video game for the Microsoft Windows Operating Systems.
+  Spelled with a lowercase "o" and an exclamation mark at the end.
 - osu!standard, the game mode that osu! was originally based on.
-- An informal greeting in the Japanese language, resulting from condensing the phrase "Ohayo gozaimasu!" (Good morning!) Pronounced with a silent u ("OSS"). Close English equivalents include "Yo!" or "Hey!". To read more about its meaning in Japanese language and culture, see [Does anyone here speak/learn Japanese?](https://osu.ppy.sh/forum/p/2686).
+- An informal greeting in the Japanese language, resulting from condensing the phrase "Ohayo gozaimasu!" (Good morning!)
+  - Pronounced with a silent u ("OSS").
+  - Close English equivalents include "Yo!" or "Hey!".
+    To read more about its meaning in Japanese language and culture, see [Does anyone here speak/learn Japanese?](https://osu.ppy.sh/forum/p/2686).
 
 ### osu!academy
 
@@ -758,10 +760,6 @@ A skin is a set of graphics and custom sample sets that can be chosen to replace
 Most of what you see and hear in osu! can be skinned.
 
 To see the dedicated sub-forum for skins, see [Skinning](https://osu.ppy.sh/forum/15).
-
-For a list of skinnable elements, see [Skinning](/wiki/Skinning/).
-
-For a tutorial, see [Skinning Tutorial](/wiki/Skinning/Tutorial/).
 
 ### Skinner
 
@@ -978,7 +976,6 @@ Version has two meanings:
   - they could be called "Easy", "Normal", "Hard", "Insane", and "Expert"
   - however, beatmappers are allowed to give custom names to the difficulty versions of their beatmaps
 - the version of a skin
-  - see [Skinning](/wiki/Skinning/)
 
 ## W
 


### PR DESCRIPTION
- fixed keyboard key letter casing
- fixed heading level for `BN`
- added `Combo multiplier effect`
- reworded various definitions to maintain easier readability
- `slider tick` to `slidertick`
- fixed `sliderbreak` (now has two definitions)
- fixed spacing between bullet and text
- fixed typo (@vincent38)
- update `Extended chat` term (@vincent38 and @RaikireHiuduo)
- various fixes (@RaikireHiuduo)