### PR TITLE
Beatmap Nominators wording update

### DIFF
--- a/wiki/People/Beatmap_Nomination_Group/en.md
+++ b/wiki/People/Beatmap_Nomination_Group/en.md
@@ -56,7 +56,7 @@ Team Members
 
 _Please note: All BNs speak English unless otherwise noted._ Link to [user group page](https://osu.ppy.sh/g/28).
 
-Also note: the game modes columns listed denotes which game mode(s) the user would focus more at, but are not forcibly subject to that game mode(s).
+Also note: the game modes columns listed below indicates the game mode(s) in which each Beatmap Nominator is formally qualified to nominate. 
 
 | Name                                              | osu!         | osu!taiko    | osu!catch    | osu!mania    | Additional Languages     |
 |---------------------------------------------------|:------------:|:------------:|:------------:|:------------:|--------------------------|


### PR DESCRIPTION
### Description

the description of "focused on one mode  but not restrained to others" is no longer true, as they must be **formally qualified** to nominate other mode maps.

### Status

finished

### Changelog

yeah
