### PR TITLE
Skinning (again⁶)

### DIFF
--- a/wiki/Skinning/Tutorial/en.md
+++ b/wiki/Skinning/Tutorial/en.md
@@ -4,6 +4,17 @@
 
 The Skinning Tutorial articles are to serve as a general how to on skinning.
 
+## Related articles
+
+- [Skinning](/wiki/Skinning)
+- [Skinning/Tutorial/skin.ini](/wiki/Skinning/Tutorial/skin.ini)
+- [Skinning/Tutorial/Interface](/wiki/Skinning/Tutorial/Interface)
+- [Skinning/Tutorial/osu!standard](/wiki/Skinning/Tutorial/osu!)
+- [Skinning/Tutorial/osu!taiko](/wiki/Skinning/Tutorial/osu!taiko)
+- [Skinning/Tutorial/osu!catch](/wiki/Skinning/Tutorial/osu!catch)
+- [Skinning/Tutorial/osu!mania](/wiki/Skinning/Tutorial/osu!mania)
+- [Skinning/Tutorial/Sounds](/wiki/Skinning/Tutorial/Sounds)
+
 ## Skinning FAQ
 
 ### What format should the images be in?

--- a/wiki/Skinning/Tutorial/en.md
+++ b/wiki/Skinning/Tutorial/en.md
@@ -1,105 +1,125 @@
 # Skinning Tutorial
 
+*Main page: [Skinning](/wiki/Skinning).*
+
 The Skinning Tutorial articles are to serve as a general how to on skinning.
 
 ## Skinning FAQ
 
+### What format should the images be in?
+
+Images should **always** be in the `.png` format. `menu-background.jpg` is the expection, this one can use `.jpg`.
+
+In addition to using the `.png` format, you should:
+
+- **Trim or crop** your images whenever possible. The osu!client will render every pixel of an image which will result in a bigger workload!
+- **Compress** images whenever possible. Compressing usually removes unnecessary info about blank pixels and reduces the file sizes dramatically.
+- Understand that certain elements **face a certain direction.** Some elements have a standard as to which direction they must face to face the correct direction when the osu!client uses it.
+
+### What are overlays?
+
+Overlays will *overlay* an element's image **and will not be colored or tinted**. Note that only a few elements contains an overlay.
+
+### Resolutions
+
+Because _osu!_ can be played at different resolutions, some skinning elements may overlap or be farther apart than what is expected. Meaning that not elements will scale themselves to fit the game window resolution.
+
+It is best to keep the following resolutions in mind while skinning.
+
+- 1024 x 768 (4:3, standard game resolution, the game is based on it)
+- 2048 x 1536 (4:3, standard game resolution in HD scaling)
+- 1366 x 768 (16:9, standard game widescreen resolution)
+- 2732 x 1536 (16:9, standard game widescreen resolution in HD scaling)
+- 1920 x 1080 (16:9, standard HD resolution)
+
+Images will be adjusted by the game itself to fit resolutions derivating from the ones mentioned above. Most of them will be rescaled to fit the playfield or repositioned on different aspect ratios.
+
+#### HD Sprites
+
+HD sprites are used in place of the normal sprites on higher resolutions, when present. Compared to normal sprites, HD sprites look much sharper and cleaner on these larger resolutions. They get scaled by the game itself automatically to fit the resolution used. Resolutions supporting HD sprites begin at a **minimum of 800 pixel in height**. HD sprites are tagged with `@2x` at the end of their names. For example: `cursor@2x.png`.
+
+HD sprites have doubled dimension sizes. For example: the normal `hitcircle.png` sprite has the dimension sizes of **128x128 pixels.** Where its HD sprite, `hitcircle@2x.png`, has the dimension sizes of **256x256 pixels.**
+
+Every sprite has an HD counterpart, even all frames in an animation can have HD counterparts. As a result, the filesize of the folder or archive will increase due to having more images than normal.
+
+All HD sprites may also be bigger in filesize due to the fact that the canvas size used is four times bigger compared to the normal sprite. There are essentially two resolution modes _osu!_ is using. Each of them prefers one set of sprites. The first mode is **LowResolution** while the second mode is **HighResolution.**
+
+- *LowResolution mode* uses the normal sprites and ignores the HD sprites **(SD-resolution skin)**
+- *HighResolution mode* prefers HD sprites and uses normal sprites as a fallback if no HD sprite is available **(HD-resolution skin)**
+
 ### Can someone make this skin from that show/game?
 
-If you have gone through the entire osu!skinning forums and you are certain that you cannot find _that_ skin, then congrats, osu! doesn't have it yet.
-With this in mind, you can take this initiative to create the skin you dream of and make it something that everyone else may want! 
+If you have gone through the entire osu!skinning forums and you are certain that you cannot find _that_ skin, then congrats, osu! doesn't have it yet. With this in mind, you can take this initiative to create the skin you dream of and make it something that everyone else may want! 
 
-Nonetheless, please, **never** request for a skin anywhere in the osu!fourms.
-Failing to follow this rule will your thread be moved to the wastelands.
+Nonetheless, please, **never** request for a skin anywhere in the osu!forums. Failing to follow this rule will your thread be moved to the wastelands.
 
 ### Where can I get this skin that a YouTuber/streamer played with?
 
-First off, don't go asking this in the osu!forums, your thread will most likely be thrown into the wastelands.
-Secondly, your best bet is to simply ask that person for the skin they're using.
+First off, don't go asking this in the osu!forums, your thread will most likely be thrown into the wastelands. Secondly, your best bet is to simply ask that person for the skin they're using.
 
 ### I want to make a skin! But what do I need?
 
-Well nice choice, but remember, skinning can be little hard for a newbie.
-In the beginning of making any skin, you should have:
+Well nice choice, but remember, skinning can be little hard for a newbie. In the beginning of making any skin, you should have:
 
-- beginner skills with any photo editing program (that supports transparency) like Photoshop, GIMP, Paint.NET, etc.
-- patience (yes, skinning does take some time)
-- an idea! (yes, this is **very** important. Try be clever when making your skin)
+- Beginner skills with any photo editing program (that supports transparency) like Photoshop, GIMP, Paint.NET, etc.
+- Patience (yes, skinning does take some time)
+- An idea! (yes, this is **very** important. Try be clever when making your skin!)
 
 ### What the "new" and "old" style skinning about?
 
-This question may also be known as, "What's skin version 1.0 and 2.0+?".
+*This question may also be known as, "What's skin version 1.0 and 2.0+?".*
 
-The new and old style skinning was an option in the osu!client.
-It was, however, removed because the skin.ini now handles the skin versioning.
+The new and old style skinning was an option in the osu!client. It was, however, removed because the skin.ini now handles the skin versioning.
 
-Old style skinning, now known as "version 1.0", is a style that was used by old default skin (before March 2013).
-After the "March 2013 update", also known as "version 2.0", peppy introduced the new default skin with its new behaviours and parts.
-There were few important changes like new spinner, countdown, hitbursts, ranking-panel behaviour.
-For a changelog of skinning updates, see [Skinning](../).
+Old style skinning, now known as "version 1.0", is a style that was used by old default skin (before March 2013). After the "March 2013 update", also known as "version 2.0", peppy introduced the new default skin with its new behaviours and parts. There were few important changes like new spinner, countdown, hitbursts, ranking-panel behaviour. For a changelog of skinning updates, see [Skinning](/wiki/skin.ini/#versions).
 
-It may not seem important to denote which version you use but know that some older features may not be available in the latest version of skinning.
+It may not seem important to denote which version you use, but know that some older features may not be available in the latest version of skinning and vise versa.
 
 ### What is skinning? Do I need some magical powers to skin?
 
 Luckily, you don't need magical powers to skin.
 
-Skinning is a simple picture changing mechanism that osu! will load upon selecting a skin in the options.
-Creating skins is easy (but creating elements, the images, is a little more difficult thing to achieve).
+Skinning is a simple picture changing mechanism that osu! will load upon selecting a skin in the options. Creating skins is easy (but creating elements, the images, is a little more difficult thing to achieve).
 
-First you need to find your `Skins` folder which is inside your osu! directory.
-From here, you could either make a new folder and call it whatever you want then start making the skin.
-(You could, instead, install the template skin, rename it, and start editing it.)
+First you need to find your `Skins` folder which is inside your osu! directory. From here, you could either make a new folder and call it whatever you want then start making the skin. (You could, instead, install the template skin, rename it, and start editing it.)
 
-You should note that osu! has over 200 skinable elements (not counting the individual animation frames).
-Don’t be scared with the amount because, remember, **you are not forced to change everything**.
+You should note that osu! has over 200 skinable elements (not counting the individual animation frames). Don’t be scared with the amount because, remember, **you are not forced to change everything**.
 
 ### What should my skinning folder contain?
 
-Generally, the skinning elements and the skin.ini file are important parts of your skin and should be included.
-Which parts you are going to add it’s completely up to you because anything you don't change, the default element will be used instead.
+Generally, the skinning elements and the skin.ini file are important parts of your skin and should be included. Which parts you are going to add it’s completely up to you because anything you don't change, the default element will be used instead.
 
-You are able to add different folders with alternative parts into your skin.
-osu! won’t care if they are there or not.
-Do note, however, the subfolder called `taiko` (name is case-insensitive) is reserved for osu!taiko skins, which will override all of the osu!taiko elements (and some interface elements when playing an osu!taiko map).
+You are able to add different folders with alternative parts into your skin. *osu!* won’t care if they are there or not. Do note, however, the subfolder called `taiko` (name is case-insensitive) is reserved for osu!taiko skins, which will override all of the osu!taiko elements (and some interface elements when playing an osu!taiko map).
 
 ### Can I use a skinned element from someone else's skin?
 
 **Never post a skin with another user's skinning element(s) without permission!**
 
-This is an important rule of skinning.
-If you got permission, or user is no longer active and it’s impossible to contact with them, just remember to credit them properly.
+This is an important rule of skinning. If you got permission, or user is no longer active and it’s impossible to contact with them, just remember to credit them properly.
 
 ### What about a skin mashup?
 
-You _could_ do that, but&mdash;even if you do get permission&mdash;please don't share those in the osu! skinning subforums.
-Please **keep those to yourself** or post it on your profile page.
-This will help skinners make their original skins stand out than the remixed/mashup-ed skins.
+You _could_ do that, but&mdash;even if you do get permission&mdash;please don't share those in the osu! skinning subforums. Please **keep those to yourself** or post it on your profile page. This will help skinners make their original skins stand out than the remixed/mashup-ed skins.
 
 ### How do I animate an element?
 
-Know that osu! allows you to animate some elements, but not all of them.
-To create an animation for an animatable element, you will need the frames for that animation frame by frame.
-With those, name them in order prefixed with the skinning element name then suffix with a hyphen (`-`), an index number (start the count at zero), then the file extension (`.png`).
+Know that osu! allows you to animate some elements, but not all of them. To create an animation for an animatable element, you will need the frames for that animation frame by frame. With those, name them in order prefixed with the skinning element name then suffix with a hyphen (`-`), an index number (start the count at zero), then the file extension (`.png`).
 
-Most of the animatable skinning elements do not limit you to the amount of frames.
-However, know that the animation rate could play the animation too slowly before the user would be able to see them.
-To find the balance between the animation rate and the frames, you'll need to do trail-and-error (see next section below for more details).
+Most of the animatable skinning elements do not limit you to the amount of frames. However, know that the animation rate could play the animation too slowly before the user would be able to see them. To find the balance between the animation rate and the frames, you'll need to do trail-and-error (see next section below for more details).
 
 Lastly, while most do, not all skinning elements use the hyphen then number system for animating a skinning element.
 For example:
 
-- `sliderb` has its frames named: sliderb0, sliderb1, sliderb2, etc.
-- `pippidonclear` has its frames named: pippidonclear0, pippidonclear1, pippidonclear2, etc.
+- `sliderb` has its frames named: `sliderb0`, `sliderb1`, `sliderb2`, etc.
+- `pippidonclear` has its frames named: `pippidonclear0`, `pippidonclear1`, `pippidonclear2`, etc.
 
 ### My animation is playing too fast/slow, how do I fix it?
 
 If your animation is too fast/slow, you have two ways to fix it
 
 1. if it is playing too fast, try to make them longer by doubling frames (or half, if too slow)
-   - i.e. frame 0 and 1 are the same picture (so picture will last 2 frames), frame 2 and 3 are second picture, etc.
-   - this will make animation slightly slower (or slightly faster);
-     however the animation rate is still the same, this means that even if you slowed/sped-up one down, another's animation rate may still be too fast/slow
+   - e.g. frame 0 and 1 are the same picture (so picture will last 2 frames), frame 2 and 3 are second picture, etc.
+   - this will make animation slightly slower (or slightly faster); however the animation rate is still the same, this means that even if you slowed/sped-up one down, another's animation rate may still be too fast/slow
 2. use the `AnimationFramerate` command in the skin.ini
    - this command affects all animations expect for a few, like pippidon or the hitcircleoverlay
 
@@ -122,11 +142,13 @@ Those are the three basic categories for skins:
 
 ### What is the skin.ini for and what does it do?
 
-The skin.ini file allows you to define specific behaviors on how osu! will display your skin.
+*See also: [skin.ini](/wiki/skin.ini).*
+
+The `skin.ini` file allows you to define specific behaviors on how osu! will display your skin.
 The list includes but isn't limited to:
 
 - name of a skin that show up in osu!
-- the creator's name (fourm name is prefered)
+- the creator's name (forum name is prefered)
 - skin version (what behavior should osu! use, not your skin's verisoning number)
 - colours
 - osu!mania key, note, and stage behaviors
@@ -134,10 +156,9 @@ The list includes but isn't limited to:
 
 ### How do I share?
 
-To make sharing your skin easy, you should export your skin as an `OSK` file.
-With this file, you can upload it then post about it in the skinning subfourms.
+To make sharing your skin easy, you should export your skin as an `.osk` file. With this file, you can upload it then post about it in the skinning subforums.
 
-Here is how to make an `OSK` file with osu!
+Here is how to make an `.osk` file with osu!
 
 1. Open to osu!
 2. Click on `Options`
@@ -161,24 +182,24 @@ R15 skins may include but are not limited to:
 
 ### Can I post R18 skins in the osu!skinning subforums?
 
-**You are _NOT_ allowed to post skins that contains any R18 content anywhere in osu!. Period.**
+**You are _never_ allowed to post skins that contains any R18 content anywhere in osu!. Period.**
 
 If you post your R18 skin anywhere in the osu!community, be aware that you will be punished for that.
 On the other hand, if you release it outside the osu!community walls, nobody will hunt you down.
 
 
-## Posting your skin in the osu! skinning subforums
+## Posting your skin in the osu!skinning subforums
 
 Of course, this is the _optional_ last step to skinning!
 
 1. Delete all non-skinned parts
    - there is no need to include them because this will make your folder larger than it should be
    - and that osu! will have to load more images than it would have to if it used its defaults anyways
-2. Next, create the `OSK` file (follow steps from above) and upload it somewhere
+2. Next, create the `.osk` file (follow steps from above) and upload it somewhere
    - Most people prefer a direct download, so you can use upppy! or puush
    - Mediafire is fine too (but of course, you aren't limited to the ones listed)
 
-### Skinning Thread Template
+### Skinning thread template
 
 If you don't know how to make friendly looking thread you can use this template by Dragvon (modified).
 

--- a/wiki/Skinning/Tutorial/en.md
+++ b/wiki/Skinning/Tutorial/en.md
@@ -19,7 +19,7 @@ The Skinning Tutorial articles are to serve as a general how to on skinning.
 
 ### What format should the images be in?
 
-Images should **always** be in the `.png` format. `menu-background.jpg` is the expection, this one can use `.jpg`.
+Images **must** use the `.png` format. However, the `menu-background.jpg` element can use either `.jpg` or `.png`.
 
 In addition to using the `.png` format, you should:
 
@@ -33,7 +33,7 @@ Overlays will *overlay* an element's image **and will not be colored or tinted**
 
 ### Resolutions
 
-Because _osu!_ can be played at different resolutions, some skinning elements may overlap or be farther apart than what is expected. Meaning that not elements will scale themselves to fit the game window resolution.
+Since _osu!_ can be played using different window resolutions, some skinning elements may overlap or be placed farther apart than what would be expected otherwise. This means that not elements will scale themselves to fit the game window resolution.
 
 It is best to keep the following resolutions in mind while skinning.
 
@@ -47,7 +47,7 @@ Images will be adjusted by the game itself to fit resolutions derivating from th
 
 #### HD Sprites
 
-HD sprites are used in place of the normal sprites on higher resolutions, when present. Compared to normal sprites, HD sprites look much sharper and cleaner on these larger resolutions. They get scaled by the game itself automatically to fit the resolution used. Resolutions supporting HD sprites begin at a **minimum of 800 pixel in height**. HD sprites are tagged with `@2x` at the end of their names. For example: `cursor@2x.png`.
+HD sprites are used in place of the normal sprites on higher resolutions, when present. Compared to normal sprites, HD sprites look much sharper and cleaner on these larger resolutions. They get scaled by the game itself automatically to fit the resolution used. Resolutions supporting HD sprites begin at a **minimum of 800 pixels in height**. HD sprites are tagged with `@2x` at the end of their names. For example: `cursor@2x.png`.
 
 HD sprites have doubled dimension sizes. For example: the normal `hitcircle.png` sprite has the dimension sizes of **128x128 pixels.** Where its HD sprite, `hitcircle@2x.png`, has the dimension sizes of **256x256 pixels.**
 
@@ -64,19 +64,19 @@ If you have gone through the entire osu!skinning forums and you are certain that
 
 Nonetheless, please, **never** request for a skin anywhere in the osu!forums. Failing to follow this rule will your thread be moved to the wastelands.
 
-### Where can I get this skin that a YouTuber/streamer played with?
+### Where can I get this skin that I saw someone play with?
 
-First off, don't go asking this in the osu!forums, your thread will most likely be thrown into the wastelands. Secondly, your best bet is to simply ask that person for the skin they're using.
+First off, don't ask this in the osu!forums. Otherwise, your thread will most likely be thrown into the wastelands. Secondly, your better off asking that person for the skin they're using.
 
 ### I want to make a skin! But what do I need?
 
-Well nice choice, but remember, skinning can be little hard for a newbie. In the beginning of making any skin, you should have:
+Nice choice, but remember, skinning can be little hard for newbies. At the beginning of making a skin, you should have:
 
 - Beginner skills with any photo editing program (that supports transparency) like Photoshop, GIMP, Paint.NET, etc.
 - Patience (yes, skinning does take some time)
-- An idea! (yes, this is **very** important. Try be clever when making your skin!)
+- An idea! (yes, this is **very** important. Try to be clever when making your skin!)
 
-### What the "new" and "old" style skinning about?
+### What is the "new" and "old" style skinning about?
 
 *This question may also be known as, "What's skin version 1.0 and 2.0+?".*
 
@@ -110,7 +110,7 @@ This is an important rule of skinning. If you got permission, or user is no long
 
 ### What about a skin mashup?
 
-You _could_ do that, but&mdash;even if you do get permission&mdash;please don't share those in the osu! skinning subforums. Please **keep those to yourself** or post it on your profile page. This will help skinners make their original skins stand out than the remixed/mashup-ed skins.
+You _could_ do that, but (even if you do get permission) please don't share those in the osu! skinning subforums. Please **keep those to yourself** and/or post it on your profile page. This will help skinners make their original skins stand out than the remixed/mashup-ed skins.
 
 ### How do I animate an element?
 
@@ -118,8 +118,7 @@ Know that osu! allows you to animate some elements, but not all of them. To crea
 
 Most of the animatable skinning elements do not limit you to the amount of frames. However, know that the animation rate could play the animation too slowly before the user would be able to see them. To find the balance between the animation rate and the frames, you'll need to do trail-and-error (see next section below for more details).
 
-Lastly, while most do, not all skinning elements use the hyphen then number system for animating a skinning element.
-For example:
+Lastly, while most do, not all skinning elements use the hyphen then number system for animating a skinning element. For example:
 
 - `sliderb` has its frames named: `sliderb0`, `sliderb1`, `sliderb2`, etc.
 - `pippidonclear` has its frames named: `pippidonclear0`, `pippidonclear1`, `pippidonclear2`, etc.
@@ -128,11 +127,11 @@ For example:
 
 If your animation is too fast/slow, you have two ways to fix it
 
-1. if it is playing too fast, try to make them longer by doubling frames (or half, if too slow)
+1. If it is playing too fast, try to make them longer by doubling frames (or halve them, if it is too slow)
    - e.g. frame 0 and 1 are the same picture (so picture will last 2 frames), frame 2 and 3 are second picture, etc.
-   - this will make animation slightly slower (or slightly faster); however the animation rate is still the same, this means that even if you slowed/sped-up one down, another's animation rate may still be too fast/slow
-2. use the `AnimationFramerate` command in the skin.ini
-   - this command affects all animations expect for a few, like pippidon or the hitcircleoverlay
+   - This will make animation slightly slower (or slightly faster); however the animation rate is still the same, this means that even if you slowed/sped-up one down, another's animation rate may still be too fast/slow.
+2. Use the `AnimationFramerate` command in the `skin.ini`.
+   - This command affects all animations expect for a few, like `pippidon` or the `hitcircleoverlay`.
 
 ### What are "normal", "simplified", and "PRO" skins?
 
@@ -165,7 +164,7 @@ The list includes but isn't limited to:
 - osu!mania key, note, and stage behaviors
 - osu!mania image names and paths
 
-### How do I share?
+### How do I share my skin?
 
 To make sharing your skin easy, you should export your skin as an `.osk` file. With this file, you can upload it then post about it in the skinning subforums.
 
@@ -203,16 +202,16 @@ On the other hand, if you release it outside the osu!community walls, nobody wil
 
 Of course, this is the _optional_ last step to skinning!
 
-1. Delete all non-skinned parts
-   - there is no need to include them because this will make your folder larger than it should be
-   - and that osu! will have to load more images than it would have to if it used its defaults anyways
-2. Next, create the `.osk` file (follow steps from above) and upload it somewhere
-   - Most people prefer a direct download, so you can use upppy! or puush
-   - Mediafire is fine too (but of course, you aren't limited to the ones listed)
+1. Delete all non-skinned parts.
+   - There is no need to include them because this will make your folder larger than it should be.
+   - Tnd that osu! will have to load more images than it would have to if it used its defaults anyways.
+2. Next, create the `.osk` file (follow steps from above) and upload it somewhere.
+   - Most people prefer a direct download, so you can use upppy! or puush.
+   - Mediafire is fine too (but of course, you aren't limited to this either).
 
 ### Skinning thread template
 
-If you don't know how to make friendly looking thread you can use this template by Dragvon (modified).
+If you don't know how to make friendly looking thread you can use this template.
 
 ```
 [General]
@@ -236,6 +235,4 @@ If you don't know how to make friendly looking thread you can use this template 
 [b]Requests[/b]: Since no one is perfect, you can use this to request help to your skin :)
 ```
 
-It is really important to include various screenshots of gameplay and the song selection, etc..
-A lot of people will want to see your skin looks like before carelessly downloading it!
-You can use upppy or puush to upload them.
+It is really important to include various screenshots of gameplay and the song selection, etc. A lot of people will want to see your skin looks like before carelessly downloading it! You can use upppy or puush to upload them.

--- a/wiki/Skinning/Tutorial/skin.ini/en.md
+++ b/wiki/Skinning/Tutorial/skin.ini/en.md
@@ -1,0 +1,53 @@
+# skin.ini
+
+*Main page: [Skinning/Tutorial](/wiki/Skinning/Tutorial).*
+
+*See also: [skin.ini](/wiki/skin.ini).*
+
+### But, what is "skin.ini"?
+
+`skin.ini` is a file that all skins could have. It is a text file that allows you to adjust various things (e.g. combo colours).
+
+## Okay, how do I adjust it?
+
+To being, let's start with a some of the basics. First, in your skin folder, create a text file and name it to `skin.ini`. Make sure to remove the `.txt` extension. Open it and paste the following text into that file. After this, all you have to do now is to fill in each of the items.
+
+```
+Name: The skin name.
+Author: Your username, so that everyone knows who created this skin.
+Version: By default, this would be automatically 1.0 if you don't type anything in here. But you should, there are some newer versions, see https://osu.ppy.sh/wiki/Skinning/skin.ini/#versions
+AllowSliderBallTint: If you want the slider ball to have the same colour as the current combo colour, type 1 here! If you don't want this, type 0.
+CursorRotate: If you want that your cursor rotates, type 1 in here! If you don't want this, type 0.
+CursorExpand: If you want that your cursor gets bigger when you click, type 1 in here! If you don't want this, type 0.
+
+[Colours]
+
+Combo1: Type a value (RGB) for the last combo colour in here.
+Combo2: Type a value (RGB) for the first combo colour in here.
+Combo3: Type a value (RGB) for the second combo colour in here.
+Combo4: Type a value (RGB) for the third combo colour in here.
+SliderBorder: Type a value (RGB) for the slider border in here.
+SliderTrackOverride: Type a value (RGB) for the slider track in here.
+
+[Fonts]
+
+HitCirclePrefix: Because it's for the default numbers, you type default in here.
+HitCircleOverlap: It decides how many pixels the two-digit numbers are far away from each other.
+ScorePrefix: Because it's for the score numbers, you type score in here.
+ScoreOverlap: It decides how many pixels the multi-digit numbers are far away from each other.
+ComboPrefix: Because it's for the combo numbers, you can type score in here. If you have elements for the combo (eg. combo-7.png), use combo then.
+ComboOverlap: It decides how many pixels the multi-digit numbers are far away from each other.
+```
+
+## Tips
+
+- `0` as value means no and `1` means yes in the most cases.
+- The words in the square brackets are really important, do not forget them!
+- Whitespace between commands and values is optional.
+- Make sure you everything is spelt correctly!
+- If you make a change in the `skin.ini` file, you must reload your skin by pressing the keyboard shortcut `Ctrl` + `Alt` + `Shift` + `S` in the osu!client.
+- For more commands and information, see [skin.ini](/wiki/skin.ini).
+
+## Trivia
+
+- Original forum post by [Lyawi](https://osu.ppy.sh/users/5851253): [Guide: How to adjust my skin.ini?](https://osu.ppy.sh/community/forums/topics/575880)

--- a/wiki/Skinning/en.md
+++ b/wiki/Skinning/en.md
@@ -1,99 +1,25 @@
 # Skinning
 
-Skinning is one of the fundamentals of all _osu!_ game modes.
-It enables users to derive from the original skinning elements to create their own!
+*See also: [Skinning Tutorial](/wiki/Skinning/Tutorial).*
 
-Over the years of _osu!_, skinning has changed dramatically in style.
-There are various ways that you can skin _osu!_
+Skinning is one of the fundamentals of all _osu!_ game modes. It enables users to derive from the original skinning elements to create their own!
 
-Skins vary from for-fun to a central theme (e.g. anime or group of people) to those that are nigh impossible to play with (e.g. oversized hitbursts, invisible followpoints, ).
-Another type of skin are _pro_ skins, where they maximize play field visibility and minimize visual obtrusions (e.g. replacing hitbursts with blank images).
+Over the years of _osu!_, skinning has changed dramatically in style. There are various ways that you can skin _osu!_
 
-## Tutorial
+Skins vary from for-fun to a central theme (e.g. anime or group of people) to those that are nigh impossible to play with (e.g. oversized hitbursts, invisible followpoints). Another type of skin are _pro_ skins, where they maximize play field visibility and minimize visual obtrusions (e.g. replacing hitbursts with blank images).
 
-_See [Skinning Tutorial](/wiki/Skinning/Tutorial/)._
+## Skinning sets
 
-## Skinning Sets
+*See also: [Ranking Criteria/Skin Set List](/wiki/Ranking_Criteria/Skin_Set_List/).*
 
-If your **beatmap** uses a skin and has any of the elements included in here, all elements of the set **should be included** even if you need to use default skin elements to complete it.
-If **all** sets are included, then you may alternatively just force default skin.
+If your skin contains a single element from the listed sets in the Ranking Criteria, it must contain all of the other elements in said skinning set.
 
-The **individual sets** can be found on these pages **divided into each game mode**.
-The user interface and the sounds shared by most game modes:
+## Related articles
 
-- [Interface Sets](Interface/)
-- [osu!standard Sets](osu!/)
-- [osu!taiko Sets](osu!taiko/)
-- [osu!catch Sets](osu!catch/)
-- [osu!mania Sets](osu!mania/)
-- [Sound Sets](Sounds/)
-
-## General Skinning Tips
-
-1. Images should **always** be in the `.png` format.
-   - `menu-background.jpg` is the expection, this one can use `.jpg`.
-
-2. **Trim or crop** your images whenever possible.
-   - The osu!client will render every pixel of an image which will result in a bigger workload!
-
-3. **Compress** images whenever possible.
-   - Compressing usually removes unnecessary info about blank pixels and reduces the file sizes dramatically.
-
-4. Certain elements **face a certain direction.**
-   - Some elements have a standard as to which direction they must face to face the correct direction when the osu!client uses it.
-
-### Overlays
-
-- Overlays will *overlay* an element's image **and will not be colored or tinted**.
-
-### Resolutions
-
-Note that _osu!_ can be played at different resolutions.
-Because of this, some skinning elements may overlap or be farther apart than what is expected.
-
-It is best to keep the following resolutions in mind while skinning.
-
-- 1024 x 768 (4:3, standard game resolution, the game is based on it)
-- 2048 x 1536 (4:3, standard game resolution in HD scaling)
-- 1366 x 768 (16:9, standard game widescreen resolution)
-- 2732 x 1536 (16:9, standard game widescreen resolution in HD scaling)
-- 1920 x 1080 (16:9, standard HD resolution)
-
-Images will be adjusted by the game itself to fit resolutions derivating from the ones mentioned above.
-Most of them will be rescaled to fit the playfield or repositioned on different aspect ratios.
-
-#### HD Sprites
-
-HD sprites are used in place of the normal sprites on higher resolutions, when present.
-Compared to normal sprites, HD sprites look much sharper and cleaner on these larger resolutions.
-They get scaled by the game itself automatically to fit the resolution used.
-Resolutions supporting HD sprites begin at a **minimum of 800 pixel in height**.
-HD sprites are tagged with `@2x` at the end of their names.
-
-- Example: cursor`@2x`.png
-
-HD sprites have doubled dimension sizes.
-
-- Example: the normal `hitcircle.png` sprite has the dimension sizes of **128x128 pixels.**
-  - Its HD sprite, `hitcircle@2x.png`, has the dimension sizes of **256x256 pixels.**
-
-Every sprite has an HD counterpart, even all frames in an animation can have HD counterparts.
-As a result, the filesize of the folder or archive will increase due to having more images than normal.
-
-All HD sprites may also be bigger in filesize due to the fact that the canvas size used is four times bigger compared to the normal sprite.
-There are essentially two resolution modes _osu!_ is using.
-Each of them prefers one set of sprites.
-The first mode is **LowResolution** while the second mode is **HighResolution.**
-
-- *LowResolution mode* uses the normal sprites and ignores the HD sprites **(SD-resolution skin)**
-- *HighResolution mode* prefers HD sprites and uses normal sprites as a fallback if no HD sprite is available **(HD-resolution skin)**
-
-### osu!supporter
-
-Currently, only 2 sprites and 2 sounds can only be modified if the user is an [osu!supporter](/wiki/osu!supporter/); otherwise, the default one will be used.
-Those skinning elements are as follows:
-
-- `menu-background.jpg`
-- `welcome_text.png`
-- `seeya.wav`
-- `welcome.wav`
+- [skin.ini](/wiki/skin.ini)
+- [Interface](/wiki/Skinning/Interface)
+- [osu!standard](/wiki/Skinning/osu!)
+- [osu!taiko](/wiki/Skinning/osu!taiko)
+- [osu!catch](/wiki/Skinning/osu!catch)
+- [osu!mania](/wiki/Skinning/osu!mania)
+- [Sounds](/wiki/Skinning/Sounds)

--- a/wiki/Skinning/en.md
+++ b/wiki/Skinning/en.md
@@ -16,10 +16,11 @@ If your skin contains a single element from the listed sets in the Ranking Crite
 
 ## Related articles
 
-- [skin.ini](/wiki/skin.ini)
-- [Interface](/wiki/Skinning/Interface)
-- [osu!standard](/wiki/Skinning/osu!)
-- [osu!taiko](/wiki/Skinning/osu!taiko)
-- [osu!catch](/wiki/Skinning/osu!catch)
-- [osu!mania](/wiki/Skinning/osu!mania)
-- [Sounds](/wiki/Skinning/Sounds)
+- [Skinning/Tutorial](/wiki/Skinning/Tutorial)
+- [Skinning/skin.ini](/wiki/skin.ini)
+- [Skinning/Interface](/wiki/Skinning/Interface)
+- [Skinning/osu!standard](/wiki/Skinning/osu!)
+- [Skinning/osu!taiko](/wiki/Skinning/osu!taiko)
+- [Skinning/osu!catch](/wiki/Skinning/osu!catch)
+- [Skinning/osu!mania](/wiki/Skinning/osu!mania)
+- [Skinning/Sounds](/wiki/Skinning/Sounds)

--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -1,5 +1,7 @@
 # skin.ini
 
+*See also: [skin.ini/Blank](/wiki/Skinning/skin.ini/Blank).*
+
 The `skin.ini` is an initialization file that is found in almost every skin folder.
 This file will define how _osu!_ will display certain skin elements.
 
@@ -16,148 +18,90 @@ The version number, seen in the headings, is what will be used in the `Version` 
 
 If your `skin.ini` does not specify a `Version`, it will default to this version.
 
-- hitcircle numbers are part of hitburst explosions
-- large expansion of hitlighting (`lighting.png`)
-- old styled spinner (`spinner-circle.png`, `spinner-background.png`, and `spinner-metre.png`)
-- segmented countdown image build-up
-- smaller selection bar images (87px height max)
-- uncolored play-warningarrow during end of breaks
-- version exclusive ranking screen buttons (`ranking-replay.png` and `ranking-retry.png`)
-- version exclusive sliderpoints display (`sliderpoint10.png` and `sliderpoint30.png`)
+- Hitcircle numbers are part of hitburst explosions.
+- Large expansion of hitlighting (`lighting.png`).
+- Old styled spinner (`spinner-circle.png`, `spinner-background.png`, and `spinner-metre.png`).
+- Segmented countdown image build-up.
+- Smaller selection bar images (87px height max).
+- Uncolored play-warningarrow during end of breaks.
+- Version exclusive ranking screen buttons (`ranking-replay.png` and `ranking-retry.png`).
+- Version exclusive sliderpoints display (`sliderpoint10.png` and `sliderpoint30.png`).
 
 ### 2.0
 
 **UI: positioning changes / osu!: visibility update (reduced clutter).**
 
-- high definition skins
-  - use the suffix `@2x.png` in the skinning element to let osu! know that the skinning element is higher in quality
-- new style spinner (`spinner-middle.png`, `spinner-middle2.png`, `spinner-top.png`, `spinner-bottom.png`, and `spinner-glow.png`)
-- countdown sequence instead of segmented image
-  - countdowns are now centered
-- hitcircle numbers are no longer part of hitburst explosions
-- red colored play-warningarrow during end of breaks
-- smaller expansion of `lighting.png`
-- anchor changes of selectionbar images
-- positioning changes of ranking screen images (generally, it is shifted down)
+- High definition skins.
+  - Use the suffix `@2x.png` in the skinning element to let osu! know that the skinning element is higher in quality.
+- New style spinner (`spinner-middle.png`, `spinner-middle2.png`, `spinner-top.png`, `spinner-bottom.png`, and `spinner-glow.png`).
+- Countdown sequence instead of segmented image.
+  - Countdowns are now centered.
+- Hitcircle numbers are no longer part of hitburst explosions.
+- Red colored play-warningarrow during end of breaks.
+- Smaller expansion of `lighting.png`.
+- Anchor changes of selectionbar images.
+- Positioning changes of ranking screen images (generally, it is shifted down).
 
 ### 2.1
 
 **osu!taiko positioning changes**
 
-- `taiko-bar-right.png` and `taiko-bar-right-glow.png` directly sits under `taiko-bar-left.png`
-- taiko drum postion changes (allows larger areas)
+- `taiko-bar-right.png` and `taiko-bar-right-glow.png` directly sits under `taiko-bar-left.png`.
+- Taiko drum postion changes (allows larger areas).
 
 ### 2.2
 
 **interface/UI changes**
 
-- thumbnail support
-- changes star rating display to scaling `star.png` instead of partially widthed `star.png`
-- panel text alignment optimisations
+- Thumbnail support.
+  - Must be enabled by the user in the [Options](/wiki/Options) and be supported by the skin in the [skin.ini](/wiki/skin.ini) file.
+- Changes star rating display to scaling `star.png` instead of partially widthed `star.png`.
+- Panel text alignment optimisations.
 
 ### 2.3
 
 **osu!catch changes**
 
-- `fruit-ryuuta.png` will no longer work from this point forward
-- new catcher images
-- new osu!catch specific combobursts (`comboburst-fruits.png`)
-  - osu!standard combobursts will no longer be used for osu!catch
+- `fruit-ryuuta.png` will no longer work from this point forward.
+- New catcher states (and images).
+- New osu!catch specific combobursts (`comboburst-fruits.png`).
+  - osu!standard combobursts will no longer be used for osu!catch.
 
 ### 2.4
 
 **osu!mania stage scaling adjustments**
 
-- downscale combo counter and hitbursts
-- column lines are drawn on both sides of the column when columns are spaced
-- introduction of hold note tails on release (works for all versions)
+- Downscale combo counter and hitbursts.
+- Column lines are drawn on both sides of the column when columns are spaced.
+- Introduction of hold note tails on release (works for all versions).
 
 ### 2.5
 
 **osu!mania column and upscroll adjustments**
 
-- new commands: `KeyFlipWhenUpsideDown` and `NoteFlipWhenUpsideDown`
-- new command: `NoteBodyStyle` (stretch, cascade from top, cascade from bottom)
-- new commands: `LightingNWidth` and `LightingLWidth`
+- New commands:
+  - `KeyFlipWhenUpsideDown` and `NoteFlipWhenUpsideDown`
+  - `NoteBodyStyle` (stretch, cascade from top, cascade from bottom)
+  - `LightingNWidth` and `LightingLWidth`
 
 ### latest
 
-**always the newest version**
+**Always the newest version**
 
 If your skin folder does not contain a `skin.ini` file, it will default to this version.
 
-- So not use this when trying to distribute skins! (a new skin version could break the skin for what version it was entended for)
-- always uses the latest version the game supports
+- **Never** use this when trying to distribute skins! (a new skin version could break the skin for what version it was entended for).
+- Always uses the latest version the game supports.
 
 ### User
 
-**not a version, but always force [latest](#latest)**
+**Not a version, but always force [latest](#latest)**
 
-- So not use this method when distribute skins!
+- **Never** use this method when distribute skins!
 - The skin folder **must** be named `User`.
 - Use this method if you only want to change a few things (e.g. cursor or numbers, etc).
 - Does not require the `skin.ini` file.
 - This folder will always force `Version: latest`
-
-## FAQ
-
-### Blank
-
-See this [blank](Blank) for a blank copy of the `skin.ini` file.
-
-### Commenting
-
-*tl;dr use `//`*
-
-To add comments (notes for people to read or code that osu! will ignore), use `//`.
-For example:
-
-```
-// Like in .osu and .osb files, single-line comments are OK, like this one!
-```
-
-### 1's and 0's
-
-*tl;dr `0 = no` and `1 = yes`*
-
-Some commands only accept a boolean value (a `true` or a `false` value).
-When skinning, osu! is setup to only recognize a `1` (one) as a `true` while a `0` (zero) as `false`.
-
-Here is a classic example:
-
-| `SliderBallFlip: 0`        | `SliderBallFlip: 1`        |
-|:--------------------------:|:--------------------------:|
-| ![](Sliderball_flip-0.gif) | ![](Sliderball_flip-1.gif) |
-
-Note that Reisen, the sliderball, does **not** flip when `0` is used.
-However, Reisen does flip when a `1` is used.
-
-### Numbers and Integers
-
-The tables below may list either a *number*, an *integer* or a *positive integer*.
-
-When viewing these tables:
-
-- *number* means a **whole** or **decimal** number (e.g. `1.5`, `4.295`, `2`, `3.0`).
-- *integer* means **whole** numbers only (e.g. `-13`, `-632`, `135` , `9`).
-  - *positive integer* means **positive whole** numbers only (e.g. `376`, `22`, or `5`).
-- *comma-split list with positive integers* is-- literally-- a list of positive integers splited with commas (e.g. `1, 2, 3, 55`).
-
-### RGB and RGB(a)
-
-A few commands may ask for a colour in the _RGB_ or _RGB(a)_ format.
-
-- For RGB, the format looks like this `R, G, B` where `R` is red, `G` is green, and `B` is blue.
-  - Most commands will only accept _RGB_, without the alpha.
-    If you specify an alpha value here, osu! will ignore it.
-- For RGB(a), the format looks like this `R, G, B, a`, in addition to above, `a` means alpha (opacity).
-  - A few commands accept _RGB(a)_, with the alpha.
-    If you don't specify an alpha value, 255 (opaque/not transparent) will be used.
-
-### Sections
-
-osu! organizes the commands with a heading command. Which may look like this `[General]`.
-osu! only uses five sections throughout the skin.ini file, which are indicated with the section headers below.
 
 ## \[General\]
 
@@ -284,7 +228,7 @@ osu! only uses five sections throughout the skin.ini file, which are indicated w
 
 ## \[Colours\]
 
-**Notice**: this header **must** be spelled as **`[Colours]`**, not `[Colors]`!
+*Note: this header **must** be spelled as **`[Colours]`**, not `[Colors]`!*
 
 - `Combo1:`
   - Question: What colour is used for the last combo?
@@ -464,7 +408,7 @@ osu! only uses five sections throughout the skin.ini file, which are indicated w
   - not using enough and the missing values will use default values.
 - **Each keycount *must* start a new section**, it should look like this (but with actual commands):
 
-```ini
+```
 ...
 
 [Mania]
@@ -498,7 +442,7 @@ Keys: 5
     - `16`
     - `18`
   - Notes:
-    - This is **_required_** per key set
+    - This is ***required*** per key set
 - `ColumnStart:`
   - Question: Where does the left column start?
   - Value: _number_

--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -103,6 +103,48 @@ If your skin folder does not contain a `skin.ini` file, it will default to this 
 - Does not require the `skin.ini` file.
 - This folder will always force `Version: latest`
 
+## Notes
+
+Before viewing the `skin.ini` commands below, here are some notes.
+
+### 1's and 0's
+
+*tl;dr `0 = no` and `1 = yes`*
+
+Some commands only accept a boolean value (a `true` or a `false` value). When skinning, *osu!* is setup to only recognize a `1` (one) as `true` while a `0` (zero) as `false`.
+
+Here is a classic example:
+
+| `SliderBallFlip: 0`        | `SliderBallFlip: 1`        |
+|:--------------------------:|:--------------------------:|
+| ![](Sliderball_flip-0.gif) | ![](Sliderball_flip-1.gif) |
+
+Note that Reisen, the sliderball, does **not** flip when `0` is used. However, Reisen does flip when a `1` is used. Depending on what spite is used, you will either get a moonwalking sliderball, or one that turns around.
+
+### Numbers and Integers
+
+The tables below may list either a *number*, an *integer* or a *positive integer*.
+
+When viewing these tables:
+
+- *number* means a **whole** or **decimal** number (e.g. `1.5`, `4.295`, `2`, `3.0`).
+- *integer* means **whole** numbers only (e.g. `-13`, `-632`, `135` , `9`).
+  - *positive integer* means **positive whole** numbers only (e.g. `376`, `22`, or `5`).
+- *comma-split list with positive integers* is-- literally-- a list of positive integers splited with commas (e.g. `1, 2, 3, 55`).
+
+### RGB and RGB(a)
+
+A few commands may ask for a colour in the _RGB_ or _RGB(a)_ format.
+
+- For RGB, the format looks like this `R, G, B` where `R` is red, `G` is green, and `B` is blue.
+  - Most commands will only accept _RGB_, without the alpha. If you specify an alpha value here, osu! will ignore it.
+- For RGB(a), the format looks like this `R, G, B, a`, in addition to above, `a` means alpha (opacity).
+  - A few commands accept _RGB(a)_, with the alpha. If you don't specify an alpha value, 255 (opaque/not transparent) will be used.
+
+### Sections
+
+*osu!* organizes the commands with a heading command. Which may look like this `[General]`. *osu!* only uses five sections throughout the skin.ini file, which are indicated with the section headers below.
+
 ## \[General\]
 
 - `Name:`


### PR DESCRIPTION
## Description

`Skinning` and `Skinning/Tutorial` and `Skinning/skin.ini` and `Skinning/Tutorial/skin.ini`

## Status

~~Pending Review~~ Done

## Changelog

- Skinning: rip out some FAQ things here and move to Tutorial
  - and add subpage articles
  - and undo single lines and use paragraphs
- Skinning/Tutorial: paste ripped parts here
  - and format it
  - and main page link back to skinning
  - and use paragraph instead of single lines
- Skinning: add related links
-  Skinning/Tutorial: add related links
- skin.ini: many fixes (see description)
  - full stops and sentence case the versioning changes for bullet points
  - replace "So not" with "\*\*Never\*\*"
  - remove FAQ, to be moved to Skinning/Tutorial/skin.ini
- skin.ini: put back FAQ but call it Notes
  - just realized that it is most talking about the tables below
- Skinning/Tutorial/skin.ini: port the guide over
  - this one <https://osu.ppy.sh/community/forums/topics/575880>

## Related

#387 