### PR TITLE
Update Contests

### DIFF
--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -36,7 +36,7 @@ Notes:
 | 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/s/342751)                                  | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/u/200768)            | [Results](https://osu.ppy.sh/news/126037472723) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
 | 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/s/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/news/134459652408) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
 | 12          | [IAHN - Candy Luv](https://osu.ppy.sh/s/456054)                                                        | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/u/2732340)         | [Results](https://osu.ppy.sh/news/144933230753) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
-| 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/s/569888)                                                      | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/u/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | ???         |
+| 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/s/569888)                                                      | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/u/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | N/A         |
 | March 2017  | [nanobii - HYPER★DRIVE](https://osu.ppy.sh/s/639991)                                                   | ![osu!catch][o!c]    | [Ascendance](https://osu.ppy.sh/u/2931883)      | TBA                                             | [Score #14](https://osu.ppy.sh/news/144933230753)      |
 | April 2017  | [cYsmix - Breeze](https://osu.ppy.sh/s/629575)                                                         | ![osu!mania][o!m]    | [Soul Evans](https://osu.ppy.sh/u/4490770)      | TBA                                             | [Score #15](https://osu.ppy.sh/community/contests/46)  |
 
@@ -192,9 +192,9 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                         | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|-----------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | Shimotsuki Haruka - Byakuya Gensoutan        | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Level9](httphttps://osu.ppy.sh/u/7232130)       | [Kibbleru](https://osu.ppy.sh/u/3193504)    |
-| 2         | Nekomata Gekidan - AsiaN distractive | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Garden](https://osu.ppy.sh/u/2849992)              | [Ellyu](https://osu.ppy.sh/u/4438154)         |
-| 3         | Camellia - Chirality             | [Suzuki_1112](https://osu.ppy.sh/u/3170678)         | [Miura](https://osu.ppy.sh/u/4990362)         | [\[ Drop \]](https://osu.ppy.sh/u/2391299)      |
+| 1         | 霜月はるか - 白夜幻想谭        | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Level9](https://osu.ppy.sh/u/7232130)       | [Kibbleru](https://osu.ppy.sh/u/3193504)    |
+| 2         | 猫叉劇団 - AsiaN distractive | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Garden](https://osu.ppy.sh/u/2849992)              | [Ellyu](https://osu.ppy.sh/u/4438154)         |
+| 3         | 猫叉劇団 - Chirality             | [Suzuki_1112](https://osu.ppy.sh/u/3170678)         | [Miura](https://osu.ppy.sh/u/4990362)         | [\[ Drop \]](https://osu.ppy.sh/u/2391299)      |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/620182)
 - [Results post](https://osu.ppy.sh/forum/t/640906)

--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -21,24 +21,24 @@ Notes:
 
 | Contest No. | Beatmap                                                                                                | Mode                 | Mapper                                          | Results                                         | Scores                                                 |
 |:-----------:|--------------------------------------------------------------------------------------------------------|:--------------------:|-------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
-| 1           | [Rostik - Liquid (Paul Rosenthal Remix)](https://osu.ppy.sh/s/123593)                                  | ![osu!standard][o!s] | [Charles445](https://osu.ppy.sh/u/85000)        | [Results](https://osu.ppy.sh/news/64561724273)  | [Score #1](https://osu.ppy.sh/p/contestresults?c=7)    |
-| 2           | [cYsmix feat. Emmy - Tear Rain](https://osu.ppy.sh/s/140662)                                           | ![osu!standard][o!s] | [jonathanlfj](https://osu.ppy.sh/u/270377)      | [Results](https://osu.ppy.sh/news/72422807506)  | [Score #2](https://osu.ppy.sh/p/contestresults?c=8)    |
-| 3           | [Chasers - Lost](https://osu.ppy.sh/s/151878)                                                          | ![osu!standard][o!s] | [ktgster](https://osu.ppy.sh/u/53378)           | [Results](https://osu.ppy.sh/news/77183675009)  | [Score #3](https://osu.ppy.sh/p/contestresults?c=9)    |
-| 4           | [Kuba Oms - My Love](https://osu.ppy.sh/s/163112)                                                      | ![osu!standard][o!s] | [W h i t e](https://osu.ppy.sh/u/685229)        | [Results](https://osu.ppy.sh/news/84122008873)  | [Score #4](https://osu.ppy.sh/p/contestresults?c=10)   |
-| 5           | [Rameses B - Flaklypa](https://osu.ppy.sh/s/190390)                                                    | ![osu!standard][o!s] | [-kevincela-](https://osu.ppy.sh/u/266596)      | [Results](https://osu.ppy.sh/news/91735660223)  | [Score #5](https://osu.ppy.sh/p/contestresults?c=11)   |
-| 6 (Aspire)  | [LeaF - Evanescent](https://osu.ppy.sh/s/227126)                                                       | ![osu!standard][o!s] | [Charles445](https://osu.ppy.sh/u/85000)        | [Results](https://osu.ppy.sh/news/102534475143) | [Score #6](https://osu.ppy.sh/p/contestresults?c=12)   |
-| 7.1         | [Soleily - Renatus](https://osu.ppy.sh/s/241526)                                                       | ![osu!standard][o!s] | [Gamu](https://osu.ppy.sh/u/611174)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.1](https://osu.ppy.sh/p/contestresults?c=13) |
-| 7.2         | [Soleily - Renatus](https://osu.ppy.sh/s/241526)                                                       | ![osu!taiko][o!t]    | [MMzz](https://osu.ppy.sh/u/128993)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.2](https://osu.ppy.sh/p/contestresults?c=14) |
-| 7.3         | [Soleily - Renatus](https://osu.ppy.sh/s/241526)                                                       | ![osu!catch][o!c]    | [Deif](https://osu.ppy.sh/u/318565)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.3](https://osu.ppy.sh/p/contestresults?c=15) |
-| 7.4         | [Soleily - Renatus](https://osu.ppy.sh/s/241526)                                                       | ![osu!mania][o!m]    | [ExPew](https://osu.ppy.sh/u/665612)            | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.4](https://osu.ppy.sh/p/contestresults?c=16) |
-| 8           | [raja_ffm - the light](https://osu.ppy.sh/b/671412)                                                    | ![osu!standard][o!s] | [Damnae](https://osu.ppy.sh/u/989377)           | [Results](https://osu.ppy.sh/news/115885774698) | [Score #8](https://osu.ppy.sh/p/contestresults?c=17)   |
-| 9           | [Furries in a Blender - Storm World](https://osu.ppy.sh/s/319473)                                      | ![osu!taiko][o!t]    | [Firce777](https://osu.ppy.sh/u/274072)         | [Results](https://osu.ppy.sh/news/122549062138) | [Score #9](https://osu.ppy.sh/p/contestresults?c=18)   |
-| 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/s/342751)                                  | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/u/200768)            | [Results](https://osu.ppy.sh/news/126037472723) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
-| 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/s/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/news/134459652408) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
-| 12          | [IAHN - Candy Luv](https://osu.ppy.sh/s/456054)                                                        | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/u/2732340)         | [Results](https://osu.ppy.sh/news/144933230753) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
-| 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/s/569888)                                                      | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/u/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | N/A         |
-| March 2017  | [nanobii - HYPER★DRIVE](https://osu.ppy.sh/s/639991)                                                   | ![osu!catch][o!c]    | [Ascendance](https://osu.ppy.sh/u/2931883)      | TBA                                             | [Score #14](https://osu.ppy.sh/news/144933230753)      |
-| April 2017  | [cYsmix - Breeze](https://osu.ppy.sh/s/629575)                                                         | ![osu!mania][o!m]    | [Soul Evans](https://osu.ppy.sh/u/4490770)      | TBA                                             | [Score #15](https://osu.ppy.sh/community/contests/46)  |
+| 1           | [Rostik - Liquid (Paul Rosenthal Remix)](https://osu.ppy.sh/beatmapsets/123593)                        | ![osu!standard][o!s] | [Charles445](https://osu.ppy.sh/users/85000)        | [Results](https://osu.ppy.sh/news/64561724273)  | [Score #1](https://osu.ppy.sh/p/contestresults?c=7)    |
+| 2           | [cYsmix feat. Emmy - Tear Rain](https://osu.ppy.sh/beatmapsets/140662)                                 | ![osu!standard][o!s] | [jonathanlfj](https://osu.ppy.sh/users/270377)      | [Results](https://osu.ppy.sh/news/72422807506)  | [Score #2](https://osu.ppy.sh/p/contestresults?c=8)    |
+| 3           | [Chasers - Lost](https://osu.ppy.sh/beatmapsets/151878)                                                | ![osu!standard][o!s] | [ktgster](https://osu.ppy.sh/users/53378)           | [Results](https://osu.ppy.sh/news/77183675009)  | [Score #3](https://osu.ppy.sh/p/contestresults?c=9)    |
+| 4           | [Kuba Oms - My Love](https://osu.ppy.sh/beatmapsets/163112)                                            | ![osu!standard][o!s] | [W h i t e](https://osu.ppy.sh/users/685229)        | [Results](https://osu.ppy.sh/news/84122008873)  | [Score #4](https://osu.ppy.sh/p/contestresults?c=10)   |
+| 5           | [Rameses B - Flaklypa](https://osu.ppy.sh/beatmapsets/190390)                                          | ![osu!standard][o!s] | [-kevincela-](https://osu.ppy.sh/users/266596)      | [Results](https://osu.ppy.sh/news/91735660223)  | [Score #5](https://osu.ppy.sh/p/contestresults?c=11)   |
+| 6 (Aspire)  | [LeaF - Evanescent](https://osu.ppy.sh/beatmapsets/227126)                                             | ![osu!standard][o!s] | [Charles445](https://osu.ppy.sh/users/85000)        | [Results](https://osu.ppy.sh/news/102534475143) | [Score #6](https://osu.ppy.sh/p/contestresults?c=12)   |
+| 7.1         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!standard][o!s] | [Gamu](https://osu.ppy.sh/users/611174)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.1](https://osu.ppy.sh/p/contestresults?c=13) |
+| 7.2         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!taiko][o!t]    | [MMzz](https://osu.ppy.sh/users/128993)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.2](https://osu.ppy.sh/p/contestresults?c=14) |
+| 7.3         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!catch][o!c]    | [Deif](https://osu.ppy.sh/users/318565)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.3](https://osu.ppy.sh/p/contestresults?c=15) |
+| 7.4         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!mania][o!m]    | [ExPew](https://osu.ppy.sh/users/665612)            | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.4](https://osu.ppy.sh/p/contestresults?c=16) |
+| 8           | [raja_ffm - the light](https://osu.ppy.sh/beatmapsets/299224)                                          | ![osu!standard][o!s] | [Damnae](https://osu.ppy.sh/users/989377)           | [Results](https://osu.ppy.sh/news/115885774698) | [Score #8](https://osu.ppy.sh/p/contestresults?c=17)   |
+| 9           | [Furries in a Blender - Storm World](https://osu.ppy.sh/beatmapsets/319473)                            | ![osu!taiko][o!t]    | [Firce777](https://osu.ppy.sh/users/274072)         | [Results](https://osu.ppy.sh/news/122549062138) | [Score #9](https://osu.ppy.sh/p/contestresults?c=18)   |
+| 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/beatmapsets/342751)                        | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/users/200768)            | [Results](https://osu.ppy.sh/news/126037472723) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
+| 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/beatmapsets/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/news/134459652408) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
+| 12          | [IAHN - Candy Luv](https://osu.ppy.sh/beatmapsets/456054)                                              | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/users/2732340)         | [Results](https://osu.ppy.sh/news/144933230753) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
+| 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/beatmapsets/569888)                                            | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/users/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | N/A         |
+| March 2017  | [nanobii - HYPER★DRIVE](https://osu.ppy.sh/beatmapsets/639991)                                         | ![osu!catch][o!c]    | [Ascendance](https://osu.ppy.sh/users/2931883)      | TBA                                             | [Score #14](https://osu.ppy.sh/community/contests/44)      |
+| April 2017  | [cYsmix - Breeze](https://osu.ppy.sh/beatmapsets/629575)                                               | ![osu!mania][o!m]    | [Soul Evans](https://osu.ppy.sh/users/4490770)      | TBA                                             | [Score #15](https://osu.ppy.sh/community/contests/46)  |
 
 ### Aspire Contest
 
@@ -51,9 +51,9 @@ Notes:
 
 | Contest No.           | Beatmap                                                                                     | Mode                 | Mapper                                          | Results                                         | Scores                                                 |
 |:---------------------:|---------------------------------------------------------------------------------------------|:--------------------:|-------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
-| Aspire 2016           | [IAHN - Transform (Original Mix)](https://osu.ppy.sh/s/484689)                              | ![osu!standard][o!s] | [Monstrata](https://osu.ppy.sh/u/2706438)       | [Results](https://osu.ppy.sh/news/147838862138) | [Score #1](https://osu.ppy.sh/p/contestresults?c=22)   |
-| Aspire 2017 Stage One | [Helblinde - The Solace of Oblivion](https://osu.ppy.sh/s/594751)                           | ![osu!standard][o!s] | [ProfessionalBox](https://osu.ppy.sh/u/3250792) | [Results](https://osu.ppy.sh/news/159160085153) | [Score #2](https://osu.ppy.sh/community/contests/43)   |
-| Aspire 2017 Stage Two | [Function Phantom - Algebra](https://osu.ppy.sh/s/654033)                                   | ![osu!taiko][o!t]    | [Supairo](https://osu.ppy.sh/u/2837231)         |  [Results](https://osu.ppy.sh/home/news/2017-08-24-aspire-2017-stage-two-osutaiko-results) | [Score #3](https://osu.ppy.sh/community/contests/47) |
+| Aspire 2016           | [IAHN - Transform (Original Mix)](https://osu.ppy.sh/beatmapsets/484689)                              | ![osu!standard][o!s] | [Monstrata](https://osu.ppy.sh/users/2706438)       | [Results](https://osu.ppy.sh/news/147838862138) | [Score #1](https://osu.ppy.sh/p/contestresults?c=22)   |
+| Aspire 2017 Stage One | [Helblinde - The Solace of Oblivion](https://osu.ppy.sh/beatmapsets/594751)                           | ![osu!standard][o!s] | [ProfessionalBox](https://osu.ppy.sh/users/3250792) | [Results](https://osu.ppy.sh/news/159160085153) | [Score #2](https://osu.ppy.sh/community/contests/43)   |
+| Aspire 2017 Stage Two | [Function Phantom - Algebra](https://osu.ppy.sh/beatmapsets/654033)                                   | ![osu!taiko][o!t]    | [Supairo](https://osu.ppy.sh/users/2837231)         |  [Results](https://osu.ppy.sh/home/news/2017-08-24-aspire-2017-stage-two-osutaiko-results) | [Score #3](https://osu.ppy.sh/community/contests/47) |
 | Aspire 2017 Stage Three | OISHII - ONIGIRI FREEWAY                                                                  | ![osu!catch][o!c]    | TBA | TBA | TBA |
 
 ## Monthly Fanart Contest
@@ -84,9 +84,9 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 
 | Placing | Results                                                                                                    | Original Artists                                               |
 |---------|------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| First   | [yealina](https://osu.ppy.sh/u/139551) - [Parallel Hearts](https://soundcloud.com/yealina/parallel-hearts) | FictionJunction                                                |
-| Second  | [Sharlo](https://osu.ppy.sh/u/1622450) - 緋色月下、狂咲ノ絶 -1st Anniversary Remix-                           | EastNewSound                                                   |
-| Third   | [MissTitannia](https://osu.ppy.sh/u/4490361) - *unknown*                                                   | *unknown*                                                      |
+| First   | [yealina](https://osu.ppy.sh/users/139551) - [Parallel Hearts](https://soundcloud.com/yealina/parallel-hearts) | FictionJunction                                                |
+| Second  | [Sharlo](https://osu.ppy.sh/users/1622450) - 緋色月下、狂咲ノ絶 -1st Anniversary Remix-                           | EastNewSound                                                   |
+| Third   | [MissTitannia](https://osu.ppy.sh/users/4490361) - *unknown*                                                   | *unknown*                                                      |
 
 
 - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/1XEL-Zb_ldV0l4jpv7IAWzER-LV-uoo9pE2nIb7PI23Y/edit?pli=1#gid=1003675360)
@@ -98,9 +98,9 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 
 | Placing | Results                                                                                                 | Original Artists                                                       |
 |---------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| First   | [Sagi](https://osu.ppy.sh/u/491799) - [Systematic Love](http://flan.s-ul.eu/OQXT0SsA)                  | [Camelia (Hatsune Miku)](https://www.youtube.com/watch?v=16iOXrf3dQ8)  |
-| Second  | [CptHampton](https://osu.ppy.sh/u/3200587) - [Drumming Song](http://flan.s-ul.eu/ZCA8KxCl)             | [Florence + The Machine](https://www.youtube.com/watch?v=TpLXQorSQe8) |
-| Third   | [yealina](https://osu.ppy.sh/u/139551) - [Hyadain no Kakakata☆Kataomoi](http://flan.s-ul.eu/8w5u4phq) | [Hyadain](https://www.youtube.com/watch?v=WhQvgHM_Nd4)                 |
+| First   | [Sagi](https://osu.ppy.sh/users/491799) - [Systematic Love](http://flan.s-ul.eu/OQXT0SsA)                  | [Camelia (Hatsune Miku)](https://www.youtube.com/watch?v=16iOXrf3dQ8)  |
+| Second  | [CptHampton](https://osu.ppy.sh/users/3200587) - [Drumming Song](http://flan.s-ul.eu/ZCA8KxCl)             | [Florence + The Machine](https://www.youtube.com/watch?v=TpLXQorSQe8) |
+| Third   | [yealina](https://osu.ppy.sh/users/139551) - [Hyadain no Kakakata☆Kataomoi](http://flan.s-ul.eu/8w5u4phq) | [Hyadain](https://www.youtube.com/watch?v=WhQvgHM_Nd4)                 |
 
 
 - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/1oqy5nZFQK7Npx2jRVDxaa2zPjDPgtdh5IdWNGrR-qns/edit?pli=1#gid=3048429)
@@ -112,9 +112,9 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 
 | Placing | Results                                                                                   | Original Artist                                           |
 |---------|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| First   | [Slyleaf](https://osu.ppy.sh/u/3322032) - [心做し Kokoronashi](http://flan.s-ul.eu/QsrQaLFm) | [Chouchou-P (Megpoid GUMI)](https://youtu.be/3SkNrZnoK5w) |
-| Second  | [Daikyi](https://osu.ppy.sh/u/811832) - [days](http://flan.s-ul.eu/WoFPI9Sn)              | [Lia](https://www.youtube.com/watch?v=gBJvkhobGAs)        |
-| Third   | [MissTitannia](https://osu.ppy.sh/u/139551) - [Vixx](http://flan.s-ul.eu/tYzf45Nk)        | *unknown*                                                 |
+| First   | [Slyleaf](https://osu.ppy.sh/users/3322032) - [心做し Kokoronashi](http://flan.s-ul.eu/QsrQaLFm) | [Chouchou-P (Megpoid GUMI)](https://youtu.be/3SkNrZnoK5w) |
+| Second  | [Daikyi](https://osu.ppy.sh/users/811832) - [days](http://flan.s-ul.eu/WoFPI9Sn)              | [Lia](https://www.youtube.com/watch?v=gBJvkhobGAs)        |
+| Third   | [MissTitannia](https://osu.ppy.sh/users/139551) - [Vixx](http://flan.s-ul.eu/tYzf45Nk)        | *unknown*                                                 |
 
 
 - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/1oqy5nZFQK7Npx2jRVDxaa2zPjDPgtdh5IdWNGrR-qns/edit?pli=1#gid=3048429)
@@ -126,9 +126,9 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
  
  | Placing | Results                                                                                   | Original Artist                                           |
  |---------|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
- | First   | [Renril](https://osu.ppy.sh/u/4955122) - [Rinne Tensei](https://assets.ppy.sh/contests/57/entries/Renril_-_Rinne_Tensei.mp3)          | [Mafumafu](https://www.youtube.com/watch?v=vU3oF90WKpw)                        |
- | Second  | [Will Stetson](https://osu.ppy.sh/u/811832) - [Ikanaide](https://assets.ppy.sh/contests/57/entries/Will_Stetson_-_Ikanaide.mp3)              | [Sohta](https://www.youtube.com/watch?v=ct_NaWo8azc)        |
- | Third   | [Thievley](https://osu.ppy.sh/u/4717672) - [All around me](https://assets.ppy.sh/contests/57/entries/Thievley_-_All_Around_Me.mp3)         | [Flyleaf](https://www.youtube.com/watch?v=xN0FFK8JSYE)                           |
+ | First   | [Renril](https://osu.ppy.sh/users/4955122) - [Rinne Tensei](https://assets.ppy.sh/contests/57/entries/Renril_-_Rinne_Tensei.mp3)          | [Mafumafu](https://www.youtube.com/watch?v=vU3oF90WKpw)                        |
+ | Second  | [Will Stetson](https://osu.ppy.sh/users/811832) - [Ikanaide](https://assets.ppy.sh/contests/57/entries/Will_Stetson_-_Ikanaide.mp3)              | [Sohta](https://www.youtube.com/watch?v=ct_NaWo8azc)        |
+ | Third   | [Thievley](https://osu.ppy.sh/users/4717672) - [All around me](https://assets.ppy.sh/contests/57/entries/Thievley_-_All_Around_Me.mp3)         | [Flyleaf](https://www.youtube.com/watch?v=xN0FFK8JSYE)                           |
  
  
  - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/183iJJIxoD8qXLXyzra5vr9kmHMnZDDI63w-lUz5SSH0/edit#gid=1357895603)
@@ -149,9 +149,9 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|----------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | TERRA - 華爛漫 -Flowers-               | [buhei](https://osu.ppy.sh/u/1371514)          | [Flask](https://osu.ppy.sh/u/959763)           | [Nyquill](https://osu.ppy.sh/u/682935)         |
-| 2         | 葉月ゆら - 宵闇花火                     | [Lan Wings](https://osu.ppy.sh/u/467860)       | [Kotone](https://osu.ppy.sh/u/26507)           | [Regou](https://osu.ppy.sh/u/419954)           |
-| 3         | An - アートコア神社                     | [Flower](https://osu.ppy.sh/u/1033017)         | [Amamiya Yuko](https://osu.ppy.sh/u/873961)    | [Regou](https://osu.ppy.sh/u/419954)           |
+| 1         | TERRA - 華爛漫 -Flowers-               | [buhei](https://osu.ppy.sh/users/1371514)          | [Flask](https://osu.ppy.sh/users/959763)           | [Nyquill](https://osu.ppy.sh/users/682935)         |
+| 2         | 葉月ゆら - 宵闇花火                     | [Lan Wings](https://osu.ppy.sh/users/467860)       | [Kotone](https://osu.ppy.sh/users/26507)           | [Regou](https://osu.ppy.sh/users/419954)           |
+| 3         | An - アートコア神社                     | [Flower](https://osu.ppy.sh/users/1033017)         | [Amamiya Yuko](https://osu.ppy.sh/users/873961)    | [Regou](https://osu.ppy.sh/users/419954)           |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/135492)
 - [Results post](https://osu.ppy.sh/forum/t/152966)
@@ -160,8 +160,8 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|----------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | Sharlo & Sabbo - 桜の花が舞い落ちるとき  | [Loneight](https://osu.ppy.sh/u/663131)        | [Macuilxochitl](https://osu.ppy.sh/u/418699)   | [eveless](https://osu.ppy.sh/u/102976)         |
-| 2         | 木製みゅーと - 七つ一旋桜                | [OSUtoto](https://osu.ppy.sh/u/847182)         | [bo0O0od](https://osu.ppy.sh/u/530547)         | [Kawaiwkyik](https://osu.ppy.sh/u/1367570)     |
+| 1         | Sharlo & Sabbo - 桜の花が舞い落ちるとき  | [Loneight](https://osu.ppy.sh/users/663131)        | [Macuilxochitl](https://osu.ppy.sh/users/418699)   | [eveless](https://osu.ppy.sh/userssers/102976)         |
+| 2         | 木製みゅーと - 七つ一旋桜                | [OSUtoto](https://osu.ppy.sh/users/847182)         | [bo0O0od](https://osu.ppy.sh/users/530547)         | [Kawaiwkyik](https://osu.ppy.sh/users/1367570)     |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/229019)
 - [Results post](https://osu.ppy.sh/forum/t/243930)
@@ -170,9 +170,9 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|----------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | 挨批熊 - 权御天下                       | [Regraz](https://osu.ppy.sh/u/3076909)         | [Syameimaru-Aya](https://osu.ppy.sh/u/3153354) | [jonathanlfj](https://osu.ppy.sh/u/270377)     |
-| 2         | 削除 - Imprinting                      | [yf_bmp](https://osu.ppy.sh/u/1243669)         | [Syameimaru-Aya](https://osu.ppy.sh/u/3153354) | [Inazuma](https://osu.ppy.sh/u/1033017)        |
-| 3         | P*Light - YELLOW SPLASH!!              | [fanzhen0019](https://osu.ppy.sh/u/418699)     | [yf_bmp](https://osu.ppy.sh/u/1243669)         | [Minakami Yuki](https://osu.ppy.sh/u/2433507)  |
+| 1         | 挨批熊 - 权御天下                       | [Regraz](https://osu.ppy.sh/users/3076909)         | [Syameimaru-Aya](https://osu.ppy.sh/users/3153354) | [jonathanlfj](https://osu.ppy.sh/users/270377)     |
+| 2         | 削除 - Imprinting                      | [yf_bmp](https://osu.ppy.sh/users/1243669)         | [Syameimaru-Aya](https://osu.ppy.sh/users/3153354) | [Inazuma](https://osu.ppy.sh/users/1033017)        |
+| 3         | P*Light - YELLOW SPLASH!!              | [fanzhen0019](https://osu.ppy.sh/users/418699)     | [yf_bmp](https://osu.ppy.sh/users/1243669)         | [Minakami Yuki](https://osu.ppy.sh/users/2433507)  |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/345263)
 - [Results post](https://osu.ppy.sh/forum/t/373843)
@@ -181,9 +181,9 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                         | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|-----------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | ClariS - SECRET                               | [FreeSongs](https://osu.ppy.sh/u/2116792)      | [handsome](https://osu.ppy.sh/u/2123087)       | [Snowy Wings](https://osu.ppy.sh/u/2234810)    |
-| 2         | 干瓢碁 - 運命のダークサイド -Rolling Gothic mix | [FreeSongs](https://osu.ppy.sh/u/2116792)      | [rui](https://osu.ppy.sh/u/74313)              | [yf_bmp](https://osu.ppy.sh/u/1243669)         |
-| 3         | Dollscythe - Flashes (Extended)               | [Skystar](https://osu.ppy.sh/u/873961)         | [Level9](https://osu.ppy.sh/u/7232130)         | [Frostings](https://osu.ppy.sh/u/2652543)      |
+| 1         | ClariS - SECRET                               | [FreeSongs](https://osu.ppy.sh/users/2116792)      | [handsome](https://osu.ppy.sh/users/2123087)       | [Snowy Wings](https://osu.ppy.sh/users/2234810)    |
+| 2         | 干瓢碁 - 運命のダークサイド -Rolling Gothic mix | [FreeSongs](https://osu.ppy.sh/users/2116792)      | [rui](https://osu.ppy.sh/users/74313)              | [yf_bmp](https://osu.ppy.sh/users/1243669)         |
+| 3         | Dollscythe - Flashes (Extended)               | [Skystar](https://osu.ppy.sh/users/873961)         | [Level9](https://osu.ppy.sh/users/7232130)         | [Frostings](https://osu.ppy.sh/users/2652543)      |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/482629)
 - [Results post](https://osu.ppy.sh/forum/t/504645)
@@ -192,9 +192,9 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 
 | Songs No. | Songs                                         | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|-----------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | 霜月はるか - 白夜幻想谭        | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Level9](https://osu.ppy.sh/u/7232130)       | [Kibbleru](https://osu.ppy.sh/u/3193504)    |
-| 2         | 猫叉劇団 - AsiaN distractive | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Garden](https://osu.ppy.sh/u/2849992)              | [Ellyu](https://osu.ppy.sh/u/4438154)         |
-| 3         | 猫叉劇団 - Chirality             | [Suzuki_1112](https://osu.ppy.sh/u/3170678)         | [Miura](https://osu.ppy.sh/u/4990362)         | [\[ Drop \]](https://osu.ppy.sh/u/2391299)      |
+| 1         | 霜月はるか - 白夜幻想谭        | [Chaoslitz](https://osu.ppy.sh/users/3621552)      | [Level9](https://osu.ppy.sh/users/7232130)       | [Kibbleru](https://osu.ppy.sh/users/3193504)    |
+| 2         | 猫叉劇団 - AsiaN distractive | [Chaoslitz](https://osu.ppy.sh/users/3621552)      | [Garden](https://osu.ppy.sh/users/2849992)              | [Ellyu](https://osu.ppy.sh/users/4438154)         |
+| 3         | 猫叉劇団 - Chirality             | [Suzuki_1112](https://osu.ppy.sh/users/3170678)         | [Miura](https://osu.ppy.sh/users/4990362)         | [\[ Drop \]](https://osu.ppy.sh/users/2391299)      |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/620182)
 - [Results post](https://osu.ppy.sh/forum/t/640906)
@@ -208,8 +208,8 @@ Newspaper Cup is an annually mapping contest which aims at attract normal player
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|----------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | wa.vs ETIA. - Akasagarbha              | [tm1209](https://osu.ppy.sh/u/2775906)         | [Philosophy2](https://osu.ppy.sh/u/372256)     | [bread129988](https://osu.ppy.sh/u/2010665)    |
-| 2         | 猫叉Master - Far east nightbird        | [Narcissu](https://osu.ppy.sh/u/1826598)       | [JJburstOwO](https://osu.ppy.sh/u/1776055)     | [Kamio Misuzu](https://osu.ppy.sh/u/2041350)   |
+| 1         | wa.vs ETIA. - Akasagarbha              | [tm1209](https://osu.ppy.sh/users/2775906)         | [Philosophy2](https://osu.ppy.sh/users/372256)     | [bread129988](https://osu.ppy.sh/users/2010665)    |
+| 2         | 猫叉Master - Far east nightbird        | [Narcissu](https://osu.ppy.sh/u/1826598)       | [JJburstOwO](https://osu.ppy.sh/users/1776055)     | [Kamio Misuzu](https://osu.ppy.sh/users/2041350)   |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/272739)
 - [Results post](https://osu.ppy.sh/forum/t/312154)
@@ -218,8 +218,8 @@ Newspaper Cup is an annually mapping contest which aims at attract normal player
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
 |-----------|----------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
-| 1         | 葉月ゆら - Eclipse Parade               | [LunaSaika](https://osu.ppy.sh/u/4018820)      | [FreeSongs](https://osu.ppy.sh/u/2116792)      | [Vert](https://osu.ppy.sh/u/3420746)           |
-| 2         | Sakuzyo - Laplace                      | [Hakurei Yoru](https://osu.ppy.sh/u/3280555)   | [liaoxingyao](https://osu.ppy.sh/u/3620963)    | [Kencho](https://osu.ppy.sh/u/3178411)     |
+| 1         | 葉月ゆら - Eclipse Parade               | [LunaSaika](https://osu.ppy.sh/users/4018820)      | [FreeSongs](https://osu.ppy.sh/users/2116792)      | [Vert](https://osu.ppy.sh/u/3420746)           |
+| 2         | Sakuzyo - Laplace                      | [Hakurei Yoru](https://osu.ppy.sh/users/3280555)   | [liaoxingyao](https://osu.ppy.sh/users/3620963)    | [Kencho](https://osu.ppy.sh/users/3178411)     |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/415669)
 - [Results post](https://osu.ppy.sh/forum/t/432070)
@@ -228,8 +228,8 @@ Newspaper Cup is an annually mapping contest which aims at attract normal player
 
 | Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place")                                        | ![Silver Crown](/wiki/shared/SCrown.png "2nd place")                                      |
 |-----------|----------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| 1         | 影翔鼓舞 - Oriental Blossom             | [yf_bmp](https://osu.ppy.sh/u/1243669), [EmingK](https://osu.ppy.sh/u/2021118)            | [Gaia](https://osu.ppy.sh/u/2683648), [Doj](https://osu.ppy.sh/u/4121612)                 |
-| 2         | ESQUARIA - 寒椿 ～ Kantsubaki           | [Regou](https://osu.ppy.sh/u/419954), [fish39](https://osu.ppy.sh/u/3522390)              | [Bluekrait](https://osu.ppy.sh/u/4205741), [Rose Pacifica](https://osu.ppy.sh/u/1393255)  |
+| 1         | 影翔鼓舞 - Oriental Blossom             | [yf_bmp](https://osu.ppy.sh/users/1243669), [EmingK](https://osu.ppy.sh/users/2021118)       | [Gaia](https://osu.ppy.sh/users/2683648), [Doj](https://osu.ppy.sh/u/4121612)                 |
+| 2         | ESQUARIA - 寒椿 ～ Kantsubaki           | [Regou](https://osu.ppy.sh/users/419954), [fish39](https://osu.ppy.sh/users/3522390)       | [Bluekrait](https://osu.ppy.sh/users/4205741), [Rose Pacifica](https://osu.ppy.sh/u/1393255)  |
 
 - [Contest thread](https://osu.ppy.sh/forum/t/546038)
 - [Results post](https://osu.ppy.sh/forum/t/570350)

--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -32,10 +32,10 @@ Notes:
 | 7.3         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!catch][o!c]    | [Deif](https://osu.ppy.sh/users/318565)             | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.3](https://osu.ppy.sh/p/contestresults?c=15) |
 | 7.4         | [Soleily - Renatus](https://osu.ppy.sh/beatmapsets/241526)                                             | ![osu!mania][o!m]    | [ExPew](https://osu.ppy.sh/users/665612)            | [Results](https://osu.ppy.sh/news/112654662093) | [Score #7.4](https://osu.ppy.sh/p/contestresults?c=16) |
 | 8           | [raja_ffm - the light](https://osu.ppy.sh/beatmapsets/299224)                                          | ![osu!standard][o!s] | [Damnae](https://osu.ppy.sh/users/989377)           | [Results](https://osu.ppy.sh/news/115885774698) | [Score #8](https://osu.ppy.sh/p/contestresults?c=17)   |
-| 9           | [Furries in a Blender - Storm World](https://osu.ppy.sh/beatmapsets/319473)                            | ![osu!taiko][o!t]    | [Firce777](https://osu.ppy.sh/users/274072)         | [Results](https://osu.ppy.sh/news/122549062138) | [Score #9](https://osu.ppy.sh/p/contestresults?c=18)   |
-| 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/beatmapsets/342751)                        | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/users/200768)            | [Results](https://osu.ppy.sh/news/126037472723) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
-| 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/beatmapsets/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/news/134459652408) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
-| 12          | [IAHN - Candy Luv](https://osu.ppy.sh/beatmapsets/456054)                                              | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/users/2732340)         | [Results](https://osu.ppy.sh/news/144933230753) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
+| 9           | [Furries in a Blender - Storm World](https://osu.ppy.sh/beatmapsets/319473)                            | ![osu!taiko][o!t]    | [Firce777](https://osu.ppy.sh/users/274072)         | [Results](https://osu.ppy.sh/home/news/2015-06-27-monthly-beatmapping-contest-9-results) | [Score #9](https://osu.ppy.sh/p/contestresults?c=18)   |
+| 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/beatmapsets/342751)                        | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/users/200768)            | [Results](https://osu.ppy.sh/home/news/2015-08-06-monthly-beatmap-contest-10-results-ctb) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
+| 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/beatmapsets/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/home/news/2015-12-03-monthly-beatmapping-contest-11-results) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
+| 12          | [IAHN - Candy Luv](https://osu.ppy.sh/beatmapsets/456054)                                              | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/users/2732340)         | [Results](https://osu.ppy.sh/home/news/2016-05-26-monthly-beatmapping-contest-12-results) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
 | 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/beatmapsets/569888)                                            | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/users/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | N/A         |
 | March 2017  | [nanobii - HYPER★DRIVE](https://osu.ppy.sh/beatmapsets/639991)                                         | ![osu!catch][o!c]    | [Ascendance](https://osu.ppy.sh/users/2931883)      | TBA                                             | [Score #14](https://osu.ppy.sh/community/contests/44)      |
 | April 2017  | [cYsmix - Breeze](https://osu.ppy.sh/beatmapsets/629575)                                               | ![osu!mania][o!m]    | [Soul Evans](https://osu.ppy.sh/users/4490770)      | TBA                                             | [Score #15](https://osu.ppy.sh/community/contests/46)  |
@@ -51,8 +51,8 @@ Notes:
 
 | Contest No.           | Beatmap                                                                                     | Mode                 | Mapper                                          | Results                                         | Scores                                                 |
 |:---------------------:|---------------------------------------------------------------------------------------------|:--------------------:|-------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
-| Aspire 2016           | [IAHN - Transform (Original Mix)](https://osu.ppy.sh/beatmapsets/484689)                              | ![osu!standard][o!s] | [Monstrata](https://osu.ppy.sh/users/2706438)       | [Results](https://osu.ppy.sh/news/147838862138) | [Score #1](https://osu.ppy.sh/p/contestresults?c=22)   |
-| Aspire 2017 Stage One | [Helblinde - The Solace of Oblivion](https://osu.ppy.sh/beatmapsets/594751)                           | ![osu!standard][o!s] | [ProfessionalBox](https://osu.ppy.sh/users/3250792) | [Results](https://osu.ppy.sh/news/159160085153) | [Score #2](https://osu.ppy.sh/community/contests/43)   |
+| Aspire 2016           | [IAHN - Transform (Original Mix)](https://osu.ppy.sh/beatmapsets/484689)                              | ![osu!standard][o!s] | [Monstrata](https://osu.ppy.sh/users/2706438)       | [Results](https://osu.ppy.sh/home/news/2016-07-23-aspire-2-concludes-winners-announced) | [Score #1](https://osu.ppy.sh/p/contestresults?c=22)   |
+| Aspire 2017 Stage One | [Helblinde - The Solace of Oblivion](https://osu.ppy.sh/beatmapsets/594751)                           | ![osu!standard][o!s] | [ProfessionalBox](https://osu.ppy.sh/users/3250792) | [Results](https://osu.ppy.sh/home/news/2017-04-03-aspire-2017-stage-one-concludes) | [Score #2](https://osu.ppy.sh/community/contests/43)   |
 | Aspire 2017 Stage Two | [Function Phantom - Algebra](https://osu.ppy.sh/beatmapsets/654033)                                   | ![osu!taiko][o!t]    | [Supairo](https://osu.ppy.sh/users/2837231)         |  [Results](https://osu.ppy.sh/home/news/2017-08-24-aspire-2017-stage-two-osutaiko-results) | [Score #3](https://osu.ppy.sh/community/contests/47) |
 | Aspire 2017 Stage Three | OISHII - ONIGIRI FREEWAY                                                                  | ![osu!catch][o!c]    | TBA | TBA | TBA |
 
@@ -104,8 +104,8 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 
 
 - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/1oqy5nZFQK7Npx2jRVDxaa2zPjDPgtdh5IdWNGrR-qns/edit?pli=1#gid=3048429)
-- [News post](https://osu.ppy.sh/news/125447383718)
-- [Results post](https://osu.ppy.sh/news/134589253878)
+- [News post](https://osu.ppy.sh/home/news/2015-07-30-osuidol-2015-sign-ups-are-live)
+- [Results post](https://osu.ppy.sh/home/news/2015-12-05-osuidol-2015-results)
 - [Offical post](https://osu.ppy.sh/forum/t/352608)
 
 ### 2016
@@ -118,8 +118,8 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 
 
 - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/1oqy5nZFQK7Npx2jRVDxaa2zPjDPgtdh5IdWNGrR-qns/edit?pli=1#gid=3048429)
-- [News post](https://osu.ppy.sh/news/145357306703)
-- [Results post](https://osu.ppy.sh/news/152901340878)
+- [News post](https://osu.ppy.sh/home/news/2016-06-03-osuidol-2016-registrations-open)
+- [Results post](https://osu.ppy.sh/home/news/2016-11-08-osuidol-2016-final-results)
 - [Offical post](https://osu.ppy.sh/forum/t/448842)
 
 ### 2017

--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -36,9 +36,9 @@ Notes:
 | 10          | [Hylian Lemon - Foresight Is for Losers](https://osu.ppy.sh/s/342751)                                  | ![osu!catch][o!c]    | [ZiRoX](https://osu.ppy.sh/u/200768)            | [Results](https://osu.ppy.sh/news/126037472723) | [Score #10](https://osu.ppy.sh/p/contestresults?c=19)  |
 | 11          | [Freedom Planet - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci)](https://osu.ppy.sh/s/385056) | ![osu!mania][o!m]    | [LordRaika](https://osu.ppy.sh/u/3265023)       | [Results](https://osu.ppy.sh/news/134459652408) | [Score #11](https://osu.ppy.sh/p/contestresults?c=20)  |
 | 12          | [IAHN - Candy Luv](https://osu.ppy.sh/s/456054)                                                        | ![osu!standard][o!s] | [Taeyang](https://osu.ppy.sh/u/2732340)         | [Results](https://osu.ppy.sh/news/144933230753) | [Score #12](https://osu.ppy.sh/p/contestresults?c=21)  |
-| 13          | BilliumMoto - HDHR                                                                                     | ![osu!standard][o!s] | TBA                                             | TBA                                             | TBA                                                    |
-| March 2017  | nanobii - HYPER★DRIVE                                                                                 | ![osu!catch][o!c]    | TBA                                             | TBA                                             | TBA                                                    |
-| April 2017  | cYsmix - Breeze                                                                                        | ![osu!mania][o!m]    | TBA                                             | TBA                                             | TBA                                                    |
+| 13          | [BilliumMoto - HDHR](https://osu.ppy.sh/s/569888)                                                      | ![osu!standard][o!s] | [RyoKazuka](https://osu.ppy.sh/u/6258586)       | [Results](https://osu.ppy.sh/home/news/2017-04-02-monthly-beatmapping-contest-13-results)  | ???         |
+| March 2017  | [nanobii - HYPER★DRIVE](https://osu.ppy.sh/s/639991)                                                   | ![osu!catch][o!c]    | [Ascendance](https://osu.ppy.sh/u/2931883)      | TBA                                             | [Score #14](https://osu.ppy.sh/news/144933230753)      |
+| April 2017  | [cYsmix - Breeze](https://osu.ppy.sh/s/629575)                                                         | ![osu!mania][o!m]    | [Soul Evans](https://osu.ppy.sh/u/4490770)      | TBA                                             | [Score #15](https://osu.ppy.sh/community/contests/46)  |
 
 ### Aspire Contest
 
@@ -53,7 +53,8 @@ Notes:
 |:---------------------:|---------------------------------------------------------------------------------------------|:--------------------:|-------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
 | Aspire 2016           | [IAHN - Transform (Original Mix)](https://osu.ppy.sh/s/484689)                              | ![osu!standard][o!s] | [Monstrata](https://osu.ppy.sh/u/2706438)       | [Results](https://osu.ppy.sh/news/147838862138) | [Score #1](https://osu.ppy.sh/p/contestresults?c=22)   |
 | Aspire 2017 Stage One | [Helblinde - The Solace of Oblivion](https://osu.ppy.sh/s/594751)                           | ![osu!standard][o!s] | [ProfessionalBox](https://osu.ppy.sh/u/3250792) | [Results](https://osu.ppy.sh/news/159160085153) | [Score #2](https://osu.ppy.sh/community/contests/43)   |
-| Aspire 2017 Stage Two | Function Phantom - Algebra                                                                  | ![osu!taiko][o!t]    | TBA                                             | TBA                                             | TBA                                                    |
+| Aspire 2017 Stage Two | [Function Phantom - Algebra](https://osu.ppy.sh/s/654033)                                   | ![osu!taiko][o!t]    | [Supairo](https://osu.ppy.sh/u/2837231)         |  [Results](https://osu.ppy.sh/home/news/2017-08-24-aspire-2017-stage-two-osutaiko-results) | [Score #3](https://osu.ppy.sh/community/contests/47) |
+| Aspire 2017 Stage Three | OISHII - ONIGIRI FREEWAY                                                                  | ![osu!catch][o!c]    | TBA | TBA | TBA |
 
 ## Monthly Fanart Contest
 
@@ -120,6 +121,21 @@ osu!idol is a contest where contestants as a solo or a duet sing their way throu
 - [News post](https://osu.ppy.sh/news/145357306703)
 - [Results post](https://osu.ppy.sh/news/152901340878)
 - [Offical post](https://osu.ppy.sh/forum/t/448842)
+
+### 2017
+ 
+ | Placing | Results                                                                                   | Original Artist                                           |
+ |---------|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+ | First   | [Renril](https://osu.ppy.sh/u/4955122) - [Rinne Tensei](https://assets.ppy.sh/contests/57/entries/Renril_-_Rinne_Tensei.mp3)          | [Mafumafu](https://www.youtube.com/watch?v=vU3oF90WKpw)                        |
+ | Second  | [Will Stetson](https://osu.ppy.sh/u/811832) - [Ikanaide](https://assets.ppy.sh/contests/57/entries/Will_Stetson_-_Ikanaide.mp3)              | [Sohta](https://www.youtube.com/watch?v=ct_NaWo8azc)        |
+ | Third   | [Thievley](https://osu.ppy.sh/u/4717672) - [All around me](https://assets.ppy.sh/contests/57/entries/Thievley_-_All_Around_Me.mp3)         | [Flyleaf](https://www.youtube.com/watch?v=xN0FFK8JSYE)                           |
+ 
+ 
+ - [Archive sheet for all stages (check by tabs below the spreadsheet)](https://docs.google.com/spreadsheets/d/183iJJIxoD8qXLXyzra5vr9kmHMnZDDI63w-lUz5SSH0/edit#gid=1357895603)
+ - [News post](https://osu.ppy.sh/home/news/2017-08-14-osu-idol-2017-auditions-now-open)
+ - [Results post](https://osu.ppy.sh/home/news/2017-12-03-osu-idol-2017-finals-community-voting-results)
+ - [Offical post](https://osu.ppy.sh/forum/t/617845)
+ 
 
 ## Community Contests
 

--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -188,6 +188,18 @@ The Pending Cup is a mapping contest where the main participants are usually Chi
 - [Contest thread](https://osu.ppy.sh/forum/t/482629)
 - [Results post](https://osu.ppy.sh/forum/t/504645)
 
+#### Pending Cup \#5 (2017)
+
+| Songs No. | Songs                                         | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") |
+|-----------|-----------------------------------------------|------------------------------------------------|------------------------------------------------|------------------------------------------------|
+| 1         | Shimotsuki Haruka - Byakuya Gensoutan        | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Level9](httphttps://osu.ppy.sh/u/7232130)       | [Kibbleru](https://osu.ppy.sh/u/3193504)    |
+| 2         | Nekomata Gekidan - AsiaN distractive | [Chaoslitz](https://osu.ppy.sh/u/3621552)      | [Garden](https://osu.ppy.sh/u/2849992)              | [Ellyu](https://osu.ppy.sh/u/4438154)         |
+| 3         | Camellia - Chirality             | [Suzuki_1112](https://osu.ppy.sh/u/3170678)         | [Miura](https://osu.ppy.sh/u/4990362)         | [\[ Drop \]](https://osu.ppy.sh/u/2391299)      |
+
+- [Contest thread](https://osu.ppy.sh/forum/t/620182)
+- [Results post](https://osu.ppy.sh/forum/t/640906)
+
+
 ### Newspaper Cup
 
 Newspaper Cup is an annually mapping contest which aims at attract normal players to join the mapping community, shows and improves mapping skills of Chinese novice mappers.
@@ -221,3 +233,13 @@ Newspaper Cup is an annually mapping contest which aims at attract normal player
 
 - [Contest thread](https://osu.ppy.sh/forum/t/546038)
 - [Results post](https://osu.ppy.sh/forum/t/570350)
+
+#### Newspaper Cup \#4 (2017)
+
+| Songs No. | Songs                                  | ![Gold Crown](/wiki/shared/GCrown.png "1st place")                                        | ![Silver Crown](/wiki/shared/SCrown.png "2nd place")                                      |
+|-----------|----------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| 1         | 葉月ゆら - サラマンドラの踊り子             |  TBA           | TBA                 |
+| 2         | P＊Light - SAY BAY           | TBA              | TBA  |
+
+- [Contest thread](https://osu.ppy.sh/forum/t/690824)
+- Results post - TBA

--- a/wiki/Contests/zh.md
+++ b/wiki/Contests/zh.md
@@ -1,3 +1,7 @@
+------
+outdated: true
+----------
+
 [o!s]: /wiki/shared/mode/osu.png
 [o!t]: /wiki/shared/mode/taiko.png
 [o!c]: /wiki/shared/mode/catch.png

--- a/wiki/Ranking_Criteria/osu!/en.md
+++ b/wiki/Ranking_Criteria/osu!/en.md
@@ -98,6 +98,7 @@ Overall rules and guidelines apply to every kind of osu! difficulty. Rhythm rela
 -   **Hit100 and hit300 must be different from corresponding geki and katu skin elements.** Hit300g, hit300k, and hit100k indicate if players perfectly hit all 300 in a combo.
 -   **A custom slider border color must be selected when a beatmap contains skin elements from the hit circle or slider sets.** This is to avoid the default slider border or a player's custom skin's slider border from conflicting with the map's specific color scheme. This is done by adding `SliderBorder: <RGB Value>` under `[Colours]` in a `.osu` file.
 -   **Slider body color cannot be too similar to slider border color.** If both of these settings are too similar to each other, then the slider border element loses its point as a visual border for the slider. Slider body color can be selected by adding `SliderTrackOverride: <RGB Value>` under `[Colours]` in a `.osu` file.
+-   **Both slider border and body colors must be manually set or not set.** Setting only one may conflict with a user's custom skin choices.
 
 #### Guidelines
 

--- a/wiki/Ranking_Criteria/osu!/en.md
+++ b/wiki/Ranking_Criteria/osu!/en.md
@@ -98,7 +98,6 @@ Overall rules and guidelines apply to every kind of osu! difficulty. Rhythm rela
 -   **Hit100 and hit300 must be different from corresponding geki and katu skin elements.** Hit300g, hit300k, and hit100k indicate if players perfectly hit all 300 in a combo.
 -   **A custom slider border color must be selected when a beatmap contains skin elements from the hit circle or slider sets.** This is to avoid the default slider border or a player's custom skin's slider border from conflicting with the map's specific color scheme. This is done by adding `SliderBorder: <RGB Value>` under `[Colours]` in a `.osu` file.
 -   **Slider body color cannot be too similar to slider border color.** If both of these settings are too similar to each other, then the slider border element loses its point as a visual border for the slider. Slider body color can be selected by adding `SliderTrackOverride: <RGB Value>` under `[Colours]` in a `.osu` file.
--   **Both slider border and body colors must be manually set or not set.** Setting only one may conflict with a user's custom skin choices.
 
 #### Guidelines
 


### PR DESCRIPTION
### Description

Replacing #951 

### Status

Need to find other contests not listed here

### Changelog

- Filled in Monthly Mapping Contests for 13/14/15
- Added Aspire Stage 2/3
- Added Osu!idol 2017
- Updated Pending and Newspaper Cup
- Finished

### Checklist 

- [x] Monthly Mapping Contests
- [x] Aspire
- [x] Osu!idol
- [x] Pending Cup
- [x] Newspaper Cup