### PR TITLE
[Help wanted] .osu: Expand the Difficulty section

### DIFF
--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -133,29 +133,41 @@ BeatmapSetID (Integer) is the ID of the beatmap set.
 Difficulty
 ----------
 
-HPDrainRate (Decimal) specifies the HP Drain difficulty.
+### Stars
 
-`HPDrainRate:5`
+All the difficulty properties defined in this subsection are expressed in *stars*, where 1 star means very easy, and 9 stars means very hard. The number of stars is always a decimal number.
 
-CircleSize (Decimal) specifies the size of hit object circles.
+```
+HPDrainRate:4
+CircleSize:3.3
+OverallDifficulty:4
+ApproachRate:4.8
+```
 
-`CircleSize:4`
+*HPDrainRate* specifies how fast the health bar decreases.
 
-OverallDifficulty (Decimal) specifies the amount of time allowed to click a hit object on time.
+TODO: The health bar decreases continuously, but also when the player misses a note. Which of the two this settings affect? How much exactly?
 
-`OverallDifficulty:6`
+*OverallDifficulty* is the most visible parameter. It defines the number of stars of a beatmap appears with in the overview. It affects the time window a hit object remains clickable.
 
-ApproachRate (Decimal) specifies the amount of time taken for the approach circle and hit object to appear.
+TODO: Doesn't it affect anything else? How is the time window defined?
 
-`ApproachRate:7`
+*CircleSize* defines the size of the hit circles and sliders in the osu!standard mode. The resulting circle radius in osu!pixels is defined by the formula `54.4 - 4.48 * CircleSize`. In osu!mania mode, *CircleSize* is the number of columns.
 
-SliderMultiplier (Decimal) specifies a multiplier for the slider velocity. Default value is 1.4 .
+*ApproachRate* defines how long hit objects appear before they should be hit.
 
-`SliderMultiplier:1.3`
+TODO: How to convert the approach rate to seconds?
 
-SliderTickRate (Decimal) specifies how often slider ticks appear. Default value is 1.
+### Sliders
 
-`SliderTickRate:1`
+```
+SliderMultiplier:1.3
+SliderTickRate:1
+```
+
+SliderMultiplier (Decimal) specifies a multiplier for the slider velocity. The reference velocity at slider multiplier = 1 is 100 osu!pixels per beat. A slider multiplier of 2 would yield a velocity of 200 osu!pixels per beat. The default slider multiplier is 1.4 when the property is omitted.
+
+TODO: SliderTickRate (Decimal) is the number of ticks per beat. It defaults to 1 tick per beat.
 
 Events
 ------

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -135,7 +135,7 @@ Difficulty
 
 ### Stars
 
-All the difficulty properties defined in this subsection are expressed in *stars*, where 1 star means very easy, and 9 stars means very hard. The number of stars is always a decimal number.
+All the difficulty properties defined in this subsection are expressed in *stars*, where 0 star means very easy, and 10 stars means very hard.
 
 ```
 HPDrainRate:4
@@ -148,15 +148,40 @@ ApproachRate:4.8
 
 TODO: The health bar decreases continuously, but also when the player misses a note. Which of the two this settings affect? How much exactly?
 
-*OverallDifficulty* is the most visible parameter. It defines the number of stars of a beatmap appears with in the overview. It affects the time window a hit object remains clickable.
+*CircleSize* (CS) defines the size of the hit circles and sliders in the osu!standard mode. The resulting circle radius in osu!pixels is defined by the formula `54.4 - 4.48 * CircleSize`. Ranked beatmaps must have a CircleSize value betwenn 2 and 7, inclusive. In osu!mania mode, *CircleSize* is the number of columns.
 
-TODO: Doesn't it affect anything else? How is the time window defined?
+### Overall Difficulty
 
-*CircleSize* defines the size of the hit circles and sliders in the osu!standard mode. The resulting circle radius in osu!pixels is defined by the formula `54.4 - 4.48 * CircleSize`. In osu!mania mode, *CircleSize* is the number of columns.
+*OverallDifficulty* (OD) is the harshness of the hit window and the difficulty of spinners.
 
-*ApproachRate* defines how long hit objects appear before they should be hit.
+- When OD < 5: `spins_per_second = 5 - 2 * (5 - OD) / 5`
+- When OD > 5: `spins_per_second = 5 + 2.5 * (OD - 5) / 5`
+- When OD = 5: `spins_per_second = 5`
 
-TODO: How to convert the approach rate to seconds?
+TODO: How is the time window defined?
+
+### Approach Rate
+
+*ApproachRate* (AR) defines when hit objects start to fade in relative to when they should be hit.
+
+```
+                                        X = perfect hit
+                p r e e m p t           ↓
+ ├───────────────────────┬──────────────┤
+ 0%      fade_in           100% opacity
+```
+
+The circle starts fading in at `X - preempt` with:
+
+- When AR < 5: `preempt = 1200ms + 600ms * (5 - AR) / 5`
+- When AR > 5: `preempt = 1200ms - 750ms * (AR - 5) / 5`
+- When AR = 5: `preempt = 1200ms`
+
+The amount of time it takes for the hit object to completely fade in is also reliant on the approach rate:
+
+- When AR < 5: `fade_in = 800ms + 400ms * (5 - AR) / 5`
+- When AR > 5: `fade_in = 800ms - 500ms * (AR - 5) / 5`
+- When AR = 5: `fade_in = 800ms`
 
 ### Sliders
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -150,7 +150,7 @@ ApproachRate:4.8
 
 The resulting circle radius in osu!pixels is defined by the formula `32 * (1 - 0.7 * (CircleSize - 5) / 5)`, alternatively written `54.4 - 4.48 * CircleSize`.
 
-Ranked beatmaps must have a CircleSize value betwenn 2 and 7, inclusive.
+Ranked beatmaps must have a CircleSize value between 2 and 7, inclusive.
 
 In osu!mania mode, *CircleSize* is the number of columns.
 
@@ -166,9 +166,9 @@ The width of the hit window is defined by the following table:
 
 | Score | Hit Window |
 | --- | --- |
-| 50 | `150ms + 50ms * (5 - AR) / 5` |
-| 100 | `100ms + 40ms * (5 - AR) / 5` |
-| 300 | `50ms + 30ms * (5 - AR) / 5` |
+| 50 | `150ms + 50ms * (5 - OD) / 5` |
+| 100 | `100ms + 40ms * (5 - OD) / 5` |
+| 300 | `50ms + 30ms * (5 - OD) / 5` |
 
 ### Approach Rate
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -155,10 +155,16 @@ TODO: The health bar decreases continuously, but also when the player misses a n
 *OverallDifficulty* (OD) is the harshness of the hit window and the difficulty of spinners.
 
 - When OD < 5: `spins_per_second = 5 - 2 * (5 - OD) / 5`
-- When OD > 5: `spins_per_second = 5 + 2.5 * (OD - 5) / 5`
 - When OD = 5: `spins_per_second = 5`
+- When OD > 5: `spins_per_second = 5 + 2.5 * (OD - 5) / 5`
 
-TODO: How is the time window defined?
+The width of the hit window is defined by the following table:
+
+| Score | Hit Window |
+| --- | --- |
+| 50 | `150ms + 50ms * (5 - AR) / 5` |
+| 100 | `100ms + 40ms * (5 - AR) / 5` |
+| 300 | `50ms + 30ms * (5 - AR) / 5` |
 
 ### Approach Rate
 
@@ -174,14 +180,14 @@ TODO: How is the time window defined?
 The circle starts fading in at `X - preempt` with:
 
 - When AR < 5: `preempt = 1200ms + 600ms * (5 - AR) / 5`
-- When AR > 5: `preempt = 1200ms - 750ms * (AR - 5) / 5`
 - When AR = 5: `preempt = 1200ms`
+- When AR > 5: `preempt = 1200ms - 750ms * (AR - 5) / 5`
 
 The amount of time it takes for the hit object to completely fade in is also reliant on the approach rate:
 
 - When AR < 5: `fade_in = 800ms + 400ms * (5 - AR) / 5`
-- When AR > 5: `fade_in = 800ms - 500ms * (AR - 5) / 5`
 - When AR = 5: `fade_in = 800ms`
+- When AR > 5: `fade_in = 800ms - 500ms * (AR - 5) / 5`
 
 ### Sliders
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -133,9 +133,7 @@ BeatmapSetID (Integer) is the ID of the beatmap set.
 Difficulty
 ----------
 
-### Stars
-
-All the difficulty properties defined in this subsection are expressed in *stars*, where 0 star means very easy, and 10 stars means very hard.
+The following 4 difficulty properties are expressed in *stars*, where 0 star means very easy, and 10 stars means very hard.
 
 ```
 HPDrainRate:4

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -133,7 +133,7 @@ BeatmapSetID (Integer) is the ID of the beatmap set.
 Difficulty
 ----------
 
-The following 4 difficulty properties are expressed in *stars*, where 0 star means very easy, and 10 stars means very hard.
+The following four difficulty properties are expressed in *stars*, where 0 is very easy, and 10 is very hard.
 
 ```
 HPDrainRate:4
@@ -142,15 +142,15 @@ OverallDifficulty:4
 ApproachRate:4.8
 ```
 
-*HPDrainRate* specifies how fast the health bar decreases. At the time of this writing, the near future definition of this property remains unsettled.
+*HPDrainRate* specifies how fast the health decreases. However, the definition of this property may be changed in the near future.
 
 ### Circle Size
 
-*CircleSize* (CS) defines the size of the hit circles and sliders in the osu!standard mode.
+*CircleSize* (CS) defines the size of the hit objects in the osu!standard mode.
 
-The resulting circle radius in osu!pixels is defined by the formula `32 * (1 - 0.7 * (CircleSize - 5) / 5)`, alternatively written `54.4 - 4.48 * CircleSize`.
+The radius in osu!pixels is defined by the formula `32 * (1 - 0.7 * (CircleSize - 5) / 5)`, alternatively written `54.4 - 4.48 * CircleSize`.
 
-Ranked beatmaps must have a CircleSize value between 2 and 7, inclusive.
+The value of *CircleSize* for ranked beatmaps must stand at from 2 to 7, inclusive.
 
 In osu!mania mode, *CircleSize* is the number of columns.
 
@@ -172,7 +172,7 @@ The width of the hit window is defined by the following table:
 
 ### Approach Rate
 
-*ApproachRate* (AR) defines when hit objects start to fade in relative to when they should be hit.
+*ApproachRate* (AR) defines when hit objects start to fade in relatively to when they should be hit.
 
 ```
                                         X = perfect hit
@@ -200,9 +200,9 @@ SliderMultiplier:1.3
 SliderTickRate:1
 ```
 
-SliderMultiplier (Decimal) specifies a multiplier for the slider velocity. The reference velocity at slider multiplier = 1 is 100 osu!pixels per beat. A slider multiplier of 2 would yield a velocity of 200 osu!pixels per beat. The default slider multiplier is 1.4 when the property is omitted.
+*SliderMultiplier* (Decimal) specifies the multiplier of the slider velocity. The velocity at slider multiplier = 1 is 100 osu!pixels per beat. A slider multiplier of 2 would yield a velocity of 200 osu!pixels per beat. The default slider multiplier is 1.4 when the property is omitted.
 
-SliderTickRate (Decimal) is the number of ticks per beat. It defaults to 1 tick per beat.
+*SliderTickRate* (Decimal) is the number of ticks per beat. The default value is 1 tick per beat.
 
 Events
 ------

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -142,7 +142,11 @@ OverallDifficulty:4
 ApproachRate:4.8
 ```
 
-*HPDrainRate* specifies how fast the health decreases. However, the definition of this property may be changed in the near future.
+### HP Drain Rate
+
+*HPDrainRate* (HP) specifies how fast the health decreases.
+
+The definition of this property may be changed in the near future.
 
 ### Circle Size
 

--- a/wiki/osu!_File_Formats/Osu_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osu_(file_format)/en.md
@@ -142,11 +142,17 @@ OverallDifficulty:4
 ApproachRate:4.8
 ```
 
-*HPDrainRate* specifies how fast the health bar decreases.
+*HPDrainRate* specifies how fast the health bar decreases. At the time of this writing, the near future definition of this property remains unsettled.
 
-TODO: The health bar decreases continuously, but also when the player misses a note. Which of the two this settings affect? How much exactly?
+### Circle Size
 
-*CircleSize* (CS) defines the size of the hit circles and sliders in the osu!standard mode. The resulting circle radius in osu!pixels is defined by the formula `54.4 - 4.48 * CircleSize`. Ranked beatmaps must have a CircleSize value betwenn 2 and 7, inclusive. In osu!mania mode, *CircleSize* is the number of columns.
+*CircleSize* (CS) defines the size of the hit circles and sliders in the osu!standard mode.
+
+The resulting circle radius in osu!pixels is defined by the formula `32 * (1 - 0.7 * (CircleSize - 5) / 5)`, alternatively written `54.4 - 4.48 * CircleSize`.
+
+Ranked beatmaps must have a CircleSize value betwenn 2 and 7, inclusive.
+
+In osu!mania mode, *CircleSize* is the number of columns.
 
 ### Overall Difficulty
 
@@ -196,7 +202,7 @@ SliderTickRate:1
 
 SliderMultiplier (Decimal) specifies a multiplier for the slider velocity. The reference velocity at slider multiplier = 1 is 100 osu!pixels per beat. A slider multiplier of 2 would yield a velocity of 200 osu!pixels per beat. The default slider multiplier is 1.4 when the property is omitted.
 
-TODO: SliderTickRate (Decimal) is the number of ticks per beat. It defaults to 1 tick per beat.
+SliderTickRate (Decimal) is the number of ticks per beat. It defaults to 1 tick per beat.
 
 Events
 ------


### PR DESCRIPTION
### Description

The difficulty section of the beatmaps is by far the most obscure one, because the property names are ambiguous, and the units completely unspecified.

> CircleSize (Decimal) specifies the size of hit object circles.

My feel: https://www.youtube.com/watch?v=OYt1kqDNlMY

I think that all the properties deserve a proper conversion formula to common units: seconds for time, and osu!pixels for lengths.

The OverallDifficulty property might require a table to show the 50, 100 and 150 time windows, depending on the mode.

### Status

Help wanted.

Search for lines starting with TODO.

### Related Issues

This is 3rd merge request for https://github.com/ppy/osu-wiki/issues/811