### PR TITLE
Change examples in Adding_Custom_Hit_Sounds from .mp3 to .wav

### DIFF
--- a/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/de.md
+++ b/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/de.md
@@ -26,15 +26,15 @@ Der Song Ordner kann mit folgenen Schritten gefunden werden:
 Die Wahl welche Art von Ton der Hitsound sein soll
 ----------------------------------
 
-Die Namensgebung ist für **finish**, **whistle**, **clap** und **normal hit** egal.
+Die Namensgebung ist für "finish", "whistle", "clap" und "normal hit" egal.
 
-Abhängig von welcher Art von den Hitsound man haben möchte, sollte der Dateiname mit **soft**, **normal** oder **drum** beginnen.
+Abhängig von welcher Art von den Hitsound man haben möchte, sollte der Dateiname mit "soft", "normal" oder "drum" beginnen.
 
 ![Tutorial Image 1](ACH_01.png "Tutorial Image 1")
 
 ### Beispiel 1
 
-Man hat die Datei (Sagen wir mal Soft clap) **soft-hitclap**.wav genannt.
+Man hat die Datei (Sagen wir mal Soft clap) `soft-hitclap.wav` genannt.
 
 Mehrere Hitsound mit den selben Namen
 -------------------------------------
@@ -43,7 +43,7 @@ Wenn mehr Abwechslung gebraucht oder mehr Optionen für Clap und so weiter benö
 
 ### Beispiel 2
 
-Wie **normal-hitclap2**.wav oder wie **soft-hitfinish3**.wav
+Wie `normal-hitclap2.wav` oder wie `soft-hitfinish3.wav`
 
 Man sollte nicht vergessen, dass im *Timing Setup* der Hitsound auf Custom mit der jeweiligen Nummer gestellt werden muss.
 

--- a/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/de.md
+++ b/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/de.md
@@ -34,7 +34,7 @@ Abhängig von welcher Art von den Hitsound man haben möchte, sollte der Dateina
 
 ### Beispiel 1
 
-Man hat die Datei (Sagen wir mal Soft clap) **soft-hitclap**.mp3 genannt.
+Man hat die Datei (Sagen wir mal Soft clap) **soft-hitclap**.wav genannt.
 
 Mehrere Hitsound mit den selben Namen
 -------------------------------------
@@ -43,7 +43,7 @@ Wenn mehr Abwechslung gebraucht oder mehr Optionen für Clap und so weiter benö
 
 ### Beispiel 2
 
-Wie **normal-hitclap2**.mp3 oder wie **soft-hitfinish3**.mp3
+Wie **normal-hitclap2**.wav oder wie **soft-hitfinish3**.wav
 
 Man sollte nicht vergessen, dass im *Timing Setup* der Hitsound auf Custom mit der jeweiligen Nummer gestellt werden muss.
 

--- a/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/en.md
+++ b/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/en.md
@@ -29,7 +29,7 @@ You then decide if you want it to be the normal hit, clap, whistle or finish.
 
 ### Example 1
 
-So then you name the file (let's say the Soft clap) `soft-hitclap.mp3`.
+So then you name the file (let's say the Soft clap) `soft-hitclap.wav`.
 
 Multiple hit sounds with the same name
 ---------------------------------------
@@ -38,7 +38,7 @@ If you want more variety and need more options for clap and all, you just add a 
 
 ### Example 2
 
-Like `normal-hitclap2.mp3` or like `soft-hitfinish3.mp3`
+Like `normal-hitclap2.wav` or like `soft-hitfinish3.wav`
 
 Don't forget to go to the timing setup and change the hit sound choice to custom, and to the specific number
 

--- a/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/pt-br.md
+++ b/wiki/Guides/Beatmapping/Adding_Custom_Hit_Sounds/pt-br.md
@@ -29,7 +29,7 @@ Você então decide se quer que seja o normal hit, clap, whistle ou finish.
 
 ### Exemplo 1
 
-Então, você nomeia o arquivo (para, diagmos, Soft clap) `soft-hitclap.mp3`.
+Então, você nomeia o arquivo (para, diagmos, Soft clap) `soft-hitclap.wav`.
 
 Vários hitsounds com o mesmo nome
 ---------------------------------------
@@ -38,7 +38,7 @@ Se você quiser mais variedade e precisa de mais opções para aplausos e tudo m
 
 ### Exemplo 2
 
-Como `normal-hitclap2.mp3` ou `soft-hitfinish3.mp3`
+Como `normal-hitclap2.wav` ou `soft-hitfinish3.wav`
 
 Não se esqueça de ir para a configuração de tempo e alterar a escolha do hitsound para o personalizado, e para o número específico.
 


### PR DESCRIPTION
### Description

The guide recommends to use the .wav format for Hit Sounds, so the examples should also use the .wav format

### Status

Finished

### Changelog

- Change examples in Adding_Custom_Hit_Sounds from .mp3 to .wav
- Fix format in German translation to match the English version
