### PR TITLE
Article Style Guide updates

### DIFF
--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -43,19 +43,23 @@ This will help make the headings stand out a bit more when editing.
 There are two styles of heading levels 1 and 2 that Markdown supplies you:
 
 ```md
-heading level 1
-===============
+title of page
+=============
 
 heading level 2
 ---------------
+
+### heading level 3
 ```
 
 or
 
 ```md
-# heading level 1
+# title of page
 
 ## heading level 2
+
+### heading level 3
 ```
 
 You can choose either the underline style or hashtag style of level 1 and level 2 headings.
@@ -68,6 +72,11 @@ The title of an article is the name of the folder that the article is located in
 For English article titles, if you need to reword the title, you must rename the folder to match the article title.
 
 All article titles are to be using the level 1 heading.
+For example:
+
+```
+# Folder Name
+```
 
 ### Section Headings
 
@@ -80,7 +89,7 @@ Instead place the link underneath the section heading.
 For example:
 
 ```
-## Editor
+## Beatmap Editor
 
 For a full explanation, see [Beatmap Editor](/wiki/Beatmap_Editor/).
 ```
@@ -115,8 +124,16 @@ Other examples may include:
 - `osu!direct`
 
 When refering to `osu!` (the game/framework itself, not the game mode), it should be in _italics_ unless it is included in the name of game modes or other services related to the game.
+For example:
 
-- *e.g.* `osu!standard` or `osu!direct`.
+- `osu!standard`
+- `osu!direct`
+
+### Serial comma
+
+When listing items of 3 or more in a sentence, use the serial comma.
+
+- The game modes of _osu!_: osu!standard, osu!taiko, osu!catch**,** and osu!mania are fun to play with others.
 
 ### Capitalisation
 
@@ -124,7 +141,7 @@ When refering to `osu!` (the game/framework itself, not the game mode), it shoul
 
 When referring the name of a language, capitalize the first letter of that language.
 
-- The #spanish chat channel are for those who speak **Spanish**.
+- The `#spanish` chat channel are for those who speak **Spanish**.
 
 ##### Chat Channels
 
@@ -137,13 +154,26 @@ For example:
 - `#multiplayer`
 - `#userlog`
 
-The private chat channel names will use the letter casing as they appear.
+The private chat channel names are to use the letter casing as they appear.
 
 #### Abbreviations
 
-Abbreviations of osu! terms must be capitalised (e.g. `CS` for `Circle Size`).
+When using abbreviations, it is really important to note what the abbreviation means upon first instance.
+For example:
 
-When shortening the word: "for example"; use `e.g.` instead of `e.x.` or `i.e.`.
+```
+The NC (Night Core) mod is similar to the DT (Double Time) mod.
+While NC and DT increases the speed of the music by 25%, NC will change the pitch of the music and adds a clap and finish to each beat.
+```
+
+Abbreviations of osu! terms **must** be capitalised.
+For example:
+
+- `CS` for `Circle Size`
+- `AR` for `Approach Rate`
+- `DT` for `Double Time`
+
+When shortening the word "for example"; use `e.g.` instead of `e.x.` or `i.e.`.
 
 #### Game Modes
 
@@ -158,7 +188,7 @@ Writting the name of the game modes, they are to be written as follows:
 
 #### Game Modifiers
 
-Game modifiers must be capitalised.
+Game modifiers **must** be capitalised.
 
 - `Hard Rock`
 - `Nightcore`
@@ -171,12 +201,6 @@ Gameplay elements should **never** be be capitalised.
 
 - In osu!standard, **beatmaps** are composed of three different gameplay elements: **circles**, **sliders**, and **spinners**.
 
-### Serial comma
-
-When listing items of 3 or more in a sentence, use the serial comma.
-
-- The game modes of osu!: osu!standard, osu!taiko, osu!catch**,** and osu!mania are fun to play with others.
-
 ### Contractions
 
 Contractions are a shortened form of a word or group of words.
@@ -188,18 +212,25 @@ For example, use:
 - `Do not` instead of `Don't`
 - `You will` instead of `You'll`
 
-### Point of View
+## Point of View
 
 When refering to the player, use `the player` or `a player`.
 **Never** use `he`/`his` or `she`/`her's`!
 Instead, use `they`/`their's`.
+
+In instances where you are talking directly to the reader (e.g. tutorial page), you could use the word `you`.
 
 ## Emphasizing
 
 When you need to emphasize something (such as warning someone not to do something or note its importance), do **not** use capital letters for emphases.
 Instead, use **bold**, _italics_, or **_both_**.
 
-For example, instead of `Do NOT contact peppy for ingame issues!` use `Do **not** contact peppy for ingame issues!`
+### Bold
+
+Use bold when you need to caution or note something's importance.
+For example:
+
+- instead of `Do NOT contact peppy for ingame issues!` use `Do **not** contact peppy for ingame issues!`
 
 ### Italics
 
@@ -215,19 +246,33 @@ Know that the overuse of emphasis will reduce its effectiveness.
 Use code (inline) when noting:
 
 - a key on the keyboard
-  - e.g. `B`, `Alt` or `Ctrl` + `Shift` + `A`
-  - When noting a keyboard key, use capital letters for single characters and [Camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
-- a name of a button
-  - e.g. `1. Let's do it.` or `4. Noooo! I didn't mean to!`
-- a name of a folder
-  - e.g. `Exports` or `Downloads`
-- a name of a directory
-  - e.g. `/Songs/` or `/Skins/User/`
-- a name of a keyword
-  - e.g. `ComboBurstStyle` or `[Events]`
+  - examples:
+    - `.`
+    - `Alt`
+    - `Ctrl` + `Shift` + `A`
+  - should use capital letters for single characters and [camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
+- the text of a button
+  - examples:
+    - `1. Let's do it.`
+    - `4. Noooo! I didn't mean to!`
+- the name of a folder
+  - examples:
+    - `Exports`
+    - `Downloads`
+- the name of a directory
+  - examples:
+    - `/Songs/`
+    - `/Skins/User/`
+- the name of a keyword
+  - examples:
+    - `ComboBurstStyle`
+    - `[Events]`
 - the name of a file extension
-  - e.g. `.jpg` or `.osz`
-  - When naming a file extension, add a period (`.`) then the file extension in lower case letters.
+  - examples:
+    - `.jpg`
+    - `.gif`
+    - `.osz`
+  - must add a period (`.`) then the file extension in lowercase letters.
 - the name of a chat channel
   - e.g. `#lobby` or `#osu`
 
@@ -236,12 +281,13 @@ Use code (inline) when noting:
 Article links must follow these rules:
 
 1. must use relative-absolute paths, unless linking to subfolder (then use relative-relative paths)
-  - e.g. `[Welcome](/wiki/Welcome/)`
-  - e.g. (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
+   - for example:
+     - `[Welcome](/wiki/Welcome/)`
+     - (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
 2. **must be spelt correctly** (links are case sensitive!!)
 3. must **not** specify the specific file name **regardless of language** (osu!wiki will handle this)
-  - do: `[Glossary](/wiki/Glossary/)`
-  - don't: `[Glossary](/wiki/Glossary/fr.md)`
+   - do: `[Glossary](/wiki/Glossary/)`
+   - don't: `[Glossary](/wiki/Glossary/fr.md)`
 4. must not link to section headings (section headings on osu!wiki does not work)
 
 External links must follow these rules:
@@ -254,17 +300,15 @@ External links must follow these rules:
   - do not use a url with long url queries, parameters, or fragments
 - the link name must be the title text of the page it is linking to
 
-Do not use the word `here` as the link text.
-As it may seem convenient to use, it could be misleading.
-Instead, take the page's title (from the top of page, or from the `<title>` tag) and use that as the link text.
-
 You can use either the reference or inline style links.
 If you are using the reference style linking, it is sugguested to place the reference links at the top of the article for quicker access.
 
 When linking to the osu!website, e.g. user profiles or beatmaps, use `new.ppy.sh` not `osu.ppy.sh`.
 <!-- `new.ppy.sh` is just a temporary subdomain for the new design. -->
 
-### Linking Types
+**Never** use protocol relative links (e.g. `//example.com`)!
+
+### Link Types
 
 There are three kinds of links:
 
@@ -276,12 +320,11 @@ The one you use may depend on the scenario.
 
 #### Absolute Links
 
-Absolute links contains the the `http://` or `https://` protocol, the sub/domain, the directory, and the file it links to (if available).
-Basically, this is a url.
+Absolute links are URLs.
 For example:
 
 ```
-https://www.example.com/osu/lazer.md
+https://www.example.com/osu/lazer.xhtml?locale=jp&state=1
 ```
 
 Use of this type of link may include:
@@ -317,6 +360,12 @@ Use of this type of link may include:
 
 - linking to an article that is a subdirectory of an article
 - linking to images for a specific article
+
+### Link Text
+
+Do not use the word `here` as the link text.
+As it may seem convenient to use, it could be misleading.
+Instead, take the page's title (from the top of page, or from the `<title>` tag) and use that as the link text.
 
 ### Section Linking
 
@@ -363,7 +412,7 @@ Thumbnails are suggested to have a width of 160px and be in the `.jpg` format (u
 
 All images don't necessarily need to have an alternative text (text that displays if the image fails to load) nor do they need to have hover text.
 
-### Clickable images
+### Clickable Images
 
 If when you need an image to be clickable, e.g. click on thumbnail to view a full sized version, you can use this syntax:
 
@@ -388,6 +437,15 @@ If you need help making a complicated table, try to see if you can improvise a s
 It is up to you whether or not if you want to beautify the tables.
 They will appear nicer when editing them; however, for those who use text wrapping, the tables will appear as a clumped mess.
 Another thing to note, a slight change in a beautified table will require you to fix the spacing of every cell, depending on how big of change you made.
+
+## Date Formatting
+
+1. To avoid having dates using different formats, all dates should be written in `DD, Month, YYYY` format
+   - e.g. `10 December 2011`
+2. Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
+3. If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
+   - e.g., `2011-12-10` or `2012-05-04`
+<!--4. Besides being the [ISO standard](https://en.wikipedia.org/wiki/ISO_8601), dates in this format will naturally sort properly, say if the table column is later made sortable.-->
 
 ## Miscellaneous
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -314,8 +314,8 @@ External links must follow these rules:
 You can use either the reference or inline style links.
 If you are using the reference style linking, it is sugguested to place the reference links at the top of the article for quicker access.
 
-When linking to the osu!website, e.g. user profiles or beatmaps, use `new.ppy.sh` not `osu.ppy.sh`.
-<!-- `new.ppy.sh` is just a temporary subdomain for the new design. -->
+When linking to the osu!website, e.g. user profiles or beatmaps, use `osu.ppy.sh` not `new.ppy.sh`.
+`new.ppy.sh` is just a temporary subdomain for the new design. 
 
 **Never** use protocol relative links (e.g. `//example.com`)!
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -567,6 +567,11 @@ Thumbnails are suggested to have a width of 160px and be in the `.jpg` format (u
 
 All images don't necessarily need to have an alternative text (text that displays if the image fails to load) nor do they need to have hover text.
 
+Do **not** give the images any links.
+On a PC platform, they will work most of the time.
+However, on mobile, they will **not** work most of the time as the pointer event triggers the hover text, not the link.
+For example, use `[osu!supporters](/wiki/osu!supporter/)` and not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`.
+
 ### Flag icons
 
 Flag icons are located inside this folder: `/wiki/shared/flag/`.
@@ -628,8 +633,6 @@ For example:
   - `game mod` (or just `mod`)
   - `play style`
   - `hit sound`
-- Do not use an inline image link for osu!supporter.
-  - Use `[osu!supporters](/wiki/osu!supporter/)`, not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`.
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
 - The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).
 - All Chinese articles are to be using Simplified Chinese.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -25,6 +25,13 @@ If you need help with GFM syntax, see [markdown-cheatsheet-online.pdf](https://g
 
 All articles in the osu-wiki repo uses the two letter language codes.
 These 2 lettered language codes must use lowercase letters, ending with the `.md` extension.
+For example:
+
+- `en.md` for English
+- `fr.md` for French
+- `ko.md` for Korean
+- `ja.md` for Japanese
+- `es.md` for Spanish
 
 Translated articles are to be placed in the appropriate English-named folder.
 
@@ -83,9 +90,11 @@ For example:
 
 ```
 # osu!mania (Español)
-# Live Streaming (日本)
+# Live Streaming (日本語)
 # Skinning osu!catch (Français)
 ```
+
+You can find a list of language names in their language at []().
 
 ### Section Headings
 
@@ -132,7 +141,7 @@ For example use:
 
 The name of the game `osu!` is **never capitalised**, even if it is the first word in the sentence.
 Any words following `osu!`, if not divided by a blank space, should not be capitalised.
-If they are divided by a blank space, they must be capitalised if they are proper nouns (e.g. osu! Tournaments).
+If they are divided by a blank space, they must be capitalised if they are proper nouns (e.g. `osu! Tournaments` or `osu! Alumni`).
 
 If you have `osu!` then a word immediately following it, make sure that the word is spelt with lowercase letters (like the game modes).
 Other examples may include:
@@ -306,16 +315,16 @@ Use code (inline) when noting:
 
 Article links must follow these rules:
 
-1. must use relative-absolute paths, unless linking to subfolder (then use relative-relative paths)
-   - for example:
-     - `[Welcome](/wiki/Welcome/)`
-     - (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
-   - see the Link Types section below
-2. **must be spelt correctly** (links are case sensitive!!)
-3. must **not** specify the specific file name **regardless of language** (osu!wiki will handle this)
-   - do: `[Glossary](/wiki/Glossary/)`
-   - don't: `[Glossary](/wiki/Glossary/fr.md)`
-4. must not link to section headings (section headings on osu!wiki does not work)
+- must use relative-absolute paths, unless linking to subfolder (then use relative-relative paths)
+  - for example:
+    - `[Welcome](/wiki/Welcome/)`
+    - (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
+  - see the Link Types section below
+- **must be spelt correctly** (links are case sensitive!!)
+- must **not** specify the specific file name **regardless of language** (osu!wiki will handle this)
+  - do: `[Glossary](/wiki/Glossary/)`
+  - don't: `[Glossary](/wiki/Glossary/fr.md)`
+- must not link to section headings (section headings on osu!wiki does not work)
 
 External links must follow these rules:
 
@@ -410,13 +419,11 @@ You will need to check to make sure it links to the correct section.
 
 Examples:
 
-```
-[Scoring](#scoring)
-[osu!mania](#osu-mania)
-[What is osu!taikio?](#what-is-osu-taiko)
-```
+- `[Scoring](#scoring)`
+- `[osu!mania](#osu-mania.2)`
+- `[What is osu!taiko?](#what-is-osu-taiko)`
 
-Section liking will work for unsafe ASCII characters; however, do know that the section link in the url will be using [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding).
+Section linking **will** work for unsafe ASCII characters; however, do know that the section link in the url will be using [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ### Beatmaps
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -94,7 +94,7 @@ For example:
 # Skinning osu!catch (Français)
 ```
 
-You can find a list of language names in their language at [Language names in their own languages and scripts](http://www.omniglot.com/language/names.htm) or [List of language names](https://en.wikipedia.org/wiki/List_of_language_names).
+You can find a list of native language names at [Language names in their own languages and scripts](http://www.omniglot.com/language/names.htm) or [List of language names](https://en.wikipedia.org/wiki/List_of_language_names).
 
 ### Section Headings
 
@@ -274,18 +274,69 @@ For example:
 - `_Elite Beat Agents_`
 - `_Taiko no Tatsujin_`
 
-As explain in the _osu!_ section, the word `osu!` (the game or framework itself) **must** be italicized.
+As explained in the _osu!_ section, the word `osu!` (the game or framework itself) **must** be italicized.
+
+## Lists
+
+All lists (bulleted or numbered) must end in a period, if it ends the stem sentence.
+
+All lists (bulleted or numbered) **must** have one empty line space before the list starts.
+Otherwise the list may be parsed incorrectly.
+
+```
+## Section
+
+- item A
+- item B
+```
+
+To break lines in a numbered list, use:
+
+```
+- The combo fire was a gameplay feature.
+  It would display a burning yellow flame after obtaining a combo of 30.
+  - This was disabled on March 5, 2013.
+    Most likely due to performance concerns.
+```
+
+There are two kinds of lists:
+
+- bulleted
+  - used when the order of each item does not matter (e.g. describing an object)
+- numbered
+  - used when the order of each item does matter (e.g. tutorial instuctions)
+
+### Sub-Lists
+
+Sub-lists are lists that are indented underneath a listed item.
+
+Please limit to a level of four (4) sub-lists at a time (if you need more, you should reconsider about how you are structuring the list).
+
+```
+- item A
+  - sub-item A.1
+    - sub-sub-item A.1.i
+      - sub-sub-sub-item A.1.i.a
+      - sub-sub-sub-item A.1.i.b
+    - sub-sub-item A.1.ii
+      - sub-sub-sub-item A.1.ii.a
+    - sub-sub-item A.1.iii
+  - sub-item A.2
+    - sub-sub-item A.2.i
+  - sub-item A.3
+- item B
+```
 
 ## Code
 
 Use code (inline) when noting:
 
 - a key on the keyboard
+  - should use capital letters for single characters and [camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
   - examples:
     - `.`
     - `Alt`
     - `Ctrl` + `Shift` + `A`
-  - should use capital letters for single characters and [camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
 - the text of a button
   - examples:
     - `1. Let's do it.`
@@ -303,13 +354,21 @@ Use code (inline) when noting:
     - `ComboBurstStyle`
     - `[Events]`
 - the name of a file extension
+  - must add a period (`.`) then the file extension in lowercase letters.
   - examples:
     - `.jpg`
     - `.gif`
     - `.osz`
-  - must add a period (`.`) then the file extension in lowercase letters.
 - the name of a chat channel
-  - e.g. `#lobby` or `#osu`
+  - examples:
+    - `#lobby`
+    - `#osu`
+
+### Code Blocks
+
+When using code blocks, use the ` ``` ` (triple grave mark) syntax.
+
+The osu!wiki site has a feature where you _could_ use four spaces to trigger the code blocks; however, this is **heavily** discouraged.
 
 ## Links
 
@@ -365,7 +424,7 @@ https://www.example.com/osu/lazer.xhtml?locale=jp&state=1
 
 Use of this type of link may include:
 
-- linking to another website
+- linking to another website.
 
 #### Relative-Absolute Links
 
@@ -378,8 +437,8 @@ For example:
 
 Use of this type of link may include:
 
-- linking to an article within the osu!wiki
-- linking to a shared image (images that are used in multiple places)
+- linking to an article within the osu!wiki.
+- linking to a shared image (images that are used in multiple places).
 
 #### Relative-Relative Links
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -94,7 +94,7 @@ For example:
 # Skinning osu!catch (Français)
 ```
 
-You can find a list of language names in their language at []().
+You can find a list of language names in their language at [Language names in their own languages and scripts](http://www.omniglot.com/language/names.htm) or [List of language names](https://en.wikipedia.org/wiki/List_of_language_names).
 
 ### Section Headings
 
@@ -500,7 +500,7 @@ Another thing to note, a slight change in a beautified table will require you to
 ## Date Formatting
 
 1. To avoid having dates using different formats, all dates should be written in `DD, Month, YYYY` format
-   - e.g. `10 December 2011`
+   - e.g. `10 December 2011` or `01 April 2008`
 2. Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
 3. If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
    - e.g., `2011-12-10` or `2012-05-04`

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -101,13 +101,11 @@ For example use:
 - `skilful` instead of `skillful`
 - `analyse` instead of `analyze`
 
-### Capitalisation
-
-#### osu!
+### osu!
 
 The name of the game `osu!` is **never capitalised**, even if it is the first word in the sentence.
 Any words following `osu!`, if not divided by a blank space, should not be capitalised (i.e _see game mode spellings below_).
-If they are divided by a blank space, they must be capitalised if they are proper nouns (i.e. osu! Tournaments).
+If they are divided by a blank space, they must be capitalised if they are proper nouns (e.g. osu! Tournaments).
 
 If you have `osu!` then a word immediately following it, make sure that the word is spelt with lowercase letters (like the game modes).
 Other examples may include:
@@ -115,6 +113,12 @@ Other examples may include:
 - `osu!wiki`
 - `osu!alumni`
 - `osu!direct`
+
+When refering to `osu!` (the game/framework itself, not the game mode), it should be in _italics_ unless it is included in the name of game modes or other services related to the game.
+
+- *e.g.* `osu!standard` or `osu!direct`.
+
+### Capitalisation
 
 #### Language Names
 
@@ -137,14 +141,16 @@ The private chat channel names will use the letter casing as they appear.
 
 #### Abbreviations
 
-Abbreviations of osu! terms must be capitalised (i.e. `CS` for `Circle Size`).
+Abbreviations of osu! terms must be capitalised (e.g. `CS` for `Circle Size`).
+
+When shortening the word: "for example"; use `e.g.` instead of `e.x.` or `i.e.`.
 
 #### Game Modes
 
 Writting the name of the game modes, they are to be written as follows:
 
 - `osu!`
-  - `osu!standard` (unofficial, but to prevent ambiguity)
+  - `osu!standard` (unofficial, but used to prevent ambiguity)
     - for folder names, it is required to use `osu!`, not `osu!standard`
 - `osu!taiko`
 - `osu!catch`
@@ -195,36 +201,45 @@ Instead, use **bold**, _italics_, or **_both_**.
 
 For example, instead of `Do NOT contact peppy for ingame issues!` use `Do **not** contact peppy for ingame issues!`
 
+### Italics
+
+Any instances of the name of a videogame should also be in italics.
+For example:
+
+- _Elite Beat Agents_.
+
+Know that the overuse of emphasis will reduce its effectiveness.
+
 ## Code
 
 Use code (inline) when noting:
 
 - a key on the keyboard
-  - i.e. `B`, `Alt` or `Ctrl` + `Shift` + `A`
+  - e.g. `B`, `Alt` or `Ctrl` + `Shift` + `A`
   - When noting a keyboard key, use capital letters for single characters and [Camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
 - a name of a button
-  - i.e. `1. Let's do it.` or `4. Noooo! I didn't mean to!`
+  - e.g. `1. Let's do it.` or `4. Noooo! I didn't mean to!`
 - a name of a folder
-  - i.e. `Exports` or `Downloads`
+  - e.g. `Exports` or `Downloads`
 - a name of a directory
-  - i.e. `/Songs/` or `/Skins/User/`
+  - e.g. `/Songs/` or `/Skins/User/`
 - a name of a keyword
-  - i.e. `ComboBurstStyle` or `[Events]`
+  - e.g. `ComboBurstStyle` or `[Events]`
 - the name of a file extension
-  - i.e. `.jpg` or `.osz`
+  - e.g. `.jpg` or `.osz`
   - When naming a file extension, add a period (`.`) then the file extension in lower case letters.
 - the name of a chat channel
-  - i.e. `#lobby`, `#osu`
+  - e.g. `#lobby` or `#osu`
 
 ## Links
 
 Article links must follow these rules:
 
 1. must use relative-absolute paths, unless linking to subfolder (then use relative-relative paths)
-  - i.e. `[Welcome](/wiki/Welcome/)`
-  - i.e. (from `Game_Modes` page) `[osu!mania](./osu!mania)`
-2. must be spelt correctly (links are case sensitive!!)
-3. must not specify the specific file name **regardless of language** (osu!wiki will handle this)
+  - e.g. `[Welcome](/wiki/Welcome/)`
+  - e.g. (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
+2. **must be spelt correctly** (links are case sensitive!!)
+3. must **not** specify the specific file name **regardless of language** (osu!wiki will handle this)
   - do: `[Glossary](/wiki/Glossary/)`
   - don't: `[Glossary](/wiki/Glossary/fr.md)`
 4. must not link to section headings (section headings on osu!wiki does not work)
@@ -246,7 +261,7 @@ Instead, take the page's title (from the top of page, or from the `<title>` tag)
 You can use either the reference or inline style links.
 If you are using the reference style linking, it is sugguested to place the reference links at the top of the article for quicker access.
 
-When linking to the osu!website, i.e. user profiles or beatmaps, use `new.ppy.sh` not `osu.ppy.sh`.
+When linking to the osu!website, e.g. user profiles or beatmaps, use `new.ppy.sh` not `osu.ppy.sh`.
 <!-- `new.ppy.sh` is just a temporary subdomain for the new design. -->
 
 ### Linking Types
@@ -341,8 +356,8 @@ Names of images must be somewhat meaningful, please don't use the timestamp or l
 Images that are used in multiple different articles must go to the `/wiki/shared/` folder.
 Images that are used for one article are to be placed inside their folders for linking.
 
-It is suggusted to add a subfolder for the images, i.e. `img/` for all images.
-If you have thumbnails and full sized images, it is suggested to use two folders and name the files the same; i.e. `pr/` for preview and `fs/` for full size.
+It is suggusted to add a subfolder for the images, e.g. `img/` for all images.
+If you have thumbnails and full sized images, it is suggested to use two folders and name the files the same; e.g. `pr/` for preview and `fs/` for full size.
 
 Thumbnails are suggested to have a width of 160px and be in the `.jpg` format (unless it has transparency).
 
@@ -350,7 +365,7 @@ All images don't necessarily need to have an alternative text (text that display
 
 ### Clickable images
 
-If when you need an image to be clickable, i.e. click on thumbnail to view a full sized version, you can use this syntax:
+If when you need an image to be clickable, e.g. click on thumbnail to view a full sized version, you can use this syntax:
 
 ```md
 [![Alt](thumnbail/link.jpg)](full/link.png "hover")
@@ -365,7 +380,7 @@ If when you need an image to be clickable, i.e. click on thumbnail to view a ful
 
 Tables use the GFM syntax.
 
-If you cannot create a table because _something_ won't work without HTML (i.e. lists inside tables), then you are overthinking both the table and the content.
+If you cannot create a table because _something_ won't work without HTML (e.g. lists inside tables), then you are overthinking both the table and the content.
 If you need help making a complicated table, try to see if you can improvise a simplier fix for it.
 
 **Never** place images inside tables.
@@ -376,8 +391,6 @@ Another thing to note, a slight change in a beautified table will require you to
 
 ## Miscellaneous
 
-- Do not use an inline image link for osu!supporter
-  - use `[osu!supporters](/wiki/osu!supporter/)`, not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`
 - These words are spelt as follows (note the space):
   - `hit circles`
   - `approach circles`
@@ -389,5 +402,7 @@ Another thing to note, a slight change in a beautified table will require you to
   - `game mod` (or just `mod`)
   - `play style`
   - `hit sound`
+- Do not use an inline image link for osu!supporter
+  - use `[osu!supporters](/wiki/osu!supporter/)`, not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
 - The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -605,3 +605,4 @@ For example:
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
 - The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).
 - All Chinese articles are to be using Simplified Chinese.
+  - This is because `ISO 639-1` notes that `zh` is Simplified Chinese.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -2,12 +2,12 @@
 
 The Article Style Guide serves as a way to help keep consistency in clarity, formatting, and layout between all articles of the osu!wiki.
 
-All articles should use plain English.
-Your word choice should explain such things in layman's terms (basically ask yourself, "If the reader is reading this, would they have to lookup any of the words?").
+All English articles should use plain English.
+Your word choice should help explain such things in layman's terms (basically ask yourself, "If the reader is reading this, would they have to lookup any of the words?").
 
 All articles must have proper grammar, correct spelling, and correct information.
 Know that reviewers may ask for changes in your pull request for blunders or suggestions.
-A good osu!wiki writer should read these reviews to help improve the overall quality of these articles to ensure optimal experience for an osu!wiki reader
+A good osu!wiki writer should read these reviews to help improve the overall quality of these articles to ensure optimal experience for an osu!wiki reader.
 
 ## GFM
 
@@ -40,12 +40,13 @@ For a list of the 2 lettered language codes, see [List of ISO 639-1 codes](https
 ## Headings
 
 All articles **must have a level 1 heading** of a translated article's title.
-This level 1 heading is to be placed at the start of the article.
+This level 1 heading is to be placed at the start of the article unless you have reference links placed there.
+If this happens, place this heading underneath the reference links.
 
-The remaining section headings must be level 2 onwards (but limit to level 5 please).
+The remaining section headings must be level 2 and onwards (but limit to level 5).
 
 Optionally, but preferably, add an extra line before and after the headings.
-This will help make the headings stand out a bit more when editing.
+This will help make the headings stand out when editing.
 
 There are two styles of heading levels 1 and 2 that Markdown supplies you:
 
@@ -76,6 +77,7 @@ Note that heading levels 3 and onwards use the hashtag style.
 
 Titles are to be in title case.
 The title of an article is the name of the folder that the article is located in.
+
 For English article titles, if you need to reword the title, you must rename the folder to match the article title.
 
 All article titles are to be using the level 1 heading.
@@ -85,8 +87,10 @@ For example:
 # Folder Name
 ```
 
+#### Untranslatable Titles
+
 In the case where a title can **not** be translated, use the language title (in English) followed by the language name (in that language) in round brackets.
-For example:
+Here are some examples:
 
 ```
 # osu!mania (Español)
@@ -95,12 +99,13 @@ For example:
 ```
 
 You can find a list of native language names at [Language names in their own languages and scripts](http://www.omniglot.com/language/names.htm) or [List of language names](https://en.wikipedia.org/wiki/List_of_language_names).
+<!-- NOTE this may introduce more inconsistencies because some languages use more than one script to represent their language! -->
 
 ### Section Headings
 
 All section headings are to use title case, just like the article titles.
 
-All section headings are to be using level 2 to level 5 headings.
+All section headings are to be using levels 2 to 5 headings.
 
 Section headings must **never** have a link in it.
 Instead place the link underneath the section heading.
@@ -114,7 +119,7 @@ For a full explanation, see [Beatmap Editor](/wiki/Beatmap_Editor/).
 
 Section headings must **never** have any styles applied to it.
 
-Section headings can have **small icons** in their section headings.
+Section headings can have **small icons** in their section headings but never images larger than 1 point (the typical font size height; usually 16 pixels).
 For example:
 
 ```
@@ -128,7 +133,7 @@ Because of this, there is no need to add one.
 
 ## Grammar
 
-In the case where the American English and the British English spellings conflict, prefer the British Engish spelling.
+In the case where varients of English and the British English spellings conflict, prefer the British Engish spelling.
 
 For example use:
 
@@ -140,21 +145,29 @@ For example use:
 ### osu!
 
 The name of the game `osu!` is **never capitalised**, even if it is the first word in the sentence.
+If `osu!` is the last word in the sentence, add a period (or the appropriate punctuation marks) immediately following `osu!`.
+For example:
+
+- `The welcome.wav file says, "Welcome to osu!."`
+
 Any words following `osu!`, if not divided by a blank space, should not be capitalised.
-If they are divided by a blank space, they must be capitalised if they are proper nouns (e.g. `osu! Tournaments` or `osu! Alumni`).
+If they are divided by a blank space, they must be capitalised if they are proper nouns.
+For example:
+
+- `osu! Tournaments`
+- `osu! Alumni`
 
 If you have `osu!` then a word immediately following it, make sure that the word is spelt with lowercase letters (like the game modes).
 Other examples may include:
 
-- `osu!wiki`
-- `osu!alumni`
+- `osu!mania`
 - `osu!direct`
+- `osu!wiki`
 
 When refering to `osu!` (the game/framework itself, not the game mode), it should be in _italics_ unless it is included in the name of game modes or other services related to the game.
 For example:
 
-- `osu!standard`
-- `osu!direct`
+- `The language that _osu!_ is written in is C# using the .NET Framework.`
 
 ### Serial comma
 
@@ -181,7 +194,7 @@ For example:
 - `#multiplayer`
 - `#userlog`
 
-The private chat channel names are to use the letter casing as they appear.
+Though you may not use them at all, the private chat channel names are to use the letter casing as they appear.
 
 #### Abbreviations
 
@@ -555,19 +568,22 @@ If you need help making a complicated table, try to see if you can improvise a s
 **Never** place images inside tables.
 
 It is up to you whether or not if you want to beautify the tables.
-They will appear nicer when editing them; however, for those who use text wrapping, the tables will appear as a clumped mess.
+They will appear nicer when editing them; however, for those who use text wrapping, those tables will appear as a clumped mess.
 Another thing to note, a slight change in a beautified table will require you to fix the spacing of every cell, depending on how big of change you made.
 
 ## Date Formatting
 
-1. To avoid having dates using different formats, all dates should be written in `DD, Month, YYYY` format
-   - e.g. `10 December 2011` or `01 April 2008`
-2. Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
-3. If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
-   - e.g. `2011-12-10` or `2012-05-04`
-<!--4. Besides being the [ISO standard](https://en.wikipedia.org/wiki/ISO_8601), dates in this format will naturally sort properly, say if the table column is later made sortable.-->
+All dates must follow these rules:
 
-For consistency, please write all dates in this format (using both): `DD, Month, YYYY (YYYY-MM-DD)`. For example:
+- To avoid having dates using different formats, all dates should be written in `DD, Month, YYYY` format
+  - e.g. `10 December 2011` or `01 April 2008`
+- Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
+- If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
+  - e.g. `2011-12-10` or `2012-05-04`
+<!--- Besides being the [ISO standard](https://en.wikipedia.org/wiki/ISO_8601), dates in this format will naturally sort properly, say if the table column is later made sortable.-->
+
+For consistency, please write all dates in this format (using both): `DD, Month, YYYY (YYYY-MM-DD)`.
+For example:
 
 - `5 August, 2015 (2015-08-05)`
 
@@ -584,7 +600,8 @@ For consistency, please write all dates in this format (using both): `DD, Month,
   - `game mod` (or just `mod`)
   - `play style`
   - `hit sound`
-- Do not use an inline image link for osu!supporter
-  - use `[osu!supporters](/wiki/osu!supporter/)`, not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`
+- Do not use an inline image link for osu!supporter.
+  - Use `[osu!supporters](/wiki/osu!supporter/)`, not `[![](/wiki/shared/osu!support.png/)](/wiki/osu!supporter/)`.
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
 - The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).
+- All Chinese articles are to be using Simplified Chinese.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -37,6 +37,34 @@ Translated articles are to be placed in the appropriate English-named folder.
 
 For a list of the 2 lettered language codes, see [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (the 639-1 column of the table).
 
+## Language Tags
+
+Language tags are varients of a certain language (i.e. English is the language family, while American, British, Canadian, and Indian Enlish are varients).
+
+All files are **not** to use language tags.
+For example, use:
+
+- `en.md` instead of:
+  - `en-gb.md`,
+  - `en-us.md`,
+  - `en-ca.md`, or
+  - `en-in.md`
+- `es.md` instead of:
+  - `es-es.md`,
+  - `es-mx.md`,
+  - `es-ar.md`,
+  - `es-co.md`, or
+  - `es-cl.md`
+- `pt.md` instead of:
+  - `pt-pt.md` or
+  - `pt-br.md`
+- `zh.md` instead of:
+  - `zh-cn.md`,
+  - `zh-tw.md`, or
+  - `zh-hk.md`
+
+This is simply to maintain consistency and simplicity while following the ISO 639-1 codes.
+
 ## Headings
 
 All articles **must have a level 1 heading** of a translated article's title.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -249,6 +249,11 @@ If you are using the reference style linking, it is sugguested to place the refe
 When linking to the osu!website, i.e. user profiles or beatmaps, use `osu.ppy.sh` not `new.ppy.sh`.
 `new.ppy.sh` is just a temporary subdomain for the new design.
 
+### Section Linking
+
+Section linking in the osu!wiki does not work as of now.
+Do not attempt to section link.
+
 ### Beatmaps
 
 Whenever you are linking to a beatmap, use this format as the link text:

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -182,6 +182,12 @@ For example, use:
 - `Do not` instead of `Don't`
 - `You will` instead of `You'll`
 
+### Point of View
+
+When refering to the player, use `the player` or `a player`.
+**Never** use `he`/`his` or `she`/`her's`!
+Instead, use `they`/`their's`.
+
 ## Emphasizing
 
 When you need to emphasize something (such as warning someone not to do something or note its importance), do **not** use capital letters for emphases.
@@ -321,4 +327,7 @@ If you need help making a complicated table, try to see if you can improvise a s
   - `play style`
   - `hit sound`
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
-- The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity
+- The term `Beatmap` may refer to a `Beatmapset`
+  - to prevent ambiguity, use:
+    - `Beatmap` when refering to the specific difficulty
+    - `Beatmapset` when refering to the set of beatmaps (beatmapset = same song mapped by same user)

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -3,7 +3,7 @@
 The Article Style Guide serves as a way to help keep consistency in clarity, formatting, and layout between all articles of the osu!wiki.
 
 All English articles should use plain English.
-Your word choice should help explain such things in layman's terms (basically ask yourself, "If the reader is reading this, would they have to lookup any of the words?").
+Your word choice should be able to explain such things in layman's terms (basically ask yourself, "If the reader is reading this, would they have to lookup any of the words?").
 
 All articles must have proper grammar, correct spelling, and correct information.
 Know that reviewers may ask for changes in your pull request for blunders or suggestions.
@@ -37,9 +37,9 @@ Translated articles are to be placed in the appropriate English-named folder.
 
 For a list of the 2 lettered language codes, see [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (the 639-1 column of the table).
 
-## Language Tags
+### Language Tags
 
-Language tags are varients of a certain language (e.g. English is the language family, while American, British, Canadian, and Indian Enlish are varients).
+Language tags are variants of a certain language (e.g. English is the language family, while American, British, Canadian, and Indian Enlish are variants).
 
 All files are **not** to use language tags.
 For example, use:
@@ -154,14 +154,13 @@ For example:
 #### ![osu! icon](/wiki/shared/Osu.gif) osu!
 ```
 
-## TOC
+## ToC
 
-The TOC (Table of Contents) will automatically be generated on the osu!wiki.
-Because of this, there is no need to add one.
+ToCs (Table of Contents) are automatically generated in osu!web, you do not need to manually make one for the article you intend to edit.
 
 ## Grammar
 
-In the case where varients of English and the British English spellings conflict, prefer the British Engish spelling.
+In the case where variants of English and the British English spellings conflict, prefer the British Engish spelling.
 
 For example use:
 
@@ -602,6 +601,13 @@ If you need help making a complicated table, try to see if you can improvise a s
 It is up to you whether or not if you want to beautify the tables.
 They will appear nicer when editing them; however, for those who use text wrapping, those tables will appear as a clumped mess.
 Another thing to note, a slight change in a beautified table will require you to fix the spacing of every cell, depending on how big of change you made.
+
+Some tools for beautifying tables are:
+
+- VS Code's Native Beautifier
+  - this will require you to use [VS Code](https://code.visualstudio.com/)
+- [Markdown Table Formatter](http://markdowntable.com/)
+  - alignment syntax (`:`) will not parse correctly
 
 ## Date Formatting
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -246,8 +246,8 @@ Instead, take the page's title (from the top of page, or from the `<title>` tag)
 You can use either the reference or inline style links.
 If you are using the reference style linking, it is sugguested to place the reference links at the top of the article for quicker access.
 
-When linking to the osu!website, i.e. user profiles or beatmaps, use `osu.ppy.sh` not `new.ppy.sh`.
-`new.ppy.sh` is just a temporary subdomain for the new design.
+When linking to the osu!website, i.e. user profiles or beatmaps, use `new.ppy.sh` not `osu.ppy.sh`.
+<!-- `new.ppy.sh` is just a temporary subdomain for the new design. -->
 
 ### Linking Types
 
@@ -317,7 +317,7 @@ Whenever you are linking to a beatmap, use this format as the link text:
 ```
 
 When linking to a beatmap, make sure that the link actually links to that difficulty.
-All beatmap difficutly urls looks like this: `osu.ppy.sh/b/{BeatmapID}`
+All beatmap difficutly urls looks like this: `new.ppy.sh/b/{BeatmapID}`
 
 ### Beatmapsets
 
@@ -327,7 +327,7 @@ If you are linking to a beatmapset, use this format as the link text:
 {artist} - {title} ({creator})
 ```
 
-All beatmapset difficutly urls looks like this: `osu.ppy.sh/s/{BeatmapSetID}`
+All beatmapset difficutly urls looks like this: `new.ppy.sh/s/{BeatmapSetID}`
 
 ## Images
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -503,7 +503,7 @@ Another thing to note, a slight change in a beautified table will require you to
    - e.g. `10 December 2011` or `01 April 2008`
 2. Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
 3. If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
-   - e.g., `2011-12-10` or `2012-05-04`
+   - e.g. `2011-12-10` or `2012-05-04`
 <!--4. Besides being the [ISO standard](https://en.wikipedia.org/wiki/ISO_8601), dates in this format will naturally sort properly, say if the table column is later made sortable.-->
 
 ## Miscellaneous

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -78,6 +78,15 @@ For example:
 # Folder Name
 ```
 
+In the case where a title cannot be translated, use the language title (in English) followed by the language name (in that language) in round brackets.
+For example:
+
+```
+# osu!mania (Español)
+# Live Streaming (日本)
+# Skinning osu!catch (Français)
+```
+
 ### Section Headings
 
 All section headings are to use title case, just like the article titles.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -7,7 +7,7 @@ Your word choice should explain such things in layman's terms (basically ask you
 
 All articles must have proper grammar, correct spelling, and correct information.
 Know that reviewers may ask for changes in your pull request for blunders or suggestions.
-A good osu!wiki writer should read these reviews to help improve the overall quality of these articles to ensure the most optimal experience for an osu!wiki reader
+A good osu!wiki writer should read these reviews to help improve the overall quality of these articles to ensure optimal experience for an osu!wiki reader
 
 ## GFM
 
@@ -96,6 +96,13 @@ For a full explanation, see [Beatmap Editor](/wiki/Beatmap_Editor/).
 
 Section headings must **never** have any styles applied to it.
 
+Section headings can have **small icons** in their section headings.
+For example:
+
+```
+#### ![osu! icon](/wiki/shared/Osu.gif) osu!
+```
+
 ## TOC
 
 The TOC (Table of Contents) will automatically be generated on the osu!wiki.
@@ -164,7 +171,7 @@ When using abbreviations, it is really important to note what the abbreviation m
 For example:
 
 ```
-The NC (Night Core) mod is similar to the DT (Double Time) mod.
+The NC (Nightcore) mod is similar to the DT (Double Time) mod.
 While NC and DT increases the speed of the music by 25%, NC will change the pitch of the music and adds a clap and finish to each beat.
 ```
 
@@ -422,6 +429,25 @@ If you have thumbnails and full sized images, it is suggested to use two folders
 Thumbnails are suggested to have a width of 160px and be in the `.jpg` format (unless it has transparency).
 
 All images don't necessarily need to have an alternative text (text that displays if the image fails to load) nor do they need to have hover text.
+
+### Flag icons
+
+Flag icons are located inside this folder: `/wiki/shared/flag/`.
+Most of these icons uses the two letter code (first letter is capitalized; second letter is lowercased) and ends with the `.gif` extension.
+A few expections are the multi-flag icons that are in the `.png` format.
+
+For a list of the 2 lettered language codes, see [List of ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (the 639-1 column of the table).
+
+When adding a flag inline, use this format:
+
+```
+![full-country-name](/wiki/shared/flag/xx.gif)
+```
+
+- `full-country-name` is the full country name
+- `xx.gif` is the two letter code for the flag
+
+To see if a flag exists, see the `/wiki/shared/flag/` folder.
 
 ## Tables
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -85,7 +85,7 @@ For example:
 # Folder Name
 ```
 
-In the case where a title cannot be translated, use the language title (in English) followed by the language name (in that language) in round brackets.
+In the case where a title can **not** be translated, use the language title (in English) followed by the language name (in that language) in round brackets.
 For example:
 
 ```
@@ -273,6 +273,8 @@ For example:
 
 - `_Elite Beat Agents_`
 - `_Taiko no Tatsujin_`
+- `*Dance Dance Revolution*`
+- `*StepMania*`
 
 As explained in the _osu!_ section, the word `osu!` (the game or framework itself) **must** be italicized.
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -39,7 +39,7 @@ For a list of the 2 lettered language codes, see [List of ISO 639-1 codes](https
 
 ## Language Tags
 
-Language tags are varients of a certain language (i.e. English is the language family, while American, British, Canadian, and Indian Enlish are varients).
+Language tags are varients of a certain language (e.g. English is the language family, while American, British, Canadian, and Indian Enlish are varients).
 
 All files are **not** to use language tags.
 For example, use:
@@ -201,7 +201,7 @@ For example:
 
 When listing items of 3 or more in a sentence, use the serial comma.
 
-- The game modes of _osu!_: osu!standard, osu!taiko, osu!catch**,** and osu!mania are fun to play with others.
+- The game modes of _osu!_: osu!standard, osu!taiko, osu!catch`,` and osu!mania are fun to play with others.
 
 ### Capitalisation
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -203,15 +203,13 @@ When listing items of 3 or more in a sentence, use the serial comma.
 
 - The game modes of _osu!_: osu!standard, osu!taiko, osu!catch`,` and osu!mania are fun to play with others.
 
-### Capitalisation
-
-#### Language Names
+### Language Names
 
 When referring to the name of a language, capitalize the first letter of that language.
 
 - The `#spanish` chat channel are for those who speak **Spanish**.
 
-##### Chat Channels
+#### Chat Channels
 
 The chat channel names are to use lowercase letters.
 For example:
@@ -224,7 +222,7 @@ For example:
 
 Though you may not use them at all, the private chat channel names are to use the letter casing as they appear.
 
-#### Abbreviations
+### Abbreviations
 
 When using abbreviations, it is really important to note what the abbreviation means upon first instance.
 For example:
@@ -243,7 +241,7 @@ For example:
 
 When shortening the word "for example"; use `e.g.` instead of `e.x.` or `i.e.`.
 
-#### Game Modes
+### Game Modes
 
 When writting the name of the game modes, they are to be written as follows:
 
@@ -256,7 +254,7 @@ When writting the name of the game modes, they are to be written as follows:
 
 You may use the old game mode names (e.g. `Catch the Beat` or `Taiko`) only when you are talking about said game mode's previous name.
 
-#### Game Modifiers
+### Game Modifiers
 
 Game modifiers **must** be capitalised.
 
@@ -265,7 +263,7 @@ Game modifiers **must** be capitalised.
 - `Double Time`
 - `Easy`
 
-#### Gameplay Elements
+### Gameplay Elements
 
 Gameplay elements should **never** be be capitalised.
 
@@ -289,8 +287,9 @@ Know that the possessive form of a word (e.g. `the player's` or `the skinner's`)
 ## Point of View
 
 When refering to the player, use `the player` or `a player`.
+
 **Never** use `he`/`his` or `she`/`hers`!
-Instead, use `they`/`theirs`.
+Instead, use `they`/`their`/`theirs`.
 
 In instances where you are talking directly to the reader (e.g. tutorial page), you could use the word `you`.
 
@@ -623,6 +622,8 @@ For example:
 ## Miscellaneous
 
 - All folders **must** contain a page of some kind, even if they are _index_ pages (pages that just link to other pages)
+- All sections **must** contain some content, even if they are redirect links to other pages
+  - `Also see [Glossary](/wiki/Glossary)`
 - These words are spelt as follows (note the space):
   - `hit circles`
   - `approach circles`

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -336,3 +336,4 @@ If you need help making a complicated table, try to see if you can improvise a s
   - to prevent ambiguity, use:
     - `Beatmap` when refering to the specific difficulty
     - `Beatmapset` when refering to the set of beatmaps (beatmapset = same song mapped by same user)
+- When refering to the Multiplayer mode, use `Multi` instead of `Multiplayer`

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -201,6 +201,7 @@ Use code (inline) when noting:
 
 - a key on the keyboard
   - i.e. `B`, `Alt` or `Ctrl` + `Shift` + `A`
+  - When noting a keyboard key, use capital letters for single characters and [Camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
 - a name of a button
   - i.e. `1. Let's do it.` or `4. Noooo! I didn't mean to!`
 - a name of a folder
@@ -211,10 +212,9 @@ Use code (inline) when noting:
   - i.e. `ComboBurstStyle` or `[Events]`
 - the name of a file extension
   - i.e. `.jpg` or `.osz`
-
-When noting a keyboard key, use capital letters for single characters and [Camel case](https://en.wikipedia.org/wiki/Camel_case) for modifers.
-
-When naming a file extension, add a period (`.`) then the file extension in lower case letters.
+  - When naming a file extension, add a period (`.`) then the file extension in lower case letters.
+- the name of a chat channel
+  - i.e. `#lobby`, `#osu`
 
 ## Links
 
@@ -262,7 +262,7 @@ The one you use may depend on the scenario.
 #### Absolute Links
 
 Absolute links contains the the `http://` or `https://` protocol, the sub/domain, the directory, and the file it links to (if available).
-Or basically, a url.
+Basically, this is a url.
 For example:
 
 ```
@@ -370,6 +370,10 @@ If you need help making a complicated table, try to see if you can improvise a s
 
 **Never** place images inside tables.
 
+It is up to you whether or not if you want to beautify the tables.
+They will appear nicer when editing them; however, for those who use text wrapping, the tables will appear as a clumped mess.
+Another thing to note, a slight change in a beautified table will require you to fix the spacing of every cell, depending on how big of change you made.
+
 ## Miscellaneous
 
 - Do not use an inline image link for osu!supporter
@@ -386,8 +390,4 @@ If you need help making a complicated table, try to see if you can improvise a s
   - `play style`
   - `hit sound`
 - The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
-- The term `Beatmap` may refer to a `Beatmapset`
-  - to prevent ambiguity, use:
-    - `Beatmap` when refering to the specific difficulty
-    - `Beatmapset` when refering to the set of beatmaps (beatmapset = same song mapped by same user)
-- When refering to the Multiplayer mode, use `Multi` instead of `Multiplayer`
+- The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -94,10 +94,12 @@ For example:
 For a full explanation, see [Beatmap Editor](/wiki/Beatmap_Editor/).
 ```
 
+Section headings must **never** have any styles applied to it.
+
 ## TOC
 
 The TOC (Table of Contents) will automatically be generated on the osu!wiki.
-Because of this, there is no need to include add one.
+Because of this, there is no need to add one.
 
 ## Grammar
 
@@ -113,7 +115,7 @@ For example use:
 ### osu!
 
 The name of the game `osu!` is **never capitalised**, even if it is the first word in the sentence.
-Any words following `osu!`, if not divided by a blank space, should not be capitalised (i.e _see game mode spellings below_).
+Any words following `osu!`, if not divided by a blank space, should not be capitalised.
 If they are divided by a blank space, they must be capitalised if they are proper nouns (e.g. osu! Tournaments).
 
 If you have `osu!` then a word immediately following it, make sure that the word is spelt with lowercase letters (like the game modes).
@@ -139,7 +141,7 @@ When listing items of 3 or more in a sentence, use the serial comma.
 
 #### Language Names
 
-When referring the name of a language, capitalize the first letter of that language.
+When referring to the name of a language, capitalize the first letter of that language.
 
 - The `#spanish` chat channel are for those who speak **Spanish**.
 
@@ -177,7 +179,7 @@ When shortening the word "for example"; use `e.g.` instead of `e.x.` or `i.e.`.
 
 #### Game Modes
 
-Writting the name of the game modes, they are to be written as follows:
+When writting the name of the game modes, they are to be written as follows:
 
 - `osu!`
   - `osu!standard` (unofficial, but used to prevent ambiguity)
@@ -185,6 +187,8 @@ Writting the name of the game modes, they are to be written as follows:
 - `osu!taiko`
 - `osu!catch`
 - `osu!mania`
+
+You may use the old game mode names (e.g. `Catch the Beat` or `Taiko`) only when you are talking about said game mode's previous name.
 
 #### Game Modifiers
 
@@ -200,6 +204,7 @@ Game modifiers **must** be capitalised.
 Gameplay elements should **never** be be capitalised.
 
 - In osu!standard, **beatmaps** are composed of three different gameplay elements: **circles**, **sliders**, and **spinners**.
+- The **beatmap** **editor** is a place where **mappers** can **map** a song of their choice.
 
 ### Contractions
 
@@ -211,6 +216,9 @@ For example, use:
 
 - `Do not` instead of `Don't`
 - `You will` instead of `You'll`
+- `It is` instead of `It's`
+
+Know that the possessive form of a word (e.g. `the player's` or `the skinner's`) are the expection (as these are not contractions).
 
 ## Point of View
 
@@ -220,10 +228,11 @@ Instead, use `they`/`their's`.
 
 In instances where you are talking directly to the reader (e.g. tutorial page), you could use the word `you`.
 
+**Never** use the first person perspective, `I`.
+
 ## Emphasizing
 
-When you need to emphasize something (such as warning someone not to do something or note its importance), do **not** use capital letters for emphases.
-Instead, use **bold**, _italics_, or **_both_**.
+Know that the overuse of emphasis will reduce its effectiveness!
 
 ### Bold
 
@@ -237,9 +246,10 @@ For example:
 Any instances of the name of a videogame should also be in italics.
 For example:
 
-- _Elite Beat Agents_.
+- `_Elite Beat Agents_`
+- `_Taiko no Tatsujin_`
 
-Know that the overuse of emphasis will reduce its effectiveness.
+As explain in the _osu!_ section, the word `osu!` (the game or framework itself) **must** be italicized.
 
 ## Code
 
@@ -284,6 +294,7 @@ Article links must follow these rules:
    - for example:
      - `[Welcome](/wiki/Welcome/)`
      - (from `Game_Modes` folder) `[osu!mania](./osu!mania)`
+   - see the Link Types section below
 2. **must be spelt correctly** (links are case sensitive!!)
 3. must **not** specify the specific file name **regardless of language** (osu!wiki will handle this)
    - do: `[Glossary](/wiki/Glossary/)`
@@ -293,7 +304,7 @@ Article links must follow these rules:
 External links must follow these rules:
 
 - prefer the `https://` protocol
-- if referencing another site, must link to a reputable source
+- if linking to another site, must link to a reputable source
 - must be a clean and direct link
   - do not use a third-party shortened link
   - do not use links that link to ads
@@ -381,7 +392,7 @@ Whenever you are linking to a beatmap, use this format as the link text:
 ```
 
 When linking to a beatmap, make sure that the link actually links to that difficulty.
-All beatmap difficutly urls looks like this: `new.ppy.sh/b/{BeatmapID}`
+All beatmap difficutly urls looks like this: `https://new.ppy.sh/b/{BeatmapID}`
 
 ### Beatmapsets
 
@@ -391,7 +402,7 @@ If you are linking to a beatmapset, use this format as the link text:
 {artist} - {title} ({creator})
 ```
 
-All beatmapset difficutly urls looks like this: `new.ppy.sh/s/{BeatmapSetID}`
+All beatmapset difficutly urls looks like this: `https://new.ppy.sh/s/{BeatmapSetID}`
 
 ## Images
 
@@ -411,19 +422,6 @@ If you have thumbnails and full sized images, it is suggested to use two folders
 Thumbnails are suggested to have a width of 160px and be in the `.jpg` format (unless it has transparency).
 
 All images don't necessarily need to have an alternative text (text that displays if the image fails to load) nor do they need to have hover text.
-
-### Clickable Images
-
-If when you need an image to be clickable, e.g. click on thumbnail to view a full sized version, you can use this syntax:
-
-```md
-[![Alt](thumnbail/link.jpg)](full/link.png "hover")
-```
-
-- `Alt` is the alternative text; if image fails to load
-- `thumbnail/link.jpg` is the link of the thumbnail
-- `full/link.jpg` is the link of the thumbnail
-- `"hover"` is the hover text; when the mouse cursor is on top of the mouse
 
 ## Tables
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -249,6 +249,60 @@ If you are using the reference style linking, it is sugguested to place the refe
 When linking to the osu!website, i.e. user profiles or beatmaps, use `osu.ppy.sh` not `new.ppy.sh`.
 `new.ppy.sh` is just a temporary subdomain for the new design.
 
+### Linking Types
+
+There are three kinds of links:
+
+- absolute
+- relative-absolute
+- relative-relative
+
+The one you use may depend on the scenario.
+
+#### Absolute Links
+
+Absolute links contains the the `http://` or `https://` protocol, the sub/domain, the directory, and the file it links to (if available).
+Or basically, a url.
+For example:
+
+```
+https://www.example.com/osu/lazer.md
+```
+
+Use of this type of link may include:
+
+- linking to another website
+
+#### Relative-Absolute Links
+
+Relative-absolute links are relative links that start in an absolute location (the root directory).
+For example:
+
+```
+/wiki/shared/False.png
+```
+
+Use of this type of link may include:
+
+- linking to an article within the osu!wiki
+- linking to a shared image (images that are used in multiple places)
+
+#### Relative-Relative Links
+
+Relative-relative links are relative links that start from the current directory.
+For example:
+
+```
+img/example.png
+./img/example.png
+../Insane/
+```
+
+Use of this type of link may include:
+
+- linking to an article that is a subdirectory of an article
+- linking to images for a specific article
+
 ### Section Linking
 
 Section linking in the osu!wiki does not work as of now.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -622,6 +622,7 @@ For example:
 
 ## Miscellaneous
 
+- All folders **must** contain a page of some kind, even if they are _index_ pages (pages that just link to other pages)
 - These words are spelt as follows (note the space):
   - `hit circles`
   - `approach circles`

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -331,13 +331,13 @@ Otherwise the list may be parsed incorrectly.
 - item B
 ```
 
-To break lines in a numbered list, use:
+To break lines in a list, use:
 
 ```
-- The combo fire was a gameplay feature.
-  It would display a burning yellow flame after obtaining a combo of 30.
-  - This was disabled on March 5, 2013.
-    Most likely due to performance concerns.
+1. The combo fire was a gameplay feature.
+   It would display a burning yellow flame after obtaining a combo of 30.
+   - This was disabled on March 5, 2013.
+     Most likely due to performance concerns.
 ```
 
 There are two kinds of lists:
@@ -428,7 +428,7 @@ Article links must follow these rules:
 
 External links must follow these rules:
 
-- prefer the `https://` protocol
+- prefer the `https://` protocol, if available
 - if linking to another site, must link to a reputable source
 - must be a clean and direct link
   - do not use a third-party shortened link
@@ -613,7 +613,7 @@ Some tools for beautifying tables are:
 
 All dates must follow these rules:
 
-- To avoid having dates using different formats, all dates should be written in `DD, Month, YYYY` format
+- To avoid having dates using different formats, all dates should be written in `DD Month YYYY` format
   - e.g. `10 December 2011` or `01 April 2008`
 - Do **not** use superscripts or suffixes such as `23<sup>rd</sup> of April` or `4th of May`.
 - If a numeric or terse date is needed (such as in a table), then use `YYYY-MM-DD`, always with 2 digits for month and day.
@@ -627,9 +627,9 @@ For example:
 
 ## Miscellaneous
 
-- All folders **must** contain a page of some kind, even if they are _index_ pages (pages that just link to other pages)
-- All sections **must** contain some content, even if they are redirect links to other pages
-  - `Also see [Glossary](/wiki/Glossary)`
+- All folders **must** contain a page of some kind, even if they are _index_ pages (pages that link to other pages).
+- All sections **must** contain some content, even those who contains subsections.
+  - `_Also see [Glossary](/wiki/Glossary)._`
 - These words are spelt as follows (note the space):
   - `hit circles`
   - `approach circles`
@@ -641,7 +641,7 @@ For example:
   - `game mod` (or just `mod`)
   - `play style`
   - `hit sound`
-- The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable)
+- The term `Difficulty` refers to a specific `Beatmap` (these terms are interchangable).
 - The term `Beatmap` may refer to a `Beatmapset`; however, to prevent ambiguity follow the definations as stated in the [Glossary](/wiki/Glossary/).
 - All Chinese articles are to be using Simplified Chinese.
   - This is because `ISO 639-1` notes that `zh` is Simplified Chinese.

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -289,8 +289,8 @@ Know that the possessive form of a word (e.g. `the player's` or `the skinner's`)
 ## Point of View
 
 When refering to the player, use `the player` or `a player`.
-**Never** use `he`/`his` or `she`/`her's`!
-Instead, use `they`/`their's`.
+**Never** use `he`/`his` or `she`/`hers`!
+Instead, use `they`/`theirs`.
 
 In instances where you are talking directly to the reader (e.g. tutorial page), you could use the word `you`.
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -394,10 +394,29 @@ Do not use the word `here` as the link text.
 As it may seem convenient to use, it could be misleading.
 Instead, take the page's title (from the top of page, or from the `<title>` tag) and use that as the link text.
 
-### Section Linking
+### Section Links
 
-Section linking in the osu!wiki does not work as of now.
-Do not attempt to section link.
+All section links follow these rules:
+
+- all letters **must** use lowercase letters
+- all special characters (e.g. `!`, `?`, `,`, `"`, `'`) **must** be replaced with a hyphen (`-`)
+  - if one of the spacial characters is the last character in the section name, remove it, but do not add a hyphen (`-`).
+- all spaces are replaced with hyphens (`-`), not underscores (`_`)
+- if a header is not unique (two or more of the same section heading names exist at any level),
+  - the first instance of said heading will follow the above rules
+  - the following instances will follow the above rules **and** must add `.` followed by an incremental integer starting from 2
+
+You will need to check to make sure it links to the correct section.
+
+Examples:
+
+```
+[Scoring](#scoring)
+[osu!mania](#osu-mania)
+[What is osu!taikio?](#what-is-osu-taiko)
+```
+
+Section liking will work for unsafe ASCII characters; however, do know that the section link in the url will be using [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ### Beatmaps
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -453,8 +453,8 @@ img/example.png
 
 Use of this type of link may include:
 
-- linking to an article that is a subdirectory of an article
-- linking to images for a specific article
+- linking to an article that is a subdirectory of an article.
+- linking to images for a specific article.
 
 ### Link Text
 

--- a/wiki/Article_Style_Guide/en.md
+++ b/wiki/Article_Style_Guide/en.md
@@ -506,6 +506,10 @@ Another thing to note, a slight change in a beautified table will require you to
    - e.g. `2011-12-10` or `2012-05-04`
 <!--4. Besides being the [ISO standard](https://en.wikipedia.org/wiki/ISO_8601), dates in this format will naturally sort properly, say if the table column is later made sortable.-->
 
+For consistency, please write all dates in this format (using both): `DD, Month, YYYY (YYYY-MM-DD)`. For example:
+
+- `5 August, 2015 (2015-08-05)`
+
 ## Miscellaneous
 
 - These words are spelt as follows (note the space):


### PR DESCRIPTION
- added which point of view to use
- fixed things in the Miscellaneous section
- noted to use `Multi`, not `Multiplayer`
- noted types of links (absolute, relative-absolute, and relative-relative)
- fixed things in the Code section
- fixed things in the Links section
- fixed things in the Miscellaneous section
- ~~**noted to use `new.ppy.sh` instead of `osu.ppy.sh`**~~
- added "Italics" section
- moved "osu!" into its own section under "Grammar"
- moved a bunch of things
- re-read the entire thing and fixed a bunch of things
- added (better?) examples
- split sections into smaller, more meaningful(?) sections
- Fix grammar mistake in TOC
- remove dummy example in osu!
- small fix in Language Names
- small fix on Game Modes
- added another example for Gameplay Elements
- added another example for Contractions
- noted that possessive and contractions aren't the same
- noted that Section Headings should never have styles
- noted to not use "I" in Point of View
- added another example in Italics
- removed Clickable Images
- note flags
- reverted the "which site to link to" thing
- noted how to do **titles without translations**
- yay(?), section links
- new Lists section
- new Code Blocks
- noted reason why to use simplified chinese for zh files
- added new section "Language Tags"
- change note about osu!support inline-img-links to all images in general
- removed Capitalization section (no content)
  - lowered headings down of this section
- fixed `her's` to `hers` and `their's` to `theirs` (added `their`)
- list some table beautifying tools