### PR TITLE
osu(ff): fix pixelLength type

### DIFF
--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -230,7 +230,7 @@ A slider also creates droplets in Catch the Beat, yellow drumrolls in Taiko, and
 
 *repeat (Integer)* is the number of times a player will go over the slider. A value of 1 will not repeat, 2 will repeat once, 3 twice, and so on.
 
-*pixelLength (Float)* is the length of the slider along the path of the described curve. If the length is greater than that of the described curve, the slider will continue in a straight line.
+*pixelLength (Double)* is the length of the slider along the path of the described curve. If the length is greater than that of the described curve, the slider will continue in a straight line.
 
 *edgeHitsounds (hitSound|...)* is a `|`-separated list of hitSounds to apply to the circles of the slider. The values are the same as those for Hit Circle hitSounds.
 


### PR DESCRIPTION
## Description

see title (osu (file format): fix `pixelLength` type)

## Status

Done, anyone else here to double check? ¯\_(ツ)_/¯

## Changelog

~~Modernize from row 233, column 15 to row 233, column 20 to speak `Double`, no more flimsy `Float`, for `pixelLength`. Thus adding an extra column to row 233, totaling 194 columns from previous 193 columns from this point on at 9:30a (UTC-5) until further pull requesting.~~

~~tl;dr~~ changed `Float` to `Double` in line 233

## Related Issues

resolves #789
