### PR TITLE
Missing a file from the skin RC

### DIFF
--- a/wiki/Ranking_Criteria/Skin_Set_List/en.md
+++ b/wiki/Ranking_Criteria/Skin_Set_List/en.md
@@ -163,6 +163,8 @@ The entirety of this skin set is gameplay relevant.
 |fruit-grapes-overlay.png   |-   |required   |128x128px   |
 |fruit-orange.png   |-   | required  |128x128px   |
 |fruit-orange-overlay.png   |-   | required  |128x128px   |
+|fruit-pear.png   |-   | required  |128x128px   |
+|fruit-pear-overlay.png   |-   | required  |128x128px   |
 |fruit-bananas.png   |should be designed differently from the other fruits   |required   |128x128px   |
 |fruit-bananas-overlay.png   |should be designed differently from the other fruits   | required  |128x128px   |
 |fruit-drop.png   |-   |required   |82x103px   |


### PR DESCRIPTION
fruit-pear-overlay.png and fruit-pear.png were missing from the skin RC. Confirmed this with JBH.
![screen shot 2017-12-10 at 10 57 53 pm](https://user-images.githubusercontent.com/30382015/33806095-99f29870-ddfd-11e7-8994-88fb643c453e.png)
