### PR TITLE
Add README for creating community tournament pages

### DIFF
--- a/wiki/Tournaments/README.md
+++ b/wiki/Tournaments/README.md
@@ -1,0 +1,16 @@
+# Community Tournaments
+
+This is the place where tournaments that have been [given approval](https://docs.google.com/spreadsheets/d/1xRV_F4mbJzEPlxaoXAsaK4cTPK5emlHdbXG43uVvwFg) can add a wiki page for their tournament. 
+
+## Contributing
+
+We don't provide a template to use since tournaments vary in structure from the official world cups. We urge you look at the world cup pages (e.g. [TWC 2017](https://github.com/ppy/osu-wiki/blob/master/wiki/Tournaments/TWC/2017/en.md)) as a reference for how an acceptable tournament wiki page should look.
+
+Please make sure to read the README on the [front page of this repository](https://github.com/ppy/osu-wiki) for other contributing guidelines.
+
+## Contributors
+
+Community tournament pages may only be accepted if the tournament has been given permission. Tournaments that have been given permission may be found here:  
+https://docs.google.com/spreadsheets/d/1xRV_F4mbJzEPlxaoXAsaK4cTPK5emlHdbXG43uVvwFg
+
+You can assume for now that all tournaments that have been given wiki permissions have also been awarded a badge.


### PR DESCRIPTION
Community tournaments that are given badges will now be able to create their own wiki posts.