### PR TITLE
Beatmap_Packs_0916 asg fixes

### DIFF
--- a/wiki/Achievements/Beatmap_Packs_0916/en.md
+++ b/wiki/Achievements/Beatmap_Packs_0916/en.md
@@ -412,7 +412,7 @@ Maps:
 
 - There are 16 packs (4 themes x 4 volumes).
   - The estimated time required to complete one beatmap pack is 1 hour (20 minutes per 1 pack).
-- There are 211 beatmapsets (206 + [3](https://osu.ppy.sh/s/2490) ![heart icon](/wiki/shared/Heart.gif) ranked + 1 ![fire icon](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) + and 1 [pending](https://osu.ppy.sh/b/19630))
+- There are 211 beatmapsets (206 + [3](https://osu.ppy.sh/s/2490) ![heart icon](/wiki/shared/Heart.gif) ranked + 1 ![fire icon](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) + 1 [pending](https://osu.ppy.sh/b/19630))
 - There are 662 difficulties (660 ![heart icon](/wiki/shared/Heart.gif) ranked + 1 ![fire icon](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) + 1 [pending](https://osu.ppy.sh/b/19630))
 - Total pack size: 1.39GB zipped or 1.47GB extracted and imported
 - The estimated import time for all 16 packs is about 3 minutes and 33 seconds

--- a/wiki/Achievements/Beatmap_Packs_0916/en.md
+++ b/wiki/Achievements/Beatmap_Packs_0916/en.md
@@ -2,384 +2,421 @@
 [media-anime-vol-2]: https://www.mediafire.com/?722os55j52ikylq
 [media-anime-vol-3]: https://www.mediafire.com/?tky7bjc58hcno6b
 [media-anime-vol-4]: https://www.mediafire.com/?j5b5b6bimr5ahdv
-[yas-anime-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T4
-[yas-anime-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T6
-[yas-anime-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T15
-[yas-anime-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T30
 [media-rhythm-vol-1]: https://www.mediafire.com/?87n2agcrcgmwxob
 [media-rhythm-vol-2]: https://www.mediafire.com/?axvxrnx637767ls
 [media-rhythm-vol-3]: https://www.mediafire.com/?781tio8fge7y7d2
 [media-rhythm-vol-4]: https://www.mediafire.com/?6hc29ws6j36dcag
-[yas-rhythm-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T9
-[yas-rhythm-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T2
-[yas-rhythm-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T16
-[yas-rhythm-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T32
 
-Beatmap Packs
-=============
+# Beatmap Packs 0916
 
 ***[Click here to return to the "Achievements" page](../)***
 
-Legacy/Original themed packs packed during osu! infancy years (2009) before being updated by [Stefan in 16 January 2016](https://osu.ppy.sh/news/137535031193).
+These are the legacy/original themed packs packed during osu! infancy years (2009) before being updated by [Stefan on 16 January 2016](https://osu.ppy.sh/news/137535031193).
+Hence why the `0916` part is in the title.
 
-Anime Pack
------------
+## Anime Pack
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* [MediaFire][media-anime-vol-1]
-* [osu.yas-online.net][yas-anime-vol-1]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
-* [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
-* [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
-* [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
-* [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
-* [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
-* [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
-* [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
-* [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
-* [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
-* [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
-* [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
-* [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
+Download:
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-1]
 
-#### Download:
-* [MediaFire][media-anime-vol-2]
-* [osu.yas-online.net][yas-anime-vol-2]
+Maps:
 
-#### Maps:
-* [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
-* [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
-* [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
-* [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
-* [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
-* [KOTOKO - agony](https://osu.ppy.sh/s/302)
-* [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
-* [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
-* [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
-* [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
-* [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
-* [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
-* [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
+- [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
+- [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
+- [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
+- [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
+- [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
+- [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
+- [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
+- [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
+- [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
+- [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
+- [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
+- [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
+- [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* [MediaFire][media-anime-vol-3]
-* [osu.yas-online.net][yas-anime-vol-3]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
-* [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
-* [Nightmare - The World](https://osu.ppy.sh/s/4851)
-* [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
-* [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
-* [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
-* [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
-* [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
-* [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
-* [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
-* [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
-* [Yui - Again](https://osu.ppy.sh/s/6535)
-* [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-2]
 
-#### Download:
-* [MediaFire][media-anime-vol-4]
-* [osu.yas-online.net][yas-anime-vol-4]
+Maps:
 
-#### Maps:
-* [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
-* [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
-* [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
-* [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
-* [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
-* [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
-* [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
-* [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
-* [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
-* [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
-* [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
-* [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
-* [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+- [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
+- [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
+- [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
+- [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
+- [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
+- [KOTOKO - agony](https://osu.ppy.sh/s/302)
+- [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
+- [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
+- [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
+- [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
+- [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
+- [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
+- [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
 
+### Volume 3
 
+> Larto/DeathxShinigami (2011)
 
-Internet Pack
----------------
+Download:
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-3]
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
-* [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
-* [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
-* [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
-* [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
-* [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
-* [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
-* [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
-* [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
-* [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
-* [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
-* [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
-* [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
+- [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
+- [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
+- [Nightmare - The World](https://osu.ppy.sh/s/4851)
+- [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
+- [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
+- [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
+- [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
+- [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
+- [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
+- [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
+- [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
+- [Yui - Again](https://osu.ppy.sh/s/6535)
+- [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-anime-vol-4]
+
+Maps:
+
+- [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
+- [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
+- [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
+- [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
+- [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
+- [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
+- [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
+- [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
+- [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
+- [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
+- [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
+- [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
+- [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+
+## Internet Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami [2011]
+
+Download:
+
+- None
+
+Maps:
+
+- [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
+- [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
+- [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
+- [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
+- [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
+- [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
+- [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
+- [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
+- [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
+- [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
+- [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
+- [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
+- [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
 
 > __Note:__ Loituma - Ievan Polkka is an unranked beatmap. You can skip this beatmap if you want to.
 
-### Volume 2 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
-* [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
-* [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
-* [You are an Idiot!](https://osu.ppy.sh/s/1628)
-* [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
-* [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
-* [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
-* [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
-* [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
-* [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
-* [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
-* [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
-* [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
+Download:
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+- None
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
-* [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
-* [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
-* [Tarou - Danjo](https://osu.ppy.sh/s/3688)
-* [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
-* [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
-* [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
-* [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
-* [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
-* [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
-* [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
-* [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
-* [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
+- [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
+- [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
+- [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
+- [You are an Idiot!](https://osu.ppy.sh/s/1628)
+- [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
+- [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
+- [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
+- [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
+- [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
+- [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
+- [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
+- [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
+- [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
 
-### Volume 4 (DeathxShinigami [2011])
+### Volume 3
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
-* [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
-* [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
-* [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
-* [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
-* [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
-* [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
-* [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
-* [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
-* [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
-* [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
-* [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
-* [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
+Download:
 
+- None
 
+Maps:
 
-Rhythm Game Music Pack
-------------------------
+- [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
+- [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
+- [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
+- [Tarou - Danjo](https://osu.ppy.sh/s/3688)
+- [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
+- [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
+- [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
+- [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
+- [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
+- [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
+- [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
+- [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
+- [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 4
 
-#### Download:
-* [MediaFire][media-rhythm-vol-1]
-* [osu.yas-online.net][yas-rhythm-vol-1]
+> DeathxShinigami (2011)
 
-#### Maps:
-* [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
-* [Speed Over Beethoven](https://osu.ppy.sh/s/96)
-* [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
-* [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
-* [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
-* [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
-* [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
-* [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
-* [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
-* [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
-* [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
-* [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
-* [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
+Download:
 
-### Volume 2 (Larto [2009]/DeathxShinigami [2011])
+- None
 
-#### Download:
-* [MediaFire][media-rhythm-vol-2]
-* [osu.yas-online.net][yas-rhythm-vol-2]
+Maps:
 
-#### Maps:
-* [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
-* [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
-* [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
-* [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
-* [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
-* [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
-* [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
-* [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
-* [Audition - Can Can](https://osu.ppy.sh/s/5177)
-* [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
-* [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
-* [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
-* [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
+- [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
+- [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
+- [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
+- [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
+- [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
+- [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
+- [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
+- [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
+- [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
+- [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
+- [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
+- [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
+- [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
 
-### Volume 3 (Larto [2010]/DeathxShinigami [2011])
+## Rhythm Game Music Pack
 
-#### Download:
-* [MediaFire][media-rhythm-vol-3]
-* [osu.yas-online.net][yas-rhythm-vol-3]
+### Volume 1
 
-#### Maps:
-* [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
-* [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
-* [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
-* [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
-* [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
-* [BanYa - Phantom](https://osu.ppy.sh/s/5180)
-* [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
-* [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
-* [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
-* [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
-* [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
-* [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
-* [Crispy - The Game](https://osu.ppy.sh/s/7983)
+> LuigiHann/DeathxShinigami (2011)
 
-### Volume 4 (DeathxShinigami [2011])
+Download:
 
-#### Download:
-* [MediaFire][media-rhythm-vol-4]
-* [osu.yas-online.net][yas-rhythm-vol-4]
+- [MediaFire][media-rhythm-vol-1]
 
-#### Maps:
-* [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
-* [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
-* [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
-* [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
-* [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
-* [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
-* [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
-* [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
-* [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
-* [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
-* [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
-* [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
-* [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+Maps:
 
+- [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
+- [Speed Over Beethoven](https://osu.ppy.sh/s/96)
+- [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
+- [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
+- [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
+- [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
+- [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
+- [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
+- [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
+- [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
+- [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
+- [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
+- [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
 
-Video Game Music Pack
------------------------
+### Volume 2
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+> Larto (2009)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
-* [Portal - Still Alive](https://osu.ppy.sh/s/92)
-* [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
-* [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
-* [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
-* [2pm - Tetris](https://osu.ppy.sh/s/633)
-* [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
-* [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
-* [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
-* [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
-* [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
-* [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
-* [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+- [MediaFire][media-rhythm-vol-2]
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+Maps:
 
-##### Download:
-* None
+- [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
+- [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
+- [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
+- [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
+- [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
+- [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
+- [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
+- [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
+- [Audition - Can Can](https://osu.ppy.sh/s/5177)
+- [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
+- [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
+- [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
+- [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
 
-#### Maps:
-* [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
-* [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
-* [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
-* [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
-* [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
-* [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
-* [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
-* [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
-* [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
-* [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
-* [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
-* [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
-* [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+### Volume 3
 
-### Volume 3 (Seibei4211/DeathxShinigami [2011])
+> Larto (2010)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
-* [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
-* [His World](https://osu.ppy.sh/s/2490)
-* [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
-* [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
-* [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
-* [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
-* [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
-* [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
-* [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
-* [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
-* [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
-* [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+- [MediaFire][media-rhythm-vol-3]
 
-### Volume 4 (DeathxShinigami [2011])
+Maps:
 
-#### Download:
-* None
+- [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
+- [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
+- [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
+- [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
+- [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
+- [BanYa - Phantom](https://osu.ppy.sh/s/5180)
+- [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
+- [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
+- [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
+- [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
+- [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
+- [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
+- [Crispy - The Game](https://osu.ppy.sh/s/7983)
 
-#### Maps:
-* [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
-* [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
-* [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
-* [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
-* [Exile - Indestructible](https://osu.ppy.sh/s/10104)
-* [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
-* [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
-* [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
-* [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
-* [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
-* [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
-* [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
-* [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
+### Volume 4
 
-Trivia
----------
+> DeathxShinigami (2011)
 
--   16 packs. (4 themes x 4 volumes)
-    -   1 hour, 20 minutes = 1 pack (Time estimation required to complete one beatmap pack)
--   211 songs (206 + [3](https://osu.ppy.sh/s/2490) ![](/wiki/shared/Heart.gif) ranked, 1 ![](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) and 1 [pending](https://osu.ppy.sh/b/19630))
--   662 difficulties (660 ![](/wiki/shared/Heart.gif) ranked, 1 ![](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) and 1 [pending](https://osu.ppy.sh/b/19630))
--   1.39 GB (zipped), 1.47 GB (imported)
--   3 minutes 33 seconds. (Import time estimation of all 16 packs)
+Download:
 
-Special thanks
----------------
+- [MediaFire][media-rhythm-vol-4]
+
+Maps:
+
+- [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
+- [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
+- [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
+- [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
+- [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
+- [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
+- [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
+- [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
+- [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
+- [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
+- [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
+- [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
+- [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+
+## Video Game Music Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
+- [Portal - Still Alive](https://osu.ppy.sh/s/92)
+- [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
+- [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
+- [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
+- [2pm - Tetris](https://osu.ppy.sh/s/633)
+- [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
+- [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
+- [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
+- [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
+- [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
+- [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
+- [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+
+### Volume 2
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
+- [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
+- [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
+- [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
+- [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
+- [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
+- [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
+- [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
+- [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
+- [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
+- [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
+- [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
+- [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+
+### Volume 3
+
+> Seibei4211/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
+- [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
+- [His World](https://osu.ppy.sh/s/2490)
+- [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
+- [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
+- [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
+- [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
+- [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
+- [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
+- [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
+- [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
+- [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
+- [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
+- [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
+- [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
+- [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
+- [Exile - Indestructible](https://osu.ppy.sh/s/10104)
+- [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
+- [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
+- [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
+- [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
+- [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
+- [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
+- [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
+- [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
+
+## Trivia
+
+- There are 16 packs (4 themes x 4 volumes).
+  - The estimated time required to complete one beatmap pack is 1 hour (20 minutes per 1 pack).
+- There are 211 beatmapsets (206 + [3](https://osu.ppy.sh/s/2490) ![heart icon](/wiki/shared/Heart.gif) ranked + 1 ![fire icon](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) + and 1 [pending](https://osu.ppy.sh/b/19630))
+- There are 662 difficulties (660 ![heart icon](/wiki/shared/Heart.gif) ranked + 1 ![fire icon](/wiki/shared/Fire.gif) [approved](https://osu.ppy.sh/b/21010) + 1 [pending](https://osu.ppy.sh/b/19630))
+- Total pack size: 1.39GB zipped or 1.47GB extracted and imported
+- The estimated import time for all 16 packs is about 3 minutes and 33 seconds
+
+### Special thanks
 
 -   [Wayback Machine](https://archive.org/web/)

--- a/wiki/Achievements/Beatmap_Packs_0916/fr.md
+++ b/wiki/Achievements/Beatmap_Packs_0916/fr.md
@@ -2,18 +2,10 @@
 [media-anime-vol-2]: https://www.mediafire.com/?722os55j52ikylq
 [media-anime-vol-3]: https://www.mediafire.com/?tky7bjc58hcno6b
 [media-anime-vol-4]: https://www.mediafire.com/?j5b5b6bimr5ahdv
-[yas-anime-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T4
-[yas-anime-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T6
-[yas-anime-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T15
-[yas-anime-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T30
 [media-rhythm-vol-1]: https://www.mediafire.com/?87n2agcrcgmwxob
 [media-rhythm-vol-2]: https://www.mediafire.com/?axvxrnx637767ls
 [media-rhythm-vol-3]: https://www.mediafire.com/?781tio8fge7y7d2
 [media-rhythm-vol-4]: https://www.mediafire.com/?6hc29ws6j36dcag
-[yas-rhythm-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T9
-[yas-rhythm-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T2
-[yas-rhythm-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T16
-[yas-rhythm-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T32
 
 Anciens packs de beatmaps
 =========================
@@ -22,352 +14,399 @@ Anciens packs de beatmaps
 
 Packs originaux pendant les années de début d'osu! (2009) avant d'être mis à jour par [Stefan le 16 janvier 2016](https://osu.ppy.sh/news/137535031193).
 
-Anime Pack
----------------
+## Anime Pack
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* [MediaFire][media-anime-vol-1]
-* [osu.yas-online.net][yas-anime-vol-1]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
-* [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
-* [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
-* [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
-* [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
-* [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
-* [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
-* [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
-* [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
-* [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
-* [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
-* [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
-* [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
+Download:
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-1]
 
-#### Download:
-* [MediaFire][media-anime-vol-2]
-* [osu.yas-online.net][yas-anime-vol-2]
+Maps:
 
-#### Maps:
-* [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
-* [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
-* [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
-* [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
-* [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
-* [KOTOKO - agony](https://osu.ppy.sh/s/302)
-* [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
-* [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
-* [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
-* [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
-* [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
-* [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
-* [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
+- [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
+- [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
+- [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
+- [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
+- [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
+- [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
+- [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
+- [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
+- [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
+- [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
+- [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
+- [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
+- [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* [MediaFire][media-anime-vol-3]
-* [osu.yas-online.net][yas-anime-vol-3]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
-* [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
-* [Nightmare - The World](https://osu.ppy.sh/s/4851)
-* [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
-* [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
-* [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
-* [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
-* [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
-* [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
-* [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
-* [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
-* [Yui - Again](https://osu.ppy.sh/s/6535)
-* [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-2]
 
-#### Download:
-* [MediaFire][media-anime-vol-4]
-* [osu.yas-online.net][yas-anime-vol-4]
+Maps:
 
-#### Maps:
-* [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
-* [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
-* [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
-* [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
-* [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
-* [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
-* [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
-* [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
-* [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
-* [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
-* [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
-* [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
-* [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+- [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
+- [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
+- [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
+- [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
+- [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
+- [KOTOKO - agony](https://osu.ppy.sh/s/302)
+- [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
+- [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
+- [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
+- [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
+- [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
+- [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
+- [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
 
+### Volume 3
 
+> Larto/DeathxShinigami (2011)
 
-Internet Pack
----------------
+Download:
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-3]
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
-* [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
-* [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
-* [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
-* [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
-* [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
-* [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
-* [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
-* [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
-* [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
-* [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
-* [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
-* [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
+- [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
+- [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
+- [Nightmare - The World](https://osu.ppy.sh/s/4851)
+- [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
+- [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
+- [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
+- [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
+- [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
+- [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
+- [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
+- [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
+- [Yui - Again](https://osu.ppy.sh/s/6535)
+- [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-anime-vol-4]
+
+Maps:
+
+- [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
+- [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
+- [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
+- [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
+- [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
+- [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
+- [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
+- [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
+- [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
+- [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
+- [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
+- [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
+- [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+
+## Internet Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami [2011]
+
+Download:
+
+- None
+
+Maps:
+
+- [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
+- [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
+- [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
+- [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
+- [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
+- [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
+- [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
+- [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
+- [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
+- [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
+- [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
+- [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
+- [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
 
 > __Note:__ Loituma - Ievan Polkka is an unranked beatmap. You can skip this beatmap if you want to.
 
-### Volume 2 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
-* [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
-* [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
-* [You are an Idiot!](https://osu.ppy.sh/s/1628)
-* [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
-* [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
-* [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
-* [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
-* [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
-* [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
-* [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
-* [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
-* [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
+Download:
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+- None
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
-* [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
-* [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
-* [Tarou - Danjo](https://osu.ppy.sh/s/3688)
-* [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
-* [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
-* [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
-* [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
-* [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
-* [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
-* [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
-* [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
-* [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
+- [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
+- [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
+- [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
+- [You are an Idiot!](https://osu.ppy.sh/s/1628)
+- [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
+- [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
+- [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
+- [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
+- [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
+- [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
+- [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
+- [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
+- [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
 
-### Volume 4 (DeathxShinigami [2011])
+### Volume 3
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
-* [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
-* [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
-* [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
-* [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
-* [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
-* [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
-* [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
-* [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
-* [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
-* [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
-* [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
-* [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
+Download:
 
+- None
 
+Maps:
 
-Rhythm Game Music Pack
-----------------------
+- [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
+- [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
+- [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
+- [Tarou - Danjo](https://osu.ppy.sh/s/3688)
+- [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
+- [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
+- [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
+- [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
+- [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
+- [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
+- [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
+- [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
+- [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 4
 
-#### Download:
-* [MediaFire][media-rhythm-vol-1]
-* [osu.yas-online.net][yas-rhythm-vol-1]
+> DeathxShinigami (2011)
 
-#### Maps:
-* [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
-* [Speed Over Beethoven](https://osu.ppy.sh/s/96)
-* [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
-* [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
-* [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
-* [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
-* [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
-* [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
-* [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
-* [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
-* [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
-* [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
-* [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
+Download:
 
-### Volume 2 (Larto [2009]/DeathxShinigami [2011])
+- None
 
-#### Download:
-* [MediaFire][media-rhythm-vol-2]
-* [osu.yas-online.net][yas-rhythm-vol-2]
+Maps:
 
-#### Maps:
-* [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
-* [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
-* [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
-* [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
-* [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
-* [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
-* [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
-* [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
-* [Audition - Can Can](https://osu.ppy.sh/s/5177)
-* [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
-* [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
-* [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
-* [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
+- [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
+- [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
+- [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
+- [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
+- [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
+- [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
+- [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
+- [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
+- [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
+- [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
+- [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
+- [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
+- [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
 
-### Volume 3 (Larto [2010]/DeathxShinigami [2011])
+## Rhythm Game Music Pack
 
-#### Download:
-* [MediaFire][media-rhythm-vol-3]
-* [osu.yas-online.net][yas-rhythm-vol-3]
+### Volume 1
 
-#### Maps:
-* [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
-* [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
-* [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
-* [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
-* [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
-* [BanYa - Phantom](https://osu.ppy.sh/s/5180)
-* [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
-* [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
-* [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
-* [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
-* [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
-* [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
-* [Crispy - The Game](https://osu.ppy.sh/s/7983)
+> LuigiHann/DeathxShinigami (2011)
 
-### Volume 4 (DeathxShinigami [2011])
+Download:
 
-#### Download:
-* [MediaFire][media-rhythm-vol-4]
-* [osu.yas-online.net][yas-rhythm-vol-4]
+- [MediaFire][media-rhythm-vol-1]
 
-#### Maps:
-* [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
-* [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
-* [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
-* [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
-* [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
-* [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
-* [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
-* [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
-* [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
-* [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
-* [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
-* [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
-* [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+Maps:
 
+- [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
+- [Speed Over Beethoven](https://osu.ppy.sh/s/96)
+- [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
+- [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
+- [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
+- [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
+- [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
+- [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
+- [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
+- [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
+- [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
+- [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
+- [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
 
-Video Game Music Pack
---------------------------
+### Volume 2
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+> Larto (2009)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
-* [Portal - Still Alive](https://osu.ppy.sh/s/92)
-* [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
-* [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
-* [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
-* [2pm - Tetris](https://osu.ppy.sh/s/633)
-* [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
-* [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
-* [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
-* [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
-* [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
-* [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
-* [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+- [MediaFire][media-rhythm-vol-2]
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+Maps:
 
-##### Download:
-* None
+- [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
+- [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
+- [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
+- [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
+- [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
+- [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
+- [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
+- [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
+- [Audition - Can Can](https://osu.ppy.sh/s/5177)
+- [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
+- [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
+- [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
+- [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
 
-#### Maps:
-* [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
-* [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
-* [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
-* [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
-* [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
-* [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
-* [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
-* [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
-* [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
-* [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
-* [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
-* [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
-* [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+### Volume 3
 
-### Volume 3 (Seibei4211/DeathxShinigami [2011])
+> Larto (2010)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
-* [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
-* [His World](https://osu.ppy.sh/s/2490)
-* [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
-* [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
-* [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
-* [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
-* [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
-* [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
-* [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
-* [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
-* [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
-* [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+- [MediaFire][media-rhythm-vol-3]
 
-### Volume 4 (DeathxShinigami [2011])
+Maps:
 
-#### Download:
-* None
+- [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
+- [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
+- [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
+- [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
+- [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
+- [BanYa - Phantom](https://osu.ppy.sh/s/5180)
+- [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
+- [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
+- [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
+- [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
+- [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
+- [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
+- [Crispy - The Game](https://osu.ppy.sh/s/7983)
 
-#### Maps:
-* [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
-* [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
-* [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
-* [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
-* [Exile - Indestructible](https://osu.ppy.sh/s/10104)
-* [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
-* [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
-* [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
-* [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
-* [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
-* [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
-* [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
-* [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-rhythm-vol-4]
+
+Maps:
+
+- [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
+- [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
+- [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
+- [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
+- [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
+- [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
+- [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
+- [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
+- [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
+- [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
+- [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
+- [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
+- [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+
+## Video Game Music Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
+- [Portal - Still Alive](https://osu.ppy.sh/s/92)
+- [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
+- [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
+- [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
+- [2pm - Tetris](https://osu.ppy.sh/s/633)
+- [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
+- [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
+- [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
+- [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
+- [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
+- [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
+- [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+
+### Volume 2
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
+- [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
+- [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
+- [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
+- [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
+- [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
+- [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
+- [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
+- [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
+- [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
+- [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
+- [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
+- [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+
+### Volume 3
+
+> Seibei4211/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
+- [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
+- [His World](https://osu.ppy.sh/s/2490)
+- [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
+- [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
+- [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
+- [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
+- [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
+- [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
+- [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
+- [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
+- [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
+- [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
+- [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
+- [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
+- [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
+- [Exile - Indestructible](https://osu.ppy.sh/s/10104)
+- [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
+- [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
+- [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
+- [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
+- [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
+- [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
+- [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
+- [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
 
 Quelques chiffres
 ------------------

--- a/wiki/Achievements/Beatmap_Packs_0916/pt-br.md
+++ b/wiki/Achievements/Beatmap_Packs_0916/pt-br.md
@@ -1,385 +1,427 @@
-[media-anime-vol-1]: http://www.mediafire.com/?9n65pm9fp8yp5bn
-[media-anime-vol-2]: http://www.mediafire.com/?722os55j52ikylq
-[media-anime-vol-3]: http://www.mediafire.com/?tky7bjc58hcno6b
-[media-anime-vol-4]: http://www.mediafire.com/?j5b5b6bimr5ahdv
-[yas-anime-vol-1]: http://osu.yas-online.net/tagthis.php?tag=T4
-[yas-anime-vol-2]: http://osu.yas-online.net/tagthis.php?tag=T6
-[yas-anime-vol-3]: http://osu.yas-online.net/tagthis.php?tag=T15
-[yas-anime-vol-4]: http://osu.yas-online.net/tagthis.php?tag=T30
-[media-rhythm-vol-1]: http://www.mediafire.com/?87n2agcrcgmwxob
-[media-rhythm-vol-2]: http://www.mediafire.com/?axvxrnx637767ls
-[media-rhythm-vol-3]: http://www.mediafire.com/?781tio8fge7y7d2
-[media-rhythm-vol-4]: http://www.mediafire.com/?6hc29ws6j36dcag
-[yas-rhythm-vol-1]: http://osu.yas-online.net/tagthis.php?tag=T9
-[yas-rhythm-vol-2]: http://osu.yas-online.net/tagthis.php?tag=T2
-[yas-rhythm-vol-3]: http://osu.yas-online.net/tagthis.php?tag=T16
-[yas-rhythm-vol-4]: http://osu.yas-online.net/tagthis.php?tag=T32
+[media-anime-vol-1]: https://www.mediafire.com/?9n65pm9fp8yp5bn
+[media-anime-vol-2]: https://www.mediafire.com/?722os55j52ikylq
+[media-anime-vol-3]: https://www.mediafire.com/?tky7bjc58hcno6b
+[media-anime-vol-4]: https://www.mediafire.com/?j5b5b6bimr5ahdv
+[media-rhythm-vol-1]: https://www.mediafire.com/?87n2agcrcgmwxob
+[media-rhythm-vol-2]: https://www.mediafire.com/?axvxrnx637767ls
+[media-rhythm-vol-3]: https://www.mediafire.com/?781tio8fge7y7d2
+[media-rhythm-vol-4]: https://www.mediafire.com/?6hc29ws6j36dcag
 
 Pacotes de Beatmap
 =============
 
 ***[Clique aqui para retornar à página "Conquistas"](../)***
 
-Pacotes temáticos clássicos/originais durante os anos de infância do osu! (2009) antes de serem atualizados por [Stefan em 16 de janeiro de 2016](http://osu.ppy.sh/news/137535031193).
+Pacotes temáticos clássicos/originais durante os anos de infância do osu! (2009) antes de serem atualizados por [Stefan em 16 de janeiro de 2016](https://osu.ppy.sh/news/137535031193).
 
 Pacote Anime
 -----------
+### Volume 1
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+> LuigiHann/DeathxShinigami (2011)
 
-#### Download:
-* [MediaFire][media-anime-vol-1]
-* [osu.yas-online.net][yas-anime-vol-1]
+Download:
 
-#### Mapas:
-* [Beat Crusaders - Hit in the USA](http://osu.ppy.sh/s/35)
-* [Chieco Kawabe - Sakura Kiss](http://osu.ppy.sh/s/147)
-* [Hirano Aya - Hare Hare Yukai](http://osu.ppy.sh/s/301)
-* [Access - Doubt & Trust](http://osu.ppy.sh/s/442)
-* [Pokemon - Pokerap](http://osu.ppy.sh/s/551)
-* [Hirano Aya (Haruhi Suzumiya) - God Knows](http://osu.ppy.sh/s/584) 
-* [Manzo - My-Pace Daiou](http://osu.ppy.sh/s/842)
-* [Younha - Houkiboshi](http://osu.ppy.sh/s/897)
-* [Miwako Okuda - Shizuku](http://osu.ppy.sh/s/1005)
-* [Neon Genesis Evangelion - Cruel Angel's Thesis](http://osu.ppy.sh/s/1377)
-* [Suemitsu & The Suemith - Allegro Cantabile](http://osu.ppy.sh/s/1414)
-* [Excel Girls - Ai (Chuuseishin)](http://osu.ppy.sh/s/1464)
-* [Dragon Ball Z - Cha-la Head-Cha-la](http://osu.ppy.sh/s/1806)
+- [MediaFire][media-anime-vol-1]
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+Mapas:
 
-#### Download:
-* [MediaFire][media-anime-vol-2]
-* [osu.yas-online.net][yas-anime-vol-2]
+- [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
+- [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
+- [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
+- [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
+- [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
+- [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
+- [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
+- [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
+- [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
+- [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
+- [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
+- [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
+- [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
 
-#### Mapas:
-* [Kana Ueda - Pumpkin Ondo](http://osu.ppy.sh/s/86)
-* [Porno Graffitti - Mellisa (TV Size)](http://osu.ppy.sh/s/150)
-* [Rie Tanaka - Ningyo Hime](http://osu.ppy.sh/s/162)
-* [Galaxy Angel - Galaxy Bang! Bang!](http://osu.ppy.sh/s/205)
-* [LOVERIN TAMBURIN - Aishitageru](http://osu.ppy.sh/s/212)
-* [KOTOKO - agony](http://osu.ppy.sh/s/302)
-* [Afromania - Minna no Peace](http://osu.ppy.sh/s/496)
-* [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](http://osu.ppy.sh/s/521)
-* [The Pillows - Ride on Shooting Star](http://osu.ppy.sh/s/956)
-* [Little Non - Hanamaru Sensation](http://osu.ppy.sh/s/2207)
-* [Lucky Star Cast - Kaeshite! Knee Socks](http://osu.ppy.sh/s/86)
-* [Horie Yui with UNSCANDAL - Scramble](http://osu.ppy.sh/s/2329)
-* [YUKI - Dramatic (TV Size)](http://osu.ppy.sh/s/2425)
+### Volume 2
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+> LuigiHann/DeathxShinigami (2011)
 
-#### Download:
-* [MediaFire][media-anime-vol-3]
-* [osu.yas-online.net][yas-anime-vol-3]
+Download:
 
-#### Mapas:
-* [Kageyama Hironobu - Ore wa Tokoton Tomaranai](http://osu.ppy.sh/s/2618)
-* [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](http://osu.ppy.sh/s/3030)
-* [Nightmare - The World](http://osu.ppy.sh/s/4851)
-* [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](http://osu.ppy.sh/s/4994)
-* [Toss & Turn - Off the Chains](http://osu.ppy.sh/s/5010)
-* [Sonic X - Gotta Go Fast](http://osu.ppy.sh/s/5235)
-* [David Rolfe - Born to Be a Winner (TV Size)](http://osu.ppy.sh/s/5410)
-* [Chiaki Ishikawa - Uninstall](http://osu.ppy.sh/s/5480)
-* [Shuntaro Okino - Cloud Age Symphony](http://osu.ppy.sh/s/5963)
-* [Yuu Kobayashi - Hanaji(TV Size)](http://osu.ppy.sh/s/6037)
-* [Yoko Hikasa - Don't Say "Lazy"](http://osu.ppy.sh/s/6257)
-* [Yui - Again](http://osu.ppy.sh/s/6535)
-* [Chihara Minori - Paradise Lost (TV Size)](http://osu.ppy.sh/s/6557)
+- [MediaFire][media-anime-vol-2]
 
-### Volume 4 (DeathxShinigami [2011])
+Mapas:
 
-#### Download:
-* [MediaFire][media-anime-vol-4]
-* [osu.yas-online.net][yas-anime-vol-4]
+- [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
+- [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
+- [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
+- [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
+- [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
+- [KOTOKO - agony](https://osu.ppy.sh/s/302)
+- [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
+- [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
+- [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
+- [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
+- [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
+- [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
+- [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
 
-#### Mapas:
-* [Chata - Dango Daikazoku](http://osu.ppy.sh/s/516)
-* [AKINO - Sousei no Aquarion (TV Size)](http://osu.ppy.sh/s/5438)
-* [Wada Kouji - Hirari (TV Size)](http://osu.ppy.sh/s/6301)
-* [SID - Uso (TV Size)](http://osu.ppy.sh/s/8422)
-* [Toyosaki Aki - Sunday Siesta](http://osu.ppy.sh/s/8829)
-* [Akemi Kanda - 1000% Sparking!](http://osu.ppy.sh/s/9556)
-* [Ikimono Gakari - Seishun Line](http://osu.ppy.sh/s/12982)
-* [Horie Yui - I My Me](http://osu.ppy.sh/s/13036)
-* [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](http://osu.ppy.sh/s/13673)
-* [Faylan - mind as Judgment (TV Size)](http://osu.ppy.sh/s/14256)
-* [The Delgados - The Light Before We Land](http://osu.ppy.sh/s/14694)
-* [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](http://osu.ppy.sh/s/16252)
-* [DOMINO - U Can Do It! (TV Size)](http://osu.ppy.sh/s/21197)
+### Volume 3
 
+> Larto/DeathxShinigami (2011)
 
+Download:
+
+- [MediaFire][media-anime-vol-3]
+
+Mapas:
+
+- [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
+- [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
+- [Nightmare - The World](https://osu.ppy.sh/s/4851)
+- [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
+- [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
+- [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
+- [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
+- [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
+- [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
+- [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
+- [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
+- [Yui - Again](https://osu.ppy.sh/s/6535)
+- [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-anime-vol-4]
+
+Mapas:
+
+- [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
+- [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
+- [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
+- [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
+- [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
+- [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
+- [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
+- [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
+- [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
+- [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
+- [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
+- [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
+- [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
 
 Pacote Internet
 ---------------
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* Nenhum
+> LuigiHann/DeathxShinigami [2011]
 
-#### Mapas:
-* [Dudelstudios - Angry Video Game Nerd Theme](http://osu.ppy.sh/s/66)
-* [Trans-Siberian Orchestra - Wizards In Winter](http://osu.ppy.sh/s/132)
-* [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](http://osu.ppy.sh/s/140)
-* [Lazy Town - Cooking by the Book](http://osu.ppy.sh/s/235)
-* [t+pazolite feat. - Okkusenman (Hardcore Mix)](http://osu.ppy.sh/s/303)
-* [The Laziest Men on Mars - Invasion of the Gabber Robots](http://osu.ppy.sh/s/339)
-* [Erwin Beekveld - They're Taking The Hobbits To Isengard](http://osu.ppy.sh/s/455)
-* [NicoNicoDouga - Farucon Pan!](http://osu.ppy.sh/s/664)
-* [I Love Egg - Egg Song](http://osu.ppy.sh/s/812)
-* [Rick Astley - Never Gonna Give You Up 2](http://osu.ppy.sh/s/977)
-* [Caramell - Caramelldansen (Speedycake Remix)](http://osu.ppy.sh/s/1018)
-* [Hatsune Miku - Ievan Polkka](http://osu.ppy.sh/s/1287)
-* [Loituma - Ievan Polkka](http://osu.ppy.sh/s/2463)
+Download:
 
-> __Observação:__ Loituma - Ievan Polkka é um mapa não rankeado. Você pode pular este beatmap caso desejar.
+- None
 
-### Volume 2 (Larto/DeathxShinigami [2011])
+Mapas:
 
-#### Download:
-* Nenhum
+- [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
+- [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
+- [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
+- [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
+- [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
+- [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
+- [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
+- [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
+- [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
+- [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
+- [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
+- [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
+- [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
 
-#### Mapas:
-* [The INTERNET - At The Playground](http://osu.ppy.sh/s/203)
-* [Jakazid - Cillit Bang (Hardcore Mix)](http://osu.ppy.sh/s/917)
-* [Funtastic Power! - This is Sparta REMIX](http://osu.ppy.sh/s/1573)
-* [You are an Idiot!](http://osu.ppy.sh/s/1628)
-* [Nico Nico Douga - U.N. Owen Was Her](http://osu.ppy.sh/s/1785)
-* [Initial D - Running in the 90's](http://osu.ppy.sh/s/2103)
-* [Do a Barrel Roll!](http://osu.ppy.sh/s/2569)
-* [YTMND - The Bubb Rubb of Time](http://osu.ppy.sh/s/3196)
-* [igiulamam - What I want you to do](http://osu.ppy.sh/s/3219)
-* [My Chemical Romance - Welcome to the Black Parade](http://osu.ppy.sh/s/3545)
-* [Chiru - GOLIMAR!!](http://osu.ppy.sh/s/3621)
-* [Funta - Kao Dekai](http://osu.ppy.sh/s/4535)
-* [Coda - Longcat's Song](http://osu.ppy.sh/s/5014)
+> __Note:__ Loituma - Ievan Polkka is an unranked beatmap. You can skip this beatmap if you want to.
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* Nenhum
+> Larto/DeathxShinigami (2011)
 
-#### Mapas:
-* [NicoNicoDouga - Nice Boat.](http://osu.ppy.sh/s/1839)
-* [Verix - Drop the Dodongo](http://osu.ppy.sh/s/3337)
-* [NicoNicoDouga - Cirno de Gozaimasu!](http://osu.ppy.sh/s/3367)
-* [Tarou - Danjo](http://osu.ppy.sh/s/3688)
-* [Ashens - Silly Monkey](http://osu.ppy.sh/s/5703)
-* [Gunther - Ding Dong Song (You Touch My Tra La La)](http://osu.ppy.sh/s/5709)
-* [WalnutFaceBrand - C-O-C-A-I-N-E](http://osu.ppy.sh/s/5823)
-* [Trey Parker - Gay Fish](http://osu.ppy.sh/s/6526)
-* [Lazy Town - You Are A Pirate](http://osu.ppy.sh/s/6626)
-* [NeoNintendo - Scrub Scrub Scrub](http://osu.ppy.sh/s/7506)
-* [MrRoboto113 - I Think I'll Eat It Now](http://osu.ppy.sh/s/7507)
-* [The Gregory Brothers - Auto-Tune the News #5](http://osu.ppy.sh/s/8034)
-* [The Lonely Island - Shrooms](http://osu.ppy.sh/s/8690)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- None
 
-#### Download:
-* Nenhum
+Mapas:
 
-#### Mapas:
-* [TuTuWan - Wo Yao Jin Ke La](http://osu.ppy.sh/s/11443)
-* [Parry Gripp - Do You Like Waffles](http://osu.ppy.sh/s/12033)
-* [The Gregory Brothers - Auto-Tune the News #9](http://osu.ppy.sh/s/12155)
-* [ISAJI - Yaranaika](http://osu.ppy.sh/s/13885)
-* [The Midnight Beast - Tik Tok (Parody)](http://osu.ppy.sh/s/14391)
-* [Pomplamoose - Telephone](http://osu.ppy.sh/s/14579)
-* [Eric Cartman - Poker Face](http://osu.ppy.sh/s/14672)
-* [Chihara Minori - Greed's Accident](http://osu.ppy.sh/s/15157)
-* [The Lonely Island (Feat. Justin Timberlake) - Motherlover](http://osu.ppy.sh/s/15628)
-* [MPAA - Piracy - It's a Crime](http://osu.ppy.sh/s/15942)
-* [Hatsune Miku - Nico Nico Messe no Uta](http://osu.ppy.sh/s/17145)
-* [yamas03 - bloomin' octagon](http://osu.ppy.sh/s/17217)
-* [8corporation - The Ultimate Trololo Mashup](http://osu.ppy.sh/s/17724)
+- [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
+- [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
+- [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
+- [You are an Idiot!](https://osu.ppy.sh/s/1628)
+- [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
+- [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
+- [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
+- [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
+- [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
+- [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
+- [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
+- [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
+- [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
 
+### Volume 3
 
+> Larto/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Mapas:
+
+- [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
+- [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
+- [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
+- [Tarou - Danjo](https://osu.ppy.sh/s/3688)
+- [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
+- [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
+- [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
+- [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
+- [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
+- [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
+- [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
+- [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
+- [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Mapas:
+
+- [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
+- [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
+- [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
+- [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
+- [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
+- [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
+- [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
+- [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
+- [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
+- [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
+- [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
+- [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
+- [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
 
 Pacote Jogos de Ritmo
 ------------------------
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* [MediaFire][media-rhythm-vol-1]
-* [osu.yas-online.net][yas-rhythm-vol-1]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Mapas:
-* [Beautiful Day - Bride in Dream](http://osu.ppy.sh/s/74)
-* [Speed Over Beethoven](http://osu.ppy.sh/s/96)
-* [Taiko no Tatsujin - Saitama2000](http://osu.ppy.sh/s/210)
-* [Gitaroo Man - 12 - The Legendary Theme (Album Version)](http://osu.ppy.sh/s/296)
-* [Banya - Beethoven Virus](http://osu.ppy.sh/s/540)
-* [Freezepop - Get Ready To Rokk](http://osu.ppy.sh/s/564)
-* [Taiko no Tatsujin - Kare Kano Kanon](http://osu.ppy.sh/s/1078)
-* [Genbu - Ganymede](http://osu.ppy.sh/s/1201)
-* [BeForU - Love Shine](http://osu.ppy.sh/s/1300)
-* [Parappa 2 - Hair Scare](http://osu.ppy.sh/s/1317)
-* [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](http://osu.ppy.sh/s/1338)
-* [Sega - Samba de Janeiro](http://osu.ppy.sh/s/1450)
-* [Naofumi Hataya - Spaceport: Introducing Ulala!!](http://osu.ppy.sh/s/1452)
+Download:
 
-### Volume 2 (Larto [2009]/DeathxShinigami [2011])
+- [MediaFire][media-rhythm-vol-1]
 
-#### Download:
-* [MediaFire][media-rhythm-vol-2]
-* [osu.yas-online.net][yas-rhythm-vol-2]
+Mapas:
 
-#### Mapas:
-* [Tatsh feat. K.Nayuki - Sphere](http://osu.ppy.sh/s/1207)
-* [Taiko no Tatsujin - Kita Saitama2000](http://osu.ppy.sh/s/1567)
-* [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](http://osu.ppy.sh/s/2534)
-* [BRANDY - The Festival of Ghost 2](http://osu.ppy.sh/s/3302)
-* [Gitaroo Man - Soft Machine](http://osu.ppy.sh/s/3435)
-* [Superbus - Radio Song](http://osu.ppy.sh/s/3499)
-* [3rd Coast - Coastal Tempo](http://osu.ppy.sh/s/4887)
-* [Money Deluxe - Funk Factory](http://osu.ppy.sh/s/5087)
-* [Audition - Can Can](http://osu.ppy.sh/s/5177)
-* [Asaki - Agnus Dei](http://osu.ppy.sh/s/5275)
-* [Scotty D - Drop The Bomb](http://osu.ppy.sh/s/5321)
-* [Dr.Flowershirts - Canon (O2 version)+](http://osu.ppy.sh/s/5349)
-* [Shoes (Missile Chewbacca) - TAP de Papapaya](http://osu.ppy.sh/s/5577)
+- [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
+- [Speed Over Beethoven](https://osu.ppy.sh/s/96)
+- [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
+- [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
+- [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
+- [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
+- [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
+- [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
+- [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
+- [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
+- [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
+- [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
+- [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
 
-### Volume 3 (Larto [2010]/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* [MediaFire][media-rhythm-vol-3]
-* [osu.yas-online.net][yas-rhythm-vol-3]
+> Larto (2009)/DeathxShinigami (2011)
 
-#### Mapas:
-* [BanYa - Csikos Post](http://osu.ppy.sh/s/1206)
-* [Mutsuhiko Izumi - Jet World](http://osu.ppy.sh/s/4357)
-* [Bust a Groove - Flyin' To Your Soul](http://osu.ppy.sh/s/4617)
-* [R2beat - Kischer Marsch](http://osu.ppy.sh/s/4772)
-* [Brandy - Visual Dream](http://osu.ppy.sh/s/4954)
-* [BanYa - Phantom](http://osu.ppy.sh/s/5180)
-* [AKIRA YAMAOKA - 250bpm](http://osu.ppy.sh/s/5672)
-* [Tsunku - Ping-Pong](http://osu.ppy.sh/s/5696)
-* [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](http://osu.ppy.sh/s/6598)
-* [Jun - Silver Dream](http://osu.ppy.sh/s/7094)
-* [SMILE.dk - Butterfly](http://osu.ppy.sh/s/7237)
-* [Nien - MiNd CoNTRoL](http://osu.ppy.sh/s/7612)
-* [Crispy - The Game](http://osu.ppy.sh/s/7983)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- [MediaFire][media-rhythm-vol-2]
 
-#### Download:
-* [MediaFire][media-rhythm-vol-4]
-* [osu.yas-online.net][yas-rhythm-vol-4]
+Mapas:
 
-#### Mapas:
-* [Beautiful Day - Bang! Bang! Bang!](http://osu.ppy.sh/s/10842)
-* [Yamajet - Over The Ocean](http://osu.ppy.sh/s/11135)
-* [Tsunku - Space Dance](http://osu.ppy.sh/s/11488)
-* [Electronic Boutique - Miles](http://osu.ppy.sh/s/12052)
-* [YMCK - Family Dondon](http://osu.ppy.sh/s/12190)
-* [Suzaku VS Genbu - Himiko](http://osu.ppy.sh/s/12710)
-* [TERRA - Touka Renjou](http://osu.ppy.sh/s/13249)
-* [DJ YOSHITAKA - Evans](http://osu.ppy.sh/s/14572)
-* [Tsukasa - Colours of Sorrow (JAP ver)](http://osu.ppy.sh/s/14778)
-* [Seiryu - 3y3s](http://osu.ppy.sh/s/15241)
-* [ORANGE RANGE - O2 (Taiko Cut)](http://osu.ppy.sh/s/18492)
-* [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](http://osu.ppy.sh/s/19809)
-* [M2U - Memory of Beach](http://osu.ppy.sh/s/22401)
+- [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
+- [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
+- [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
+- [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
+- [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
+- [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
+- [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
+- [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
+- [Audition - Can Can](https://osu.ppy.sh/s/5177)
+- [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
+- [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
+- [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
+- [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
 
+### Volume 3
+
+> Larto (2010)/DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-rhythm-vol-3]
+
+Mapas:
+
+- [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
+- [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
+- [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
+- [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
+- [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
+- [BanYa - Phantom](https://osu.ppy.sh/s/5180)
+- [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
+- [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
+- [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
+- [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
+- [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
+- [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
+- [Crispy - The Game](https://osu.ppy.sh/s/7983)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-rhythm-vol-4]
+
+Mapas:
+
+- [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
+- [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
+- [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
+- [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
+- [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
+- [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
+- [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
+- [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
+- [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
+- [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
+- [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
+- [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
+- [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
 
 Pacote Jogos
 -----------------------
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* Nenhum
+> LuigiHann/DeathxShinigami (2011)
 
-#### Mapas:
-* [Team Nekokan - Can't Defeat Airman](http://osu.ppy.sh/s/25)
-* [Portal - Still Alive](http://osu.ppy.sh/s/92)
-* [Rabbit Joint - Legend of Zelda](http://osu.ppy.sh/s/125)
-* [Noriyuki Iwadare - Pursuit ~ Caught](http://osu.ppy.sh/s/154)
-* [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](http://osu.ppy.sh/s/312)
-* [2pm - Tetris](http://osu.ppy.sh/s/633)
-* [Masato Nakamura - Staff Credits](http://osu.ppy.sh/s/688)
-* [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](http://osu.ppy.sh/s/704)
-* [Kentaro Ishizaka - Star Wolf (Brawl remix)](http://osu.ppy.sh/s/1092)
-* [The World Ends With You OST - DejaVu](http://osu.ppy.sh/s/1211)
-* [Corran - Cave Story Escape Route OC ReMix](http://osu.ppy.sh/s/1231)
-* [Nintendo - Super Mario Bros Medley](http://osu.ppy.sh/s/1281)
-* [The Black Mages - Battle Theme (Final Fantasy VI)](http://osu.ppy.sh/s/1635)
+Download:
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+- None
 
-##### Download:
-* Nenhum
+Mapas:
 
-#### Mapas:
-* [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](http://osu.ppy.sh/s/243)
-* [Nintendo - Super Mario Bros. (TECHNO remix)](http://osu.ppy.sh/s/628)
-* [The Legend of Zelda - The Wind Waker - Molgera](http://osu.ppy.sh/s/1044)
-* [Nights: Journey of Dreams - Dreams Dreams (Will Version)](http://osu.ppy.sh/s/1123)
-* [Catherine Warwick - Pollyanna (I Believe In You)](http://osu.ppy.sh/s/1367)
-* [Nobuo Uematsu - Dark Saint](http://osu.ppy.sh/s/1525)
-* [Animal Crossing - DJ KK](http://osu.ppy.sh/s/1818)
-* [Trauma Center: New Blood - Opening](http://osu.ppy.sh/s/2008)
-* [The Wingless - All the World in One Girl](http://osu.ppy.sh/s/2128)
-* [Michiru Yamane/Masahiko Kimura - Bloody Tears](http://osu.ppy.sh/s/2147)
-* [Hiroshi Iuchi - Theme of Butsutekkai](http://osu.ppy.sh/s/2404)
-* [Mario Tennis 64 - Peach's Secret Court](http://osu.ppy.sh/s/2420)
-* [Hyadain - Battle with the Four Fiends](http://osu.ppy.sh/s/2619)
+- [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
+- [Portal - Still Alive](https://osu.ppy.sh/s/92)
+- [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
+- [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
+- [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
+- [2pm - Tetris](https://osu.ppy.sh/s/633)
+- [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
+- [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
+- [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
+- [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
+- [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
+- [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
+- [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
 
-### Volume 3 (Seibei4211/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* Nenhum
+> LuigiHann/DeathxShinigami (2011)
 
-#### Mapas:
-* [Victims of Science - The Device Has Been Modified](http://osu.ppy.sh/s/1890)
-* [Phoenix Wright - Sugimori Masakazu - Compilation](http://osu.ppy.sh/s/2085)
-* [His World](http://osu.ppy.sh/s/2490)
-* [Trauma Center: Second Opinion - Vulnerability](http://osu.ppy.sh/s/2983)
-* [Grant Kirkhope - Weldar](http://osu.ppy.sh/s/3150)
-* [Capcom Sound Team - Thunder Tornado](http://osu.ppy.sh/s/3221)
-* [Yasunori Mitsuda - Edge of Death](http://osu.ppy.sh/s/3384)
-* [Nobuo Uematsu - FFIX Battle Theme](http://osu.ppy.sh/s/3511)
-* [Rei Kondoh - The Sun Rises](http://osu.ppy.sh/s/3613)
-* [The EX-Box Boys - Braid - Counting You Up](http://osu.ppy.sh/s/4033)
-* [Nintendo/Michiko Naruko - Ocarina of Time Medley](http://osu.ppy.sh/s/4299)
-* [Shinji Miyazaki - Gym Leader Battle](http://osu.ppy.sh/s/4305)
-* [Koji Kondo - Dire Dire Docks](http://osu.ppy.sh/s/4629)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- None
 
-#### Download:
-* Nenhum
+Mapas:
 
-#### Mapas:
-* [Megadeth - Grabbag](http://osu.ppy.sh/s/7077)
-* [David J. Franco - Scribblenauts Theme](http://osu.ppy.sh/s/9580)
-* [Yuka Tsujiyoko - Shy Guy's Toybox](http://osu.ppy.sh/s/9668)
-* [Nobuo Uematsu - Fight Against Culex](http://osu.ppy.sh/s/9854)
-* [Exile - Indestructible](http://osu.ppy.sh/s/10104)
-* [Danimal Cannon - Rockin' on Heaven's Door](http://osu.ppy.sh/s/10880)
-* [Junichi Masuda - Opening](http://osu.ppy.sh/s/13489)
-* [Zircon - Dirt Devil (OC ReMix)](http://osu.ppy.sh/s/14205)
-* [Shoji Meguro - Reach Out to the Truth (Instrumental)](http://osu.ppy.sh/s/14458)
-* [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](http://osu.ppy.sh/s/16669)
-* [Ken Nakagawa - Cyclone](http://osu.ppy.sh/s/17373)
-* [Crush 40 - Sonic Heroes](http://osu.ppy.sh/s/21836)
-* [Anamanaguchi - Scott Pilgrim Anthem](http://osu.ppy.sh/s/23073)
+- [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
+- [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
+- [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
+- [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
+- [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
+- [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
+- [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
+- [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
+- [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
+- [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
+- [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
+- [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
+- [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+
+### Volume 3
+
+> Seibei4211/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Mapas:
+
+- [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
+- [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
+- [His World](https://osu.ppy.sh/s/2490)
+- [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
+- [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
+- [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
+- [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
+- [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
+- [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
+- [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
+- [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
+- [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
+- [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Mapas:
+
+- [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
+- [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
+- [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
+- [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
+- [Exile - Indestructible](https://osu.ppy.sh/s/10104)
+- [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
+- [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
+- [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
+- [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
+- [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
+- [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
+- [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
+- [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
 
 Curiosidades
 ---------
 
 -   16 pacotes. (4 temas x 4 volumes)
     -   1 hora e 20 minutos = 1 pacote (Estimativa de tempo necessária para completar um pacote de beatmap)
--   211 canções (206 + [3](http://osu.ppy.sh/s/2490) ![](/wiki/shared/Heart.gif) rankeadas, 1 ![](/wiki/shared/Fire.gif) [aprovada](http://osu.ppy.sh/b/21010) e 1 [pendente](http://osu.ppy.sh/b/19630))
--   662 dificuldades (660 ![](/wiki/shared/Heart.gif) rankeadas, 1 ![](/wiki/shared/Fire.gif) [aprovadas](http://osu.ppy.sh/b/21010) e 1 [pendente](http://osu.ppy.sh/b/19630))
+-   211 canções (206 + [3](https://osu.ppy.sh/s/2490) ![](/wiki/shared/Heart.gif) rankeadas, 1 ![](/wiki/shared/Fire.gif) [aprovada](https://osu.ppy.sh/b/21010) e 1 [pendente](https://osu.ppy.sh/b/19630))
+-   662 dificuldades (660 ![](/wiki/shared/Heart.gif) rankeadas, 1 ![](/wiki/shared/Fire.gif) [aprovadas](https://osu.ppy.sh/b/21010) e 1 [pendente](https://osu.ppy.sh/b/19630))
 -   1.39 GB (compactado), 1.47 GB (importado)
 -   3 minutos e 33 segundos. (Estimativa do tempo de importação de todos os 16 pacotes)
 
 Agradecimentos especiais
 ---------------
 
--   [Wayback Machine](http://archive.org/web/)
+-   [Wayback Machine](https://archive.org/web/)

--- a/wiki/Achievements/Beatmap_Packs_0916/ru.md
+++ b/wiki/Achievements/Beatmap_Packs_0916/ru.md
@@ -2,372 +2,411 @@
 [media-anime-vol-2]: https://www.mediafire.com/?722os55j52ikylq
 [media-anime-vol-3]: https://www.mediafire.com/?tky7bjc58hcno6b
 [media-anime-vol-4]: https://www.mediafire.com/?j5b5b6bimr5ahdv
-[yas-anime-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T4
-[yas-anime-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T6
-[yas-anime-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T15
-[yas-anime-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T30
 [media-rhythm-vol-1]: https://www.mediafire.com/?87n2agcrcgmwxob
 [media-rhythm-vol-2]: https://www.mediafire.com/?axvxrnx637767ls
 [media-rhythm-vol-3]: https://www.mediafire.com/?781tio8fge7y7d2
 [media-rhythm-vol-4]: https://www.mediafire.com/?6hc29ws6j36dcag
-[yas-rhythm-vol-1]: https://osu.yas-online.net/tagthis.php?tag=T9
-[yas-rhythm-vol-2]: https://osu.yas-online.net/tagthis.php?tag=T2
-[yas-rhythm-vol-3]: https://osu.yas-online.net/tagthis.php?tag=T16
-[yas-rhythm-vol-4]: https://osu.yas-online.net/tagthis.php?tag=T32
 
-Beatmap Packs (Русский)
-=======================
+Beatmap Packs 0916 (Русский)
+============================
 
 ***[Вернуться к описанию достижений](../)***
 
 Оригинальные тематические архивы карт прямиком из 2009 до их обновления [Stefan'ом 16 января 2016](https://osu.ppy.sh/news/137535031193).
 
-Anime Pack
------------
+## Anime Pack
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 1
 
-#### Download:
-* [MediaFire][media-anime-vol-1]
-* [osu.yas-online.net][yas-anime-vol-1]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
-* [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
-* [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
-* [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
-* [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
-* [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
-* [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
-* [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
-* [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
-* [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
-* [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
-* [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
-* [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
+Download:
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-1]
 
-#### Download:
-* [MediaFire][media-anime-vol-2]
-* [osu.yas-online.net][yas-anime-vol-2]
+Maps:
 
-#### Maps:
-* [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
-* [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
-* [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
-* [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
-* [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
-* [KOTOKO - agony](https://osu.ppy.sh/s/302)
-* [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
-* [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
-* [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
-* [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
-* [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
-* [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
-* [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
+- [Beat Crusaders - Hit in the USA](https://osu.ppy.sh/s/35)
+- [Chieco Kawabe - Sakura Kiss](https://osu.ppy.sh/s/147)
+- [Hirano Aya - Hare Hare Yukai](https://osu.ppy.sh/s/301)
+- [Access - Doubt & Trust](https://osu.ppy.sh/s/442)
+- [Pokemon - Pokerap](https://osu.ppy.sh/s/551)
+- [Hirano Aya (Haruhi Suzumiya) - God Knows](https://osu.ppy.sh/s/584)
+- [Manzo - My-Pace Daiou](https://osu.ppy.sh/s/842)
+- [Younha - Houkiboshi](https://osu.ppy.sh/s/897)
+- [Miwako Okuda - Shizuku](https://osu.ppy.sh/s/1005)
+- [Neon Genesis Evangelion - Cruel Angel's Thesis](https://osu.ppy.sh/s/1377)
+- [Suemitsu & The Suemith - Allegro Cantabile](https://osu.ppy.sh/s/1414)
+- [Excel Girls - Ai (Chuuseishin)](https://osu.ppy.sh/s/1464)
+- [Dragon Ball Z - Cha-la Head-Cha-la](https://osu.ppy.sh/s/1806)
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* [MediaFire][media-anime-vol-3]
-* [osu.yas-online.net][yas-anime-vol-3]
+> LuigiHann/DeathxShinigami (2011)
 
-#### Maps:
-* [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
-* [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
-* [Nightmare - The World](https://osu.ppy.sh/s/4851)
-* [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
-* [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
-* [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
-* [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
-* [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
-* [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
-* [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
-* [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
-* [Yui - Again](https://osu.ppy.sh/s/6535)
-* [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+Download:
 
-### Volume 4 (DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-2]
 
-#### Download:
-* [MediaFire][media-anime-vol-4]
-* [osu.yas-online.net][yas-anime-vol-4]
+Maps:
 
-#### Maps:
-* [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
-* [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
-* [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
-* [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
-* [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
-* [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
-* [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
-* [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
-* [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
-* [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
-* [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
-* [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
-* [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+- [Kana Ueda - Pumpkin Ondo](https://osu.ppy.sh/s/86)
+- [Porno Graffitti - Mellisa (TV Size)](https://osu.ppy.sh/s/150)
+- [Rie Tanaka - Ningyo Hime](https://osu.ppy.sh/s/162)
+- [Galaxy Angel - Galaxy Bang! Bang!](https://osu.ppy.sh/s/205)
+- [LOVERIN TAMBURIN - Aishitageru](https://osu.ppy.sh/s/212)
+- [KOTOKO - agony](https://osu.ppy.sh/s/302)
+- [Afromania - Minna no Peace](https://osu.ppy.sh/s/496)
+- [Ootsuki Kenji - Hitotoshite Jiku Ga Bureteiru](https://osu.ppy.sh/s/521)
+- [The Pillows - Ride on Shooting Star](https://osu.ppy.sh/s/956)
+- [Little Non - Hanamaru Sensation](https://osu.ppy.sh/s/2207)
+- [Lucky Star Cast - Kaeshite! Knee Socks](https://osu.ppy.sh/s/86)
+- [Horie Yui with UNSCANDAL - Scramble](https://osu.ppy.sh/s/2329)
+- [YUKI - Dramatic (TV Size)](https://osu.ppy.sh/s/2425)
 
+### Volume 3
 
+> Larto/DeathxShinigami (2011)
 
-Internet Pack
---------------
+Download:
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+- [MediaFire][media-anime-vol-3]
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
-* [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
-* [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
-* [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
-* [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
-* [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
-* [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
-* [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
-* [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
-* [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
-* [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
-* [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
-* [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
+- [Kageyama Hironobu - Ore wa Tokoton Tomaranai](https://osu.ppy.sh/s/2618)
+- [Lucky Star - Motteke! Sailor Fuku (REDALiCE Remix)](https://osu.ppy.sh/s/3030)
+- [Nightmare - The World](https://osu.ppy.sh/s/4851)
+- [Galaxy Angel Rune's cast - Uchuu de Koi wa Rurun Ruuuun](https://osu.ppy.sh/s/4994)
+- [Toss & Turn - Off the Chains](https://osu.ppy.sh/s/5010)
+- [Sonic X - Gotta Go Fast](https://osu.ppy.sh/s/5235)
+- [David Rolfe - Born to Be a Winner (TV Size)](https://osu.ppy.sh/s/5410)
+- [Chiaki Ishikawa - Uninstall](https://osu.ppy.sh/s/5480)
+- [Shuntaro Okino - Cloud Age Symphony](https://osu.ppy.sh/s/5963)
+- [Yuu Kobayashi - Hanaji(TV Size)](https://osu.ppy.sh/s/6037)
+- [Yoko Hikasa - Don't Say "Lazy"](https://osu.ppy.sh/s/6257)
+- [Yui - Again](https://osu.ppy.sh/s/6535)
+- [Chihara Minori - Paradise Lost (TV Size)](https://osu.ppy.sh/s/6557)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-anime-vol-4]
+
+Maps:
+
+- [Chata - Dango Daikazoku](https://osu.ppy.sh/s/516)
+- [AKINO - Sousei no Aquarion (TV Size)](https://osu.ppy.sh/s/5438)
+- [Wada Kouji - Hirari (TV Size)](https://osu.ppy.sh/s/6301)
+- [SID - Uso (TV Size)](https://osu.ppy.sh/s/8422)
+- [Toyosaki Aki - Sunday Siesta](https://osu.ppy.sh/s/8829)
+- [Akemi Kanda - 1000% Sparking!](https://osu.ppy.sh/s/9556)
+- [Ikimono Gakari - Seishun Line](https://osu.ppy.sh/s/12982)
+- [Horie Yui - I My Me](https://osu.ppy.sh/s/13036)
+- [THEATRE BROOK - Uragiri no Yuuyake ( TV Size )](https://osu.ppy.sh/s/13673)
+- [Faylan - mind as Judgment (TV Size)](https://osu.ppy.sh/s/14256)
+- [The Delgados - The Light Before We Land](https://osu.ppy.sh/s/14694)
+- [Susumu Hirasawa - Shiroi Oka - Maromi no Theme](https://osu.ppy.sh/s/16252)
+- [DOMINO - U Can Do It! (TV Size)](https://osu.ppy.sh/s/21197)
+
+## Internet Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami [2011]
+
+Download:
+
+- None
+
+Maps:
+
+- [Dudelstudios - Angry Video Game Nerd Theme](https://osu.ppy.sh/s/66)
+- [Trans-Siberian Orchestra - Wizards In Winter](https://osu.ppy.sh/s/132)
+- [Lemon Demon - The Ultimate Showdown of Ultimate Destiny](https://osu.ppy.sh/s/140)
+- [Lazy Town - Cooking by the Book](https://osu.ppy.sh/s/235)
+- [t+pazolite feat. - Okkusenman (Hardcore Mix)](https://osu.ppy.sh/s/303)
+- [The Laziest Men on Mars - Invasion of the Gabber Robots](https://osu.ppy.sh/s/339)
+- [Erwin Beekveld - They're Taking The Hobbits To Isengard](https://osu.ppy.sh/s/455)
+- [NicoNicoDouga - Farucon Pan!](https://osu.ppy.sh/s/664)
+- [I Love Egg - Egg Song](https://osu.ppy.sh/s/812)
+- [Rick Astley - Never Gonna Give You Up 2](https://osu.ppy.sh/s/977)
+- [Caramell - Caramelldansen (Speedycake Remix)](https://osu.ppy.sh/s/1018)
+- [Hatsune Miku - Ievan Polkka](https://osu.ppy.sh/s/1287)
+- [Loituma - Ievan Polkka](https://osu.ppy.sh/s/2463)
 
 > __Note:__ Loituma - Ievan Polkka is an unranked beatmap. You can skip this beatmap if you want to.
 
-### Volume 2 (Larto/DeathxShinigami [2011])
+### Volume 2
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
-* [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
-* [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
-* [You are an Idiot!](https://osu.ppy.sh/s/1628)
-* [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
-* [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
-* [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
-* [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
-* [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
-* [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
-* [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
-* [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
-* [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
+Download:
 
-### Volume 3 (Larto/DeathxShinigami [2011])
+- None
 
-#### Download:
-* None
+Maps:
 
-#### Maps:
-* [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
-* [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
-* [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
-* [Tarou - Danjo](https://osu.ppy.sh/s/3688)
-* [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
-* [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
-* [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
-* [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
-* [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
-* [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
-* [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
-* [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
-* [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
+- [The INTERNET - At The Playground](https://osu.ppy.sh/s/203)
+- [Jakazid - Cillit Bang (Hardcore Mix)](https://osu.ppy.sh/s/917)
+- [Funtastic Power! - This is Sparta REMIX](https://osu.ppy.sh/s/1573)
+- [You are an Idiot!](https://osu.ppy.sh/s/1628)
+- [Nico Nico Douga - U.N. Owen Was Her](https://osu.ppy.sh/s/1785)
+- [Initial D - Running in the 90's](https://osu.ppy.sh/s/2103)
+- [Do a Barrel Roll!](https://osu.ppy.sh/s/2569)
+- [YTMND - The Bubb Rubb of Time](https://osu.ppy.sh/s/3196)
+- [igiulamam - What I want you to do](https://osu.ppy.sh/s/3219)
+- [My Chemical Romance - Welcome to the Black Parade](https://osu.ppy.sh/s/3545)
+- [Chiru - GOLIMAR!!](https://osu.ppy.sh/s/3621)
+- [Funta - Kao Dekai](https://osu.ppy.sh/s/4535)
+- [Coda - Longcat's Song](https://osu.ppy.sh/s/5014)
 
-### Volume 4 (DeathxShinigami [2011])
+### Volume 3
 
-#### Download:
-* None
+> Larto/DeathxShinigami (2011)
 
-#### Maps:
-* [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
-* [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
-* [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
-* [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
-* [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
-* [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
-* [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
-* [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
-* [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
-* [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
-* [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
-* [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
-* [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
+Download:
 
+- None
 
+Maps:
 
-Rhythm Game Music Pack
-----------------------
+- [NicoNicoDouga - Nice Boat.](https://osu.ppy.sh/s/1839)
+- [Verix - Drop the Dodongo](https://osu.ppy.sh/s/3337)
+- [NicoNicoDouga - Cirno de Gozaimasu!](https://osu.ppy.sh/s/3367)
+- [Tarou - Danjo](https://osu.ppy.sh/s/3688)
+- [Ashens - Silly Monkey](https://osu.ppy.sh/s/5703)
+- [Gunther - Ding Dong Song (You Touch My Tra La La)](https://osu.ppy.sh/s/5709)
+- [WalnutFaceBrand - C-O-C-A-I-N-E](https://osu.ppy.sh/s/5823)
+- [Trey Parker - Gay Fish](https://osu.ppy.sh/s/6526)
+- [Lazy Town - You Are A Pirate](https://osu.ppy.sh/s/6626)
+- [NeoNintendo - Scrub Scrub Scrub](https://osu.ppy.sh/s/7506)
+- [MrRoboto113 - I Think I'll Eat It Now](https://osu.ppy.sh/s/7507)
+- [The Gregory Brothers - Auto-Tune the News #5](https://osu.ppy.sh/s/8034)
+- [The Lonely Island - Shrooms](https://osu.ppy.sh/s/8690)
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+### Volume 4
 
-#### Download:
-* [MediaFire][media-rhythm-vol-1]
-* [osu.yas-online.net][yas-rhythm-vol-1]
+> DeathxShinigami (2011)
 
-#### Maps:
-* [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
-* [Speed Over Beethoven](https://osu.ppy.sh/s/96)
-* [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
-* [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
-* [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
-* [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
-* [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
-* [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
-* [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
-* [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
-* [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
-* [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
-* [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
+Download:
 
-### Volume 2 (Larto [2009]/DeathxShinigami [2011])
+- None
 
-#### Download:
-* [MediaFire][media-rhythm-vol-2]
-* [osu.yas-online.net][yas-rhythm-vol-2]
+Maps:
 
-#### Maps:
-* [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
-* [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
-* [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
-* [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
-* [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
-* [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
-* [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
-* [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
-* [Audition - Can Can](https://osu.ppy.sh/s/5177)
-* [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
-* [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
-* [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
-* [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
+- [TuTuWan - Wo Yao Jin Ke La](https://osu.ppy.sh/s/11443)
+- [Parry Gripp - Do You Like Waffles](https://osu.ppy.sh/s/12033)
+- [The Gregory Brothers - Auto-Tune the News #9](https://osu.ppy.sh/s/12155)
+- [ISAJI - Yaranaika](https://osu.ppy.sh/s/13885)
+- [The Midnight Beast - Tik Tok (Parody)](https://osu.ppy.sh/s/14391)
+- [Pomplamoose - Telephone](https://osu.ppy.sh/s/14579)
+- [Eric Cartman - Poker Face](https://osu.ppy.sh/s/14672)
+- [Chihara Minori - Greed's Accident](https://osu.ppy.sh/s/15157)
+- [The Lonely Island (Feat. Justin Timberlake) - Motherlover](https://osu.ppy.sh/s/15628)
+- [MPAA - Piracy - It's a Crime](https://osu.ppy.sh/s/15942)
+- [Hatsune Miku - Nico Nico Messe no Uta](https://osu.ppy.sh/s/17145)
+- [yamas03 - bloomin' octagon](https://osu.ppy.sh/s/17217)
+- [8corporation - The Ultimate Trololo Mashup](https://osu.ppy.sh/s/17724)
 
-### Volume 3 (Larto [2010]/DeathxShinigami [2011])
+## Rhythm Game Music Pack
 
-#### Download:
-* [MediaFire][media-rhythm-vol-3]
-* [osu.yas-online.net][yas-rhythm-vol-3]
+### Volume 1
 
-#### Maps:
-* [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
-* [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
-* [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
-* [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
-* [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
-* [BanYa - Phantom](https://osu.ppy.sh/s/5180)
-* [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
-* [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
-* [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
-* [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
-* [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
-* [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
-* [Crispy - The Game](https://osu.ppy.sh/s/7983)
+> LuigiHann/DeathxShinigami (2011)
 
-### Volume 4 (DeathxShinigami [2011])
+Download:
 
-#### Download:
-* [MediaFire][media-rhythm-vol-4]
-* [osu.yas-online.net][yas-rhythm-vol-4]
+- [MediaFire][media-rhythm-vol-1]
 
-#### Maps:
-* [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
-* [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
-* [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
-* [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
-* [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
-* [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
-* [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
-* [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
-* [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
-* [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
-* [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
-* [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
-* [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+Maps:
 
+- [Beautiful Day - Bride in Dream](https://osu.ppy.sh/s/74)
+- [Speed Over Beethoven](https://osu.ppy.sh/s/96)
+- [Taiko no Tatsujin - Saitama2000](https://osu.ppy.sh/s/210)
+- [Gitaroo Man - 12 - The Legendary Theme (Album Version)](https://osu.ppy.sh/s/296)
+- [Banya - Beethoven Virus](https://osu.ppy.sh/s/540)
+- [Freezepop - Get Ready To Rokk](https://osu.ppy.sh/s/564)
+- [Taiko no Tatsujin - Kare Kano Kanon](https://osu.ppy.sh/s/1078)
+- [Genbu - Ganymede](https://osu.ppy.sh/s/1201)
+- [BeForU - Love Shine](https://osu.ppy.sh/s/1300)
+- [Parappa 2 - Hair Scare](https://osu.ppy.sh/s/1317)
+- [Guitar Freaks 4th Mix & Drummania 3rd Mix - Carnival Day](https://osu.ppy.sh/s/1338)
+- [Sega - Samba de Janeiro](https://osu.ppy.sh/s/1450)
+- [Naofumi Hataya - Spaceport: Introducing Ulala!!](https://osu.ppy.sh/s/1452)
 
-Video Game Music Pack
-----------------------
+### Volume 2
 
-### Volume 1 (LuigiHann/DeathxShinigami [2011])
+> Larto (2009)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
-* [Portal - Still Alive](https://osu.ppy.sh/s/92)
-* [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
-* [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
-* [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
-* [2pm - Tetris](https://osu.ppy.sh/s/633)
-* [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
-* [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
-* [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
-* [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
-* [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
-* [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
-* [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+- [MediaFire][media-rhythm-vol-2]
 
-### Volume 2 (LuigiHann/DeathxShinigami [2011])
+Maps:
 
-##### Download:
-* None
+- [Tatsh feat. K.Nayuki - Sphere](https://osu.ppy.sh/s/1207)
+- [Taiko no Tatsujin - Kita Saitama2000](https://osu.ppy.sh/s/1567)
+- [Space Channel 5 Part 2 - Guitar Showdown (Report 2-2)](https://osu.ppy.sh/s/2534)
+- [BRANDY - The Festival of Ghost 2](https://osu.ppy.sh/s/3302)
+- [Gitaroo Man - Soft Machine](https://osu.ppy.sh/s/3435)
+- [Superbus - Radio Song](https://osu.ppy.sh/s/3499)
+- [3rd Coast - Coastal Tempo](https://osu.ppy.sh/s/4887)
+- [Money Deluxe - Funk Factory](https://osu.ppy.sh/s/5087)
+- [Audition - Can Can](https://osu.ppy.sh/s/5177)
+- [Asaki - Agnus Dei](https://osu.ppy.sh/s/5275)
+- [Scotty D - Drop The Bomb](https://osu.ppy.sh/s/5321)
+- [Dr.Flowershirts - Canon (O2 version)+](https://osu.ppy.sh/s/5349)
+- [Shoes (Missile Chewbacca) - TAP de Papapaya](https://osu.ppy.sh/s/5577)
 
-#### Maps:
-* [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
-* [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
-* [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
-* [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
-* [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
-* [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
-* [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
-* [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
-* [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
-* [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
-* [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
-* [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
-* [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+### Volume 3
 
-### Volume 3 (Seibei4211/DeathxShinigami [2011])
+> Larto (2010)/DeathxShinigami (2011)
 
-#### Download:
-* None
+Download:
 
-#### Maps:
-* [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
-* [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
-* [His World](https://osu.ppy.sh/s/2490)
-* [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
-* [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
-* [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
-* [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
-* [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
-* [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
-* [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
-* [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
-* [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
-* [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+- [MediaFire][media-rhythm-vol-3]
 
-### Volume 4 (DeathxShinigami [2011])
+Maps:
 
-#### Download:
-* None
+- [BanYa - Csikos Post](https://osu.ppy.sh/s/1206)
+- [Mutsuhiko Izumi - Jet World](https://osu.ppy.sh/s/4357)
+- [Bust a Groove - Flyin' To Your Soul](https://osu.ppy.sh/s/4617)
+- [R2beat - Kischer Marsch](https://osu.ppy.sh/s/4772)
+- [Brandy - Visual Dream](https://osu.ppy.sh/s/4954)
+- [BanYa - Phantom](https://osu.ppy.sh/s/5180)
+- [AKIRA YAMAOKA - 250bpm](https://osu.ppy.sh/s/5672)
+- [Tsunku - Ping-Pong](https://osu.ppy.sh/s/5696)
+- [DJ YOSHITAKA - Bloody Tears(IIDX EDITION)](https://osu.ppy.sh/s/6598)
+- [Jun - Silver Dream](https://osu.ppy.sh/s/7094)
+- [SMILE.dk - Butterfly](https://osu.ppy.sh/s/7237)
+- [Nien - MiNd CoNTRoL](https://osu.ppy.sh/s/7612)
+- [Crispy - The Game](https://osu.ppy.sh/s/7983)
 
-#### Maps:
-* [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
-* [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
-* [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
-* [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
-* [Exile - Indestructible](https://osu.ppy.sh/s/10104)
-* [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
-* [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
-* [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
-* [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
-* [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
-* [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
-* [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
-* [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- [MediaFire][media-rhythm-vol-4]
+
+Maps:
+
+- [Beautiful Day - Bang! Bang! Bang!](https://osu.ppy.sh/s/10842)
+- [Yamajet - Over The Ocean](https://osu.ppy.sh/s/11135)
+- [Tsunku - Space Dance](https://osu.ppy.sh/s/11488)
+- [Electronic Boutique - Miles](https://osu.ppy.sh/s/12052)
+- [YMCK - Family Dondon](https://osu.ppy.sh/s/12190)
+- [Suzaku VS Genbu - Himiko](https://osu.ppy.sh/s/12710)
+- [TERRA - Touka Renjou](https://osu.ppy.sh/s/13249)
+- [DJ YOSHITAKA - Evans](https://osu.ppy.sh/s/14572)
+- [Tsukasa - Colours of Sorrow (JAP ver)](https://osu.ppy.sh/s/14778)
+- [Seiryu - 3y3s](https://osu.ppy.sh/s/15241)
+- [ORANGE RANGE - O2 (Taiko Cut)](https://osu.ppy.sh/s/18492)
+- [Chai Found Music Workshop - Kikyoku ~Seasons of Asia~](https://osu.ppy.sh/s/19809)
+- [M2U - Memory of Beach](https://osu.ppy.sh/s/22401)
+
+## Video Game Music Pack
+
+### Volume 1
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Team Nekokan - Can't Defeat Airman](https://osu.ppy.sh/s/25)
+- [Portal - Still Alive](https://osu.ppy.sh/s/92)
+- [Rabbit Joint - Legend of Zelda](https://osu.ppy.sh/s/125)
+- [Noriyuki Iwadare - Pursuit ~ Caught](https://osu.ppy.sh/s/154)
+- [Yu Miyake, Masayuki Tanaka - Katamari on the Rocks](https://osu.ppy.sh/s/312)
+- [2pm - Tetris](https://osu.ppy.sh/s/633)
+- [Masato Nakamura - Staff Credits](https://osu.ppy.sh/s/688)
+- [Harry Gregson-Wiliams - Metal Gear Solid 2 Main Theme](https://osu.ppy.sh/s/704)
+- [Kentaro Ishizaka - Star Wolf (Brawl remix)](https://osu.ppy.sh/s/1092)
+- [The World Ends With You OST - DejaVu](https://osu.ppy.sh/s/1211)
+- [Corran - Cave Story Escape Route OC ReMix](https://osu.ppy.sh/s/1231)
+- [Nintendo - Super Mario Bros Medley](https://osu.ppy.sh/s/1281)
+- [The Black Mages - Battle Theme (Final Fantasy VI)](https://osu.ppy.sh/s/1635)
+
+### Volume 2
+
+> LuigiHann/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [IOSYS - Marisa wa Taihen na Mono wo Nusunde Ikimashita](https://osu.ppy.sh/s/243)
+- [Nintendo - Super Mario Bros. (TECHNO remix)](https://osu.ppy.sh/s/628)
+- [The Legend of Zelda - The Wind Waker - Molgera](https://osu.ppy.sh/s/1044)
+- [Nights: Journey of Dreams - Dreams Dreams (Will Version)](https://osu.ppy.sh/s/1123)
+- [Catherine Warwick - Pollyanna (I Believe In You)](https://osu.ppy.sh/s/1367)
+- [Nobuo Uematsu - Dark Saint](https://osu.ppy.sh/s/1525)
+- [Animal Crossing - DJ KK](https://osu.ppy.sh/s/1818)
+- [Trauma Center: New Blood - Opening](https://osu.ppy.sh/s/2008)
+- [The Wingless - All the World in One Girl](https://osu.ppy.sh/s/2128)
+- [Michiru Yamane/Masahiko Kimura - Bloody Tears](https://osu.ppy.sh/s/2147)
+- [Hiroshi Iuchi - Theme of Butsutekkai](https://osu.ppy.sh/s/2404)
+- [Mario Tennis 64 - Peach's Secret Court](https://osu.ppy.sh/s/2420)
+- [Hyadain - Battle with the Four Fiends](https://osu.ppy.sh/s/2619)
+
+### Volume 3
+
+> Seibei4211/DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Victims of Science - The Device Has Been Modified](https://osu.ppy.sh/s/1890)
+- [Phoenix Wright - Sugimori Masakazu - Compilation](https://osu.ppy.sh/s/2085)
+- [His World](https://osu.ppy.sh/s/2490)
+- [Trauma Center: Second Opinion - Vulnerability](https://osu.ppy.sh/s/2983)
+- [Grant Kirkhope - Weldar](https://osu.ppy.sh/s/3150)
+- [Capcom Sound Team - Thunder Tornado](https://osu.ppy.sh/s/3221)
+- [Yasunori Mitsuda - Edge of Death](https://osu.ppy.sh/s/3384)
+- [Nobuo Uematsu - FFIX Battle Theme](https://osu.ppy.sh/s/3511)
+- [Rei Kondoh - The Sun Rises](https://osu.ppy.sh/s/3613)
+- [The EX-Box Boys - Braid - Counting You Up](https://osu.ppy.sh/s/4033)
+- [Nintendo/Michiko Naruko - Ocarina of Time Medley](https://osu.ppy.sh/s/4299)
+- [Shinji Miyazaki - Gym Leader Battle](https://osu.ppy.sh/s/4305)
+- [Koji Kondo - Dire Dire Docks](https://osu.ppy.sh/s/4629)
+
+### Volume 4
+
+> DeathxShinigami (2011)
+
+Download:
+
+- None
+
+Maps:
+
+- [Megadeth - Grabbag](https://osu.ppy.sh/s/7077)
+- [David J. Franco - Scribblenauts Theme](https://osu.ppy.sh/s/9580)
+- [Yuka Tsujiyoko - Shy Guy's Toybox](https://osu.ppy.sh/s/9668)
+- [Nobuo Uematsu - Fight Against Culex](https://osu.ppy.sh/s/9854)
+- [Exile - Indestructible](https://osu.ppy.sh/s/10104)
+- [Danimal Cannon - Rockin' on Heaven's Door](https://osu.ppy.sh/s/10880)
+- [Junichi Masuda - Opening](https://osu.ppy.sh/s/13489)
+- [Zircon - Dirt Devil (OC ReMix)](https://osu.ppy.sh/s/14205)
+- [Shoji Meguro - Reach Out to the Truth (Instrumental)](https://osu.ppy.sh/s/14458)
+- [Masashi Hamauzu - Hope Given "Dance of the Dog's Howl"](https://osu.ppy.sh/s/16669)
+- [Ken Nakagawa - Cyclone](https://osu.ppy.sh/s/17373)
+- [Crush 40 - Sonic Heroes](https://osu.ppy.sh/s/21836)
+- [Anamanaguchi - Scott Pilgrim Anthem](https://osu.ppy.sh/s/23073)
 
 В цифрах
 -----------


### PR DESCRIPTION
- redo layout for Beatmap_Packs_0916 (all locales)
- remove linking to osu.yas-online.net
- clean up excessive headings
- reword the phrasing for trivia section (EN only)