### PR TITLE
[ES] Beatmaps spanish translation

### DIFF
--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -6,7 +6,7 @@ Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Sub
 
 ## Estatus de rankeo
 
-Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominators (BN)](/wiki/Beatmap_Nominators). Los mapas rankeados y aprobados afectan a las estadísticas de los usuarios cuando son jugados, a diferencia de los mapas [pendientes (pending)](#pendiente) o [abandonados (graveyarded)](#abandonado) beatmap.
+Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominators (BN)](/wiki/Beatmap_Nominators). Los mapas rankeados y aprobados afectan a las estadísticas de los usuarios cuando son jugados, a diferencia de los mapas [pendientes (pending)](#pendiente) o [abandonados (graveyarded)](#abandonado).
 
 ### Beatmaps rankeados
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -20,9 +20,9 @@ Los beatmaps aprobados (approved) vienen indicados con este icono: (![Check icon
 
 Los mapas cualificados (qualified) vienen indicados con el icono: (![Check icon](/wiki/shared/status/qualified.png)) en la pantalla de selección  de canciones. Estos beatmaps están en la última etapa del proceso de mapeo y modding. Al seleccionarlos, muestran un mensaje que avisa de que:
 
--No otorgan [PP](/wiki/pp)
+- No otorgan [PP](/wiki/pp)
 
--Todas las puntuaciones serán borradas cuando su estatus de rankeo cambie.
+- Todas las puntuaciones serán borradas cuando su estatus de rankeo cambie.
 
 Cuando un mapa es cualificado significa que cumple los criterios de rankeo y que ha sido comprobado por al menos dos nominadores. 
 
@@ -33,9 +33,9 @@ Durante esta semana, los [QATs](/wiki/QAT) podrán decidir devolver el mapa a lo
 
 Los beatmaps Loved, literalmente _amados_, vienen indicados con el icono: (![Heart icon](/wiki/shared/status/loved.png)) en la pantalla de selección de canciones. Estos mapas pueden cumplir o no los criterios de rankeo, pero han sido reconocidos por la comunidad como mapas valiosos. Al seleccionarlos, muestran un mensaje que avisa de que:
 
--No otorgan [PP](/wiki/pp)
+- No otorgan [PP](/wiki/pp)
 
--Todas sus puntuaciones serán borradas si el autor del beatmap decide editarlo.
+- Todas sus puntuaciones serán borradas si el autor del beatmap decide editarlo.
 
 El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un [sistema de votación](https://osu.ppy.sh/forum/t/549835)(en inglés). Para que un mapa alcance el estatus de Loved.
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -1,6 +1,6 @@
 # Beatmaps
 
-Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS] (/wiki/Glossary/#ds-games).Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects] situados en el espacio y el tiempo al ritmo de la música. Pueden tener, como fondo, una imagen, un vídeo o un [storyboard](/wiki/storyboard).
+Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games).Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener, como fondo, una imagen, un vídeo o un [storyboard](/wiki/storyboard).
 
 Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad.Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!
 
@@ -10,7 +10,7 @@ Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominat
 
 ### Beatmaps rankeados
 
-Los beatmaps rankeados (ranked) vienen indicados con este icono: (![Double upwards chevron icon](/wiki/shared/status/ranked.png)) en la pantalla de selección de canciones. Estos beatmaps siguen a rajatabla todos los [criterios de ranking](/wiki/ranking_criteria) para asegurar que tienen unos mínimos de calidad y jugabilidad, así como que la información que se muestra en ellos es correcta.
+Los beatmaps rankeados (ranked) vienen indicados con este icono: (![Double upwards chevron icon](/wiki/shared/status/ranked.png)) en la pantalla de selección de canciones. Estos beatmaps siguen a rajatabla todos los [criterios de rankeo](/wiki/ranking_criteria) para asegurar que tienen unos mínimos de calidad y jugabilidad, así como que la información que se muestra en ellos es correcta.
 
 ### Beatmaps aprobados
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -1,12 +1,12 @@
 # Beatmaps
 
-Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games). Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener como fondo una imagen, un vídeo o un [storyboard](/wiki/storyboard).
+Los beatmaps son los niveles a completar en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games). Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener como fondo una imagen, un vídeo o un [storyboard](/wiki/storyboard).
 
 Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad. Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!.
 
 ## Estatus de rankeo
 
-Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominators (BN)](/wiki/Beatmap_Nominators). Los mapas rankeados y aprobados afectan a las estadísticas de los usuarios cuando son jugados, a diferencia de los mapas [pendientes (pending)](#pending) o [abandonados (graveyarded)](#graveyard) beatmap.
+Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominators (BN)](/wiki/Beatmap_Nominators). Los mapas rankeados y aprobados afectan a las estadísticas de los usuarios cuando son jugados, a diferencia de los mapas [pendientes (pending)](#pendiente) o [abandonados (graveyarded)](#abandonado) beatmap.
 
 ### Beatmaps rankeados
 
@@ -43,7 +43,7 @@ Los mapas pendientes (pending) vienen indicados con el icono: (![Question mark i
 
 Los beatmaps pendientes no afectan a las estadísticas de usuario.
 
-[Los creadores](/wiki/Creators)  deben buscar [modders](/wiki/modders) de la comunidad y al menos dos [Beatmap Nominators](/wiki/Beatmap_Nominators) para que el proceso siga adelante.
+[Los creadores](/wiki/Creators) deben buscar [modders](/wiki/modders) de la comunidad y al menos dos [Beatmap Nominators](/wiki/Beatmap_Nominators) para que el proceso siga adelante.
 
 Los mapas inactivos que llevan al menos 4 semanas en el estatus pendiente son movidos al estatus de abandonado.
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -2,7 +2,7 @@
 
 Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games). Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener como fondo una imagen, un vídeo o un [storyboard](/wiki/storyboard).
 
-Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad.Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!
+Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad. Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!.
 
 ## Estatus de rankeo
 
@@ -12,32 +12,28 @@ Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominat
 
 Los beatmaps rankeados (ranked) vienen indicados con este icono: (![Double upwards chevron icon](/wiki/shared/status/ranked.png)) en la pantalla de selección de canciones. Estos beatmaps siguen a rajatabla todos los [criterios de rankeo](/wiki/ranking_criteria) para asegurar que tienen unos mínimos de calidad y jugabilidad, así como que la información que se muestra en ellos es correcta.
 
-### Beatmaps aprobados
+### Mapas calificados 
 
-Los beatmaps aprobados (approved) vienen indicados con este icono: (![Check icon](/wiki/shared/status/approved.png))  en la pantalla de selección de canciones. El estatus de aprobado es utilizado para canciones que superan los 5 minutos de longitud, que son conocidos como [marathon](/wiki/marathon). La mayoría de los mapas aprobados no tienen dificultades [fácil](/wiki/easy) ni [normal](/wiki/normal).
+Los mapas calificados (qualified) vienen indicados con el icono: (![Check icon](/wiki/shared/status/qualified.png)) en la pantalla de selección  de canciones. Estos beatmaps están en la última etapa del proceso de mapeo y modding. Al seleccionarlos, muestran un mensaje que avisa de que:
 
-### Mapas cualificados 
-
-Los mapas cualificados (qualified) vienen indicados con el icono: (![Check icon](/wiki/shared/status/qualified.png)) en la pantalla de selección  de canciones. Estos beatmaps están en la última etapa del proceso de mapeo y modding. Al seleccionarlos, muestran un mensaje que avisa de que:
-
-- No otorgan [PP](/wiki/pp)
+- No otorgan [PP](/wiki/pp).
 
 - Todas las puntuaciones serán borradas cuando su estatus de rankeo cambie.
 
-Cuando un mapa es cualificado significa que cumple los criterios de rankeo y que ha sido comprobado por al menos dos nominadores. 
+Cuando un mapa es calificado significa que cumple los criterios de rankeo y que ha sido comprobado por al menos dos Beatmap Nominators. 
 
-El estatus de cualificado dura una semana como mínimo antes de pasar a estar rankeados o aprobados de forma definitiva. 
+El estatus de calificado dura una semana como mínimo antes de pasar a estar rankeados o aprobados de forma definitiva. 
 Durante esta semana, los [QATs](/wiki/QAT) podrán decidir devolver el mapa a los estados previos si consideran que aún existen problemas a resolver. 
 
 ### Loved
 
 Los beatmaps Loved, literalmente _amados_, vienen indicados con el icono: (![Heart icon](/wiki/shared/status/loved.png)) en la pantalla de selección de canciones. Estos mapas pueden cumplir o no los criterios de rankeo, pero han sido reconocidos por la comunidad como mapas valiosos. Al seleccionarlos, muestran un mensaje que avisa de que:
 
-- No otorgan [PP](/wiki/pp)
+- No otorgan [PP](/wiki/pp).
 
 - Todas sus puntuaciones serán borradas si el autor del beatmap decide editarlo.
 
-El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un [sistema de votación](https://osu.ppy.sh/forum/t/549835)(en inglés). Para que un mapa alcance el estatus de Loved.
+El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un [sistema de votación](https://osu.ppy.sh/forum/t/549835) (en inglés). Para que un mapa alcance el estatus de Loved.
 
 ### Pendiente
 
@@ -47,7 +43,7 @@ Los mapas pendientes (pending) vienen indicados con el icono: (![Question mark i
 
 Los beatmaps pendientes no afectan a las estadísticas de usuario.
 
-[Los creadores](/wiki/Creators)  deben buscar [modders](/wiki/modders) de la comunidad y al menos dos [Nominadores](/wiki/Beatmap_Nominators) para que el proceso siga adelante.
+[Los creadores](/wiki/Creators)  deben buscar [modders](/wiki/modders) de la comunidad y al menos dos [Beatmap Nominators](/wiki/Beatmap_Nominators) para que el proceso siga adelante.
 
 Los mapas inactivos que llevan al menos 4 semanas en el estatus pendiente son movidos al estatus de abandonado.
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -1,6 +1,6 @@
 # Beatmaps
 
-Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games).Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener, como fondo, una imagen, un vídeo o un [storyboard](/wiki/storyboard).
+Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS](/wiki/Glossary/#ds-games). Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects) situados en el espacio y el tiempo al ritmo de la música. Pueden tener como fondo una imagen, un vídeo o un [storyboard](/wiki/storyboard).
 
 Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad.Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!
 
@@ -53,7 +53,7 @@ Los mapas inactivos que llevan al menos 4 semanas en el estatus pendiente son mo
 
 ### Abandonado
 
-Los mapas abandonados (Graveyarded) vienen indicados con el icono:(![Question mark icon](/wiki/shared/status/graveyard.png)) en la pantalla de selección de canciones.Son mapas pendientes que han sido movidos automáticamente porque no han sido actualizados ni se ha comentado su hilo en el foro durante las últimas 4 semanas. Estos mapas no pueden actualizarse hasta que no sean revividos por su creador.
+Los mapas abandonados (Graveyarded) vienen indicados con el icono:(![Question mark icon](/wiki/shared/status/graveyard.png)) en la pantalla de selección de canciones. Son mapas pendientes que han sido movidos automáticamente porque no han sido actualizados ni se ha comentado su hilo en el foro durante las últimas 4 semanas. Estos mapas no pueden actualizarse hasta que no sean revividos por su creador.
 
 Los mapas abandonados no afectan a las características de usuario.
 

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -1,0 +1,56 @@
+# Beatmaps
+
+Los beatmaps son los niveles a batir en [osu!](/wiki/osu!_glossary), similares a los de los [Juegos de DS] (/wiki/Glossary/#ds-games).Los beatmaps se componen de una canción y varios [hit objects](/wiki/hit_objects] situados en el espacio y el tiempo al ritmo de la música. Pueden tener, como fondo, una imagen, un vídeo o un [storyboard](/wiki/storyboard).
+
+Los beatmaps pueden subirse a la web a través del [BSS](/wiki/BSS) (Beatmap Submission System: sistema de envío de beatmaps) y son sometidos a un proceso de aprobación llamado [modding](/wiki/modding) para mantener los máximos estándares de calidad posibles en términos de jugabilidad.Puedes encontrar los beatmaps en el [buscador de mapas](https://osu.ppy.sh/beatmapsets) en la web de osu!
+
+## Estatus de rankeo
+
+Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominators (BN)](/wiki/Beatmap_Nominators). Los mapas rankeados y aprobados afectan a las estadísticas de los usuarios cuando son jugados, a diferencia de los mapas [pendientes (pending)](#pending) o [abandonados (graveyarded)](#graveyard) beatmap.
+
+### Beatmaps rankeados
+
+Los beatmaps rankeados (ranked) vienen indicados con este icono: (![Double upwards chevron icon](/wiki/shared/status/ranked.png)) en la pantalla de selección de canciones. Estos beatmaps siguen a rajatabla todos los [criterios de ranking](/wiki/ranking_criteria) para asegurar que tienen unos mínimos de calidad y jugabilidad, así como que la información que se muestra en ellos es correcta.
+
+### Beatmaps aprobados
+Los beatmaps aprobados (approved) vienen indicados con este icono: (![Check icon](/wiki/shared/status/approved.png))  en la pantalla de selección de canciones. El estatus de aprobado es utilizado para canciones que superan los 5 minutos de longitud, que son conocidos como [marathon](/wiki/marathon). La mayoría de los mapas aprobados no tienen dificultades [fácil](/wiki/easy) ni [normal](/wiki/normal).
+
+### Mapas cualificados 
+
+Los mapas cualificados (qualified) vienen indicados con el icono: (![Check icon](/wiki/shared/status/qualified.png)) en la pantalla de selección  de canciones. Estos beatmaps están en la última etapa del proceso de mapeo y modding. Al seleccionarlos, muestran un mensaje que avisa de que:
+
+-No otorgan [PP](/wiki/pp)
+-Todas las puntuaciones serán borradas cuando su estatus de rankeo cambie.
+
+Cuando un mapa es cualificado significa que cumple los criterios de rankeo y que ha sido comprobado por al menos dos nominadores. 
+
+El estatus de cualificado dura una semana como mínimo antes de pasar a estar rankeados o aprobados de forma definitiva. 
+Durante esta semana, los [QATs](/wiki/QAT) podrán decidir devolver el mapa a los estados previos si consideran que aún existen problemas a resolver. 
+
+### Loved
+
+Los beatmaps Loved, literalmente _amados_, vienen indicados con el icono: (![Heart icon](/wiki/shared/status/loved.png)) en la pantalla de selección de canciones. Estos mapas pueden cumplir o no los criterios de rankeo, pero han sido reconocidos por la comunidad como mapas valiosos. Al seleccionarlos, muestran un mensaje que avisa de que:
+
+-No otorgan PP
+-Todas sus puntuaciones serán borradas si el autor del beatmap decide editarlo.
+
+El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un [sistema de votación](https://osu.ppy.sh/forum/t/549835)(en inglés). Para que un mapa alcance el estatus de Loved.
+
+### Pendiente
+
+_Ver también: [Procedimiento de rankeo de mapas](/wiki/Beatmap_Ranking_Procedure)_
+Los mapas pendientes (pending) vienen indicados con el icono: (![Question mark icon](/wiki/shared/status/pending.png)) en la pantalla de selección de canciones. Un beatmap con el estatus pendiente es un mapa que espera ser [modeado](/wiki/modded). 
+
+Los beatmaps pendientes no afectan a las estadísticas de usuario.
+
+[Los creadores](/wiki/Creators)  deben buscar [modders](/wiki/modders) de la comunidad y al menos dos [Nominadores](/wiki/Beatmap_Nominators) para que el proceso siga adelante.
+
+Los mapas inactivos que llevan al menos 4 semanas en el estatus pendiente son movidos al estatus de abandonado.
+
+### Abandonado
+
+Los mapas abandonados (Graveyarded) vienen indicados con el icono:(![Question mark icon](/wiki/shared/status/graveyard.png)) en la pantalla de selección de canciones.Son mapas pendientes que han sido movidos automáticamente porque no han sido actualizados ni se ha comentado su hilo en el foro durante las últimas 4 semanas. Estos mapas no pueden actualizarse hasta que no sean revividos por su creador.
+
+Los mapas abandonados no afectan a las características de usuario.
+
+Con el objetivo de ahorrar espacio para nuevos beatmaps, los mapas abandonados pueden ser eliminados de la web si pasan demasiado tiempo sin ser revividos.

--- a/wiki/Beatmaps/es.md
+++ b/wiki/Beatmaps/es.md
@@ -13,6 +13,7 @@ Los mapas rankeados y aprobados requieren la aprobación de dos [Beatmap Nominat
 Los beatmaps rankeados (ranked) vienen indicados con este icono: (![Double upwards chevron icon](/wiki/shared/status/ranked.png)) en la pantalla de selección de canciones. Estos beatmaps siguen a rajatabla todos los [criterios de ranking](/wiki/ranking_criteria) para asegurar que tienen unos mínimos de calidad y jugabilidad, así como que la información que se muestra en ellos es correcta.
 
 ### Beatmaps aprobados
+
 Los beatmaps aprobados (approved) vienen indicados con este icono: (![Check icon](/wiki/shared/status/approved.png))  en la pantalla de selección de canciones. El estatus de aprobado es utilizado para canciones que superan los 5 minutos de longitud, que son conocidos como [marathon](/wiki/marathon). La mayoría de los mapas aprobados no tienen dificultades [fácil](/wiki/easy) ni [normal](/wiki/normal).
 
 ### Mapas cualificados 
@@ -20,6 +21,7 @@ Los beatmaps aprobados (approved) vienen indicados con este icono: (![Check icon
 Los mapas cualificados (qualified) vienen indicados con el icono: (![Check icon](/wiki/shared/status/qualified.png)) en la pantalla de selección  de canciones. Estos beatmaps están en la última etapa del proceso de mapeo y modding. Al seleccionarlos, muestran un mensaje que avisa de que:
 
 -No otorgan [PP](/wiki/pp)
+
 -Todas las puntuaciones serán borradas cuando su estatus de rankeo cambie.
 
 Cuando un mapa es cualificado significa que cumple los criterios de rankeo y que ha sido comprobado por al menos dos nominadores. 
@@ -31,7 +33,8 @@ Durante esta semana, los [QATs](/wiki/QAT) podrán decidir devolver el mapa a lo
 
 Los beatmaps Loved, literalmente _amados_, vienen indicados con el icono: (![Heart icon](/wiki/shared/status/loved.png)) en la pantalla de selección de canciones. Estos mapas pueden cumplir o no los criterios de rankeo, pero han sido reconocidos por la comunidad como mapas valiosos. Al seleccionarlos, muestran un mensaje que avisa de que:
 
--No otorgan PP
+-No otorgan [PP](/wiki/pp)
+
 -Todas sus puntuaciones serán borradas si el autor del beatmap decide editarlo.
 
 El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un [sistema de votación](https://osu.ppy.sh/forum/t/549835)(en inglés). Para que un mapa alcance el estatus de Loved.
@@ -39,6 +42,7 @@ El estatus de Loved proporciona un marcador de máximas puntuaciones. Existe un 
 ### Pendiente
 
 _Ver también: [Procedimiento de rankeo de mapas](/wiki/Beatmap_Ranking_Procedure)_
+
 Los mapas pendientes (pending) vienen indicados con el icono: (![Question mark icon](/wiki/shared/status/pending.png)) en la pantalla de selección de canciones. Un beatmap con el estatus pendiente es un mapa que espera ser [modeado](/wiki/modded). 
 
 Los beatmaps pendientes no afectan a las estadísticas de usuario.


### PR DESCRIPTION
### Description

Adding the translation for the "beatmaps" page,.

### Status

Pending Review

### Related Issues 

I have a lot of doubts. I simply do not feel confortable with the choices of "terminology". I looked for some extra info in other wiki pages, but there isn't much translated. The problem is: leave english terminology for every single "osu specific" term (like... "modder"), translate every single one to spanish (as in "modeador" which is not used) or pick each one individually regarding how the people actually call them(so "modder" would be good, but "modeo" too).

I chose the latter, but as I say, I don't feel confortable. I don't feel experienced enough to make a decision, so I hope reviewers can help me. I can't find help on the Styles page.
