### PR TITLE
Typo/Grammar Fix

### DIFF
--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -583,7 +583,7 @@ This topic was discussed in an episode of [osu!talk](/wiki/osu!talk) ([osu!talk 
 
 ### Pass
 
-Pass has three meanings:
+Pass has two meanings:
 
 - the completion of a [beatmap](/wiki/beatmap) with or without the use of mods
 - the player having more than 50% health during a [break](/wiki/break)

--- a/wiki/osu!wiki_contribution_guide/en.md
+++ b/wiki/osu!wiki_contribution_guide/en.md
@@ -570,7 +570,7 @@ Otherwise, the pull request may not be accepted to the official branch!**
 
 ## Repo Sync and cleanups
 
-Two important things you must do at all costs:
+Two important things you must do at all cost:
 
 1. Updating your ``master`` branch to the latest official ``master`` commit.
 2. If the branch has merge conflicts, fix it immediately.

--- a/wiki/osu!wiki_contribution_guide/en.md
+++ b/wiki/osu!wiki_contribution_guide/en.md
@@ -570,7 +570,7 @@ Otherwise, the pull request may not be accepted to the official branch!**
 
 ## Repo Sync and cleanups
 
-Two important things you must do at all cost:
+Two important things you must do at all costs:
 
 1. Updating your ``master`` branch to the latest official ``master`` commit.
 2. If the branch has merge conflicts, fix it immediately.


### PR DESCRIPTION
### Description

Listed 'pass' as having three meanings when only having two (Glossary)
_Added an 's' to the end of 'at all cost*s*', grammatically correct_ - reverted

I don't know if these changes are needed (sorry), first time on GitHub and these very minor issues bugged me out too much.

### Status

Changes Requested (?)

### Changelog

<!-- 
Details of what was changed goes here.
Format is :
- Change 1
- Change 2
-->