### PR TITLE
.osu file format: expand the hit objects section

### DIFF
--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -201,9 +201,9 @@ This section is made of CSV lines. The first 5 fields are common to every hit ob
 
 To map these coordinates for a standard 640x480 screen, you need to add 64 pixels to *x* and 48 pixels to *y* to respect a uniform padding. Without the padding, an object at (0, 0) will be cut on the top left for the screen.
 
-For some hit objects, like spinners or notes in osu!taiko, the position is completely irrelevant.
+For some hit objects, like spinners, the position is completely irrelevant.
 
-For osu!mania, only *x* is relevant.
+For osu!mania, only *x* is relevant. See the osu!mania hold note section below.
 
 #### Time
 
@@ -369,12 +369,14 @@ A hold note unique to osu!mania.
 
 **Example**: `329,192,16504,128,0,16620:0:0:0:0:`
 
-*x* (Integer) determines which column a note will fall on. The value does not have to be precise. *y* is ignored.
+*x* (Integer) determines which column a note will fall on. *y* is ignored.
 
-TODO: Range of *x*?
+The number of column is defined by the *CircleSize* property in the Difficulty section. Columns are indexed from 0.
 
-TODO: Define *x* more precisely.
+The column for a note is computed with `x / column width` with `column width = 512 / number of columns`. The resulting value is floored, then clamped between 0 and (#column - 1) for safety.
 
-TODO: Default value for *y*?
+To avoid rounding errors, *x* is best picked in the middle of the range for its column. For example, in 4K mode, the first column ranges from 0 to 128, so the safest value for x is 64.
+
+For the 7K + 1 mode, the column index is `1 + x / (512 / 7)`, leaving the column 0 for the specials.
 
 *endTime* (Integer) is the time when the key should be released, in milliseconds from the beginning of the song.

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -191,31 +191,23 @@ Hit Objects
 
 ### Common structure
 
-This section is made of CSV lines. The first 5 fields are common to every hit
-objects, and an optional last *addition* fields.
+This section is made of CSV lines. The first 5 fields are common to every hit objects, and an optional last *addition* fields.
 
 **Syntax**: `x,y,time,type,hitSound...,addition`
 
 #### Position
 
-*x* and *y* are integers representing the position of the center of the hit
-object. *x* ranges from 0 to 512 pixels, inclusive, and *y* ranges from 0 to
-384 pixels, inclusive. The origin, (0, 0) is at the top left of the screen.
+*x* and *y* are integers representing the position of the center of the hit object. *x* ranges from 0 to 512 pixels, inclusive, and *y* ranges from 0 to 384 pixels, inclusive. The origin, (0, 0) is at the top left of the screen.
 
-To map these coordinates for a standard 640x480 screen, you need to add 64
-pixels to *x* and 48 pixels to *y* to respect a uniform padding. Without the
-padding, an object at (0, 0) will be cut on the top left for the screen.
+To map these coordinates for a standard 640x480 screen, you need to add 64 pixels to *x* and 48 pixels to *y* to respect a uniform padding. Without the padding, an object at (0, 0) will be cut on the top left for the screen.
 
-Hit objects whose position is irrelevant, like spinners in osu! or any note in
-osu!taiko, have the special position (256,192), which is the center of the
-screen.
+Hit objects whose position is irrelevant, like spinners in osu! or any note in osu!taiko, have the special position (256,192), which is the center of the screen.
 
 TODO: What about osu!mania?
 
 #### Time
 
-*time* is an integral number of milliseconds from the beginning of the song,
-and specifies when the hit begins.
+*time* is an integral number of milliseconds from the beginning of the song, and specifies when the hit begins.
 
 #### Type
 
@@ -225,16 +217,12 @@ and specifies when the hit begins.
 - Bit 1 (2): slider.
 - Bit 2 (4): new combo.
 - Bit 3 (8): spinner.
-- Bits 4-6 (16, 32, 64) form a 3-bit number (0-7) that chooses how many combo
-  colors to skip. Note that 0 means 1 color is skipped anyway by the new combo
-  field. A skip value of 1 therefore skips 2 colors.
+- Bits 4-6 (16, 32, 64) form a 3-bit number (0-7) that chooses how many combo colors to skip. Note that 0 means 1 color is skipped anyway by the new combo field. A skip value of 1 therefore skips 2 colors.
 - Bit 7 (128) is for an osu!mania hold note.
 
-Circles, sliders, spinners, and hold notes can be OR'd with new combos and the
-combo skip value, but not with each other.
+Circles, sliders, spinners, and hold notes can be OR'd with new combos and the combo skip value, but not with each other.
 
-Unconfirmed: a non-zero combo skip value is ignored when the new combo bit is
-not set.
+Unconfirmed: a non-zero combo skip value is ignored when the new combo bit is not set.
 
 Examples:
 
@@ -244,8 +232,7 @@ Examples:
 
 #### Hit sounds
 
-*hitSound* (Integer) is a bitmap of hit sounds to play when the hit object is
-successfully hit.
+*hitSound* (Integer) is a bitmap of hit sounds to play when the hit object is successfully hit.
 
 - Unconfirmed: Bit 0 (1): hitnormal.
 - Bit 1 (2): hitwhistle.
@@ -260,17 +247,13 @@ Unconfirmed: Multiple sounds will overlap if multiple bits are set.
 
 #### Addition
 
-The *addition* field is optional and define extra parameters related to the hit
-sound samples. It defaults to `0:0:0:0:`.
+The *addition* field is optional and define extra parameters related to the hit sound samples. It defaults to `0:0:0:0:`.
 
-Unconfirmed: This field is deprecated. You may omit it entirely, or write
-`0:0:0:0:` instead.
+Unconfirmed: This field is deprecated. You may omit it entirely, or write `0:0:0:0:` instead.
 
 **Syntax**: `sampleSet:additions:customIndex:sampleVolume:filename`
 
-*sampleSet* (Integer) changes the sample set of the normal hit sound, and
-*additions* (Integer) changes the sample set for the other hit sounds (whistle,
-finish, clap). The values for these are:
+*sampleSet* (Integer) changes the sample set of the normal hit sound, and *additions* (Integer) changes the sample set for the other hit sounds (whistle, finish, clap). The values for these are:
 
 - 0: Auto. In that case, you need to use the sample set information from the timing point.
 - 1: Normal.
@@ -279,16 +262,13 @@ finish, clap). The values for these are:
 
 *customIndex* (Integer) is the custom sample set index, e.g. 3 in `soft-hitnormal3.wav`.
 
-Unconfirmed: The special index 1 doesn't appear in the filename. For example:
-`normal-hitfinish.wav`.
+Unconfirmed: The special index 1 doesn't appear in the filename. For example `normal-hitfinish.wav`.
 
-Unconfirmed: The special index 0 means you need to get the sample index from
-the timing point.
+Unconfirmed: The special index 0 means you need to get the sample index from the timing point.
 
 *sampleVolume* (Integer) is the volume of the sample, and ranges from 0-100 (percent).
 
-*filename* (String) names an audio file in the folder to play instead of sounds
-from sample sets, relative to the beatmap's directory.
+*filename* (String) names an audio file in the folder to play instead of sounds from sample sets, relative to the beatmap's directory.
 
 Unconfirmed: A comma in the *filename* may break everything.
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -189,6 +189,111 @@ Combo# (Integer List) is a list of three numbers, each from 0 - 255 defining an 
 Hit Objects
 -----------
 
+### Common structure
+
+This section is made of CSV lines. The first 5 fields are common to every hit
+objects, and an optional last *addition* fields.
+
+**Syntax**: `x,y,time,type,hitSound...,addition`
+
+#### Position
+
+*x* and *y* are integers representing the position of the center of the hit
+object. *x* ranges from 0 to 512 pixels, inclusive, and *y* ranges from 0 to
+384 pixels, inclusive. The origin, (0, 0) is at the top left of the screen.
+
+To map these coordinates for a standard 640x480 screen, you need to add 64
+pixels to *x* and 48 pixels to *y* to respect a uniform padding. Without the
+padding, an object at (0, 0) will be cut on the top left for the screen.
+
+Hit objects whose position is irrelevant, like spinners in osu! or any note in
+osu!taiko, have the special position (256,192), which is the center of the
+screen.
+
+TODO: What about osu!mania?
+
+#### Time
+
+*time* is an integral number of milliseconds from the beginning of the song,
+and specifies when the hit begins.
+
+#### Type
+
+*type* is a bitmap specifying the object type and attributes.
+
+- Bit 0 (1): circle.
+- Bit 1 (2): slider.
+- Bit 2 (4): new combo.
+- Bit 3 (8): spinner.
+- Bits 4-6 (16, 32, 64) form a 3-bit number (0-7) that chooses how many combo
+  colors to skip. Note that 0 means 1 color is skipped anyway by the new combo
+  field. A skip value of 1 thefore skips 2 colors.
+- Bit 7 (128) is for an osu!mania hold note.
+
+Circles, sliders, spinners, and hold notes can be OR'd with new combos and the
+combo skip value, but not with each other.
+
+Unconfirmed: a non-zero combo skip value is ignored when the new combo bit is
+not set.
+
+Examples:
+
+- `1`: circle.
+- `5 = 1 + 4`: circle starting a new combo.
+- `22 = 16 + 4 + 2`: slider starting a new combo, skipping 2 colors.
+
+#### Hit sounds
+
+*hitSound* (Integer) is a bitmap of hit sounds to play when the hit object is
+successfully hit.
+
+- Unconfirmed: Bit 0 (1): hitnormal.
+- Bit 1 (2): hitwhistle.
+- Bit 2 (4): hitfinish.
+- Bit 3 (8): hitclap.
+
+Unconfirmed: The special value 0 is the same as 1 (hitnormal).
+
+Unconfirmed: If bit 0 is not set, the normal sound is not played.
+
+Unconfirmed: Multiple sounds will overlap if multiple bits are set.
+
+#### Addition
+
+The *addition* field is optional and define extra parameters related to the hit
+sound samples. It defaults to `0:0:0:0:`.
+
+Unconfirmed: This field is deprecated. You may omit it entirely, or write
+`0:0:0:0:` instead.
+
+**Syntax**: `sampleSet:additions:customIndex:sampleVolume:filename`
+
+*sampleSet* (Integer) changes the sample set of the normal hit sound, and
+*additions* (Integer) changes the sample set for the other hit sounds (whistle,
+finish, clap). The values for these are:
+
+- 0: Auto. In that case, you need to use the sample set information from the timing point.
+- 1: Normal.
+- 2: Soft.
+- 3: Drum.
+
+*customIndex* (Integer) is the custom sample set index, e.g. 3 in `soft-hitnormal3.wav`.
+
+Unconfirmed: The special index 1 doesn't appear in the filename. For example:
+`normal-hitfinish.wav`.
+
+Unconfirmed: The special index 0 means you need to get the sample index from
+the timing point.
+
+*sampleVolume* (Integer) is the volume of the sample, and ranges from 0-100 (percent).
+
+*filename* (String) names an audio file in the folder to play instead of sounds
+from sample sets, relative to the beatmap's directory.
+
+Unconfirmed: A comma in the *filename* may break everything.
+
+### Objects
+
 **Hit Circle Syntax:**
 
 `x,y,time,type,hitSound,addition`
@@ -196,26 +301,6 @@ Hit Objects
 `164,260,2434,1,0,0:0:0:0:`
 
 A hit circle is a single hit in all osu! game modes.
-
-*x (Integer)* ranges from 0 to 512 (inclusive) and *y (Integer)* ranges from 0 to 384 (inclusive).
-
-*time (Integer)* is in milliseconds from the beginning of the song.
-
-*type (Integer)* is a bitmap for the hitobject type:
-
-Bit 0 (1) = circle, bit 1 (2) = slider, bit 2 (4) = new combo, bit 3 (8) = spinner. Bits 4-6 (16, 32, 64) form a 3-bit number (0-7) that chooses how many combo colors to skip. Bit 7 (128) is for an osu!mania hold note. Circles, sliders, and spinners can be OR'd with new combos and the combo skip value, but not with each other.
-
-`1` - circle, `5` - circle starting a new combo, `22` - slider starting a new combo, skipping 2 colors.
-
-*hitSound (Integer)* is a bitmap of hitsounds to play on top of the normal hitsound:
-
-Bit 1 (2) = hitwhistle, bit 2 (4) = hitfinish, bit 3 (8) = hitclap.
-
-*addition (sampleSet:additions:customIndex:sampleVolume:filename)* is optional and defines the samplesets of the hitobject. It defaults to "0:0:0:0:". *sampleSet (Integer)* changes the sampleset of the object, and *addition (Integer)* changes the sampleset for additions (whistle, finish, clap). The values for these are:
-
-0 = Auto, 1 = Normal, 2 = Soft, 3 = Drum
-
-*customIndex (Integer)* is the custom sampleset index, e.g. 3 for `normal-3.wav`. *sampleVolume (Integer)* is the volume of the sample, 0-100 (percent). *filename (String)* names an audio file in the folder to play instead of sounds from samplesets.
 
 **Slider Syntax:**
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -201,9 +201,7 @@ This section is made of CSV lines. The first 5 fields are common to every hit ob
 
 To map these coordinates for a standard 640x480 screen, you need to add 64 pixels to *x* and 48 pixels to *y* to respect a uniform padding. Without the padding, an object at (0, 0) will be cut on the top left for the screen.
 
-Hit objects whose position is irrelevant, like spinners in osu! or any note in osu!taiko, have the special position (256,192), which is the center of the screen.
-
-TODO: What about osu!mania?
+Hit objects whose position is irrelevant, like spinners in osu! or any note in osu!taiko, have the special position (256,192), which is the center of the screen. For osu!mania, only *x* is relevant.
 
 #### Time
 
@@ -234,16 +232,24 @@ Examples:
 
 *hitSound* (Integer) is a bitmap of hit sounds to play when the hit object is successfully hit.
 
-- Unconfirmed: Bit 0 (1): hitnormal.
-- Bit 1 (2): hitwhistle.
-- Bit 2 (4): hitfinish.
-- Bit 3 (8): hitclap.
+- Unconfirmed: Bit 0 (1): normal.
+- Bit 1 (2): whistle.
+- Bit 2 (4): finish.
+- Bit 3 (8): clap.
 
 Unconfirmed: The special value 0 is the same as 1 (hitnormal).
 
 Unconfirmed: If bit 0 is not set, the normal sound is not played.
 
 Unconfirmed: Multiple sounds will overlap if multiple bits are set.
+
+The sample set and custom index are usually specified in the timing point associated to the hit object, but may be customized in the *addition* field.
+
+The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, where:
+
+- *sample set* is normal, soft, or drum.
+- *sound* is normal, whistle, finish, or clap.
+- *index* is the custom index. It is omitted when equal to 0 or 1.
 
 #### Addition
 
@@ -266,7 +272,7 @@ Unconfirmed: The special index 1 doesn't appear in the filename. For example `no
 
 Unconfirmed: The special index 0 means you need to get the sample index from the timing point.
 
-*sampleVolume* (Integer) is the volume of the sample, and ranges from 0-100 (percent).
+*sampleVolume* (Integer) is the volume of the sample, and ranges from 0 to 100 (percent).
 
 *filename* (String) names an audio file in the folder to play instead of sounds from sample sets, relative to the beatmap's directory.
 
@@ -274,11 +280,11 @@ Unconfirmed: A comma in the *filename* may break everything.
 
 ### Hit Circles
 
+A hit circle is a single hit in all osu! game modes.
+
 **Syntax**: `x,y,time,type,hitSound,addition`
 
 **Example**: `164,260,2434,1,0,0:0:0:0:`
-
-A hit circle is a single hit in all osu! game modes.
 
 ### Sliders
 
@@ -361,13 +367,13 @@ Hit sounds play at the end of the spinner.
 
 ### osu!mania Hold Notes
 
+A hold note unique to osu!mania.
+
 **Syntax**: `x,y,time,type,hitSound,endTime:addition`
 
 **Example**: `329,192,16504,128,0,16620:0:0:0:0:`
 
-A hold note unique to osu!mania.
-
-*x* (Integer) determines which column/key a note will fall on. The value does not have to be precise. *y* is ignored.
+*x* (Integer) determines which column a note will fall on. The value does not have to be precise. *y* is ignored.
 
 TODO: Range of *x*?
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -255,7 +255,11 @@ The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, wher
 - *sound* is normal, whistle, finish, or clap.
 - *index* is the custom index. It is omitted when equal to 0 or 1.
 
-Unconfirmed: When the sample file cannot be found, it falls back on the corresponding sample without the sample index.
+The loader searches for the sample file in one these directories, by order of priority:
+
+1. Inside the beatmap directory with its index, *unless* the custom index 0.
+2. Inside the skin directory, without the index.
+3. Inside the default osu! resources, without the index.
 
 #### Extras
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -234,14 +234,12 @@ Examples:
 
 *hitSound* (Integer) is a bitmap of hit sounds to play when the hit object is successfully hit.
 
-- Unconfirmed: Bit 0 (1): normal.
+- Bit 0 (1): normal.
 - Bit 1 (2): whistle.
 - Bit 2 (4): finish.
 - Bit 3 (8): clap.
 
-Unconfirmed: The special value 0 is the same as 1 (hitnormal).
-
-Unconfirmed: If bit 0 is not set, the normal sound is not played.
+The normal sound is always played, so bit 0 is irrelevant today. The only exception is for osu!mania, with the skin's *LayeredHitSounds* property.
 
 Multiple sounds will overlap if multiple bits are set.
 
@@ -276,7 +274,7 @@ The *extras* field is optional and define additional parameters related to the h
 
 When *sampleSet* is 0, its value is inherited from the timing point.
 
-Unconfirmed: When *additionSet* is 0, it takes the value of *sampleSet*.
+Today, *additionSet* inherits from *sampleSet*. Otherwise, it inherits from the timing point.
 
 *customIndex* (Integer) is the custom sample set index, e.g. 3 in `soft-hitnormal3.wav`. The special index 1 doesn't appear in the filename, for example `normal-hitfinish.wav`. The special index 0 means it is inherited from the timing point.
 
@@ -349,7 +347,7 @@ The duration you will get is in the same unit as *BeatDuration*, usually millise
 
 *edgeAdditions (sampleSet:additionSet|...)* is a `|`-separated list of samples sets to apply to the circles of the slider. The list contains exactly *repeat + 1* elements. *sampleSet* and *additionSet* are the same as for hit circles' *extras* fields.
 
-Unconfirmed: When *sampleSet* is 0, it inherits from the *extras* field of the hit object, and then from the timing point. *additionSet* inherits from its paired *sampleSet*, the *additionSet* in *extras*, the *sampleSet* in *extras*, then the timing point.
+When *sampleSet* is 0, it inherits from the *sampleSet* in the *extras* field of the hit object, and then from the timing point. *additionSet* inherits from the *additionSet* in *extras*, then the timing point.
 
 The final *extras* defines the sample to use on the slider body. It functions like *extras* for a circle.
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -48,7 +48,7 @@ SampleSet (String) specifies which set of hit sounds will be used throughout the
 
 `SampleSet: Soft`
 
-StackLeniency (Float) is how often closely placed hit objects will be stacked together.
+StackLeniency (Decimal) is how often closely placed hit objects will be stacked together.
 
 `StackLeniency: 0.7`
 
@@ -71,7 +71,7 @@ Bookmarks (Integer List, milliseconds) is a list of comma-separated times of edi
 
 `Bookmarks: 94171`
 
-DistanceSpacing (Float) is a multiplier for the "Distance Snap" feature.
+DistanceSpacing (Decimal) is a multiplier for the "Distance Snap" feature.
 
 `DistanceSpacing: 1.22`
 
@@ -133,27 +133,27 @@ BeatmapSetID (Integer) is the ID of the beatmap set.
 Difficulty
 ----------
 
-HPDrainRate (Float) specifies the HP Drain difficulty.
+HPDrainRate (Decimal) specifies the HP Drain difficulty.
 
 `HPDrainRate:5`
 
-CircleSize (Float) specifies the size of hit object circles.
+CircleSize (Decimal) specifies the size of hit object circles.
 
 `CircleSize:4`
 
-OverallDifficulty (Float) specifies the amount of time allowed to click a hit object on time.
+OverallDifficulty (Decimal) specifies the amount of time allowed to click a hit object on time.
 
 `OverallDifficulty:6`
 
-ApproachRate (Float) specifies the amount of time taken for the approach circle and hit object to appear.
+ApproachRate (Decimal) specifies the amount of time taken for the approach circle and hit object to appear.
 
 `ApproachRate:7`
 
-SliderMultiplier (Float) specifies a multiplier for the slider velocity. Default value is 1.4 .
+SliderMultiplier (Decimal) specifies a multiplier for the slider velocity. Default value is 1.4 .
 
 `SliderMultiplier:1.3`
 
-SliderTickRate (Float) specifies how often slider ticks appear. Default value is 1.
+SliderTickRate (Decimal) specifies how often slider ticks appear. Default value is 1.
 
 `SliderTickRate:1`
 
@@ -324,7 +324,7 @@ The first Bézier curve in the segment is quadratic with the following points: (
 
 #### Length and duration
 
-*pixelLength* (Float) is the length of the slider along the path of the described curve. It is specified in osu!pixels, i.e. relative to the 512×384 virtual screen.
+*pixelLength* (Decimal) is the length of the slider along the path of the described curve. It is specified in osu!pixels, i.e. relative to the 512×384 virtual screen.
 
 The *pixelLength* is not the length of the curve path described above, but the actual length the slider should have. If the *pixelLength* is smaller than the path length, the path must be shrinked. Conversely, if the *pixelLength* is bigger than the path length, the path must be naturally extended: a longer line for linear sliders, a longer arc for perfect circle curves, and a final linear segment for Bézier paths.
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -191,9 +191,9 @@ Hit Objects
 
 ### Common structure
 
-This section is made of CSV lines. The first 5 fields are common to every hit objects, and an optional last *addition* fields.
+This section is made of CSV lines. The first 5 fields are common to every hit objects, and an optional last *extras* fields.
 
-**Syntax**: `x,y,time,type,hitSound...,addition`
+**Syntax**: `x,y,time,type,hitSound...,extras`
 
 #### Position
 
@@ -245,7 +245,7 @@ Unconfirmed: If bit 0 is not set, the normal sound is not played.
 
 Multiple sounds will overlap if multiple bits are set.
 
-The sample set and custom index are usually specified in the timing point associated to the hit object, but may be customized in the *addition* field.
+The sample set and custom index are usually specified in the timing point associated to the hit object, but may be customized in the *extras* field.
 
 The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, where:
 
@@ -253,13 +253,13 @@ The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, wher
 - *sound* is normal, whistle, finish, or clap.
 - *index* is the custom index. It is omitted when equal to 0 or 1.
 
-#### Addition
+#### Extras
 
-The *addition* field is optional and define extra parameters related to the hit sound samples. It defaults to `0:0:0:0:`.
+The *extras* field is optional and define additional parameters related to the hit sound samples. It defaults to `0:0:0:0:`.
 
-**Syntax**: `sampleSet:additionsSet:customIndex:sampleVolume:filename`
+**Syntax**: `sampleSet:additionSet:customIndex:sampleVolume:filename`
 
-*sampleSet* (Integer) changes the sample set of the normal hit sound, and *additionsSet* (Integer) changes the sample set for the other hit sounds (whistle, finish, clap). The values for these are:
+*sampleSet* (Integer) changes the sample set of the normal hit sound, and *additionSet* (Integer) changes the sample set for the other hit sounds (whistle, finish, clap). The values for these are:
 
 - 0: Auto. In that case, you need to use the sample set information from the timing point.
 - 1: Normal.
@@ -282,7 +282,7 @@ Unconfirmed: A comma in the *filename* may break everything.
 
 A hit circle is a single hit in all osu! game modes.
 
-**Syntax**: `x,y,time,type,hitSound,addition`
+**Syntax**: `x,y,time,type,hitSound,extras`
 
 **Example**: `164,260,2434,1,0,0:0:0:0:`
 
@@ -290,7 +290,7 @@ A hit circle is a single hit in all osu! game modes.
 
 A slider also creates droplets in Catch the Beat, yellow drumrolls in Taiko, and does not appear in osu!mania.
 
-**Syntax**: `x,y,time,type,hitSound,sliderType|curvePoints,repeat,pixelLength,edgeHitsounds,edgeAdditions,addition`
+**Syntax**: `x,y,time,type,hitSound,sliderType|curvePoints,repeat,pixelLength,edgeHitsounds,edgeAdditions,extras`
 
 **Example**: `424,96,66,2,0,B|380:120|332:96|332:96|304:124,1,130,2|0,0:0|0:0,0:0:0:0:`
 
@@ -341,15 +341,13 @@ The duration you will get is in the same unit as *BeatDuration*, usually millise
 
 *edgeHitsounds (hitSound|...)* is a `|`-separated list of *hitSounds* to apply to the circles of the slider. The values are the same as those for regular hit objects. The list must contain exactly *repeat + 1* values, where the first value is the hit sound to play when the slider is first clicked, and the last one when the slider is released.
 
-*edgeAdditions (sampleSet:additions|...)* is a `|`-separated list of samples sets to apply to the circles of the slider. The list contains exactly *repeat + 1* elements. *sampleSet* and *additions* are the same as in a hit circle's *addition* field.
+*edgeAdditions (sampleSet:additionSet|...)* is a `|`-separated list of samples sets to apply to the circles of the slider. The list contains exactly *repeat + 1* elements. *sampleSet* and *additionSet* are the same as for hit circles' *extras* fields.
 
-The final *addition* defines the sample set to use on the slider body. It functions like *addition* for a circle.
-
-Unconfirmed: Both *edgeAdditions* and *addition* look deprecated.
+The final *extras* defines the sample to use on the slider body. It functions like *extras* for a circle.
 
 ### Spinners
 
-**Syntax**: `x,y,time,type,hitSound,endTime,addition`
+**Syntax**: `x,y,time,type,hitSound,endTime,extras`
 
 **Example**: `256,192,730,12,8,3983`
 
@@ -363,7 +361,7 @@ Hit sounds play at the end of the spinner.
 
 A hold note unique to osu!mania.
 
-**Syntax**: `x,y,time,type,hitSound,endTime:addition`
+**Syntax**: `x,y,time,type,hitSound,endTime:extras`
 
 **Example**: `329,192,16504,128,0,16620:0:0:0:0:`
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -227,7 +227,7 @@ and specifies when the hit begins.
 - Bit 3 (8): spinner.
 - Bits 4-6 (16, 32, 64) form a 3-bit number (0-7) that chooses how many combo
   colors to skip. Note that 0 means 1 color is skipped anyway by the new combo
-  field. A skip value of 1 thefore skips 2 colors.
+  field. A skip value of 1 therefore skips 2 colors.
 - Bit 7 (128) is for an osu!mania hold note.
 
 Circles, sliders, spinners, and hold notes can be OR'd with new combos and the
@@ -292,23 +292,21 @@ from sample sets, relative to the beatmap's directory.
 
 Unconfirmed: A comma in the *filename* may break everything.
 
-### Objects
+### Hit Circles
 
-**Hit Circle Syntax:**
+**Syntax**: `x,y,time,type,hitSound,addition`
 
-`x,y,time,type,hitSound,addition`
-
-`164,260,2434,1,0,0:0:0:0:`
+**Example**: `164,260,2434,1,0,0:0:0:0:`
 
 A hit circle is a single hit in all osu! game modes.
 
-**Slider Syntax:**
+### Sliders
 
 A slider also creates droplets in Catch the Beat, yellow drumrolls in Taiko, and does not appear in osu!mania.
 
-`x,y,time,type,hitSound,sliderType|curvePoints,repeat,pixelLength,edgeHitsounds,edgeAdditions,addition`
+**Syntax**: `x,y,time,type,hitSound,sliderType|curvePoints,repeat,pixelLength,edgeHitsounds,edgeAdditions,addition`
 
-`424,96,66,2,0,B|380:120|332:96|332:96|304:124,1,130,2|0,0:0|0:0,0:0:0:0:`
+**Example**: `424,96,66,2,0,B|380:120|332:96|332:96|304:124,1,130,2|0,0:0|0:0,0:0:0:0:`
 
 *x*, *y*, *time*, and *type* behave the same as described in Hit Circle Syntax.
 
@@ -328,28 +326,32 @@ A slider also creates droplets in Catch the Beat, yellow drumrolls in Taiko, and
 
 *addition* defines the samplesets to use on the slider body. It functions like *addition* for a circle.
 
-**Spinner Syntax:**
+### Spinners
 
-`x,y,time,type,hitSound,endTime,addition`
+**Syntax**: `x,y,time,type,hitSound,endTime,addition`
 
-`256,192,730,12,8,3983`
+**Example**: `256,192,730,12,8,3983`
 
 A spinner also creates bananas in Catch the Beat, a spinner in Taiko, and does not appear in osu!mania.
 
-*type*, *time*, *hitSound*, and *addition* behave the same as described in Hit Circle Syntax.
+*endTime (Integer)* is when the spinner will end, in milliseconds from the beginning of the song.
 
-*endTime (Integer)* is when the spinner will end, in milliseconds from the beginning of the song. NOTE: Hit sounds play at the end of the spinner.
+Hit sounds play at the end of the spinner.
 
-**osu!mania Hold Note Syntax**
+### osu!mania Hold Notes
 
-`x,y,time,type,hitSound,endTime:addition`
+**Syntax**: `x,y,time,type,hitSound,endTime:addition`
 
-`329,192,16504,128,0,16620:0:0:0:0:`
+**Example**: `329,192,16504,128,0,16620:0:0:0:0:`
 
 A hold note unique to osu!mania.
 
-**time**, **type**, **hitSound**, and **addition** behave the same as described in Hit Circle Syntax.
+*x* (Integer) determines which column/key a note will fall on. The value does not have to be precise. *y* is ignored.
 
-**x (Integer)** determines which column/key a note will fall on. The value does not have to be precise. **y (Integer)** is ignored.
+TODO: Range of *x*?
 
-**endTime (Integer)** is the time when the key should be released.
+TODO: Define *x* more precisely.
+
+TODO: Default value for *y*?
+
+*endTime* (Integer) is the time when the key should be released, in milliseconds from the beginning of the song.

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -345,7 +345,7 @@ The duration you will get is in the same unit as *BeatDuration*, usually millise
 
 *edgeAdditions (sampleSet:additionSet|...)* is a `|`-separated list of samples sets to apply to the circles of the slider. The list contains exactly *repeat + 1* elements. *sampleSet* and *additionSet* are the same as for hit circles' *extras* fields.
 
-Unconfirmed: When *sampleSet* is 0, it inherits from the *extras* field of the hit object, and then from the timing point. *additionSet* inherits from its paired *sampleSet*, the *additionSet* in *extras*, the *sampleSet* in *extras, then the timing point.
+Unconfirmed: When *sampleSet* is 0, it inherits from the *extras* field of the hit object, and then from the timing point. *additionSet* inherits from its paired *sampleSet*, the *additionSet* in *extras*, the *sampleSet* in *extras*, then the timing point.
 
 The final *extras* defines the sample to use on the slider body. It functions like *extras* for a circle.
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -255,6 +255,8 @@ The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, wher
 - *sound* is normal, whistle, finish, or clap.
 - *index* is the custom index. It is omitted when equal to 0 or 1.
 
+Unconfirmed: When the sample file cannot be found, it falls back on the corresponding sample without the sample index.
+
 #### Extras
 
 The *extras* field is optional and define additional parameters related to the hit sound samples. It defaults to `0:0:0:0:`.

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -3,8 +3,8 @@
 
 **.osu** is a human-readable file format containing information about a single beatmap.
 
-Format
----------
+Global structure
+----------------
 
 The first line of the file specifies the version of beatmap file. Example:
 
@@ -25,10 +25,8 @@ Example:
 
 `[General]`
 
-Sections
----------
-
-### General
+General
+-------
 
 AudioFilename (String) specifies the location of the audio file relative to the current folder.
 
@@ -66,7 +64,8 @@ WidescreenStoryboard (Boolean) specifies whether or not the storyboard should be
 
 `WidescreenStoryboard: 0`
 
-### Editor
+Editor
+------
 
 Bookmarks (Integer List, milliseconds) is a list of comma-separated times of editor bookmarks.
 
@@ -88,7 +87,8 @@ TimelineZoom (Integer) specifies the zoom in the editor timeline.
 
 `TimelineZoom: 1`
 
-### Metadata
+Metadata
+--------
 
 Title (String) is the title of the song limited to ASCII characters.
 
@@ -130,7 +130,8 @@ BeatmapSetID (Integer) is the ID of the beatmap set.
 
 `BeatmapSetID:114987`
 
-### Difficulty
+Difficulty
+----------
 
 HPDrainRate (Float) specifies the HP Drain difficulty.
 
@@ -156,11 +157,13 @@ SliderTickRate (Float) specifies how often slider ticks appear. Default value is
 
 `SliderTickRate:1`
 
-### Events
+Events
+------
 
 See [Storyboard Scripting](/wiki/Storyboard_Scripting)
 
-### Timing Points
+Timing Points
+-------------
 
 Timing Points describe a number of properties regarding offsets, beats per minute and hit sounds. Offset (Integer, milliseconds) defines when the Timing Point takes effect. Milliseconds per Beat (Double) defines the beats per minute of the song. For certain calculations, it is easier to use milliseconds per beat. Meter (Integer) defines the number of beats in a measure. Sample Type (Integer) defines the type of hit sound samples that are used. Sample Set (Integer) defines the set of hit sounds that are used. Volume (Integer) is a value from 0 - 100 that defines the volume of hit sounds. Kiai Mode (Boolean) defines whether or not Kiai Time effects are active. Inherited (Boolean) defines whether or not the Timing Point is an inherited Timing Point.
 
@@ -176,13 +179,15 @@ Example of an inherited Timing Point:
 
 `10171,-100,4,2,0,60,0,1`
 
-### Colours
+Colours
+-------
 
 Combo# (Integer List) is a list of three numbers, each from 0 - 255 defining an RGB color.
 
 `Combo1 : 245,245,245`
 
-### Hit Objects
+Hit Objects
+-----------
 
 **Hit Circle Syntax:**
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -247,6 +247,8 @@ Multiple sounds will overlap if multiple bits are set.
 
 The sample set and custom index are usually specified in the timing point associated to the hit object, but may be customized in the *extras* field.
 
+The normal hit sound and additions may belong to different sample sets, referred to as *sampleSet* and *additionSet*.
+
 The filename of the sample to play is `{sample set}-hit{sound}{index}.wav`, where:
 
 - *sample set* is normal, soft, or drum.
@@ -261,22 +263,20 @@ The *extras* field is optional and define additional parameters related to the h
 
 *sampleSet* (Integer) changes the sample set of the normal hit sound, and *additionSet* (Integer) changes the sample set for the other hit sounds (whistle, finish, clap). The values for these are:
 
-- 0: Auto. In that case, you need to use the sample set information from the timing point.
+- 0: Auto. See below.
 - 1: Normal.
 - 2: Soft.
 - 3: Drum.
 
-*customIndex* (Integer) is the custom sample set index, e.g. 3 in `soft-hitnormal3.wav`.
+When *sampleSet* is 0, its value is inherited from the timing point.
 
-The special index 1 doesn't appear in the filename. For example `normal-hitfinish.wav`.
+Unconfirmed: When *additionSet* is 0, it takes the value of *sampleSet*.
 
-The special index 0 means you need to get the sample index from the timing point.
+*customIndex* (Integer) is the custom sample set index, e.g. 3 in `soft-hitnormal3.wav`. The special index 1 doesn't appear in the filename, for example `normal-hitfinish.wav`. The special index 0 means it is inherited from the timing point.
 
 *sampleVolume* (Integer) is the volume of the sample, and ranges from 0 to 100 (percent).
 
 *filename* (String) names an audio file in the folder to play instead of sounds from sample sets, relative to the beatmap's directory.
-
-Unconfirmed: A comma in the *filename* may break everything.
 
 ### Hit Circles
 
@@ -342,6 +342,8 @@ The duration you will get is in the same unit as *BeatDuration*, usually millise
 *edgeHitsounds (hitSound|...)* is a `|`-separated list of *hitSounds* to apply to the circles of the slider. The values are the same as those for regular hit objects. The list must contain exactly *repeat + 1* values, where the first value is the hit sound to play when the slider is first clicked, and the last one when the slider is released.
 
 *edgeAdditions (sampleSet:additionSet|...)* is a `|`-separated list of samples sets to apply to the circles of the slider. The list contains exactly *repeat + 1* elements. *sampleSet* and *additionSet* are the same as for hit circles' *extras* fields.
+
+Unconfirmed: When *sampleSet* is 0, it inherits from the *extras* field of the hit object, and then from the timing point. *additionSet* inherits from its paired *sampleSet*, the *additionSet* in *extras*, the *sampleSet* in *extras, then the timing point.
 
 The final *extras* defines the sample to use on the slider body. It functions like *extras* for a circle.
 


### PR DESCRIPTION
### Description

The current description of the hit objects in the article describing the .osu format is far from complete, and a source of frustration when writing a beatmap parser.

To start, I've expanded the [HitObjects] section, which the the subject of this pull request. I'd plan to expand the other sections in later pull requests.

### Status

Help wanted.

I have prefixed some paragraphs with *Unconfirmed* or *TODO* when I was missing a piece of information.

### Related Issues

See #811.