### PR TITLE
Updating and Fixing the MWC 2016 4K and 7K articles

### DIFF
--- a/wiki/Tournaments/MWC/2016/4K/en.md
+++ b/wiki/Tournaments/MWC/2016/4K/en.md
@@ -3,40 +3,41 @@ osu!mania 4K World Cup 2016
 
 ![MWC 4K 2016 logo](logo.png)
 
-The **osu!mania 4K World Cup 2016** (***MWC4K 2016*** ) is a country-based 4-key osu!mania tournament hosted by the [osu! staff](/wiki/People/The_Team). It is part of the 3rd installment of the osu!mania World Cup.
+The **osu!mania 4K World Cup 2016** (***MWC4K 2016***) is a country-based 4-key osu!mania tournament hosted by the [osu! staff](/wiki/People/The_Team). It is part of the 3rd installment of the osu!mania World Cup.
 
 ## Tournament Schedule
 
-
-| Event              | Timestamp                 |
-|--------------------|---------------------------|
-| Registration Phase | 28 Jun - 17 Jul 2016      |
-| Drawings           | 31 Jul 2016 (14:00 UTC+0) |
-| Group Stage        | 06-07 Aug 2016            |
-| Round of 16        | 13-14 Aug 2016            |
-| Quarterfinals      | 20-21 Aug 2016            |
-| Semifinals         | 27-28 Aug 2016            |
-| Finals - Week 1    | 03-04 Sep 2016            |
-| Finals - Week 2    | 10-11 Sep 2016            |
+| Event              | Timestamp               |
+|-------------------:|-------------------------|
+| Registration Phase | 2016-06-28/2016-07-17   |
+| Drawings           | 2016-07-31 14:00:00 UTC |
+| Group Stage        | 2016-08-06/2016-08-07   |
+| Round of 16        | 2016-08-13/2016-08-14   |
+| Quarterfinals      | 2016-08-20/2016-08-21   |
+| Semifinals         | 2016-08-27/2016-08-28   |
+| Finals             | 2016-09-03/2016-09-04   |
+| Grand Finals       | 2016-09-10/2016-09-11   |
 
 ## Prizes
 
 We are aiming to have a minimum $1,900 cash prize pool for this world cup. You can support raising this amount of money by **[purchasing a profile banner for your team here!](https://store.ppy.sh/store/product/150)**
 
 | Placing | Prize(s) |
-|---|---|
+|:---:|:---|
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 50% of the raised prize pool, profile badge, "osu!mania Champion" user title |
-| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge                                  |
-| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge                                  |
+| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge |
+| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge |
 
 ## Organization
 
-| Job | Person(s) |
+The osu!mania 4K World Cup 2016 is run by various community members by distributing the multitude of tasks into various fields of responsibility.
+
+| Position | Member(s) |
 |---|---|
 | Tournament Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) |
-| Map Selectors         | ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/users/2124783), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) |
-| Commentators          | ![][flag_US] [Daikyi](https://osu.ppy.sh/users/811832), ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_GB] [-Konner-](https://osu.ppy.sh/users/6108644), ![][flag_FR] [Slainv](https://osu.ppy.sh/users/4823843), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), ![][flag_CA] [Tasha](https://osu.ppy.sh/users/1031958), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
-| Statistician          | ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) |
+| Map Selectors | ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/users/2124783), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) |
+| Commentators | ![][flag_US] [Daikyi](https://osu.ppy.sh/users/811832), ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_GB] [-Konner-](https://osu.ppy.sh/users/6108644), ![][flag_FR] [Slainv](https://osu.ppy.sh/users/4823843), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), ![][flag_CA] [Tasha](https://osu.ppy.sh/users/1031958), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
+| Statistician | ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) |
 
 ------------------------------------------------------------------------
 
@@ -61,134 +62,90 @@ We are aiming to have a minimum $1,900 cash prize pool for this world cup. You c
 | ![][flag_GB] United Kingdom | ![][flag_ES] Spain       | ![][flag_SG] Singapore   | ![][flag_RU] Russian Federation |
 | ![][flag_US] United States  | ![][flag_TH] Thailand    | ![][flag_CH] Switzerland | ![][flag_SE] Sweden             |
 
-| Country | Group A Members |
-|---|---|
-| ![][flag_CL] Chile     | **[Arkener](https://osu.ppy.sh/users/4116072)**, [Urusai](https://osu.ppy.sh/users/469808), [Demitoo](https://osu.ppy.sh/users/1206206), [sebaex](https://osu.ppy.sh/users/4686036), [WalterToro](https://osu.ppy.sh/users/5281416), [bastianaraya](https://osu.ppy.sh/users/3181733) |
-| ![][flag_TH] Thailand  | **[\_S h i r o\_](https://osu.ppy.sh/users/766374)**, [nowsmart](https://osu.ppy.sh/users/1935034), [- N A K O -](https://osu.ppy.sh/users/2526720), [Zenonia](https://osu.ppy.sh/users/437945), [\[13\] BECK](https://osu.ppy.sh/users/2656374), [bhonris](https://osu.ppy.sh/users/2838908) |
-| ![][flag_AU] Australia | **[Shirinisu](https://osu.ppy.sh/users/4922584)**, [NotDeadYet](https://osu.ppy.sh/users/4081831), [PotassiumF](https://osu.ppy.sh/users/4247722), [Alchalyne](https://osu.ppy.sh/users/3999031), [Parachor](https://osu.ppy.sh/users/5241655), [Evios](https://osu.ppy.sh/users/2058022) |
-| ![][flag_MO] Macau     | **[idqoos123](https://osu.ppy.sh/users/3946113)**, [LuciDestiny](https://osu.ppy.sh/users/8041703), [1063520328](https://osu.ppy.sh/users/4939686) |
+| | Country | Group A Members |
+|:---:|:---:|---|
+| ![][flag_CL] | **Chile** | **[Arkener](https://osu.ppy.sh/users/4116072)**, [Urusai](https://osu.ppy.sh/users/469808), [Demitoo](https://osu.ppy.sh/users/1206206), [sebaex](https://osu.ppy.sh/users/4686036), [WalterToro](https://osu.ppy.sh/users/5281416), [bastianaraya](https://osu.ppy.sh/users/3181733) |
+| ![][flag_TH] | **Thailand**  | **[\_S h i r o\_](https://osu.ppy.sh/users/766374)**, [nowsmart](https://osu.ppy.sh/users/1935034), [- N A K O -](https://osu.ppy.sh/users/2526720), [Zenonia](https://osu.ppy.sh/users/437945), [\[13\] BECK](https://osu.ppy.sh/users/2656374), [bhonris](https://osu.ppy.sh/users/2838908) |
+| ![][flag_AU] | **Australia** | **[Shirinisu](https://osu.ppy.sh/users/4922584)**, [NotDeadYet](https://osu.ppy.sh/users/4081831), [PotassiumF](https://osu.ppy.sh/users/4247722), [Alchalyne](https://osu.ppy.sh/users/3999031), [Parachor](https://osu.ppy.sh/users/5241655), [Evios](https://osu.ppy.sh/users/2058022) |
+| ![][flag_MO] | **Macau** | **[idqoos123](https://osu.ppy.sh/users/3946113)**, [LuciDestiny](https://osu.ppy.sh/users/8041703), [1063520328](https://osu.ppy.sh/users/4939686) |
 
-| Country | Group B Members |
-|---|---|
-| ![][flag_BR] Brazil      | **[Guilhermeziat](https://osu.ppy.sh/users/3661387)**, [HanssFangirl](https://osu.ppy.sh/users/2288363), [FelipeLink](https://osu.ppy.sh/users/4917435), [AutotelicBrown](https://osu.ppy.sh/users/4238941), [andreymc](https://osu.ppy.sh/users/5691061), [Konoe-chan](https://osu.ppy.sh/users/5828575) |
-| ![][flag_ES] Spain       | **[aitor98](https://osu.ppy.sh/users/3154852)**, [Userbacker](https://osu.ppy.sh/users/1872307), [AlvaRo5498](https://osu.ppy.sh/users/4490967), [Asesingta](https://osu.ppy.sh/users/5037769), [R3k3T3](https://osu.ppy.sh/users/4520329), [BadAccPlayer](https://osu.ppy.sh/users/4541413) |
-| ![][flag_CH] Switzerland | **[Akayro](https://osu.ppy.sh/users/2573716)**, [Haprapra](https://osu.ppy.sh/users/3974114), [basti78](https://osu.ppy.sh/users/28222), [Gamer97](https://osu.ppy.sh/users/4952941) |
-| ![][flag_LT] Lithuania   | **[simasx1111](https://osu.ppy.sh/users/5176599)**, [PenguinEatsFish](https://osu.ppy.sh/users/6588446), [Metallica](https://osu.ppy.sh/users/6560198) |
+| | Country | Group B Members |
+|:---:|:---:|---|
+| ![][flag_BR] | **Brazil** | **[Guilhermeziat](https://osu.ppy.sh/users/3661387)**, [HanssFangirl](https://osu.ppy.sh/users/2288363), [FelipeLink](https://osu.ppy.sh/users/4917435), [AutotelicBrown](https://osu.ppy.sh/users/4238941), [andreymc](https://osu.ppy.sh/users/5691061), [Konoe-chan](https://osu.ppy.sh/users/5828575) |
+| ![][flag_ES] | **Spain** | **[aitor98](https://osu.ppy.sh/users/3154852)**, [Userbacker](https://osu.ppy.sh/users/1872307), [AlvaRo5498](https://osu.ppy.sh/users/4490967), [Asesingta](https://osu.ppy.sh/users/5037769), [R3k3T3](https://osu.ppy.sh/users/4520329), [BadAccPlayer](https://osu.ppy.sh/users/4541413) |
+| ![][flag_CH] | **Switzerland** | **[Akayro](https://osu.ppy.sh/users/2573716)**, [Haprapra](https://osu.ppy.sh/users/3974114), [basti78](https://osu.ppy.sh/users/28222), [Gamer97](https://osu.ppy.sh/users/4952941) |
+| ![][flag_LT] | **Lithuania** | **[simasx1111](https://osu.ppy.sh/users/5176599)**, [PenguinEatsFish](https://osu.ppy.sh/users/6588446), [Metallica](https://osu.ppy.sh/users/6560198) |
 
-| Country | Group C Members |
-|---|---|
-| ![][flag_GB] United Kingdom | **[-Konner-](https://osu.ppy.sh/users/6108644)**, [yipyapyop](https://osu.ppy.sh/users/5156656), [Pope Gadget](https://osu.ppy.sh/users/2288341), [Pipper](https://osu.ppy.sh/users/4168230), [Xonica](https://osu.ppy.sh/users/3586776), [Hayabusa](https://osu.ppy.sh/users/3104108) |
-| ![][flag_PL] Poland         | **[Tidek](https://osu.ppy.sh/users/743282)**, [Hudonom](https://osu.ppy.sh/users/1654221), [SitekX](https://osu.ppy.sh/users/3840946), [\_underjoy](https://osu.ppy.sh/users/2235750), [Grubonom](https://osu.ppy.sh/users/5757447), [Transformau5](https://osu.ppy.sh/users/3109917) |
-| ![][flag_NO] Norway         | **[Staiain](https://osu.ppy.sh/users/86188)**, [Duyang](https://osu.ppy.sh/users/5021522), [HennyCovers](https://osu.ppy.sh/users/4266693), [Priest](https://osu.ppy.sh/users/3037964), [KarlF](https://osu.ppy.sh/users/3494742), [Hjeg](https://osu.ppy.sh/users/2764122) |
-| ![][flag_HK] Hong Kong      | **[Opean](https://osu.ppy.sh/users/4544555)**, [Mooncha](https://osu.ppy.sh/users/5417362), [xYakumo\_Yukarix](https://osu.ppy.sh/users/3801443) |
+| | Country | Group C Members |
+|:---:|:---:|---|
+| ![][flag_GB] | **United Kingdom** | **[-Konner-](https://osu.ppy.sh/users/6108644)**, [yipyapyop](https://osu.ppy.sh/users/5156656), [Pope Gadget](https://osu.ppy.sh/users/2288341), [Pipper](https://osu.ppy.sh/users/4168230), [Xonica](https://osu.ppy.sh/users/3586776), [Hayabusa](https://osu.ppy.sh/users/3104108) |
+| ![][flag_PL] | **Poland** | **[Tidek](https://osu.ppy.sh/users/743282)**, [Hudonom](https://osu.ppy.sh/users/1654221), [SitekX](https://osu.ppy.sh/users/3840946), [\_underjoy](https://osu.ppy.sh/users/2235750), [Grubonom](https://osu.ppy.sh/users/5757447), [Transformau5](https://osu.ppy.sh/users/3109917) |
+| ![][flag_NO] | **Norway** | **[Staiain](https://osu.ppy.sh/users/86188)**, [Duyang](https://osu.ppy.sh/users/5021522), [HennyCovers](https://osu.ppy.sh/users/4266693), [Priest](https://osu.ppy.sh/users/3037964), [KarlF](https://osu.ppy.sh/users/3494742), [Hjeg](https://osu.ppy.sh/users/2764122) |
+| ![][flag_HK] | **Hong Kong** | **[Opean](https://osu.ppy.sh/users/4544555)**, [Mooncha](https://osu.ppy.sh/users/5417362), [xYakumo\_Yukarix](https://osu.ppy.sh/users/3801443) |
 
-| Country | Group D Members |
-|---|---|
-| ![][flag_KR] South Korea | **[jakads](https://osu.ppy.sh/users/259972)**, [Cobo-](https://osu.ppy.sh/users/1482965), [cheetose](https://osu.ppy.sh/users/3817144), [w1sp](https://osu.ppy.sh/users/2770796), [WindyS](https://osu.ppy.sh/users/1190879), [\_GUMA\_](https://osu.ppy.sh/users/2306590) |
-| ![][flag_AR] Argentina   | **[juankristal](https://osu.ppy.sh/users/443656)**, [lxLucasxl](https://osu.ppy.sh/users/3632846), [Genwin](https://osu.ppy.sh/users/5748843), [aluuu](https://osu.ppy.sh/users/4585260), [Grindei](https://osu.ppy.sh/users/4228356), [Icaruz](https://osu.ppy.sh/users/2605137) |
-| ![][flag_FI] Finland     | **[Jepetski](https://osu.ppy.sh/users/3794665)**, [LoliScarlet](https://osu.ppy.sh/users/5014674), [Herkkupala](https://osu.ppy.sh/users/3602620), [matti644](https://osu.ppy.sh/users/1982941) |
-| ![][flag_NL] Netherlands | **[mijkolsmith](https://osu.ppy.sh/users/4307765)**, [Chronocide](https://osu.ppy.sh/users/5425324), [CreationEU](https://osu.ppy.sh/users/4004441) |
+| | Country | Group D Members |
+|:---:|:---:|---|
+| ![][flag_KR] | **South Korea** | **[jakads](https://osu.ppy.sh/users/259972)**, [Cobo-](https://osu.ppy.sh/users/1482965), [cheetose](https://osu.ppy.sh/users/3817144), [w1sp](https://osu.ppy.sh/users/2770796), [WindyS](https://osu.ppy.sh/users/1190879), [\_GUMA\_](https://osu.ppy.sh/users/2306590) |
+| ![][flag_AR] | **Argentina** | **[juankristal](https://osu.ppy.sh/users/443656)**, [lxLucasxl](https://osu.ppy.sh/users/3632846), [Genwin](https://osu.ppy.sh/users/5748843), [aluuu](https://osu.ppy.sh/users/4585260), [Grindei](https://osu.ppy.sh/users/4228356), [Icaruz](https://osu.ppy.sh/users/2605137) |
+| ![][flag_FI] | **Finland** | **[Jepetski](https://osu.ppy.sh/users/3794665)**, [LoliScarlet](https://osu.ppy.sh/users/5014674), [Herkkupala](https://osu.ppy.sh/users/3602620), [matti644](https://osu.ppy.sh/users/1982941) |
+| ![][flag_NL] | **Netherlands** | **[mijkolsmith](https://osu.ppy.sh/users/4307765)**, [Chronocide](https://osu.ppy.sh/users/5425324), [CreationEU](https://osu.ppy.sh/users/4004441) |
 
-| Country | Group E Members |
-|---|---|
-| ![][flag_US] United States | **[Halogen-](https://osu.ppy.sh/users/169992)**, [Zyph](https://osu.ppy.sh/users/1600432), [Shadow_SM](https://osu.ppy.sh/users/4552987), [Gekido-](https://osu.ppy.sh/users/4693052), [Chrubble](https://osu.ppy.sh/users/2594280), [Daikyi](https://osu.ppy.sh/users/811832) |
-| ![][flag_PH] Philippines   | **[arcwinolivirus](https://osu.ppy.sh/users/2039089)**, [KatayokuNoTori](https://osu.ppy.sh/users/5968733), [scissorsf](https://osu.ppy.sh/users/6378800), [Ainyan](https://osu.ppy.sh/users/3770641), [Frizu](https://osu.ppy.sh/users/4067614), [SurfChu85](https://osu.ppy.sh/users/4469895) |
-| ![][flag_SG] Singapore     | **[danielrox](https://osu.ppy.sh/users/4893212)**, [Paralit](https://osu.ppy.sh/users/876528), [OrienST8](https://osu.ppy.sh/users/4574597), [wafuu](https://osu.ppy.sh/users/2095061), [Raveille](https://osu.ppy.sh/users/1388767), [Level 51](https://osu.ppy.sh/users/3617847)              |
-| ![][flag_BE] Belgium       | **[Akeyro](https://osu.ppy.sh/users/1933624)**, [Joeycheng02](https://osu.ppy.sh/users/4381142), [Yetified](https://osu.ppy.sh/users/6914714), [kyle5342](https://osu.ppy.sh/users/4951361) |
+| | Country | Group E Members |
+|:---:|:---:|---|
+| ![][flag_US] | **United States** | **[Halogen-](https://osu.ppy.sh/users/169992)**, [Zyph](https://osu.ppy.sh/users/1600432), [Shadow_SM](https://osu.ppy.sh/users/4552987), [Gekido-](https://osu.ppy.sh/users/4693052), [Chrubble](https://osu.ppy.sh/users/2594280), [Daikyi](https://osu.ppy.sh/users/811832) |
+| ![][flag_PH] | **Philippines** | **[arcwinolivirus](https://osu.ppy.sh/users/2039089)**, [KatayokuNoTori](https://osu.ppy.sh/users/5968733), [scissorsf](https://osu.ppy.sh/users/6378800), [Ainyan](https://osu.ppy.sh/users/3770641), [Frizu](https://osu.ppy.sh/users/4067614), [SurfChu85](https://osu.ppy.sh/users/4469895) |
+| ![][flag_SG] | **Singapore** | **[danielrox](https://osu.ppy.sh/users/4893212)**, [Paralit](https://osu.ppy.sh/users/876528), [OrienST8](https://osu.ppy.sh/users/4574597), [wafuu](https://osu.ppy.sh/users/2095061), [Raveille](https://osu.ppy.sh/users/1388767), [Level 51](https://osu.ppy.sh/users/3617847)              |
+| ![][flag_BE] | **Belgium** | **[Akeyro](https://osu.ppy.sh/users/1933624)**, [Joeycheng02](https://osu.ppy.sh/users/4381142), [Yetified](https://osu.ppy.sh/users/6914714), [kyle5342](https://osu.ppy.sh/users/4951361) |
 
-| Country | Group F Members |
-|---|---|
-| ![][flag_CA] Canada             | **[Ashix-](https://osu.ppy.sh/users/981144)**, [beary605](https://osu.ppy.sh/users/2198070), [Hinpoppo](https://osu.ppy.sh/users/6032845), [CommandoBlack](https://osu.ppy.sh/users/7025841), [GameControl](https://osu.ppy.sh/users/5185455), [Piggy](https://osu.ppy.sh/users/5390121) |
-| ![][flag_MY] Malaysia           | **[Cryolien](https://osu.ppy.sh/users/1626983)**, [Explosive-XII](https://osu.ppy.sh/users/7735071), [LawXIII](https://osu.ppy.sh/users/3703360), [UchihaxHoNG](https://osu.ppy.sh/users/4836079), [seyren95](https://osu.ppy.sh/users/1761259), [kaname-san92](https://osu.ppy.sh/users/764535) |
-| ![][flag_NZ] New Zealand        | **[Worms](https://osu.ppy.sh/users/1963937)**, [FantumEX](https://osu.ppy.sh/users/3394802), [Frampleton](https://osu.ppy.sh/users/3580643), [Nyao](https://osu.ppy.sh/users/2068663), [Alamanar](https://osu.ppy.sh/users/7621152), [Spicy Meme](https://osu.ppy.sh/users/6571078) |
-| ![][flag_RU] Russian Federation | **[PhobosX](https://osu.ppy.sh/users/2570019)**, [EYA-](https://osu.ppy.sh/users/6375083), [SpinForWin](https://osu.ppy.sh/users/5527957), [AJIekceu](https://osu.ppy.sh/users/940656), [Rygamine](https://osu.ppy.sh/users/5145890), [Dereku](https://osu.ppy.sh/users/2607745) |
+| | Country | Group F Members |
+|:---:|:---:|---|
+| ![][flag_CA] | **Canada** | **[Ashix-](https://osu.ppy.sh/users/981144)**, [beary605](https://osu.ppy.sh/users/2198070), [Hinpoppo](https://osu.ppy.sh/users/6032845), [CommandoBlack](https://osu.ppy.sh/users/7025841), [GameControl](https://osu.ppy.sh/users/5185455), [Piggy](https://osu.ppy.sh/users/5390121) |
+| ![][flag_MY] | **Malaysia** | **[Cryolien](https://osu.ppy.sh/users/1626983)**, [Explosive-XII](https://osu.ppy.sh/users/7735071), [LawXIII](https://osu.ppy.sh/users/3703360), [UchihaxHoNG](https://osu.ppy.sh/users/4836079), [seyren95](https://osu.ppy.sh/users/1761259), [kaname-san92](https://osu.ppy.sh/users/764535) |
+| ![][flag_NZ] | **New Zealand** | **[Worms](https://osu.ppy.sh/users/1963937)**, [FantumEX](https://osu.ppy.sh/users/3394802), [Frampleton](https://osu.ppy.sh/users/3580643), [Nyao](https://osu.ppy.sh/users/2068663), [Alamanar](https://osu.ppy.sh/users/7621152), [Spicy Meme](https://osu.ppy.sh/users/6571078) |
+| ![][flag_RU] | **Russian Federation** | **[PhobosX](https://osu.ppy.sh/users/2570019)**, [EYA-](https://osu.ppy.sh/users/6375083), [SpinForWin](https://osu.ppy.sh/users/5527957), [AJIekceu](https://osu.ppy.sh/users/940656), [Rygamine](https://osu.ppy.sh/users/5145890), [Dereku](https://osu.ppy.sh/users/2607745) |
 
-| Country | Group G Members |
-|---|---|
-| ![][flag_JP] Japan   | **[inteliser](https://osu.ppy.sh/users/1824775)**, [PiraTom](https://osu.ppy.sh/users/1847698), [Sharped Tiala](https://osu.ppy.sh/users/6879936), [Snow Wind](https://osu.ppy.sh/users/2163585), [DenkyuSM](https://osu.ppy.sh/users/7194397) |
-| ![][flag_DE] Germany | **[Phil](https://osu.ppy.sh/users/3191489)**, [Xay](https://osu.ppy.sh/users/961417), [stankill](https://osu.ppy.sh/users/2583455), [lEdelWeiss](https://osu.ppy.sh/users/6017975), [Sakura Kyoko](https://osu.ppy.sh/users/4282445), [Dreamgate](https://osu.ppy.sh/users/3921273) |
-| ![][flag_IT] Italy   | **[Virtox](https://osu.ppy.sh/users/6631567)**, [\[Kaikyu\]](https://osu.ppy.sh/users/7231991), [GianluTroll](https://osu.ppy.sh/users/5757189), [\[ Akise \]](https://osu.ppy.sh/users/5124074), [magnans](https://osu.ppy.sh/users/1363449) |
-| ![][flag_SE] Sweden  | **[Couil](https://osu.ppy.sh/users/6872025)**, [\[ Vento \]](https://osu.ppy.sh/users/1612580), [-Saoeri-](https://osu.ppy.sh/users/6702799), [Craty](https://osu.ppy.sh/users/3918056), [RilipGirlfriend](https://osu.ppy.sh/users/4999669), [Lamaredia](https://osu.ppy.sh/users/3362365) |
+| | Country | Group G Members |
+|:---:|:---:|---|
+| ![][flag_JP] | **Japan** | **[inteliser](https://osu.ppy.sh/users/1824775)**, [PiraTom](https://osu.ppy.sh/users/1847698), [Sharped Tiala](https://osu.ppy.sh/users/6879936), [Snow Wind](https://osu.ppy.sh/users/2163585), [DenkyuSM](https://osu.ppy.sh/users/7194397) |
+| ![][flag_DE] | **Germany** | **[Phil](https://osu.ppy.sh/users/3191489)**, [Xay](https://osu.ppy.sh/users/961417), [stankill](https://osu.ppy.sh/users/2583455), [lEdelWeiss](https://osu.ppy.sh/users/6017975), [Sakura Kyoko](https://osu.ppy.sh/users/4282445), [Dreamgate](https://osu.ppy.sh/users/3921273) |
+| ![][flag_IT] | **Italy** | **[Virtox](https://osu.ppy.sh/users/6631567)**, [\[Kaikyu\]](https://osu.ppy.sh/users/7231991), [GianluTroll](https://osu.ppy.sh/users/5757189), [\[ Akise \]](https://osu.ppy.sh/users/5124074), [magnans](https://osu.ppy.sh/users/1363449) |
+| ![][flag_SE] | **Sweden** | **[Couil](https://osu.ppy.sh/users/6872025)**, [\[ Vento \]](https://osu.ppy.sh/users/1612580), [-Saoeri-](https://osu.ppy.sh/users/6702799), [Craty](https://osu.ppy.sh/users/3918056), [RilipGirlfriend](https://osu.ppy.sh/users/4999669), [Lamaredia](https://osu.ppy.sh/users/3362365) |
 
-| Country | Group H Members |
-|---|---|
-| ![][flag_FR] France    | **[bumpinho](https://osu.ppy.sh/users/1594604)**, [lim38](https://osu.ppy.sh/users/2741170), [\[ AlexHgC \]](https://osu.ppy.sh/users/4304933), [adrien062](https://osu.ppy.sh/users/2131990), [Elementaires](https://osu.ppy.sh/users/2284328), [Todestrieb](https://osu.ppy.sh/users/4056690) |
-| ![][flag_ID] Indonesia | **[Fiea](https://osu.ppy.sh/users/3183277)**, [Kephin](https://osu.ppy.sh/users/5033561), [ExKagii-](https://osu.ppy.sh/users/4591324), [DoNotMess](https://osu.ppy.sh/users/1596318), [lpddemon](https://osu.ppy.sh/users/5101276), [reyss](https://osu.ppy.sh/users/4557440) |
-| ![][flag_DK] Denmark   | **[Jole](https://osu.ppy.sh/users/2883132)**, [Ramena](https://osu.ppy.sh/users/1245964), [Crowii](https://osu.ppy.sh/users/3795152), [mart732c](https://osu.ppy.sh/users/4402263), [Oriba Hoi](https://osu.ppy.sh/users/7129731) |
-| ![][flag_MX] Mexico    | **[\_Mytros\_](https://osu.ppy.sh/users/6507028)**, [Pollo184](https://osu.ppy.sh/users/3350481), [Chizuru-](https://osu.ppy.sh/users/4301301), [ShaddBladex](https://osu.ppy.sh/users/2530995) |
+| | Country | Group H Members |
+|:---:|:---:|---|
+| ![][flag_FR] | **France** | **[bumpinho](https://osu.ppy.sh/users/1594604)**, [lim38](https://osu.ppy.sh/users/2741170), [\[ AlexHgC \]](https://osu.ppy.sh/users/4304933), [adrien062](https://osu.ppy.sh/users/2131990), [Elementaires](https://osu.ppy.sh/users/2284328), [Todestrieb](https://osu.ppy.sh/users/4056690) |
+| ![][flag_ID] | **Indonesia** | **[Fiea](https://osu.ppy.sh/users/3183277)**, [Kephin](https://osu.ppy.sh/users/5033561), [ExKagii-](https://osu.ppy.sh/users/4591324), [DoNotMess](https://osu.ppy.sh/users/1596318), [lpddemon](https://osu.ppy.sh/users/5101276), [reyss](https://osu.ppy.sh/users/4557440) |
+| ![][flag_DK] | **Denmark** | **[Jole](https://osu.ppy.sh/users/2883132)**, [Ramena](https://osu.ppy.sh/users/1245964), [Crowii](https://osu.ppy.sh/users/3795152), [mart732c](https://osu.ppy.sh/users/4402263), [Oriba Hoi](https://osu.ppy.sh/users/7129731) |
+| ![][flag_MX] | **Mexico** | **[\_Mytros\_](https://osu.ppy.sh/users/6507028)**, [Pollo184](https://osu.ppy.sh/users/3350481), [Chizuru-](https://osu.ppy.sh/users/4301301), [ShaddBladex](https://osu.ppy.sh/users/2530995) |
 
 ------------------------------------------------------------------------
 
 ## Mappools
 
-### Group Stage
+### Finals
 
-**[Download the mappack here!](https://www.mediafire.com/download/p39r1ckct4kjg91/MWC_4K_2016_Group_Stage.rar)**
+**This mappool will be used in Finals and Grand Finals**
 
-- NoMod
-  - [The Ghost of 3.13 - Last Star In The Universe (Shoegazer) \[Nocturne\]](https://osu.ppy.sh/b/678855)
-  - [Yamamoto Momiji - Doutei Korose (short Ver.) (ALEFY) \[EXH\]](https://osu.ppy.sh/b/923934)
-  - [Yokomin feat. Yuzuki Yukari - Story In Everlasting Princess (\[ A v a l o n \]) \[4K Hyper\]](https://osu.ppy.sh/b/739982)
-  - [Yooh - Electronic Sound Lab (XeoStyle) \[MX\]](https://osu.ppy.sh/b/673946)
-  - [Anamanaguchi - Power Supply (Halogen-) \[Charge\]](https://osu.ppy.sh/b/901153)
-  - [NAGI - inside (Jinjin) \[Longing\]](https://osu.ppy.sh/b/1016139)
-  - [Gavin G - Refresh (game rock) \[Momo's MX\]](https://osu.ppy.sh/b/638907)
-  - [Rush - Malignant Narcissism (Pope Gadget) \[R40\]](https://osu.ppy.sh/b/954903)
-  - [Lindsey Stirling - Senbonzakura (MrSergio) \[Harby's HD\]](https://osu.ppy.sh/b/671989)
-  - [Vospi - roboposition!! (arviejhay) \[4K HD\]](https://osu.ppy.sh/b/400180)
-- FreeMod
-  - [NISH - Space Time (\_underjoy) \[4K Another\]](https://osu.ppy.sh/b/888588)
-  - [Shiki - Endless Dream (Shoegazer) \[Hyper\]](https://osu.ppy.sh/b/867245)
-  - [DJ OKAWARI - Canon (schwarzvgrune) \[Clamorous (Insane)\]](https://osu.ppy.sh/b/661929)
-  - [SON OF KICK - Hours ft. Lady Leshurr & Paigey Cakey (Irreversible) \[Feru's HD\]](https://osu.ppy.sh/b/745024)
-- Tiebreaker
-  - [KotoriP - Black Out The Alternative (Pope Gadget) \[The Former\]](https://osu.ppy.sh/b/726209)
-
-### Round of 16
-
-**[Download the mappack here!](https://www.mediafire.com/download/8ixrt0vl4si4fko/MWC_4K_2016_Round_of_16.rar)**
+[Download the mappack here!](https://www.mediafire.com/download/k67i387mj5kdmec/MWC_4K_2016_Finals.rar)
 
 - NoMod
-  - [Nobuo Uematsu - Liberi Fatali (Halogen-) \[Insane\]](https://osu.ppy.sh/b/816901)
-  - [xxdbxx - Taekwonburi (nowsmart) \[4K MX\]](https://osu.ppy.sh/b/465220)
-  - [Yu\_Asahina - Trickstarz (hi19hi19) \[Hard\]](https://osu.ppy.sh/b/770549)
-  - [Shawn Wasabi - Marble Soda (Hydria) \[Pope's Insane\]](https://osu.ppy.sh/b/967910)
-  - [Omoi - Snow Drive (Weegle) \[The Last Way Home\]](https://osu.ppy.sh/b/797441)
-  - [alan - Over the clouds -BURST mix- (LordRaika) \[4K MX\]](https://osu.ppy.sh/b/564610)
-  - [LeaF - Calamity Fortune (Shoegazer) \[Euphoria\]](https://osu.ppy.sh/b/938145)
-  - [sawawa - Cirno Break (Verniy\_Chan) \[MEGA's EXHAUST\]](https://osu.ppy.sh/b/646643)
-  - [Helblinde - Rewrite Nightmare (Jepetski) \[Experiment\]](https://osu.ppy.sh/b/719525)
-  - [Feryquitous - Strahv (Tornspirit) \[Regret\]](https://osu.ppy.sh/b/891620)
+  - [Tatsh - IMAGE -MATERIAL- \<Version 0\> (Fullerene-) \[Refraction\]](https://osu.ppy.sh/b/1048210)
+  - [ZUN - Voyage 1970 (Halogen-) \[Hourai Elixir\]](https://osu.ppy.sh/b/961223)
+  - [Hommarju - Hellfire (snoverpk) \[GRAVITY\]](https://osu.ppy.sh/b/1003669)
+  - [Fleshgod Apocalypse - The Violation (Shoegazer) \[Desecration\]](https://osu.ppy.sh/b/1056624)
+  - [sun3 - Morgenglut 2012 (\_underjoy) \[4K Lv. XXX\]](https://osu.ppy.sh/b/993347)
+  - [Suguro - Sun Valley (K2 Remix) (Guilhermeziat) \[le 8-bit\]](https://osu.ppy.sh/b/950875)
+  - [t+pazolite vs RoughSketch - Readymade Luv (Ciel) \[Homemade Chocolate\]](https://osu.ppy.sh/b/1045122)
+  - [Camellia - Fastest Crash (Shoegazer) \[Paroxysm\]](https://osu.ppy.sh/b/924286)
+  - [Kommisar - Southern Waters Assault 8bit (Gekido-) \[LN Master\]](https://osu.ppy.sh/b/1022204)
+  - [LeaF - I (Tidek) \[Limbo\]](https://osu.ppy.sh/b/921164)
 - FreeMod
-  - [100-200-400 - Fascination MAXX (Ereedon) \[\_UJ's 4K Heavy\]](https://osu.ppy.sh/b/927196)
-  - [UNDEAD CORPORATION - karakurenawi (Tidek) \[Insane\]](https://osu.ppy.sh/b/730528)
-  - [Hommarju - Sounds of Summer (\[Shana Lesus\]) \[Another\]](https://osu.ppy.sh/b/770372)
-  - [ginkiha - nightfall (Abraxos) \[rave's dream\]](https://osu.ppy.sh/b/1010821)
+  - [t+pazolite with siromaru - Chambarising (Evening) \[Challenge\]](https://osu.ppy.sh/b/923890)
+  - [xi - FREEDOM DiVE (razlteh) \[Fullerene's 4K DIMENSIONS\]](https://osu.ppy.sh/b/473228)
+  - [ikaruga_nex - Mirage (inteliser) \[UNLIMITED \[LN\]\]](https://osu.ppy.sh/b/1038091)
+  - [Camellia - dreamless wanderer (Fullerene-) \[Ethereal Shift\]](https://osu.ppy.sh/b/714878)
 - Tiebreaker
-  - [aaaa - Bokutachi no Tabi to Epilogue.\[Long ver.\] (Daikyi) \[Final Voyage\]](https://osu.ppy.sh/b/834266)
-
-### Quarterfinals
-
-**[Download the mappack here!](https://www.mediafire.com/download/x8fv79n1mb1miss/MWC_4K_2016_Quarterfinals.rar)**
-
-- NoMod
-  - [Memme - Chinese Restaurant (ajeemaniz) \[Insanity "Noodles"\]](https://osu.ppy.sh/b/579715)
-  - [DEV/NULL - Rave 7 (hi19hi19) \[Hard\]](https://osu.ppy.sh/b/480466)
-  - [Camellia - Ultimate Ascension (Fresh Chicken) \[GRAVITY\]](https://osu.ppy.sh/b/1017927)
-  - [Neun\_jack - Gypsy gets the Tek (LeiN-) \[wag\]](https://osu.ppy.sh/b/991504)
-  - [Morimori Atsushi + Verdammt - Le Fruit Defendu (MasterSonic10) \[INFINITE Lv.15\]](https://osu.ppy.sh/b/782892)
-  - [BlackY - Depravity CLiMAXXX (Valedict) \[Desperado\]](https://osu.ppy.sh/b/893354)
-  - [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm (-Kamikaze-) \[Calculation\]](https://osu.ppy.sh/b/973263)
-  - [lapix - Foolish Hero (dionzz99) \[Fooled\]](https://osu.ppy.sh/b/1040762)
-  - [Venetian Snares - She Runs (Shoegazer) \[Breakaway\]](https://osu.ppy.sh/b/961767)
-  - [maras k - Play Time!! (MasterSonic10) \[SC\]](https://osu.ppy.sh/b/692198)
-- FreeMod
-  - [DesoloZ - Summoned Beast Battle (Halogen-) \[Destruction\]](https://osu.ppy.sh/b/901157)
-  - [DJ'TEKINA//SOMETHING - Palette GAMMA (Cadmium-113) \[Affection\]](https://osu.ppy.sh/b/888774)
-  - [Terminal 11 - The Bird's Poisoned Bathwater (Xay) \[Xay's 4k\]](https://osu.ppy.sh/b/1000029)
-  - [kemu - Ikasama Life game (Thievley) \[Smith's MX\]](https://osu.ppy.sh/b/1005445)
-- Tiebreaker
-  - [b4kn - Act V - The Battle At Mammoth Mountain (Halogen-) \[Finale\]](https://osu.ppy.sh/b/1040978)
+  - [Camellia - I Can Fly In The Universe (Evening) \[Schizophrenia\]](https://osu.ppy.sh/b/1055345)
 
 ### Semifinals
 
@@ -213,30 +170,74 @@ We are aiming to have a minimum $1,900 cash prize pool for this world cup. You c
 - Tiebreaker
   - [D.B.O.Y.D x Kommisar - Interstellar Retribution (MasterSonic10) \[Disbelief\]](https://osu.ppy.sh/b/823799)
 
-### Finals
+### Quarterfinals
 
-**This mappool will be used in Finals - Week 1 and Finals - Week 2**
-
-[Download the mappack here!](https://www.mediafire.com/download/k67i387mj5kdmec/MWC_4K_2016_Finals.rar)
+**[Download the mappack here!](https://www.mediafire.com/download/x8fv79n1mb1miss/MWC_4K_2016_Quarterfinals.rar)**
 
 - NoMod
-  - [Tatsh - IMAGE -MATERIAL- \<Version 0\> (Fullerene-) \[Refraction\]](https://osu.ppy.sh/b/1048210)
-  - [ZUN - Voyage 1970 (Halogen-) \[Hourai Elixir\]](https://osu.ppy.sh/b/961223)
-  - [Hommarju - Hellfire (snoverpk) \[GRAVITY\]](https://osu.ppy.sh/b/1003669)
-  - [Fleshgod Apocalypse - The Violation (Shoegazer) \[Desecration\]](https://osu.ppy.sh/b/1056624)
-  - [sun3 - Morgenglut 2012 (_underjoy) \[4K Lv. XXX\]](https://osu.ppy.sh/b/993347)
-  - [Suguro - Sun Valley (K2 Remix) (Guilhermeziat) \[le 8-bit\]](https://osu.ppy.sh/b/950875)
-  - [t+pazolite vs RoughSketch - Readymade Luv (Ciel) \[Homemade Chocolate\]](https://osu.ppy.sh/b/1045122)
-  - [Camellia - Fastest Crash (Shoegazer) \[Paroxysm\]](https://osu.ppy.sh/b/924286)
-  - [Kommisar - Southern Waters Assault 8bit (Gekido-) \[LN Master\]](https://osu.ppy.sh/b/1022204)
-  - [LeaF - I (Tidek) \[Limbo\]](https://osu.ppy.sh/b/921164)
+  - [Memme - Chinese Restaurant (ajeemaniz) \[Insanity "Noodles"\]](https://osu.ppy.sh/b/579715)
+  - [DEV/NULL - Rave 7 (hi19hi19) \[Hard\]](https://osu.ppy.sh/b/480466)
+  - [Camellia - Ultimate Ascension (Fresh Chicken) \[GRAVITY\]](https://osu.ppy.sh/b/1017927)
+  - [Neun\_jack - Gypsy gets the Tek (LeiN-) \[wag\]](https://osu.ppy.sh/b/991504)
+  - [Morimori Atsushi + Verdammt - Le Fruit Defendu (MasterSonic10) \[INFINITE Lv.15\]](https://osu.ppy.sh/b/782892)
+  - [BlackY - Depravity CLiMAXXX (Valedict) \[Desperado\]](https://osu.ppy.sh/b/893354)
+  - [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm (-Kamikaze-) \[Calculation\]](https://osu.ppy.sh/b/973263)
+  - [lapix - Foolish Hero (dionzz99) \[Fooled\]](https://osu.ppy.sh/b/1040762)
+  - [Venetian Snares - She Runs (Shoegazer) \[Breakaway\]](https://osu.ppy.sh/b/961767)
+  - [maras k - Play Time!! (MasterSonic10) \[SC\]](https://osu.ppy.sh/b/692198)
 - FreeMod
-  - [t+pazolite with siromaru - Chambarising (Evening) \[Challenge\]](https://osu.ppy.sh/b/923890)
-  - [xi - FREEDOM DiVE (razlteh) \[Fullerene's 4K DIMENSIONS\]](https://osu.ppy.sh/b/473228)
-  - [ikaruga_nex - Mirage (inteliser) \[UNLIMITED \[LN\]\]](https://osu.ppy.sh/b/1038091)
-  - [Camellia - dreamless wanderer (Fullerene-) \[Ethereal Shift\]](https://osu.ppy.sh/b/714878)
+  - [DesoloZ - Summoned Beast Battle (Halogen-) \[Destruction\]](https://osu.ppy.sh/b/901157)
+  - [DJ'TEKINA//SOMETHING - Palette GAMMA (Cadmium-113) \[Affection\]](https://osu.ppy.sh/b/888774)
+  - [Terminal 11 - The Bird's Poisoned Bathwater (Xay) \[Xay's 4k\]](https://osu.ppy.sh/b/1000029)
+  - [kemu - Ikasama Life game (Thievley) \[Smith's MX\]](https://osu.ppy.sh/b/1005445)
 - Tiebreaker
-  - [Camellia - I Can Fly In The Universe (Evening) \[Schizophrenia\]](https://osu.ppy.sh/b/1055345)
+  - [b4kn - Act V - The Battle At Mammoth Mountain (Halogen-) \[Finale\]](https://osu.ppy.sh/b/1040978)
+
+### Round of 16
+
+**[Download the mappack here!](https://www.mediafire.com/download/8ixrt0vl4si4fko/MWC_4K_2016_Round_of_16.rar)**
+
+- NoMod
+  - [Nobuo Uematsu - Liberi Fatali (Halogen-) \[Insane\]](https://osu.ppy.sh/b/816901)
+  - [xxdbxx - Taekwonburi (nowsmart) \[4K MX\]](https://osu.ppy.sh/b/465220)
+  - [Yu\_Asahina - Trickstarz (hi19hi19) \[Hard\]](https://osu.ppy.sh/b/770549)
+  - [Shawn Wasabi - Marble Soda (Hydria) \[Pope's Insane\]](https://osu.ppy.sh/b/967910)
+  - [Omoi - Snow Drive (Weegle) \[The Last Way Home\]](https://osu.ppy.sh/b/797441)
+  - [alan - Over the clouds -BURST mix- (LordRaika) \[4K MX\]](https://osu.ppy.sh/b/564610)
+  - [LeaF - Calamity Fortune (Shoegazer) \[Euphoria\]](https://osu.ppy.sh/b/938145)
+  - [sawawa - Cirno Break (Verniy\_Chan) \[MEGA's EXHAUST\]](https://osu.ppy.sh/b/646643)
+  - [Helblinde - Rewrite Nightmare (Jepetski) \[Experiment\]](https://osu.ppy.sh/b/719525)
+  - [Feryquitous - Strahv (Tornspirit) \[Regret\]](https://osu.ppy.sh/b/891620)
+- FreeMod
+  - [100-200-400 - Fascination MAXX (Ereedon) \[\_UJ's 4K Heavy\]](https://osu.ppy.sh/b/927196)
+  - [UNDEAD CORPORATION - karakurenawi (Tidek) \[Insane\]](https://osu.ppy.sh/b/730528)
+  - [Hommarju - Sounds of Summer (\[Shana Lesus\]) \[Another\]](https://osu.ppy.sh/b/770372)
+  - [ginkiha - nightfall (Abraxos) \[rave's dream\]](https://osu.ppy.sh/b/1010821)
+- Tiebreaker
+  - [aaaa - Bokutachi no Tabi to Epilogue.\[Long ver.\] (Daikyi) \[Final Voyage\]](https://osu.ppy.sh/b/834266)
+
+### Group Stage
+
+**[Download the mappack here!](https://www.mediafire.com/download/p39r1ckct4kjg91/MWC_4K_2016_Group_Stage.rar)**
+
+- NoMod
+  - [The Ghost of 3.13 - Last Star In The Universe (Shoegazer) \[Nocturne\]](https://osu.ppy.sh/b/678855)
+  - [Yamamoto Momiji - Doutei Korose (short Ver.) (ALEFY) \[EXH\]](https://osu.ppy.sh/b/923934)
+  - [Yokomin feat. Yuzuki Yukari - Story In Everlasting Princess (\[ A v a l o n \]) \[4K Hyper\]](https://osu.ppy.sh/b/739982)
+  - [Yooh - Electronic Sound Lab (XeoStyle) \[MX\]](https://osu.ppy.sh/b/673946)
+  - [Anamanaguchi - Power Supply (Halogen-) \[Charge\]](https://osu.ppy.sh/b/901153)
+  - [NAGI - inside (Jinjin) \[Longing\]](https://osu.ppy.sh/b/1016139)
+  - [Gavin G - Refresh (game rock) \[Momo's MX\]](https://osu.ppy.sh/b/638907)
+  - [Rush - Malignant Narcissism (Pope Gadget) \[R40\]](https://osu.ppy.sh/b/954903)
+  - [Lindsey Stirling - Senbonzakura (MrSergio) \[Harby's HD\]](https://osu.ppy.sh/b/671989)
+  - [Vospi - roboposition!! (arviejhay) \[4K HD\]](https://osu.ppy.sh/b/400180)
+- FreeMod
+  - [NISH - Space Time (\_underjoy) \[4K Another\]](https://osu.ppy.sh/b/888588)
+  - [Shiki - Endless Dream (Shoegazer) \[Hyper\]](https://osu.ppy.sh/b/867245)
+  - [DJ OKAWARI - Canon (schwarzvgrune) \[Clamorous (Insane)\]](https://osu.ppy.sh/b/661929)
+  - [SON OF KICK - Hours ft. Lady Leshurr & Paigey Cakey (Irreversible) \[Feru's HD\]](https://osu.ppy.sh/b/745024)
+- Tiebreaker
+  - [KotoriP - Black Out The Alternative (Pope Gadget) \[The Former\]](https://osu.ppy.sh/b/726209)
 
 ------------------------------------------------------------------------
 
@@ -244,122 +245,122 @@ We are aiming to have a minimum $1,900 cash prize pool for this world cup. You c
 
 **[Detailed match statistics here!](https://docs.google.com/spreadsheets/d/1GSFF2W81heDb8oTdrp_R-w4sTNBvf3tv0Rdmpxsw_U0/pubhtml)**
 
-### Group Stage
+### Grand Finals
 
-| Saturday, 6\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| Macau ![][flag_MO]              | 0      - **4** | ![][flag_AU] **Australia**     | [#1](https://osu.ppy.sh/community/matches/26845650) |
-| New Zealand ![][flag_NZ]        | 0      - **4** | ![][flag_MY] **Malaysia**      | [#1](https://osu.ppy.sh/community/matches/26845652) |
-| **Singapore** ![][flag_SG]      | **4**  - 0     | ![][flag_PH] Philippines       | [#1](https://osu.ppy.sh/community/matches/26846360) |
-| Sweden ![][flag_SE]             | 0      - **4** | ![][flag_JP]  **Japan**        | [#1](https://osu.ppy.sh/community/matches/26846361) |
-| Hong Kong ![][flag_HK]          | 0      - **4** | ![][flag_NO] **Norway**        | -win by default-               |
-| Russian Federation ![][flag_RU] | 0      - **4** | ![][flag_MY] **Malaysia**      | [#1](https://osu.ppy.sh/community/matches/26847344) |
-| Denmark ![][flag_DK]            | 0      - **4** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/26847345) |
-| Germany ![][flag_DE]            | 0      - **4** | ![][flag_JP] **Japan**         | [#1](https://osu.ppy.sh/community/matches/26847346) |
-| Hong Kong ![][flag_HK]          | 0      - **4** | ![][flag_PL] **Poland**        | [#1](https://osu.ppy.sh/community/matches/26847347) |
-| Belgium ![][flag_BE]            | 1      - **4** | ![][flag_SG] **Singapore**     | [#1](https://osu.ppy.sh/community/matches/26848325) |
-| Netherlands ![][flag_NL]        | 1      - **4** | ![][flag_FI] **Finland**       | [#1](https://osu.ppy.sh/community/matches/26848327) |
-| **Sweden** ![][flag_SE]         | **4**  - 1     | ![][flag_IT] Italy             | [#1](https://osu.ppy.sh/community/matches/26848328) |
-| **Poland** ![][flag_PL]         | **4**  - 0     | ![][flag_GB] United Kingdom    | [#1](https://osu.ppy.sh/community/matches/26848329) |
-| Thailand ![][flag_TH]           | 3      - **4** | ![][flag_CL] **Chile**         | [#1](https://osu.ppy.sh/community/matches/26851869) |
-| Mexico ![][flag_MX]             | 0      - **4** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/26851870) |
-| Finland ![][flag_FI]            | 0      - **4** | ![][flag_AR] **Argentina**     | [#1](https://osu.ppy.sh/community/matches/26851871) |
-| Spain ![][flag_ES]              | 0      - **4** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/26851872) |
-| Mexico ![][flag_MX]             | 1      - **4** | ![][flag_DK] **Denmark**       | [#1](https://osu.ppy.sh/community/matches/26853123) |
-| Netherlands ![][flag_NL]        | 1      - **4** | ![][flag_AR] **Argentina**     | [#1](https://osu.ppy.sh/community/matches/26853124) |
-| Lithuania ![][flag_LT]          | 0      - **4** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/26853125) |
-| Belgium ![][flag_BE]            | 0      - **4** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/26854197) |
-| Russian Federation ![][flag_RU] | 1      - **4** | ![][flag_CA] **Canada**        | [#1](https://osu.ppy.sh/community/matches/26854198) |
-| **Switzerland** ![][flag_CH]    | **4**  - 1     | ![][flag_ES] Spain             | [#1](https://osu.ppy.sh/community/matches/26854199) |
+| 2016-09-10 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **South Korea** ![][flag_KR] | **7** | 0 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/27652825) |
 
-| Sunday, 7\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| Australia ![][flag_AU]          | 3      - **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/26862320) |
-| Argentina ![][flag_AR]          | 0      - **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/26862322) |
-| Philippines ![][flag_PH]        | 0      - **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/26863256) |
-| **Malaysia** ![][flag_MY]       | **4**  - 2     | ![][flag_CA] Canada             | [#1](https://osu.ppy.sh/community/matches/26863257) |
-| Singapore ![][flag_SG]          | 0      - **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/26864181) |
-| New Zealand ![][flag_NZ]        | 0      - **4** | ![][flag_CA] **Canada**         | [#1](https://osu.ppy.sh/community/matches/26864182) |
-| Macau ![][flag_MO]              | 0      - **4** | ![][flag_TH] **Thailand**       | -win by default-               |
-| Russian Federation ![][flag_RU]  | 2      - **4** | ![][flag_NZ] **New Zealand**    | [#1](https://osu.ppy.sh/community/matches/26868897) |
-| Indonesia ![][flag_ID]          | 2      - **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26868898) |
-| Netherlands ![][flag_NL]        | 1      - **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/26869611) |
-| Italy ![][flag_IT]              | 0      - **4** | ![][flag_JP] **Japan**          | -win by default-               |
-| Lithuania ![][flag_LT]          | 2      - **4** | ![][flag_ES] **Spain**          | [#1](https://osu.ppy.sh/community/matches/26869614) |
-| **Australia** ![][flag_AU]      | **4**  - 2     | ![][flag_TH] Thailand           | [#1](https://osu.ppy.sh/community/matches/26870315) |
-| Belgium ![][flag_BE]            | 2      - **4** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/26870316) |
-| Hong Kong ![][flag_HK]          | 0      - **4** | ![][flag_GB] **United Kingdom** | -win by default-               |
-| Norway ![][flag_NO]             | 0      - **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/26870319) |
-| **Sweden** ![][flag_SE]         | **4**  - 3     | ![][flag_DE] Germany            | [#1](https://osu.ppy.sh/community/matches/26872090) |
-| Finland ![][flag_FI]            | 0      - **4** | ![][flag_KR] **South Korea**    | -win by default-               |
-| Lithuania ![][flag_LT]          | 0      - **4** | ![][flag_CH] **Switzerland**    | [#1](https://osu.ppy.sh/community/matches/26872092) |
-| Macau ![][flag_MO]              | 0      - **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/26873166) |
-| Denmark ![][flag_DK]            | 0      - **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26873167) |
-| Norway ![][flag_NO]             | 0      - **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/26873168) |
-| Mexico ![][flag_MX]             | 0      - **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26874271) |
-| Italy ![][flag_IT]              | 1      - **4** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/26874272) |
-| Switzerland ![][flag_CH]        | 1      - **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/26874273) |
+### Finals
 
-### Round of 16
+| 2016-09-03 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| United States ![][flag_US] | 0 | **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/27505279) |
+| **Japan** ![][flag_JP]     | **6** | 3 | ![][flag_GB] United Kingdom  | [#1](https://osu.ppy.sh/community/matches/27510481) |
+| **Brazil** ![][flag_BR]    | **6** | 0 | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/27512221) |
+| Japan ![][flag_JP]         | 0 | **6** | ![][flag_BR] **Brazil**      | [#1](https://osu.ppy.sh/community/matches/27513965) |
 
-| Saturday, 13\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| Singapore ![][flag_SG]         | 0      - **5** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/27007849) |
-| Australia ![][flag_AU]         | 1      - **5** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/27008721) |
-| Switzerland ![][flag_CH]       | 0      - **5** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/27009804) |
-| Malaysia ![][flag_MY]          | 1      - **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/27011029) |
-| Chile ![][flag_CL]             | 2      - **5** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/27012590) |
-| **Brazil** ![][flag_BR]        | **5**  - 0     | ![][flag_SE] Sweden             | [#1](https://osu.ppy.sh/community/matches/27016306) |
-| Canada ![][flag_CA]            | 0      - **5** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/27017355) |
-| **United States** ![][flag_US] | **5**  - 0     | ![][flag_AR] Argentina          | [#1](https://osu.ppy.sh/community/matches/27018723) |
-
-### Quarterfinals
-
-| Sunday, 21\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| **Canada** ![][flag_CA]        | **5**  - 2     | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/27192490) |
-| Japan ![][flag_JP]             | 0      - **5** | ![][flag_KR] **South Korea**    | -win by default-               |
-| Switzerland ![][flag_CH]       | 0      - **5** | ![][flag_SG] **Singapore**      | -win by default-               |
-| Indonesia ![][flag_ID]         | 1      - **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/27201519) |
-| **Chile** ![][flag_CL]         | **5**  - 3     | ![][flag_MY] Malaysia           | [#1](https://osu.ppy.sh/community/matches/27202248) |
-| Poland ![][flag_PL]            | 1      - **5** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/27206508) |
-| **Argentina** ![][flag_AR]     | **5**  - 0     | ![][flag_SE] Sweden             | [#1](https://osu.ppy.sh/community/matches/27207843) |
-| **United States** ![][flag_US] | **5**  - 2     | ![][flag_BR] Brazil             | [#1](https://osu.ppy.sh/community/matches/27209327) |
+| 2016-09-04 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| United States ![][flag_US] | 2 | **6** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/27551501) |
 
 ### Semifinals
 
-| Saturday, 28\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| **South Korea** ![][flag_KR] | **6**  - 0     | ![][flag_FR] France            | [#1](https://osu.ppy.sh/community/matches/27342270) |
-| Argentina ![][flag_AR]       | 0      - **6** | ![][flag_JP] **Japan**         | -win by default-                    |
-| Singapore ![][flag_SG]       | 0      - **6** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/27346316) |
-| **Canada** ![][flag_CA]      | **6**  - 4     | ![][flag_ID] Indonesia         | [#1](https://osu.ppy.sh/community/matches/27348592) |
-| **Chile** ![][flag_CL]       | **6**  - 3     | ![][flag_PL] Poland            | [#1](https://osu.ppy.sh/community/matches/27350846) |
-| United Kingdom ![][flag_GB]  | 4      - **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/27353347) |
+| 2016-08-28 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **South Korea** ![][flag_KR] | **6** | 0 | ![][flag_FR] France            | [#1](https://osu.ppy.sh/community/matches/27342270) |
+| Argentina ![][flag_AR]       | 0 | **6** | ![][flag_JP] **Japan**         | -win by default- |
+| Singapore ![][flag_SG]       | 0 | **6** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/27346316) |
+| **Canada** ![][flag_CA]      | **6** | 4 | ![][flag_ID] Indonesia         | [#1](https://osu.ppy.sh/community/matches/27348592) |
+| **Chile** ![][flag_CL]       | **6** | 3 | ![][flag_PL] Poland            | [#1](https://osu.ppy.sh/community/matches/27350846) |
+| United Kingdom ![][flag_GB]  | 4 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/27353347) |
 
-| Sunday. 29\. August 2016 | | | |
-|----:|:---:|:---|:---:|
-| Chile ![][flag_CL]      | 0      - **6** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/27372674) |
-| **Brazil** ![][flag_BR] | **6**  - 0     | ![][flag_CA] Canada    | [#1](https://osu.ppy.sh/community/matches/27382022) |
+| 2016-08-29 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Chile ![][flag_CL]      | 0 | **6** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/27372674) |
+| **Brazil** ![][flag_BR] | **6** | 0 | ![][flag_CA] Canada    | [#1](https://osu.ppy.sh/community/matches/27382022) |
 
-### Finals - Week 1
+### Quarterfinals
 
-| Saturday, 3\. September 2016 | | | |
-|----:|:---:|:---|:---:|
-| United States ![][flag_US] | 0      - **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/27505279) |
-| **Japan** ![][flag_JP]     | **6**  - 3     | ![][flag_GB] United Kingdom  | [#1](https://osu.ppy.sh/community/matches/27510481) |
-| **Brazil** ![][flag_BR]    | **6**  - 0     | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/27512221) |
-| Japan ![][flag_JP]         | 0      - **6** | ![][flag_BR] **Brazil**      | [#1](https://osu.ppy.sh/community/matches/27513965) |
+| 2016-08-21 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **Canada** ![][flag_CA]        | **5** | 2 | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/27192490) |
+| Japan ![][flag_JP]             | 0 | **5** | ![][flag_KR] **South Korea**    | -win by default- |
+| Switzerland ![][flag_CH]       | 0 | **5** | ![][flag_SG] **Singapore**      | -win by default- |
+| Indonesia ![][flag_ID]         | 1 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/27201519) |
+| **Chile** ![][flag_CL]         | **5** | 3 | ![][flag_MY] Malaysia           | [#1](https://osu.ppy.sh/community/matches/27202248) |
+| Poland ![][flag_PL]            | 1 | **5** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/27206508) |
+| **Argentina** ![][flag_AR]     | **5** | 0 | ![][flag_SE] Sweden             | [#1](https://osu.ppy.sh/community/matches/27207843) |
+| **United States** ![][flag_US] | **5** | 2 | ![][flag_BR] Brazil             | [#1](https://osu.ppy.sh/community/matches/27209327) |
 
-| Sunday, 4\. September 2016 | | | |
-|----:|:---:|:---|:---:|
-| United States ![][flag_US] | 2 - **6** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/27551501) |
+### Round of 16
 
-### Finals - Week 2
+| 2016-08-13 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Singapore ![][flag_SG]         | 0 | **5** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/27007849) |
+| Australia ![][flag_AU]         | 1 | **5** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/27008721) |
+| Switzerland ![][flag_CH]       | 0 | **5** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/27009804) |
+| Malaysia ![][flag_MY]          | 1 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/27011029) |
+| Chile ![][flag_CL]             | 2 | **5** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/27012590) |
+| **Brazil** ![][flag_BR]        | **5** | 0 | ![][flag_SE] Sweden             | [#1](https://osu.ppy.sh/community/matches/27016306) |
+| Canada ![][flag_CA]            | 0 | **5** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/27017355) |
+| **United States** ![][flag_US] | **5** | 0 | ![][flag_AR] Argentina          | [#1](https://osu.ppy.sh/community/matches/27018723) |
 
-| Saturday, 10\. September 2016 | | | |
-|----:|:---:|:---|:---:|
-| **South Korea** ![][flag_KR] | **7** - 0 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/27652825) |
+### Group Stage
+
+| 2016-08-06 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Macau ![][flag_MO]              | 0 | **4** | ![][flag_AU] **Australia**     | [#1](https://osu.ppy.sh/community/matches/26845650) |
+| New Zealand ![][flag_NZ]        | 0 | **4** | ![][flag_MY] **Malaysia**      | [#1](https://osu.ppy.sh/community/matches/26845652) |
+| **Singapore** ![][flag_SG]      | **4** | 0 | ![][flag_PH] Philippines       | [#1](https://osu.ppy.sh/community/matches/26846360) |
+| Sweden ![][flag_SE]             | 0 | **4** | ![][flag_JP]  **Japan**        | [#1](https://osu.ppy.sh/community/matches/26846361) |
+| Hong Kong ![][flag_HK]          | 0 | **4** | ![][flag_NO] **Norway**        | -win by default- |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_MY] **Malaysia**      | [#1](https://osu.ppy.sh/community/matches/26847344) |
+| Denmark ![][flag_DK]            | 0 | **4** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/26847345) |
+| Germany ![][flag_DE]            | 0 | **4** | ![][flag_JP] **Japan**         | [#1](https://osu.ppy.sh/community/matches/26847346) |
+| Hong Kong ![][flag_HK]          | 0 | **4** | ![][flag_PL] **Poland**        | [#1](https://osu.ppy.sh/community/matches/26847347) |
+| Belgium ![][flag_BE]            | 1 | **4** | ![][flag_SG] **Singapore**     | [#1](https://osu.ppy.sh/community/matches/26848325) |
+| Netherlands ![][flag_NL]        | 1 | **4** | ![][flag_FI] **Finland**       | [#1](https://osu.ppy.sh/community/matches/26848327) |
+| **Sweden** ![][flag_SE]         | **4** | 1 | ![][flag_IT] Italy             | [#1](https://osu.ppy.sh/community/matches/26848328) |
+| **Poland** ![][flag_PL]         | **4** | 0 | ![][flag_GB] United Kingdom    | [#1](https://osu.ppy.sh/community/matches/26848329) |
+| Thailand ![][flag_TH]           | 3 | **4** | ![][flag_CL] **Chile**         | [#1](https://osu.ppy.sh/community/matches/26851869) |
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/26851870) |
+| Finland ![][flag_FI]            | 0 | **4** | ![][flag_AR] **Argentina**     | [#1](https://osu.ppy.sh/community/matches/26851871) |
+| Spain ![][flag_ES]              | 0 | **4** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/26851872) |
+| Mexico ![][flag_MX]             | 1 | **4** | ![][flag_DK] **Denmark**       | [#1](https://osu.ppy.sh/community/matches/26853123) |
+| Netherlands ![][flag_NL]        | 1 | **4** | ![][flag_AR] **Argentina**     | [#1](https://osu.ppy.sh/community/matches/26853124) |
+| Lithuania ![][flag_LT]          | 0 | **4** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/26853125) |
+| Belgium ![][flag_BE]            | 0 | **4** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/26854197) |
+| Russian Federation ![][flag_RU] | 1 | **4** | ![][flag_CA] **Canada**        | [#1](https://osu.ppy.sh/community/matches/26854198) |
+| **Switzerland** ![][flag_CH]    | **4** | 1 | ![][flag_ES] Spain             | [#1](https://osu.ppy.sh/community/matches/26854199) |
+
+| 2016-08-07 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Australia ![][flag_AU]          | 3 | **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/26862320) |
+| Argentina ![][flag_AR]          | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/26862322) |
+| Philippines ![][flag_PH]        | 0 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/26863256) |
+| **Malaysia** ![][flag_MY]       | **4** | 2 | ![][flag_CA] Canada             | [#1](https://osu.ppy.sh/community/matches/26863257) |
+| Singapore ![][flag_SG]          | 0 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/26864181) |
+| New Zealand ![][flag_NZ]        | 0 | **4** | ![][flag_CA] **Canada**         | [#1](https://osu.ppy.sh/community/matches/26864182) |
+| Macau ![][flag_MO]              | 0 | **4** | ![][flag_TH] **Thailand**       | -win by default- |
+| Russian Federation ![][flag_RU] | 2 | **4** | ![][flag_NZ] **New Zealand**    | [#1](https://osu.ppy.sh/community/matches/26868897) |
+| Indonesia ![][flag_ID]          | 2 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26868898) |
+| Netherlands ![][flag_NL]        | 1 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/26869611) |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_JP] **Japan**          | -win by default- |
+| Lithuania ![][flag_LT]          | 2 | **4** | ![][flag_ES] **Spain**          | [#1](https://osu.ppy.sh/community/matches/26869614) |
+| **Australia** ![][flag_AU]      | **4** | 2 | ![][flag_TH] Thailand           | [#1](https://osu.ppy.sh/community/matches/26870315) |
+| Belgium ![][flag_BE]            | 2 | **4** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/26870316) |
+| Hong Kong ![][flag_HK]          | 0 | **4** | ![][flag_GB] **United Kingdom** | -win by default- |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/26870319) |
+| **Sweden** ![][flag_SE]         | **4** | 3 | ![][flag_DE] Germany            | [#1](https://osu.ppy.sh/community/matches/26872090) |
+| Finland ![][flag_FI]            | 0 | **4** | ![][flag_KR] **South Korea**    | -win by default- |
+| Lithuania ![][flag_LT]          | 0 | **4** | ![][flag_CH] **Switzerland**    | [#1](https://osu.ppy.sh/community/matches/26872092) |
+| Macau ![][flag_MO]              | 0 | **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/26873166) |
+| Denmark ![][flag_DK]            | 0 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26873167) |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/26873168) |
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/26874271) |
+| Italy ![][flag_IT]              | 1 | **4** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/26874272) |
+| Switzerland ![][flag_CH]        | 1 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/26874273) |
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/MWC/2016/7K/en.md
+++ b/wiki/Tournaments/MWC/2016/7K/en.md
@@ -5,41 +5,40 @@ osu!mania 7K World Cup 2016
 
 The **osu!mania 7K World Cup 2016** (***MWC 7K 2016***) is a country-based osu!mania 7-key tournament hosted by the [osu! staff](/wiki/People/The_Team). It is part of the 2nd installment of the osu!mania World Cup.
 
-Tournament schedule
--------------------------
+## Tournament Schedule
 
 | Event              | Timestamp                |
-|--------------------|--------------------------|
-| Registration Phase | 1-20 Dec 2015            |
-| Drawings           | 3 Jan 2016 (14:00 UTC+0) |
-| Group Stage        | 9-10 Jan 2016            |
-| Round of 16        | 16-17 Jan 2016           |
-| Quarterfinals      | 23-24 Jan 2016           |
-| Semifinals         | 30-31 Jan 2016           |
-| Finals - Week 1    | 6-7 Feb 2016             |
-| Finals - Week 2    | 13-14 Feb 2016           |
+|-------------------:|--------------------------|
+| Registration Phase | 2015-12-01/2015-12-20    |
+| Drawings           | 2016-01-03 14:00:00 UTC  |
+| Group Stage        | 2016-01-09/2016-01-10    |
+| Round of 16        | 2016-01-16/2016-01-17    |
+| Quarterfinals      | 2016-01-23/2016-01-24    |
+| Semifinals         | 2016-01-30/2016-01-31    |
+| Finals             | 2016-02-06/2016-02-07    |
+| Grand Finals       | 2016-02-13/2016-02-14    |
 
-Prizes
-----------
+## Prizes
 
 We are aiming to have a minimum $1,900 cash prize pool for this world cup. You can help raising this amount of cash by purchasing a **[support banner for your profile](https://store.ppy.sh/store/product/70)** and show your support for a team! All purchases assist us raising the aimed pool of money!
 
-| Placing                                                    | Prize(s)                                                                     |
-|------------------------------------------------------------|------------------------------------------------------------------------------|
+| Placing | Prize(s) |
+|:---:|:---|
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 50% of the raised prize pool, profile badge, "osu!mania Champion" user title |
-| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge                                  |
-| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge                                  |
+| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge |
+| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge |
 
-Organization
--------------
+## Organization
 
-| Job                   | Person(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Tournament Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/u/71366) // ![][flag_DE] [p3n](https://osu.ppy.sh/u/123703) // ![][flag_ES] [Deif](https://osu.ppy.sh/u/318565) // ![][flag_FR] [shARPII](https://osu.ppy.sh/u/776257)                                                                                                                                                                                                                     |
-| Map Selectors         | ![][flag_GB] [Starry-](https://osu.ppy.sh/u/2166199) // ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/u/2124783)                                                                                                                                                                                                                                                                                                                                             |
-| Streamers             | ![][flag_DE] [Loctav](https://osu.ppy.sh/u/71366) // ![][flag_PL] [Marcin](https://osu.ppy.sh/u/722665)                                                                                                                                                                                                                                                                                                                                                     |
-| Commentators          | ![][flag_US] [ztrot](https://osu.ppy.sh/u/6347) // ![][flag_NZ] [deadbeat](https://osu.ppy.sh/u/128370) // ![][flag_AR] [juankristal](https://osu.ppy.sh/u/443656) // ![][flag_US] [Zak](https://osu.ppy.sh/u/1375955) // ![][flag_US] [Halogen-](https://osu.ppy.sh/u/169992) // ![][flag_US] [Azlynn](https://osu.ppy.sh/u/7016667) // ![][flag_SG] [DJNightmare](https://osu.ppy.sh/u/70909) |
-| Statistician          | ![][flag_PL] [Marcin](https://osu.ppy.sh/u/722665)                                                                                                                                                                                                                                                                                                                                                                                                                      |
+The osu!mania 7K World Cup 2016 is run by various community members by distributing the multitude of tasks into various fields of responsibility.
+
+| Position | Member(s) |
+|---|---|
+| Tournament Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) |
+| Map Selectors | ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199), ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/users/2124783) |
+| Streamers | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
+| Commentators | ![][flag_US] [Azlynn](https://osu.ppy.sh/users/7016667), ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_SG] [DJNightmare](https://osu.ppy.sh/users/70909), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992), ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
+| Statistician | ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
 
 ------------------------------------------------------------------------
 
@@ -51,56 +50,54 @@ Organization
 
 ------------------------------------------------------------------------
 
-Participants
------------
+## Participants
 
-| 1st Seed                                        | 2nd Seed                                         | 3rd Seed                                    | 4th Seed                                             | 5th Seed                                 |
-|-------------------------------------------------|--------------------------------------------------|---------------------------------------------|------------------------------------------------------|------------------------------------------|
-| ![][flag_CN] China         | ![][flag_BR] Brazil         | ![][flag_AU] Australia | ![][flag_DE] Germany            | ![][flag_CA] Canada |
-| ![][flag_JP] Japan         | ![][flag_ID] Indonesia      | ![][flag_FR] France    | ![][flag_PH] Philippines        | ![][flag_IT] Italy  |
-| ![][flag_KR] South Korea   | ![][flag_MY] Malaysia       | ![][flag_SG] Singapore | ![][flag_PL] Poland             | ![][flag_NO] Norway |
-| ![][flag_US] United States | ![][flag_GB] United Kingdom | ![][flag_TW] Taiwan    | ![][flag_RU] Russian Federation | ![][flag_SE] Sweden |
+| 1st Seed | 2nd Seed | 3rd Seed | 4th Seed | 5th Seed |
+|---|---|---|---|---|
+| ![][flag_CN] China | ![][flag_BR] Brazil | ![][flag_AU] Australia | ![][flag_DE] Germany | ![][flag_CA] Canada |
+| ![][flag_JP] Japan | ![][flag_ID] Indonesia | ![][flag_FR] France | ![][flag_PH] Philippines | ![][flag_IT] Italy |
+| ![][flag_KR] South Korea | ![][flag_MY] Malaysia | ![][flag_SG] Singapore | ![][flag_PL] Poland | ![][flag_NO] Norway |
+| ![][flag_US] United States | ![][flag_GB] United Kingdom | ![][flag_TW] Taiwan | ![][flag_RU] Russian Federation | ![][flag_SE] Sweden |
 
-| Country                                              | Group A Members                                                                                                                                                                                                           |
-|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_SE] Sweden             | **[Rilipworldwide](https://osu.ppy.sh/u/4238239)**, [venus212](https://osu.ppy.sh/u/3664680), [Cparn](https://osu.ppy.sh/u/3395312), [VortexCoyote](https://osu.ppy.sh/u/4999669)                                                                 |
-| ![][flag_RU] Russian Federation | **[Daleenie](https://osu.ppy.sh/u/1540597)**, [Kivicat](https://osu.ppy.sh/u/2790640), [PhobosX](https://osu.ppy.sh/u/2570019), [DarkSider2442](https://osu.ppy.sh/u/1130069), [Akary](https://osu.ppy.sh/u/3912608), [AJIekceu](https://osu.ppy.sh/u/940656) |
-| ![][flag_SG] Singapore          | **[danielrox](https://osu.ppy.sh/u/4893212)**, [Evening](https://osu.ppy.sh/u/2193881), [Level 51](https://osu.ppy.sh/u/3617847), [DFC Tan](https://osu.ppy.sh/u/5704437), [Paralit](https://osu.ppy.sh/u/876528), [DJNightmare](https://osu.ppy.sh/u/70909)  |
-| ![][flag_GB] United Kingdom     | **[Hayabusa](https://osu.ppy.sh/u/3104108)**, [Fee](https://osu.ppy.sh/u/3121449), [Pope Gadget](https://osu.ppy.sh/u/2288341), [Mat](https://osu.ppy.sh/u/2668921), [Vygatron](https://osu.ppy.sh/u/3628783)                                           |
-| ![][flag_JP] Japan              | **[OmegaJack](https://osu.ppy.sh/u/205391)**, [metyabo](https://osu.ppy.sh/u/623773), [inteliser](https://osu.ppy.sh/u/1824775), [HNC_yk](https://osu.ppy.sh/u/2163585)                                                                           |
+| | Country | Group A Members |
+|:---:|:---:|---|
+| ![][flag_JP] | **Japan** | **[OmegaJack](https://osu.ppy.sh/users/205391)**, [metyabo](https://osu.ppy.sh/users/623773), [inteliser](https://osu.ppy.sh/users/1824775), [HNC_yk](https://osu.ppy.sh/users/2163585) |
+| ![][flag_GB] | **United Kingdom** | **[Hayabusa](https://osu.ppy.sh/users/3104108)**, [Fee](https://osu.ppy.sh/users/3121449), [Pope Gadget](https://osu.ppy.sh/users/2288341), [Mat](https://osu.ppy.sh/users/2668921), [Vygatron](https://osu.ppy.sh/users/3628783) |
+| ![][flag_SG] | **Singapore** | **[danielrox](https://osu.ppy.sh/users/4893212)**, [Evening](https://osu.ppy.sh/users/2193881), [Level 51](https://osu.ppy.sh/users/3617847), [DFC Tan](https://osu.ppy.sh/users/5704437), [Paralit](https://osu.ppy.sh/users/876528), [DJNightmare](https://osu.ppy.sh/users/70909) |
+| ![][flag_RU] | **Russian Federation** | **[Daleenie](https://osu.ppy.sh/users/1540597)**, [Kivicat](https://osu.ppy.sh/users/2790640), [PhobosX](https://osu.ppy.sh/users/2570019), [DarkSider2442](https://osu.ppy.sh/users/1130069), [Akary](https://osu.ppy.sh/users/3912608), [AJIekceu](https://osu.ppy.sh/users/940656) |
+| ![][flag_SE] | **Sweden** | **[Rilipworldwide](https://osu.ppy.sh/users/4238239)**, [venus212](https://osu.ppy.sh/users/3664680), [Cparn](https://osu.ppy.sh/users/3395312), [VortexCoyote](https://osu.ppy.sh/users/4999669) |
 
-| Country                                       | Group B Members                                                                                                                                                                                                                    |
-|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_CA] Canada      | **[Ashix-](https://osu.ppy.sh/u/981144)**, [-kazu](https://osu.ppy.sh/u/3205712), [Lithifloresca](https://osu.ppy.sh/u/2814282), [Prim-](https://osu.ppy.sh/u/103255), [arsonisfun](https://osu.ppy.sh/u/3157167), [SkyDemon13](https://osu.ppy.sh/u/4108187)          |
-| ![][flag_DE] Germany     | **[rohen04](https://osu.ppy.sh/u/369614)**, [Dualshock](https://osu.ppy.sh/u/1902591), [Reikokaz](https://osu.ppy.sh/u/1263173), [[Kazuto]](https://osu.ppy.sh/u/3204488), [Phil](https://osu.ppy.sh/u/3191489)                                                  |
-| ![][flag_FR] France      | **[Elementaires](https://osu.ppy.sh/u/2284328)**, [lim38](https://osu.ppy.sh/u/2741170), [CharlisMadCut](https://osu.ppy.sh/u/2863607), [PyaKura](https://osu.ppy.sh/u/2284536), [bumpinho](https://osu.ppy.sh/u/1594604), [Yami Le Lama](https://osu.ppy.sh/u/888986) |
-| ![][flag_BR] Brazil      | **[NateTheROOBIN](https://osu.ppy.sh/u/2288363)**, [spoonguy](https://osu.ppy.sh/u/932381), [Keweft](https://osu.ppy.sh/u/75777), [roko100789](https://osu.ppy.sh/u/3224958), [Pesaac](https://osu.ppy.sh/u/2882138), [zZ_Natsu_Zz](https://osu.ppy.sh/u/4685756)      |
-| ![][flag_KR] South Korea | **[Rose](https://osu.ppy.sh/u/2276572)**, [jakads](https://osu.ppy.sh/u/259972), [Zei-](https://osu.ppy.sh/u/1530308), [cr1sp](https://osu.ppy.sh/u/5332153), [SeonRae](https://osu.ppy.sh/u/288233), [ChaosUniverse](https://osu.ppy.sh/u/6600984)                    |
+| | Country | Group B Members |
+|:---:|:---:|---|
+| ![][flag_KR] | **South Korea** | **[Rose](https://osu.ppy.sh/users/2276572)**, [jakads](https://osu.ppy.sh/users/259972), [Zei-](https://osu.ppy.sh/users/1530308), [cr1sp](https://osu.ppy.sh/users/5332153), [SeonRae](https://osu.ppy.sh/users/288233), [ChaosUniverse](https://osu.ppy.sh/users/6600984) |
+| ![][flag_BR] | **Brazil** | **[NateTheROOBIN](https://osu.ppy.sh/users/2288363)**, [spoonguy](https://osu.ppy.sh/users/932381), [Keweft](https://osu.ppy.sh/users/75777), [roko100789](https://osu.ppy.sh/users/3224958), [Pesaac](https://osu.ppy.sh/users/2882138), [zZ_Natsu_Zz](https://osu.ppy.sh/users/4685756) |
+| ![][flag_FR] | **France** | **[Elementaires](https://osu.ppy.sh/users/2284328)**, [lim38](https://osu.ppy.sh/users/2741170), [CharlisMadCut](https://osu.ppy.sh/users/2863607), [PyaKura](https://osu.ppy.sh/users/2284536), [bumpinho](https://osu.ppy.sh/users/1594604), [Yami Le Lama](https://osu.ppy.sh/users/888986) |
+| ![][flag_DE] | **Germany** | **[rohen04](https://osu.ppy.sh/users/369614)**, [Dualshock](https://osu.ppy.sh/users/1902591), [Reikokaz](https://osu.ppy.sh/users/1263173), [[Kazuto]](https://osu.ppy.sh/users/3204488), [Phil](https://osu.ppy.sh/users/3191489) |
+| ![][flag_CA] | **Canada** | **[Ashix-](https://osu.ppy.sh/users/981144)**, [-kazu](https://osu.ppy.sh/users/3205712), [Lithifloresca](https://osu.ppy.sh/users/2814282), [Prim-](https://osu.ppy.sh/users/103255), [arsonisfun](https://osu.ppy.sh/users/3157167), [SkyDemon13](https://osu.ppy.sh/users/4108187) |
 
-| Country                                         | Group C Members                                                                                                                                                                                                                        |
-|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_NO] Norway        | **[Liqh](https://osu.ppy.sh/u/3409838)**, [Hjeg](https://osu.ppy.sh/u/2764122), [Staiain](https://osu.ppy.sh/u/86188), [ArcticFqx](https://osu.ppy.sh/u/4100949)                                                                                               |
-| ![][flag_PL] Poland        | **[Modren](https://osu.ppy.sh/u/1828621)**, [Hudonom](https://osu.ppy.sh/u/1654221), [SitekX](https://osu.ppy.sh/u/3840946), [Ereedon](https://osu.ppy.sh/u/1887068), [Transformau5](https://osu.ppy.sh/u/3109917), [Tidek](https://osu.ppy.sh/u/743282)                   |
-| ![][flag_TW] Taiwan        | **[c36098651](https://osu.ppy.sh/u/2048577)**, [SacredReisen](https://osu.ppy.sh/u/2232063), [Super Radio](https://osu.ppy.sh/u/2452290), [y85782122](https://osu.ppy.sh/u/2287176), [Taiwan-YRK](https://osu.ppy.sh/u/2115269), [mliencheng](https://osu.ppy.sh/u/586659) |
-| ![][flag_MY] Malaysia      | **[Cryolien](https://osu.ppy.sh/u/1626983)**, [HunterproX](https://osu.ppy.sh/u/1343562), [KagaNyan](https://osu.ppy.sh/u/438109), [[MY]Idiot](https://osu.ppy.sh/u/2059742), [InabaYap](https://osu.ppy.sh/u/2041034)                                               |
-| ![][flag_US] United States | **[Blocko](https://osu.ppy.sh/u/4075092)**, [Nivrad00](https://osu.ppy.sh/u/1984634), [iJinjin](https://osu.ppy.sh/u/3360737), [Sillyveon](https://osu.ppy.sh/u/3936677), [Gekido-](https://osu.ppy.sh/u/4693052), [Flippopotamus](https://osu.ppy.sh/u/3565377)           |
+| | Country | Group C Members |
+|:---:|:---:|---|
+| ![][flag_US] | **United States** | **[Blocko](https://osu.ppy.sh/users/4075092)**, [Nivrad00](https://osu.ppy.sh/users/1984634), [iJinjin](https://osu.ppy.sh/users/3360737), [Sillyveon](https://osu.ppy.sh/users/3936677), [Gekido-](https://osu.ppy.sh/users/4693052), [Flippopotamus](https://osu.ppy.sh/users/3565377) |
+| ![][flag_MY] | **Malaysia** | **[Cryolien](https://osu.ppy.sh/users/1626983)**, [HunterproX](https://osu.ppy.sh/users/1343562), [KagaNyan](https://osu.ppy.sh/users/438109), [[MY]Idiot](https://osu.ppy.sh/users/2059742), [InabaYap](https://osu.ppy.sh/users/2041034) |
+| ![][flag_TW] | **Taiwan** | **[c36098651](https://osu.ppy.sh/users/2048577)**, [SacredReisen](https://osu.ppy.sh/users/2232063), [Super Radio](https://osu.ppy.sh/users/2452290), [y85782122](https://osu.ppy.sh/users/2287176), [Taiwan-YRK](https://osu.ppy.sh/users/2115269), [mliencheng](https://osu.ppy.sh/users/586659) |
+| ![][flag_PL] | **Poland** | **[Modren](https://osu.ppy.sh/users/1828621)**, [Hudonom](https://osu.ppy.sh/users/1654221), [SitekX](https://osu.ppy.sh/users/3840946), [Ereedon](https://osu.ppy.sh/users/1887068), [Transformau5](https://osu.ppy.sh/users/3109917), [Tidek](https://osu.ppy.sh/users/743282) |
+| ![][flag_NO] | **Norway** | **[Liqh](https://osu.ppy.sh/users/3409838)**, [Hjeg](https://osu.ppy.sh/users/2764122), [Staiain](https://osu.ppy.sh/users/86188), [ArcticFqx](https://osu.ppy.sh/users/4100949) |
 
-| Country                                       | Group D Members                                                                                                                                                                                                                 |
-|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_IT] Italy       | **[Ikkun](https://osu.ppy.sh/u/1059945)**, [TheOwnerAlpha](https://osu.ppy.sh/u/3461860), [[DaYan]](https://osu.ppy.sh/u/17439), [Uqia](https://osu.ppy.sh/u/1990732)                                                                                   |
-| ![][flag_PH] Philippines | **[BjornGV](https://osu.ppy.sh/u/1636180)**, [kei101895](https://osu.ppy.sh/u/3032245), [Lenfried-](https://osu.ppy.sh/u/5314573), [technowaves](https://osu.ppy.sh/u/4072820), [-BlueFire-](https://osu.ppy.sh/u/1192936)                                    |
-| ![][flag_AU] Australia   | **[zKskita](https://osu.ppy.sh/u/457515)**, [Alchalyne](https://osu.ppy.sh/u/3999031), [sankansuki](https://osu.ppy.sh/u/2877926), [ApocaZumbee](https://osu.ppy.sh/u/3431615), [Evios](https://osu.ppy.sh/u/2058022), [Tornspirit](https://osu.ppy.sh/u/1338883)   |
-| ![][flag_ID] Indonesia   | **[Nyooo](https://osu.ppy.sh/u/2319372)**, [Fiea](https://osu.ppy.sh/u/3183277), [Astray-](https://osu.ppy.sh/u/3397008), [Kephin](https://osu.ppy.sh/u/5033561), [projectc1](https://osu.ppy.sh/u/2663343), [tenri-ayukawa](https://osu.ppy.sh/u/3185294)          |
-| ![][flag_CN] China       | **[Sern888](https://osu.ppy.sh/u/2089244)**, [[Crz]ZhangFan](https://osu.ppy.sh/u/89545), [Degeneracy](https://osu.ppy.sh/u/427355), [Basillisa](https://osu.ppy.sh/u/6004963), [ljqandylee](https://osu.ppy.sh/u/141469), [SweetSoul](https://osu.ppy.sh/u/220624) |
+| | Country | Group D Members |
+|:---:|:---:|---|
+| ![][flag_CN] | **China** | **[Sern888](https://osu.ppy.sh/users/2089244)**, [[Crz]ZhangFan](https://osu.ppy.sh/users/89545), [Degeneracy](https://osu.ppy.sh/users/427355), [Basillisa](https://osu.ppy.sh/users/6004963), [ljqandylee](https://osu.ppy.sh/users/141469), [SweetSoul](https://osu.ppy.sh/users/220624) |
+| ![][flag_ID] | **Indonesia** | **[Nyooo](https://osu.ppy.sh/users/2319372)**, [Fiea](https://osu.ppy.sh/users/3183277), [Astray-](https://osu.ppy.sh/users/3397008), [Kephin](https://osu.ppy.sh/users/5033561), [projectc1](https://osu.ppy.sh/users/2663343), [tenri-ayukawa](https://osu.ppy.sh/users/3185294) |
+| ![][flag_AU] | **Australia** | **[zKskita](https://osu.ppy.sh/users/457515)**, [Alchalyne](https://osu.ppy.sh/users/3999031), [sankansuki](https://osu.ppy.sh/users/2877926), [ApocaZumbee](https://osu.ppy.sh/users/3431615), [Evios](https://osu.ppy.sh/users/2058022), [Tornspirit](https://osu.ppy.sh/users/1338883) |
+| ![][flag_PH] | **Philippines** | **[BjornGV](https://osu.ppy.sh/users/1636180)**, [kei101895](https://osu.ppy.sh/users/3032245), [Lenfried-](https://osu.ppy.sh/users/5314573), [technowaves](https://osu.ppy.sh/users/4072820), [-BlueFire-](https://osu.ppy.sh/users/1192936) |
+| ![][flag_IT] | **Italy** | **[Ikkun](https://osu.ppy.sh/users/1059945)**, [TheOwnerAlpha](https://osu.ppy.sh/users/3461860), [[DaYan]](https://osu.ppy.sh/users/17439), [Uqia](https://osu.ppy.sh/users/1990732) |
 
 ------------------------------------------------------------------------
 
-Mappools
--------------
+## Mappools
 
 ### Finals
 
-**This mappool will be used in Finals - Week 1 and Finals - Week 2**
+**This mappool will be used in Finals and Grand Finals**
 
 **[Download the mappack here!](https://www.mediafire.com/download/9179zq7bew4tj72/MWC_7K_2016_Finals.rar)**
 
@@ -216,142 +213,123 @@ Mappools
 
 ------------------------------------------------------------------------
 
-Match Results
-----------------
+## Match Results
 
 ### Grand Finals
 
-**Sunday, 14\. February 2016**
+| 2016-02-14 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| South Korea ![][flag_KR] | 0 | **7** | ![][flag_CN] **China**   | [#1](https://osu.ppy.sh/community/matches/22642271) |
+| **China** ![][flag_CN]   | **7** | 4 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/22643409) |
 
-| Team A                                        | Score     | Team B                                        | History                        |
-|-----------------------------------------------|-----------|-----------------------------------------------|--------------------------------|
-| ![][flag_KR] South Korea | 0 - **7** | **China** ![][flag_CN]   | [#1](https://osu.ppy.sh/mp/22642271) |
-| ![][flag_CN] **China**   | **7** - 4 | South Korea ![][flag_KR] | [#1](https://osu.ppy.sh/mp/22643409) |
+### Finals
 
-### Finals - Week 1
+| 2016-02-06 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| Singapore ![][flag_SG] | 1 | **6** | ![][flag_CN] **China**       | [#1](https://osu.ppy.sh/community/matches/22424367) |
+| Malaysia ![][flag_MY]  | 0 | **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/22426065) |
+| **Japan** ![][flag_JP] | **6** | 0 | ![][flag_TW] Taiwan          | [#1](https://osu.ppy.sh/community/matches/22428318) |
 
-**Saturday, 6\. February 2016**
-
-| Team A                                      | Score     | Team B                                            | History                        |
-|---------------------------------------------|-----------|---------------------------------------------------|--------------------------------|
-| ![][flag_SG] Singapore | 1 - **6** | **China** ![][flag_CN]       | [#1](https://osu.ppy.sh/mp/22424367) |
-| ![][flag_MY] Malaysia  | 0 - **6** | **South Korea** ![][flag_KR] | [#1](https://osu.ppy.sh/mp/22426065) |
-| ![][flag_JP] **Japan** | **6** - 0 | Taiwan ![][flag_TW]          | [#1](https://osu.ppy.sh/mp/22428318) |
-
-**Sunday, 7\. February 2016**
-
-| Team A                                      | Score     | Team B                                     | History                        |
-|---------------------------------------------|-----------|--------------------------------------------|--------------------------------|
-| ![][flag_CN] **China** | **6** - 0 | Japan ![][flag_JP]    | [#1](https://osu.ppy.sh/mp/22457102) |
-| ![][flag_CN] **China** | **6** - 0 | Malaysia ![][flag_MY] | [#1](https://osu.ppy.sh/mp/22459042) |
+| 2016-02-07 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| **China** ![][flag_CN] | **6** | 0 | ![][flag_JP] Japan    | [#1](https://osu.ppy.sh/community/matches/22457102) |
+| **China** ![][flag_CN] | **6** | 0 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/22459042) |
 
 ### Semifinals
 
-**Saturday, 30\. January 2016**
+| 2016-01-30 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| Australia ![][flag_AU] | 0 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/22231572) |
+| China ![][flag_CN]     | 1 | **6** | ![][flag_KR] **South Korea**   | [#1](https://osu.ppy.sh/community/matches/22232589) |
+| **Japan** ![][flag_JP] | **6** | 3 | ![][flag_ID] Indonesia         | [#1](https://osu.ppy.sh/community/matches/22234901) |
+| Taiwan ![][flag_TW]    | 1 | **6** | ![][flag_MY] **Malaysia**      | [#1](https://osu.ppy.sh/community/matches/22236266) |
+| Poland ![][flag_PL]    | 4 | **6** | ![][flag_PH] **Philippines**   | [#1](https://osu.ppy.sh/community/matches/22237979) |
+| Brazil ![][flag_BR]    | 4 | **6** | ![][flag_SG] **Singapore**     | [#1](https://osu.ppy.sh/community/matches/22240673) |
 
-| Team A                                      | Score         | Team B                                              | History                        |
-|---------------------------------------------|---------------|-----------------------------------------------------|--------------------------------|
-| ![][flag_AU] Australia | 0     - **6** | **United States** ![][flag_US] | [#1](https://osu.ppy.sh/mp/22231572) |
-| ![][flag_CN] China     | 1     - **6** | **South Korea** ![][flag_KR]   | [#1](https://osu.ppy.sh/mp/22232589) |
-| ![][flag_JP] **Japan** | **6** - 3     | Indonesia ![][flag_ID]         | [#1](https://osu.ppy.sh/mp/22234901) |
-| ![][flag_TW] Taiwan    | 1     - **6** | **Malaysia** ![][flag_MY]      | [#1](https://osu.ppy.sh/mp/22236266) |
-| ![][flag_PL] Poland    | 4     - **6** | **Philippines** ![][flag_PH]   | [#1](https://osu.ppy.sh/mp/22237979) |
-| ![][flag_BR] Brazil    | 4     - **6** | **Singapore** ![][flag_SG]     | [#1](https://osu.ppy.sh/mp/22240673) |
-
-**Sunday, 31\. January 2016**
-
-| Team A                                          | Score     | Team B                                          | History            |
-|-------------------------------------------------|-----------|-------------------------------------------------|--------------------|
-| ![][flag_JP] **Japan**     | **6** - 0 | United States ![][flag_US] | - N/A -            |
-| ![][flag_SG] **Singapore** | **6** - 0 | Philippines ![][flag_PH]   | - Win by default - |
+| 2016-01-31 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| **Japan** ![][flag_JP]     | **6** | 0 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/22265355) |
+| **Singapore** ![][flag_SG] | **6** | 0 | ![][flag_PH] Philippines   | - Win by default - |
 
 ### Quarterfinals
 
-| Team A                                               | Score     | Team B                                            | History                        |
-|------------------------------------------------------|-----------|---------------------------------------------------|--------------------------------|
-| ![][flag_CN] **China**          | **5** - 0 | United States ![][flag_US]   | [#1](https://osu.ppy.sh/mp/22039893) |
-| ![][flag_ID] Indonesia          | 0 - **5** | **South Korea** ![][flag_KR] | [#1](https://osu.ppy.sh/mp/22041291) |
-| ![][flag_PH] Philippines        | 1 - **5** | **Taiwan** ![][flag_TW]      | [#1](https://osu.ppy.sh/mp/22042907) |
-| ![][flag_SG] Singapore          | 1 - **5** | **Malaysia** ![][flag_MY]    | [#1](https://osu.ppy.sh/mp/22044289) |
-| ![][flag_AU] **Australia**      | **5** - 0 | Germany ![][flag_DE]         | [#1](https://osu.ppy.sh/mp/22046733) |
-| ![][flag_JP] **Japan**          | **5** - 0 | France ![][flag_FR]          | [#1](https://osu.ppy.sh/mp/22048705) |
-| ![][flag_GB] United Kingdom     | 0 - **5** | **Poland** ![][flag_PL]      | - Win by default -             |
-| ![][flag_RU] Russian Federation | 0 - **5** | **Brazil** ![][flag_BR]      | [#1](https://osu.ppy.sh/mp/22054192) |
+| 2016-01-23 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| **China** ![][flag_CN]          | **5** | 0 | ![][flag_US] United States   | [#1](https://osu.ppy.sh/community/matches/22039893) |
+| Indonesia ![][flag_ID]          | 0 | **5** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/22041291) |
+| Philippines ![][flag_PH]        | 1 | **5** | ![][flag_TW] **Taiwan**      | [#1](https://osu.ppy.sh/community/matches/22042907) |
+| Singapore ![][flag_SG]          | 1 | **5** | ![][flag_MY] **Malaysia**    | [#1](https://osu.ppy.sh/community/matches/22044289) |
+| **Australia** ![][flag_AU]      | **5** | 0 | ![][flag_DE] Germany         | [#1](https://osu.ppy.sh/community/matches/22046733) |
+| **Japan** ![][flag_JP]          | **5** | 0 | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/22048705) |
+| United Kingdom ![][flag_GB]     | 0 | **5** | ![][flag_PL] **Poland**      | - Win by default - |
+| Russian Federation ![][flag_RU] | 0 | **5** | ![][flag_BR] **Brazil**      | [#1](https://osu.ppy.sh/community/matches/22054192) |
 
 ### Round of 16
 
-**Saturday, 16\. January 2016**
-
-| Team A                                            | Score     | Team B                                               | History                        |
-|---------------------------------------------------|-----------|------------------------------------------------------|--------------------------------|
-| ![][flag_SG] **Singapore**   | **5** - 0 | Australia ![][flag_AU]          | [#1](https://osu.ppy.sh/mp/21844684) |
-| ![][flag_JP] Japan           | 0 - **5** | **Philippines** ![][flag_PH]    | - Win by default -             |
-| ![][flag_CN] **China**       | **5** - 0 | Russian Federation ![][flag_RU] | [#1](https://osu.ppy.sh/mp/21846586) |
-| ![][flag_KR] **South Korea** | **5** - 0 | Poland ![][flag_PL]             | [#1](https://osu.ppy.sh/mp/21848487) |
-| ![][flag_FR] France          | 1 - **5** | **Taiwan** ![][flag_TW]         | [#1](https://osu.ppy.sh/mp/21849713) |
-| ![][flag_MY] **Malaysia**    | **5** - 1 | Germany ![][flag_DE]            | [#1](https://osu.ppy.sh/mp/21851398) |
-| ![][flag_GB] United Kingdom  | 0 - **5** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/21853348) |
-| ![][flag_BR] Brazil          | 1 - **5** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/mp/21865722) |
+| 2016-01-16 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| **Singapore** ![][flag_SG]   | **5** | 0 | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/21844684) |
+| Japan ![][flag_JP]           | 0 | **5** | ![][flag_PH] **Philippines**    | - Win by default - |
+| **China** ![][flag_CN]       | **5** | 0 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/21846586) |
+| **South Korea** ![][flag_KR] | **5** | 0 | ![][flag_PL] Poland             | [#1](https://osu.ppy.sh/community/matches/21848487) |
+| France ![][flag_FR]          | 1 | **5** | ![][flag_TW] **Taiwan**         | [#1](https://osu.ppy.sh/community/matches/21849713) |
+| **Malaysia** ![][flag_MY]    | **5** | 1 | ![][flag_DE] Germany            | [#1](https://osu.ppy.sh/community/matches/21851398) |
+| United Kingdom ![][flag_GB]  | 0 | **5** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/21853348) |
+| Brazil ![][flag_BR]          | 1 | **5** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/21865722) |
 
 ### Group Stage
 
 **[Find the Group Stage Statistics here!](https://docs.google.com/spreadsheets/d/1rUBWY0m7faZ9dFNkaVhXxJ9bpqAjHUZR8xRmHFxjoEs/pubhtml)**
 
-**Saturday, 9\. January 2016**
+| 2016-01-09 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| Canada ![][flag_CA]             | 0 | **4** | ![][flag_KR] **South Korea**        | [#1](https://osu.ppy.sh/community/matches/21645045) |
+| Taiwan ![][flag_TW]             | 0 | **4** | ![][flag_US] **United States**      | [#1](https://osu.ppy.sh/community/matches/21645051) |
+| Australia ![][flag_AU]          | 0 | **4** | ![][flag_ID] **Indonesia**          | [#1](https://osu.ppy.sh/community/matches/21645052) |
+| Philippines ![][flag_PH]        | 0 | **4** | ![][flag_AU] **Australia**          | - Win by default - |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_SG] **Singapore**          | [#1](https://osu.ppy.sh/community/matches/21652250) |
+| Taiwan ![][flag_TW]             | 1 | **4** | ![][flag_MY] **Malaysia**           | [#1](https://osu.ppy.sh/community/matches/21652252) |
+| Australia ![][flag_AU]          | 0 | **4** | ![][flag_CN] **China**              | [#1](https://osu.ppy.sh/community/matches/21653171) |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_PH] **Philippines**        | - Win by default - |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_MY] **Malaysia**           | [#1](https://osu.ppy.sh/community/matches/21654308) |
+| Germany ![][flag_DE]            | 0 | **4** | ![][flag_KR] **South Korea**        | [#1](https://osu.ppy.sh/community/matches/21654310) |
+| Sweden ![][flag_SE]             | 0 | **4** | ![][flag_SG] **Singapore**          | [#1](https://osu.ppy.sh/community/matches/21654313) |
+| United Kingdom ![][flag_GB]     | 0 | **4** | ![][flag_JP] **Japan**              | - Win by default - |
+| Philippines ![][flag_PH]        | 0 | **4** | ![][flag_ID] **Indonesia**          | [#1](https://osu.ppy.sh/community/matches/21655618) |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_CN] **China**              | [#1](https://osu.ppy.sh/community/matches/21655616) |
+| **Singapore** ![][flag_SG]      | **4** | 0 | ![][flag_GB] United Kingdom         | - Win by default - |
+| Poland ![][flag_PL]             | 0 | **4** | ![][flag_MY] **Malaysia**           | [#1](https://osu.ppy.sh/community/matches/21657212) |
+| Germany ![][flag_DE]            | 3 | **4** | ![][flag_FR] **France**             | [#1](https://osu.ppy.sh/community/matches/21657223) |
+| Sweden ![][flag_SE]             | 0 | **4** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/21667376) |
+| **France** ![][flag_FR]         | **4** | 1 | ![][flag_BR] Brazil                 | [#1](https://osu.ppy.sh/community/matches/21667387) |
+| Canada ![][flag_CA]             | 1 | **4** | ![][flag_FR] **France**             | [#1](https://osu.ppy.sh/community/matches/21669541) |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_US] **United States**      | [#1](https://osu.ppy.sh/community/matches/21669547) |
 
-| Team A                                               | Score          | Team B                                                   | History                        |
-|------------------------------------------------------|----------------|----------------------------------------------------------|--------------------------------|
-| ![][flag_CA] Canada             | 0      - **4** | **South Korea** ![][flag_KR]        | [#1](https://osu.ppy.sh/mp/21645045) |
-| ![][flag_TW] Taiwan             | 0      - **4** | **United States** ![][flag_US]      | [#1](https://osu.ppy.sh/mp/21645051) |
-| ![][flag_AU] Australia          | 0      - **4** | **Indonesia** ![][flag_ID]          | [#1](https://osu.ppy.sh/mp/21645052) |
-| ![][flag_PH] Philippines        | 0      - **4** | **Australia** ![][flag_AU]          | - Win by default -             |
-| ![][flag_RU] Russian Federation | 0      - **4** | **Singapore** ![][flag_SG]          | [#1](https://osu.ppy.sh/mp/21652250) |
-| ![][flag_TW] Taiwan             | 1      - **4** | **Malaysia** ![][flag_MY]           | [#1](https://osu.ppy.sh/mp/21652252) |
-| ![][flag_AU] Australia          | 0      - **4** | **China** ![][flag_CN]              | [#1](https://osu.ppy.sh/mp/21653171) |
-| ![][flag_IT] Italy              | 0      - **4** | **Philippines** ![][flag_PH]        | - Win by default -             |
-| ![][flag_NO] Norway             | 0      - **4** | **Malaysia** ![][flag_MY]           | [#1](https://osu.ppy.sh/mp/21654308) |
-| ![][flag_DE] Germany            | 0      - **4** | **South Korea** ![][flag_KR]        | [#1](https://osu.ppy.sh/mp/21654310) |
-| ![][flag_SE] Sweden             | 0      - **4** | **Singapore** ![][flag_SG]          | [#1](https://osu.ppy.sh/mp/21654313) |
-| ![][flag_GB] United Kingdom     | 0      - **4** | **Japan** ![][flag_JP]              | - Win by default -             |
-| ![][flag_PH] Philippines        | 0      - **4** | **Indonesia** ![][flag_ID]          | [#1](https://osu.ppy.sh/mp/21655618) |
-| ![][flag_IT] Italy              | 0      - **4** | **China** ![][flag_CN]              | [#1](https://osu.ppy.sh/mp/21655616) |
-| ![][flag_SG] **Singapore**      | **4**  - 0     | United Kingdom ![][flag_GB]         | - Win by default -             |
-| ![][flag_PL] Poland             | 0      - **4** | **Malaysia** ![][flag_MY]           | [#1](https://osu.ppy.sh/mp/21657212) |
-| ![][flag_DE] Germany            | 3      - **4** | **France** ![][flag_FR]             | [#1](https://osu.ppy.sh/mp/21657223) |
-| ![][flag_SE] Sweden             | **0**  - **4** | **Russian Federation** ![][flag_RU] | [#1](https://osu.ppy.sh/mp/21667376) |
-| ![][flag_FR] **France**         | **4**  - 1     | Brazil ![][flag_BR]                 | [#1](https://osu.ppy.sh/mp/21667387) |
-| ![][flag_CA] Canada             | 1      - **4** | **France** ![][flag_FR]             | [#1](https://osu.ppy.sh/mp/21669541) |
-| ![][flag_NO] Norway             | **0**  - **4** | **United States** ![][flag_US]      | [#1](https://osu.ppy.sh/mp/21669547) |
-
-**Sunday, 10\. January 2016**
-
-| Team A                                               | Score          | Team B                                               | History                        |
-|------------------------------------------------------|----------------|------------------------------------------------------|--------------------------------|
-| ![][flag_SG] Singapore          | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/21685098) |
-| ![][flag_MY] **Malaysia**       | **4**  - 1     | United States ![][flag_US]      | [#1](https://osu.ppy.sh/mp/21685099) |
-| ![][flag_PH] Philippines        | 0      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/mp/21685103) |
-| ![][flag_RU] Russian Federation | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/21690252) |
-| ![][flag_NO] Norway             | 0      - **4** | **Taiwan** ![][flag_TW]         | [#1](https://osu.ppy.sh/mp/21690253) |
-| ![][flag_FR] France             | 0      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/mp/21690255) |
-| ![][flag_ID] Indonesia          | 0      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/mp/21691300) |
-| ![][flag_IT] Italy              | 0      - **4** | **Australia** ![][flag_AU]      | [#1](https://osu.ppy.sh/mp/21691304) |
-| ![][flag_IT] Italy              | 0      - **4** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/21692579) |
-| ![][flag_SE] Sweden             | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/21692580) |
-| ![][flag_PL] Poland             | 2      - **4** | **Taiwan** ![][flag_TW]         | [#1](https://osu.ppy.sh/mp/21694006) |
-| ![][flag_BR] Brazil             | 0      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/mp/21694009) |
-| ![][flag_NO] Norway             | 0      - **4** | **Poland** ![][flag_PL]         | [#1](https://osu.ppy.sh/mp/21702067) |
-| ![][flag_DE] Germany            | 1      - **4** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/mp/21702078) |
-| ![][flag_RU] Russian Federation | 1      - **4** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/mp/21704087) |
-| ![][flag_CA] Canada             | 0      - **4** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/mp/21703959) |
-| ![][flag_SE] Sweden             | 0      - **4** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/mp/21705864) |
-| ![][flag_CA] Canada             | 0      - **4** | **Germany** ![][flag_DE]        | [#1](https://osu.ppy.sh/mp/21705868) |
-| ![][flag_PL] Poland             | 0      - **4** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/mp/21705874) |
-
+| 2016-01-10 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+| Singapore ![][flag_SG]          | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/21685098) |
+| **Malaysia** ![][flag_MY]       | **4** | 1 | ![][flag_US] United States      | [#1](https://osu.ppy.sh/community/matches/21685099) |
+| Philippines ![][flag_PH]        | 0 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/21685103) |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/21690252) |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_TW] **Taiwan**         | [#1](https://osu.ppy.sh/community/matches/21690253) |
+| France ![][flag_FR]             | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/21690255) |
+| Indonesia ![][flag_ID]          | 0 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/21691300) |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_AU] **Australia**      | [#1](https://osu.ppy.sh/community/matches/21691304) |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/21692579) |
+| Sweden ![][flag_SE]             | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/21692580) |
+| Poland ![][flag_PL]             | 2 | **4** | ![][flag_TW] **Taiwan**         | [#1](https://osu.ppy.sh/community/matches/21694006) |
+| Brazil ![][flag_BR]             | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/21694009) |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/21702067) |
+| Germany ![][flag_DE]            | 1 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/21702078) |
+| Russian Federation ![][flag_RU] | 1 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/21704087) |
+| Canada ![][flag_CA]             | 0 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/21703959) |
+| Sweden ![][flag_SE]             | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/21705864) |
+| Canada ![][flag_CA]             | 0 | **4** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/21705868) |
+| Poland ![][flag_PL]             | 0 | **4** | ![][flag_US]  **United States** | [#1](https://osu.ppy.sh/community/matches/21705874) |
 
 ------------------------------------------------------------------------
 
-Ruleset
----------
+## Ruleset
 
 ### Tournament Rules
 


### PR DESCRIPTION
### Description

Updates, cleans and fixes the MWC 2016 4K and 7K articles.

### Status

Finished; Pending Review

### Changelog

- Changing date format to follow the ASC
- Flags on his own column in participants
- Changing order in groups from higher to lower seed.
- Changing order of mappools and results from more recent to oldest
- Editing and fixing results tables
- Changing links to follow the ASC

### Related Issues

Related to #350