### PR TITLE
Fix Articles with broken redirects to ASG (which was redone to ASC)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Please review the following before submitting a PR:
-osu!'s Article Styling Guide: https://osu.ppy.sh/help/wiki/Article_Style_Guide
+osu!'s Article Styling Standards: https://osu.ppy.sh/help/wiki/Article_Styling_Criteria
 -->
 
 <!-- Please remove the comments once you have formulated your Pull Request Message -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- Please review the following before submitting a PR:
-osu!'s Article Styling Standards: https://osu.ppy.sh/help/wiki/Article_Styling_Criteria
+osu!'s Article Styling Criteria: https://osu.ppy.sh/help/wiki/Article_Styling_Criteria
 -->
 
 <!-- Please remove the comments once you have formulated your Pull Request Message -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Thanks for taking the time to make the osu!wiki better!
 
 To help you get started on the right track, check out the following resources to help you get started:
 
-- The [Article Style Guide](https://osu.ppy.sh/help/wiki/Article_Style_Guide) for the styling standards in wiki.
+- The [Article Styling Criteria](https://osu.ppy.sh/help/wiki/Article_Styling_Criteria) for the styling standards in wiki.
 
 - The [Getting Started Guide](https://osu.ppy.sh/help/wiki/osu!wiki_contribution_guide) _(New to the GitHub workflow? You should read this first)_.
 

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Contributions to the osu!wiki are now done through GitHub.
 
 A basic guide to using GitHub, specifically tailored for the osu!wiki project, is available at the [osu!wiki Contribution Guide](https://osu.ppy.sh/help/wiki/osu!wiki_contribution_guide).
 
-The article style guide, which _must_ be adhered to for all new and rewritten pages going forward, is available at the [Article Style Guide](https://osu.ppy.sh/help/wiki/Article_Style_Guide).
+The article style guide, which _must_ be adhered to for all new and rewritten pages going forward, is available at the [Article Styling Criteria](https://osu.ppy.sh/help/wiki/Article_Styling_Criteria).

--- a/wiki/Article_Styling_Criteria/en.md
+++ b/wiki/Article_Styling_Criteria/en.md
@@ -2,7 +2,7 @@
 
 _See also: [Article Styling Criteria/News](/wiki/Article_Styling_Criteria/News)._
 
-The article styling criteria (ASG) serves as a enforced styling standard to keep consistency in clarity, formatting, and layout in all articles of the osu!wiki.
+The article styling criteria (ASC) serves as a enforced styling standard to keep consistency in clarity, formatting, and layout in all articles of the osu!wiki.
 
 All articles should try to aim at having proper grammar, correct spelling, and correct information. Keep in mind that reviewers will ask for changes in your pull request(s) for blunders or suggestions. A good osu!wiki writer/editor should read these reviews to help improve the overall quality of these articles to ensure an optimal experience for the reader.
 

--- a/wiki/Article_Styling_Criteria/en.md
+++ b/wiki/Article_Styling_Criteria/en.md
@@ -578,5 +578,5 @@ The term `Difficulty` refers to a specific `Beatmap` (these terms are interchang
 ---
 
 Use "beatmaps" instead of "maps".
-580	
-581	Use "creator" instead of "beatmapper" or "mapper".
+
+Use "creator" instead of "beatmapper" or "mapper".

--- a/wiki/Index/en.md
+++ b/wiki/Index/en.md
@@ -308,7 +308,7 @@ We are still working on a design for the index page, so excuse what follows. If 
 
 ## osu!wiki Contribute
 
-- [Article Style Guide](/wiki/Article_Style_Guide "Article Style Guide")
+- [Article Styling Criteria](/wiki/Article_Styling_Criteria "Article Styling Criteria")
 - [osu!wiki contribution guide](/wiki/osu!wiki_contribution_guide "osu!wiki contribution guide")
 - [How You Can Help!](/wiki/How_You_Can_Help! "How You Can Help!")
 

--- a/wiki/osu!wiki_contribution_guide/en.md
+++ b/wiki/osu!wiki_contribution_guide/en.md
@@ -835,7 +835,7 @@ With GFM, we can also use:
 
 While Markdown and GFM _does_ support a few HTML tags in GitHub, osu!wiki articles will not be using them.
 
-For further information on a styling guide when writing a page, check out [Article Styling Criteria][ASG].
+For further information on a styling guide when writing a page, check out [Article Styling Criteria][ASC].
 
 ### Why does the file I uploaded not load on the osu!wiki?
 

--- a/wiki/osu!wiki_contribution_guide/en.md
+++ b/wiki/osu!wiki_contribution_guide/en.md
@@ -1,5 +1,5 @@
 <!-- Internal -->
-[ASG]: /wiki/Article_Style_Guide "Article Style Guide"
+[ASC]: /wiki/Article_Styling_Criteria "Article Styling Criteria"
 [GitHub osu-wiki]: https://github.com/ppy/osu-wiki "osu-wiki in GitHub"
 [GH Issue]: https://github.com/ppy/osu-wiki/issues "osu-wiki Issues page"
 
@@ -53,7 +53,7 @@ If you have previous experience in using GitHub, feel free to skip this guide an
 
 For complete reference and help with using GitHub, please visit [GitHub Help][GitHub Help].
 
-For a styling guide when writing a page, check out [Article Style Guide][ASG] instead.
+For the styling guide when writing a page, check out [Article Styling Criteria][ASC] instead.
 
 If you have any questions, you can inquire at the [osu!dev Discord Server][osu!dev Discord], under ``#osu-wiki`` preferably.
 
@@ -835,7 +835,7 @@ With GFM, we can also use:
 
 While Markdown and GFM _does_ support a few HTML tags in GitHub, osu!wiki articles will not be using them.
 
-For further information on a styling guide when writing a page, check out [Article Style Guide][ASG].
+For further information on a styling guide when writing a page, check out [Article Styling Criteria][ASG].
 
 ### Why does the file I uploaded not load on the osu!wiki?
 

--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -1,9 +1,9 @@
-﻿"about":                       "About"
+"about":                       "About"
 
 "accuracy":                    "Accuracy"
 
-"article_style_guide":         "Article_Style_Guide"
-"asg":                         "Article_Style_Guide"
+"article_styling_criteria":    "Article_Styling_Criteria"
+"asc":                         "Article_Styling_Criteria"
 
 "banchobot":                   "BanchoBot"
 


### PR DESCRIPTION
### Description

Fixes broken redirects to the old ASG (which is now ASC)

### Status
**Finished**; Pending Merge.

### Changelog
- Patched ``osu!wiki_contribution_guide/en.md`` ``CONTRIBUTING.md`` ``README.md`` and ``.github/PULL_REQUEST_TEMPLATE.md`` with correct redirect.
- Remove gitdiff artifact from ASC.
