### PR TITLE
Updating and Fixing the MWC 2015, MWC 2017 4K and 7K articles

### DIFF
--- a/wiki/Tournaments/MWC/2015/en.md
+++ b/wiki/Tournaments/MWC/2015/en.md
@@ -3,41 +3,40 @@ osu!mania 4K World Cup 2015
 
 ![MWC 2015 logo](logo.png)
 
-The **osu!mania 4K World Cup 2015** (***MWC 4K 2015*** ) is a country-based osu!mania 4-key tournament hosted by the [osu! staff](/wiki/People/The_Team). It is the 2nd installment of the osu!mania World Cup. It lasts from the 13th July till 27th September 2015.
+The **osu!mania 4K World Cup 2015** (***MWC 4K 2015***) is a country-based osu!mania 4-key tournament hosted by the [osu! staff](/wiki/People/The_Team). It is the 2nd installment of the osu!mania World Cup. It lasts from the 13th July till 27th September 2015.
 
-Tournament schedule
-------------------------
+## Tournament Schedule
 
-| Event              | Timestamp                 |
-|--------------------|---------------------------|
-| Registration Phase | 13 Jul - 2 Aug 2015       |
-| Drawings           | 16 Aug 2015 (14:00 UTC+0) |
-| Group Stage        | 22-23 Aug 2015            |
-| Round of 16        | 29-30 Aug 2015            |
-| Quarterfinals      | 5-6 Sep 2015              |
-| Semi-finals        | 12-13 Sep 2015            |
-| Finals - Week 1    | 19-20 Sep 2015            |
-| Finals - Week 2    | 26-27 sep 2015            |
+| Event              | Timestamp               |
+|-------------------:|-------------------------|
+| Registration Phase | 2015-07-13/2015-08-02   |
+| Drawings           | 2015-08-16 14:00:00 UTC |
+| Group Stage        | 2015-08-22/2015-08-23   |
+| Round of 16        | 2015-08-29/2015-08-30   |
+| Quarterfinals      | 2015-09-05/2015-09-06   |
+| Semi-finals        | 2015-09-12/2015-09-13   |
+| Finals             | 2015-09-19/2015-09-20   |
+| Grand Finals       | 2015-09-26/2015-09-27   |
 
-Prizes
----------
+## Prizes
 
-| Placing                                                    | Prize(s)                                                                                |
-|------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| Placing | Prize(s) |
+|:---:|---|
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 month supporter tag, profile badge, "osu!mania Champion" user title, osu! merchandise |
-| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 month supporter tag, profile badge                                                    |
-| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag, profile badge                                                    |
+| ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 month supporter tag, profile badge |
+| ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag, profile badge |
 
-Organization
--------------
+## Organization
 
-| Job                   | Person(s)                                                                                                                                                                                                                                                                                                                                                                                                    |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Tournament Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/u/71366) // ![][flag_DE] [p3n](https://osu.ppy.sh/u/123703) // ![][flag_ES] [Deif](https://osu.ppy.sh/u/318565) // ![][flag_FR] [shARPII](https://osu.ppy.sh/u/776257)                                                                                                                                              |
-| Map Selectors         | ![][flag_GB] [Starry-](https://osu.ppy.sh/u/2166199) // ![][flag_TW] [Spy](https://osu.ppy.sh/u/1217122)                                                                                                                                                                                                                                                                             |
-| Streamers             | ![][flag_DE] [Loctav](https://osu.ppy.sh/u/71366) // ![][flag_PL] [Marcin](https://osu.ppy.sh/u/722665)                                                                                                                                                                                                                                                                              |
-| Commentators          | ![][flag_CA] [Tasha](https://osu.ppy.sh/u/1031958) // ![][flag_US] [ztrot](https://osu.ppy.sh/u/6347) // ![][flag_NZ] [deadbeat](https://osu.ppy.sh/u/128370) // ![][flag_AR] [juankristal](https://osu.ppy.sh/u/443656) // ![][flag_US] [Zak](https://osu.ppy.sh/u/1375955) // ![][flag_US] [Halogen-](https://osu.ppy.sh/u/169992) |
-| Statistician          | ![][flag_PL] [Marcin](https://osu.ppy.sh/u/722665)                                                                                                                                                                                                                                                                                                                                               |
+The osu!mania 7K World Cup 2016 is run by various community members by distributing the multitude of tasks into various fields of responsibility.
+
+| Position | Member(s) |
+|---|---|
+| Tournament Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) |
+| Map Selectors | ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199), ![][flag_TW] [Spy](https://osu.ppy.sh/users/1217122) |
+| Streamers | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
+| Commentators | ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992), ![][flag_CA] [Tasha](https://osu.ppy.sh/users/1031958), ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
+| Statistician | ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
 
 ------------------------------------------------------------------------
 
@@ -45,11 +44,10 @@ Organization
 
 ------------------------------------------------------------------------
 
-Participants
-------------
+## Participants
 
-| Top Seed                                      | High Seed                                  | Low Seed                                   | No Seed                                           |
-|-----------------------------------------------|--------------------------------------------|--------------------------------------------|---------------------------------------------------|
+| Top Seed | High Seed | Low Seed | No Seed |
+|---|---|---|---|
 | ![][flag_BR] Brazil         | ![][flag_AR] Argentina   | ![][flag_CL] Chile       | ![][flag_IL] Israel             |
 | ![][flag_CN] China          | ![][flag_CA] Canada      | ![][flag_DK] Denmark     | ![][flag_IT] Italy              |
 | ![][flag_AU] Australia      | ![][flag_FR] France      | ![][flag_FI] Finland     | ![][flag_MX] Mexico             |
@@ -59,158 +57,69 @@ Participants
 | ![][flag_GB] United Kingdom | ![][flag_KR] South Korea | ![][flag_SG] Singapore   | ![][flag_VE] Venezuela          |
 | ![][flag_US] United States  | ![][flag_TW] Taiwan      | ![][flag_TH] Thailand    | ![][flag_VN] Vietnam            |
 
-| Country                                  | Group A Members                                                                                                                                                                                                                                     |
-|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_VE] Venezuela | **[Kankenaisanxd](https://osu.ppy.sh/u/4698537)**, [Besbinbo](https://osu.ppy.sh/u/4437819), [rakion269](https://osu.ppy.sh/u/2693272)                                                                                                                                |
-| ![][flag_TH] Thailand  | **[\[13\] BECK](https://osu.ppy.sh/u/2656374)**, [irisdevil](https://osu.ppy.sh/u/2623676), [oat0005](https://osu.ppy.sh/u/4110257), [-Loli\-Sora-](https://osu.ppy.sh/u/4183185), [divaviva](https://osu.ppy.sh/u/2221251), [Noobish](https://osu.ppy.sh/u/502592)                     |
-| ![][flag_CA] Canada    | **[beary605](https://osu.ppy.sh/u/2198070)**, [Ashix-](https://osu.ppy.sh/u/981144), [Bites](https://osu.ppy.sh/u/1671598), [CammyKun](https://osu.ppy.sh/u/3607503), [Slyhand](https://osu.ppy.sh/u/4789720), [KenjiTomika](https://osu.ppy.sh/u/3895749)                              |
-| ![][flag_CN] China     | **[Wind God Boy](https://osu.ppy.sh/u/3003417)**, [\[Crz\]Sword](https://osu.ppy.sh/u/5242158), [\[Crz\]Jun](https://osu.ppy.sh/u/4301792), [[Crz]ScSolAr](https://osu.ppy.sh/u/1591215), [\[Crz\]ZhangFan](https://osu.ppy.sh/u/89545), [\[Crz\]Lucifer](https://osu.ppy.sh/u/5270332) |
+| | Country | Group A Members |
+|:---:|:---:|---|
+| ![][flag_CN] | **China** | **[Wind God Boy](https://osu.ppy.sh/users/3003417)**, [\[Crz\]Sword](https://osu.ppy.sh/users/5242158), [\[Crz\]Jun](https://osu.ppy.sh/users/4301792), [[Crz]ScSolAr](https://osu.ppy.sh/users/1591215), [\[Crz\]ZhangFan](https://osu.ppy.sh/users/89545), [\[Crz\]Lucifer](https://osu.ppy.sh/users/5270332) |
+| ![][flag_CA] | **Canada** | **[beary605](https://osu.ppy.sh/users/2198070)**, [Ashix-](https://osu.ppy.sh/users/981144), [Bites](https://osu.ppy.sh/users/1671598), [CammyKun](https://osu.ppy.sh/users/3607503), [Slyhand](https://osu.ppy.sh/users/4789720), [KenjiTomika](https://osu.ppy.sh/users/3895749) |
+| ![][flag_TH] | **Thailand** | **[\[13\] BECK](https://osu.ppy.sh/users/2656374)**, [irisdevil](https://osu.ppy.sh/users/2623676), [oat0005](https://osu.ppy.sh/users/4110257), [-Loli\-Sora-](https://osu.ppy.sh/users/4183185), [divaviva](https://osu.ppy.sh/users/2221251), [Noobish](https://osu.ppy.sh/users/502592) |
+| ![][flag_VE] | **Venezuela** | **[Kankenaisanxd](https://osu.ppy.sh/users/4698537)**, [Besbinbo](https://osu.ppy.sh/users/4437819), [rakion269](https://osu.ppy.sh/users/2693272) |
 
-| Country                                           | Group B Members                                                                                                                                                                                                                      |
-|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_RU] Russian Federation | **[PhobosX](https://osu.ppy.sh/u/2570019)**, [AJIekceu](https://osu.ppy.sh/u/940656), [MisterPlegas](https://osu.ppy.sh/u/3677208), [sanjizzle](https://osu.ppy.sh/u/2172690), [burnmyshadow](https://osu.ppy.sh/u/5950), [Dereku](https://osu.ppy.sh/u/2607745)         |
-| ![][flag_NO] Norway             | **[Staiain](https://osu.ppy.sh/u/86188)**, [MOEpaw](https://osu.ppy.sh/u/3043738), [The Quarryman](https://osu.ppy.sh/u/2713295), [Liqh](https://osu.ppy.sh/u/3409838), [Hjeg](https://osu.ppy.sh/u/2764122), [NekoFlaa](https://osu.ppy.sh/u/80640)                     |
-| ![][flag_NL] Netherlands        | **[Tifyron](https://osu.ppy.sh/u/4519755)**, [nebbii](https://osu.ppy.sh/u/3799729), [Vytaan](https://osu.ppy.sh/u/56908), [Redon](https://osu.ppy.sh/u/3572355), [Arras](https://osu.ppy.sh/u/1023599), [slimmecodo1](https://osu.ppy.sh/u/1800103)                     |
-| ![][flag_ID] Indonesia          | **[E1sa](https://osu.ppy.sh/u/3183277)**, [DoNotMess](https://osu.ppy.sh/u/1596318), [Flame\_Rune](https://osu.ppy.sh/u/3282208), [\[ex-StepM\] Ano](https://osu.ppy.sh/u/4515859), [ExKagii-](https://osu.ppy.sh/u/4591324), [gaktau1234](https://osu.ppy.sh/u/3777233) |
+| | Country | Group B Members |
+|:---:|:---:|---|
+| ![][flag_ID] | **Indonesia** | **[E1sa](https://osu.ppy.sh/users/3183277)**, [DoNotMess](https://osu.ppy.sh/users/1596318), [Flame\_Rune](https://osu.ppy.sh/users/3282208), [\[ex-StepM\] Ano](https://osu.ppy.sh/users/4515859), [ExKagii-](https://osu.ppy.sh/users/4591324), [gaktau1234](https://osu.ppy.sh/users/3777233) |
+| ![][flag_NL] | **Netherlands** | **[Tifyron](https://osu.ppy.sh/users/4519755)**, [nebbii](https://osu.ppy.sh/users/3799729), [Vytaan](https://osu.ppy.sh/users/56908), [Redon](https://osu.ppy.sh/users/3572355), [Arras](https://osu.ppy.sh/users/1023599), [slimmecodo1](https://osu.ppy.sh/users/1800103) |
+| ![][flag_NO] | **Norway** | **[Staiain](https://osu.ppy.sh/users/86188)**, [MOEpaw](https://osu.ppy.sh/users/3043738), [The Quarryman](https://osu.ppy.sh/users/2713295), [Liqh](https://osu.ppy.sh/users/3409838), [Hjeg](https://osu.ppy.sh/users/2764122), [NekoFlaa](https://osu.ppy.sh/users/80640) |
+| ![][flag_RU] | **Russian Federation** | **[PhobosX](https://osu.ppy.sh/users/2570019)**, [AJIekceu](https://osu.ppy.sh/users/940656), [MisterPlegas](https://osu.ppy.sh/users/3677208), [sanjizzle](https://osu.ppy.sh/users/2172690), [burnmyshadow](https://osu.ppy.sh/users/5950), [Dereku](https://osu.ppy.sh/users/2607745) |
 
-| Country                                    | Group C Members                                                                                                                                                                                                                              |
-|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_PE] Peru        | **[akuma123](https://osu.ppy.sh/u/914472)**, [2axterix2](https://osu.ppy.sh/u/1282989), [Amakaire](https://osu.ppy.sh/u/4471271), [jepchus45](https://osu.ppy.sh/u/2372182)                                                                                          |
-| ![][flag_SG] Singapore   | **[danielrox](https://osu.ppy.sh/u/4893212)**, [kimchi97](https://osu.ppy.sh/u/3722725), [DFC Tan](https://osu.ppy.sh/u/5704437), [Degojix](https://osu.ppy.sh/u/3655301), [NeroXVI](https://osu.ppy.sh/u/3584991), [The5e4I](https://osu.ppy.sh/u/3710926)                      |
-| ![][flag_KR] South Korea | **[Runa](https://osu.ppy.sh/u/4643294)**, [SeonRae](https://osu.ppy.sh/u/288233), [\[ Raven \]](https://osu.ppy.sh/u/6542193), [pocket123](https://osu.ppy.sh/u/4220388), [In\_Fo](https://osu.ppy.sh/u/1704592), [Backho-](https://osu.ppy.sh/u/1868086)                        |
-| ![][flag_BR] Brazil      | **[NateTheROOBIN](https://osu.ppy.sh/u/2288363)**, [Guilhermeziat](https://osu.ppy.sh/u/3661387), [FelipeLink](https://osu.ppy.sh/u/4917435), [spoonguy](https://osu.ppy.sh/u/932381), [roko100789](https://osu.ppy.sh/u/3224958), [LuckySonicGHz](https://osu.ppy.sh/u/3949268) |
+| | Country | Group C Members |
+|:---:|:---:|---|
+| ![][flag_BR] | **Brazil** | **[NateTheROOBIN](https://osu.ppy.sh/users/2288363)**, [Guilhermeziat](https://osu.ppy.sh/users/3661387), [FelipeLink](https://osu.ppy.sh/users/4917435), [spoonguy](https://osu.ppy.sh/users/932381), [roko100789](https://osu.ppy.sh/users/3224958), [LuckySonicGHz](https://osu.ppy.sh/users/3949268) |
+| ![][flag_KR] | **South Korea** | **[Runa](https://osu.ppy.sh/users/4643294)**, [SeonRae](https://osu.ppy.sh/users/288233), [\[ Raven \]](https://osu.ppy.sh/users/6542193), [pocket123](https://osu.ppy.sh/users/4220388), [In\_Fo](https://osu.ppy.sh/users/1704592), [Backho-](https://osu.ppy.sh/users/1868086) |
+| ![][flag_SG] | **Singapore** | **[danielrox](https://osu.ppy.sh/users/4893212)**, [kimchi97](https://osu.ppy.sh/users/3722725), [DFC Tan](https://osu.ppy.sh/users/5704437), [Degojix](https://osu.ppy.sh/users/3655301), [NeroXVI](https://osu.ppy.sh/users/3584991), [The5e4I](https://osu.ppy.sh/users/3710926)|
+| ![][flag_PE] | **Peru** | **[akuma123](https://osu.ppy.sh/users/914472)**, [2axterix2](https://osu.ppy.sh/users/1282989), [Amakaire](https://osu.ppy.sh/users/4471271), [jepchus45](https://osu.ppy.sh/users/2372182) |
 
-| Country                                    | Group D Members                                                                                                                                                                                                                |
-|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_MX] Mexico      | **[-SP556](https://osu.ppy.sh/u/6031847)**, [alex\_sennin](https://osu.ppy.sh/u/3549708), [Zetscythe](https://osu.ppy.sh/u/3360499), [Batman301](https://osu.ppy.sh/u/5027853), [\[Mixel\]](https://osu.ppy.sh/u/4861880), [Leydan](https://osu.ppy.sh/u/2851324)  |
-| ![][flag_NZ] New Zealand | **[Mudkips](https://osu.ppy.sh/u/2502706)**, [w33p1ng4ng31](https://osu.ppy.sh/u/1963937), [FantumEX](https://osu.ppy.sh/u/3394802), [Nyao](https://osu.ppy.sh/u/2068663), [Dionysaw](https://osu.ppy.sh/u/4294475), [- T y l e r -](https://osu.ppy.sh/u/4636461) |
-| ![][flag_PL] Poland      | **[Tidek](https://osu.ppy.sh/u/743282)**, [TheZiemniax](https://osu.ppy.sh/u/2235750), [-Kamikaze-](https://osu.ppy.sh/u/2124783), [SitekX](https://osu.ppy.sh/u/3840946), [Krolxp](https://osu.ppy.sh/u/6382502), [Moskas](https://osu.ppy.sh/u/1934077)          |
-| ![][flag_JP] Japan       | **[OmegaJack](https://osu.ppy.sh/u/205391)**, [PiraTom](https://osu.ppy.sh/u/1847698), [HNC\_yk](https://osu.ppy.sh/u/2163585), [YU-G](https://osu.ppy.sh/u/6367706), [inteliser](https://osu.ppy.sh/u/1824775), [ashradwimps](https://osu.ppy.sh/u/5165305)       |
+| | Country | Group D Members |
+|:---:|:---:|---|
+| ![][flag_JP] | **Japan** | **[OmegaJack](https://osu.ppy.sh/users/205391)**, [PiraTom](https://osu.ppy.sh/users/1847698), [HNC\_yk](https://osu.ppy.sh/users/2163585), [YU-G](https://osu.ppy.sh/users/6367706), [inteliser](https://osu.ppy.sh/users/1824775), [ashradwimps](https://osu.ppy.sh/users/5165305) |
+| ![][flag_PL] | **Poland** | **[Tidek](https://osu.ppy.sh/users/743282)**, [TheZiemniax](https://osu.ppy.sh/users/2235750), [-Kamikaze-](https://osu.ppy.sh/users/2124783), [SitekX](https://osu.ppy.sh/users/3840946), [Krolxp](https://osu.ppy.sh/users/6382502), [Moskas](https://osu.ppy.sh/users/1934077) |
+| ![][flag_NZ] | **New Zealand** | **[Mudkips](https://osu.ppy.sh/users/2502706)**, [w33p1ng4ng31](https://osu.ppy.sh/users/1963937), [FantumEX](https://osu.ppy.sh/users/3394802), [Nyao](https://osu.ppy.sh/users/2068663), [Dionysaw](https://osu.ppy.sh/users/4294475), [- T y l e r -](https://osu.ppy.sh/users/4636461) |
+| ![][flag_MX] | **Mexico** | **[-SP556](https://osu.ppy.sh/users/6031847)**, [alex\_sennin](https://osu.ppy.sh/users/3549708), [Zetscythe](https://osu.ppy.sh/users/3360499), [Batman301](https://osu.ppy.sh/users/5027853), [\[Mixel\]](https://osu.ppy.sh/users/4861880), [Leydan](https://osu.ppy.sh/users/2851324) |
 
-| Country                                  | Group E Members                                                                                                                                                                                                                     |
-|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_SE] Sweden    | **[Rilipworldwide](https://osu.ppy.sh/u/4238239)**, [WannabeCparn](https://osu.ppy.sh/u/2090864), [GringoSEVEN1](https://osu.ppy.sh/u/3213412), [Vaiche](https://osu.ppy.sh/u/4268678), [Frobom3](https://osu.ppy.sh/u/4668555), [fjz345](https://osu.ppy.sh/u/3376734) |
-| ![][flag_DK] Denmark   | **[Jole](https://osu.ppy.sh/u/2883132)**, [mart732c](https://osu.ppy.sh/u/4402263), [Hemppas Waifu](https://osu.ppy.sh/u/3795152), [Ciggins](https://osu.ppy.sh/u/4570124), [Demane](https://osu.ppy.sh/u/2886774)                                                |
-| ![][flag_AR] Argentina | **[juankristal](https://osu.ppy.sh/u/443656)**, [lxLucasxl](https://osu.ppy.sh/u/3632846), [Grindei](https://osu.ppy.sh/u/4228356), [Ze_Potente](https://osu.ppy.sh/u/4272364), [n1nj4](https://osu.ppy.sh/u/4540361), [Ryuk_ftw](https://osu.ppy.sh/u/2628463)         |
-| ![][flag_MY] Malaysia  | **[Cryolien](https://osu.ppy.sh/u/1626983)**, [Sern888](https://osu.ppy.sh/u/2089244), [seyren95](https://osu.ppy.sh/u/1761259), [mssheng1998](https://osu.ppy.sh/u/1343562), [KagaNyan](https://osu.ppy.sh/u/438109), [kaname-san92](https://osu.ppy.sh/u/764535)      |
+| | Country | Group E Members |
+|:---:|:---:|---|
+| ![][flag_MY] | **Malaysia** | **[Cryolien](https://osu.ppy.sh/users/1626983)**, [Sern888](https://osu.ppy.sh/users/2089244), [seyren95](https://osu.ppy.sh/users/1761259), [mssheng1998](https://osu.ppy.sh/users/1343562), [KagaNyan](https://osu.ppy.sh/users/438109), [kaname-san92](https://osu.ppy.sh/users/764535) |
+| ![][flag_AR] | **Argentina** | **[juankristal](https://osu.ppy.sh/users/443656)**, [lxLucasxl](https://osu.ppy.sh/users/3632846), [Grindei](https://osu.ppy.sh/users/4228356), [Ze_Potente](https://osu.ppy.sh/users/4272364), [n1nj4](https://osu.ppy.sh/users/4540361), [Ryuk_ftw](https://osu.ppy.sh/users/2628463) |
+| ![][flag_DK] | **Denmark** | **[Jole](https://osu.ppy.sh/users/2883132)**, [mart732c](https://osu.ppy.sh/users/4402263), [Hemppas Waifu](https://osu.ppy.sh/users/3795152), [Ciggins](https://osu.ppy.sh/users/4570124), [Demane](https://osu.ppy.sh/users/2886774) |
+| ![][flag_SE] | **Sweden** | **[Rilipworldwide](https://osu.ppy.sh/users/4238239)**, [WannabeCparn](https://osu.ppy.sh/users/2090864), [GringoSEVEN1](https://osu.ppy.sh/users/3213412), [Vaiche](https://osu.ppy.sh/users/4268678), [Frobom3](https://osu.ppy.sh/users/4668555), [fjz345](https://osu.ppy.sh/users/3376734) |
 
-| Country                                    | Group F Members                                                                                                                                                                                                                          |
-|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_IT] Italy       | **[\[ C r a c k \]](https://osu.ppy.sh/u/3628274)**, [NixoNS](https://osu.ppy.sh/u/6380163), [TheOwnerAlpha](https://osu.ppy.sh/u/3461860), [superbala98](https://osu.ppy.sh/u/4280549), [rik30031](https://osu.ppy.sh/u/3281583)                                      |
-| ![][flag_DE] Germany     | **[Dualshock](https://osu.ppy.sh/u/1902591)**, [\[timefrozen\]](https://osu.ppy.sh/u/3921273), [- Bad Apple -](https://osu.ppy.sh/u/4282445), [rohen04](https://osu.ppy.sh/u/369614), [Reikokaz](https://osu.ppy.sh/u/1263173), [Feerum](https://osu.ppy.sh/u/4815717)       |
-| ![][flag_PH] Philippines | **[Tokiiwa](https://osu.ppy.sh/u/4029511)**, [arcwinolivirus](https://osu.ppy.sh/u/2039089), [Ainyan](https://osu.ppy.sh/u/3770641), [Aiko-neechan](https://osu.ppy.sh/u/5546195), [RonAcuisa](https://osu.ppy.sh/u/3034081), [gunxblade128](https://osu.ppy.sh/u/6573652)   |
-| ![][flag_AU] Australia   | **[Alchalyne](https://osu.ppy.sh/u/3999031)**, [Tornspirit](https://osu.ppy.sh/u/1338883), [CannuJul](https://osu.ppy.sh/u/3601697), [MasterSonic10](https://osu.ppy.sh/u/1249224), [Aroused Lollies](https://osu.ppy.sh/u/2956184), [-X Y Z-](https://osu.ppy.sh/u/1610833) |
+| | Country | Group F Members |
+|:---:|:---:|---|
+| ![][flag_AU] | **Australia** | **[Alchalyne](https://osu.ppy.sh/users/3999031)**, [Tornspirit](https://osu.ppy.sh/users/1338883), [CannuJul](https://osu.ppy.sh/users/3601697), [MasterSonic10](https://osu.ppy.sh/users/1249224), [Aroused Lollies](https://osu.ppy.sh/users/2956184), [-X Y Z-](https://osu.ppy.sh/users/1610833) |
+| ![][flag_PH] | **Philippines** | **[Tokiiwa](https://osu.ppy.sh/users/4029511)**, [arcwinolivirus](https://osu.ppy.sh/users/2039089), [Ainyan](https://osu.ppy.sh/users/3770641), [Aiko-neechan](https://osu.ppy.sh/users/5546195), [RonAcuisa](https://osu.ppy.sh/users/3034081), [gunxblade128](https://osu.ppy.sh/users/6573652) |
+| ![][flag_DE] | **Germany** | **[Dualshock](https://osu.ppy.sh/users/1902591)**, [\[timefrozen\]](https://osu.ppy.sh/users/3921273), [- Bad Apple -](https://osu.ppy.sh/users/4282445), [rohen04](https://osu.ppy.sh/users/369614), [Reikokaz](https://osu.ppy.sh/users/1263173), [Feerum](https://osu.ppy.sh/users/4815717) |
+| ![][flag_IT] | **Italy** | **[\[ C r a c k \]](https://osu.ppy.sh/users/3628274)**, [NixoNS](https://osu.ppy.sh/users/6380163), [TheOwnerAlpha](https://osu.ppy.sh/users/3461860), [superbala98](https://osu.ppy.sh/users/4280549), [rik30031](https://osu.ppy.sh/users/3281583) |
 
-| Country                                       | Group G Members                                                                                                                                                                                                                    |
-|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_IL] Israel         | **[-Zero-](https://osu.ppy.sh/u/4192103)**, [Shahar664](https://osu.ppy.sh/u/3448980), [Avdi](https://osu.ppy.sh/u/4382773), [CookChefSteak](https://osu.ppy.sh/u/3069698)                                                                                 |
-| ![][flag_FI] Finland        | **[Jepetski](https://osu.ppy.sh/u/3794665)**, [Spidu](https://osu.ppy.sh/u/5192), [Princesswell](https://osu.ppy.sh/u/4789005), [MarkMayFire](https://osu.ppy.sh/u/4508575), [Diidzyh](https://osu.ppy.sh/u/1497090), [DesuMetal](https://osu.ppy.sh/u/5014674)        |
-| ![][flag_FR] France         | **[lim38](https://osu.ppy.sh/u/2741170)**, [adrien062](https://osu.ppy.sh/u/2131990), [Todestrieb](https://osu.ppy.sh/u/4056690), [Shadowzyx](https://osu.ppy.sh/u/3384640), [Elementaires](https://osu.ppy.sh/u/2284328), [Yami Le Lama](https://osu.ppy.sh/u/888986) |
-| ![][flag_GB] United Kingdom | **[Pope Gadget](https://osu.ppy.sh/u/2288341)**, [yipyapyop](https://osu.ppy.sh/u/5156656), [Hayabusa](https://osu.ppy.sh/u/3104108), [Cozzzy](https://osu.ppy.sh/u/2003917), [Junk Brunstoe](https://osu.ppy.sh/u/4676382), [Mat](https://osu.ppy.sh/u/2668921)       |
+| | Country | Group G Members |
+|:---:|:---:|---|
+| ![][flag_GB] | **United Kingdom** | **[Pope Gadget](https://osu.ppy.sh/users/2288341)**, [yipyapyop](https://osu.ppy.sh/users/5156656), [Hayabusa](https://osu.ppy.sh/users/3104108), [Cozzzy](https://osu.ppy.sh/users/2003917), [Junk Brunstoe](https://osu.ppy.sh/users/4676382), [Mat](https://osu.ppy.sh/users/2668921) |
+| ![][flag_FR] | **France** | **[lim38](https://osu.ppy.sh/users/2741170)**, [adrien062](https://osu.ppy.sh/users/2131990), [Todestrieb](https://osu.ppy.sh/users/4056690), [Shadowzyx](https://osu.ppy.sh/users/3384640), [Elementaires](https://osu.ppy.sh/users/2284328), [Yami Le Lama](https://osu.ppy.sh/users/888986) |
+| ![][flag_FI] | **Finland** | **[Jepetski](https://osu.ppy.sh/users/3794665)**, [Spidu](https://osu.ppy.sh/users/5192), [Princesswell](https://osu.ppy.sh/users/4789005), [MarkMayFire](https://osu.ppy.sh/users/4508575), [Diidzyh](https://osu.ppy.sh/users/1497090), [DesuMetal](https://osu.ppy.sh/users/5014674) |
+| ![][flag_IL] | **Israel** | **[-Zero-](https://osu.ppy.sh/users/4192103)**, [Shahar664](https://osu.ppy.sh/users/3448980), [Avdi](https://osu.ppy.sh/users/4382773), [CookChefSteak](https://osu.ppy.sh/users/3069698) |
 
-| Country                                      | Group H Members                                                                                                                                                                                                                    |
-|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_VN] Vietnam       | **[Devilchilly](https://osu.ppy.sh/u/2656302)**, [Purrinya](https://osu.ppy.sh/u/2915643), [Yuuto Gaming](https://osu.ppy.sh/u/4774715)                                                                                                              |
-| ![][flag_CL] Chile         | **[Urusai](https://osu.ppy.sh/u/469808)**, [soulbaster](https://osu.ppy.sh/u/4262648), [Garrus Brouker](https://osu.ppy.sh/u/4601944), [knito12](https://osu.ppy.sh/u/4987038), [sasuke3000](https://osu.ppy.sh/u/560981), [akonee-chan](https://osu.ppy.sh/u/4811164) |
-| ![][flag_TW] Taiwan        | **[MimF7\_tw](https://osu.ppy.sh/u/4135993)**, [y85782122](https://osu.ppy.sh/u/2287176), [j1515jjj1313](https://osu.ppy.sh/u/1801343), [Aya123544](https://osu.ppy.sh/u/4842590), [Sakaki](https://osu.ppy.sh/u/2656856), [luckygino](https://osu.ppy.sh/u/1967808)   |
-| ![][flag_US] United States | **[EtienneXC](https://osu.ppy.sh/u/5610085)**, [Halogen-](https://osu.ppy.sh/u/169992), [\_Hibiki\_](https://osu.ppy.sh/u/4830970), [Theriann](https://osu.ppy.sh/u/4552987), [Zyph](https://osu.ppy.sh/u/1600432), [Chrubble](https://osu.ppy.sh/u/2594280)           |
+| | Country | Group H Members |
+|:---:|:---:|---|
+| ![][flag_US] | **United States** | **[EtienneXC](https://osu.ppy.sh/users/5610085)**, [Halogen-](https://osu.ppy.sh/users/169992), [\_Hibiki\_](https://osu.ppy.sh/users/4830970), [Theriann](https://osu.ppy.sh/users/4552987), [Zyph](https://osu.ppy.sh/users/1600432), [Chrubble](https://osu.ppy.sh/users/2594280) |
+| ![][flag_TW] | **Taiwan** | **[MimF7\_tw](https://osu.ppy.sh/users/4135993)**, [y85782122](https://osu.ppy.sh/users/2287176), [j1515jjj1313](https://osu.ppy.sh/users/1801343), [Aya123544](https://osu.ppy.sh/users/4842590), [Sakaki](https://osu.ppy.sh/users/2656856), [luckygino](https://osu.ppy.sh/users/1967808) |
+| ![][flag_CL] | **Chile** | **[Urusai](https://osu.ppy.sh/users/469808)**, [soulbaster](https://osu.ppy.sh/users/4262648), [Garrus Brouker](https://osu.ppy.sh/users/4601944), [knito12](https://osu.ppy.sh/users/4987038), [sasuke3000](https://osu.ppy.sh/users/560981), [akonee-chan](https://osu.ppy.sh/users/4811164) |
+| ![][flag_VN] | **Vietnam** | **[Devilchilly](https://osu.ppy.sh/users/2656302)**, [Purrinya](https://osu.ppy.sh/users/2915643), [Yuuto Gaming](https://osu.ppy.sh/users/4774715) |
 
 ------------------------------------------------------------------------
 
-Mappools
----------
-
-### Group Stage
-
-**[Download the map pack here!](https://www.mediafire.com/download/ea93b8bb99w1vt5/MWC_4K_2015_Group_Stage.rar)**
-
-- FreeMod
-  - [Qrispy Joybox - snow prism (LNP-) \[MX\]](https://osu.ppy.sh/b/487578)
-  - [yak\_won - Lucid (Critical\_Star) \[MX\]](https://osu.ppy.sh/b/476043)
-  - [Vospi - We Met Dat Night (Halogen-) \[MX\]](https://osu.ppy.sh/b/374172)
-  - [Ryu\* - We're so Happy (Spy) \[victorica's 4K HD+\]](https://osu.ppy.sh/b/314892)
-  - [Ryu\* - Sakura Mirage (Spy) \[ADVANCED Lv.12\]](https://osu.ppy.sh/b/439140)
-  - [Tokisawa Nao - Analyze (Heart of Bitch) \[ecafree2's 4K SC\]](https://osu.ppy.sh/b/429628)
-  - [nora2r - VISION (SanadaYukimura) \[ADVANCED\]](https://osu.ppy.sh/b/723147)
-  - [S-C-U feat. Qrispy Joybox - anemone (Starry-) \[Special\]](https://osu.ppy.sh/b/738032)
-  - [Celas - Azul (Remix) (Marirose) \[Bie' Hyper\]](https://osu.ppy.sh/b/714074)
-  - [SHK - Couple Breaking (Sky\_Demon) \[MX\]](https://osu.ppy.sh/b/376721)
-  - [Qrispy Joybox feat.mao - Good-bye Tears (LNP-) \[MX\]](https://osu.ppy.sh/b/637229)
-  - [3R2 - Beyond the Horizon (hokin1995) \[MX\]](https://osu.ppy.sh/b/505719)
-- Tiebreaker
-  - [Momobako & Aihara Kaori - Senbonzakura (victorica\_db) \[Insane\]](https://osu.ppy.sh/b/494045)
-
-### Round of 16
-
-**[Download the map pack here!](https://www.mediafire.com/download/a2deedhozg0wzcm/MWC_4K_2015_Round_of_16_.rar)**
-
-- FreeMod
-  - [Junk - Qualia (Mashiro-Fang) \[S.Star's 4K MX\]](https://osu.ppy.sh/b/432217)
-  - [ikaruga\_nex - gigadelic(m3rkAb4\# R3m!x) (Starry-) \[EXHAUST Lv.13\]](https://osu.ppy.sh/b/751036)
-  - [Soleily - Violet Soul (Spy) \[victorica's GRAVITY Lv.15\]](https://osu.ppy.sh/b/554742)
-  - [Orangestar - Asu no Yozora Shoukaihan (LovinYou) \[Insane\]](https://osu.ppy.sh/b/679332)
-  - [BlackY's BEATFLOOR - Creutz=Wilknare (Short Ver.) (SanadaYukimura) \[Insane\]](https://osu.ppy.sh/b/651992)
-  - [Hige Driver join. SELEN - Dadadadadadadadadada (victorica\_db) \[Lv.14\]](https://osu.ppy.sh/b/549360)
-  - [Tatsh - HEAVENLY MOON (Spy) \[EXTREME\]](https://osu.ppy.sh/b/561923)
-  - [Yooh - Shanghai Kouchakan ~ Chinese Tea Orchid Remix (SanadaYukimura) \[EXHAUST\]](https://osu.ppy.sh/b/590575)
-  - [Junk - Yellow Smile(bms edit) (Starry-) \[Another\]](https://osu.ppy.sh/b/678460)
-  - [C-Show - Invitation from Mr.C (\_FrEsH\_ChICkEn\_) \[EXHAUST\]](https://osu.ppy.sh/b/659683)
-  - [P\*Light - TRIGGER\*HAPPY (Kuo Kyoka) \[Spy's 4K EXHAUST Lv.20\]](https://osu.ppy.sh/b/323459)
-  - [S-C-U - Ambitious (\[ A v a l o n \]) \[Spy's Another\]](https://osu.ppy.sh/b/753220)
-  - [Seiryu - Water Horizon (Spy) \[victorica's 4K ExtrA\]](https://osu.ppy.sh/b/360805)
-  - [ETIA. - Nihonshiki Koukaku-OukaRanman- (Taiwan-NAK) \[Lv.15\]](https://osu.ppy.sh/b/602235)
-- Tiebreaker
-  - [Halozy - Kanshou no Matenrou (Feerum) \[World's End\]](https://osu.ppy.sh/b/577429)
-
-### Quarterfinals
-
-**[Download the mappack here!](https://www.mediafire.com/download/0dhr36bhyp8lzwb/MWC_4K_2015_Quarter_Finals.rar)**
-
-- FreeMod
-  - [xi - Garyou Tensei (LNP-) \[4K MX\]](https://osu.ppy.sh/b/530544)
-  - [Helblinde - Grief & Malice (Fullerene-) \[4K Kriemhild Gretchen\]](https://osu.ppy.sh/b/554655)
-  - [SasakureP - bokura no 16bit warz (CrazyStar) \[16bit\]](https://osu.ppy.sh/b/630173)
-  - [loz - Cinderella Cage -Trancecore Mix- (Jepetski) \[Lunatic\]](https://osu.ppy.sh/b/694425)
-  - [ZOGRAPHOS (Yu\_Asahina+Yamajet) - Verse IV (Ichigaki) \[EXHAUST\]](https://osu.ppy.sh/b/603737)
-  - [sun3 - ApolloN (bbu2) \[LeiN-'s 4K Insane\]](https://osu.ppy.sh/b/669917)
-  - [wa. remixed celas - Gin no Kaze (Marirose) \[4K Another\]](https://osu.ppy.sh/b/752775)
-  - [Izayoi Sak - Blue Planet (Shoegazer) \[Another\]](https://osu.ppy.sh/b/716960)
-  - [Soleily - Renatus (Tidek) \[Insane\]](https://osu.ppy.sh/b/552746)
-  - [xi - Wish upon Twin Stars (LNP-) \[EXHAUST Lv.15\]](https://osu.ppy.sh/b/540060)
-  - [Camellia - overcomplexification (Starry-) \[Lv.10\]](https://osu.ppy.sh/b/718998)
-  - [High Speed Music Team Sharpnel - M.A.M.A. (arcwinolivirus) \[MX\]](https://osu.ppy.sh/b/429550)
-  - [BlackY - Black Rose (Marirose) \[4K Another\]](https://osu.ppy.sh/b/668992)
-  - [xi - Aragami (Blocko) \[snover's 4K Another\]](https://osu.ppy.sh/b/760458)
-- Tiebreaker
-  - [Camellia - Lunatic Rough Party](https://osu.ppy.sh/b/646319)
-
-### Semifinals
-
-**[Download the mappack here!](https://www.mediafire.com/download/mwzkd8fx1hb8973/MWC_4K_2015_Semifinals.rar)**
-
-- FreeMod
-  - [you - Hold Angel (Shoegazer) \[Insane\]](https://osu.ppy.sh/b/763511)
-  - [COOL&CREATE - BEAT-NEW-WORLD (Feerum) \[Jinjin's GRAVITY Lv.16\]](https://osu.ppy.sh/b/716737) 
-  - [3034 - NS18 (Fullerene-) \[EXTREME\]](https://osu.ppy.sh/b/777353)
-  - [ZiGZaG HACKER - V^3 (Hello World) (Quick Draw) \[4K SC\]](https://osu.ppy.sh/b/723816)
-  - [xi - Hesperides (Ichigaki) \[Master\]](https://osu.ppy.sh/b/735806)
-  - [Utsu-P feat.Kagamine Rin - Tokyo Teddy Bear (puxtu) \[SHD\]](https://osu.ppy.sh/b/747621)
-  - [Kaneko Chiharu - Yukionna (CannuJul) \[Jepetski's GRAVITY\]](https://osu.ppy.sh/b/772991)
-  - [siromaru - Absurd Gaff (arcwinolivirus) \[Assassination \[SC\]\]](https://osu.ppy.sh/b/766794)
-  - [xi - Quietus Ray (DE-CADE) \[Ichi's INFINITE Lv.16\]](https://osu.ppy.sh/b/517247)
-  - [Daiki Kasho - John Tanaka's Theme (Shoegazer) \[Astrofalcon\]](https://osu.ppy.sh/b/690803)
-  - [Hermit - Dysnomia (-Kamikaze-) \[Tidek's 4K Monochrome\]](https://osu.ppy.sh/b/763657)
-  - [LV.4 - Angel dust (LeiN-) \[Another\]](https://osu.ppy.sh/b/704844)
-  - [xi - Blue Zenith (Jepetski) \[Zen's Black Another\]](https://osu.ppy.sh/b/718163)
-  - [SD-501 - Cyberstorm (DJKurara Remix) (Quick Draw) \[4K SC\]](https://osu.ppy.sh/b/654145)
-  - [Nightmare - Dream To Nightmare (Shoegazer) \[Catatonia (SV)\]](https://osu.ppy.sh/b/775984)
-  - [The Quick Brown Fox - WANDERLUST (Nivrad00) \[Jinjin's 4K Extra\]](https://osu.ppy.sh/b/530698)
-- Tiebreaker
-  - [goreshit - burn this moment into the retina of my eye (Tidek) \[Fear\]](https://osu.ppy.sh/b/692640)
+## Mappools
 
 ### Finals
 
-**This mappool will be used in Finals - Week 1 and Finals - Week 2**
+**This mappool will be used in Finals and Grand Finals**
 
 **[Download the mappack here!](https://www.mediafire.com/download/3z76r2xd707sl2n/MWC_4K_2015_Finals.rar)**
 
@@ -236,154 +145,219 @@ Mappools
 - Tiebreaker
   - [xi - PEACE BREAKER (Fullerene-) \[FINAL PUNISHMENT\]](https://osu.ppy.sh/b/777348)
 
-
-------------------------------------------------------------------------
-
-Match Results
--------------
-
-### Grand Finals
-
-**Sunday, 27\. September 2015**
-
-| Team A                                           | Score      | Team B                               | History                        |
-|:-------------------------------------------------|:----------:|-------------------------------------:|--------------------------------|
-| ![][flag_US] **United States** | **7**  - 0 | Japan ![][flag_JP] | [#1](https://osu.ppy.sh/mp/19202583) |
-
-### Finals - Week 1
-
-**Saturday, 19\. September 2015**
-
-| Team A                                        | Score          | Team B                                           | History                        |
-|:----------------------------------------------|:--------------:|-------------------------------------------------:|--------------------------------|
-| ![][flag_MY] Malaysia       | 0      - **6** | **Japan** ![][flag_JP]         | [#1](https://osu.ppy.sh/mp/19033684) |
-| ![][flag_CN] China          | 0      - **6** | **Brazil** ![][flag_BR]        | [#1](https://osu.ppy.sh/mp/19035062) |
-| ![][flag_JP] **Japan**      | **6**  - 1     | Brazil ![][flag_BR]            | [#1](https://osu.ppy.sh/mp/19036723) |
-| ![][flag_GB] United Kingdom | 0      - **6** | **United States** ![][flag_US] | [#1](https://osu.ppy.sh/mp/19047914) |
-
-**Sunday, 20\. September 2015**
-
-| Team A                                        | Score     | Team B                                   | History                        |
-|:----------------------------------------------|:---------:|-----------------------------------------:|--------------------------------|
-| ![][flag_GB] United Kingdom | 3 - **6** | **Japan** ![][flag_JP] | [#1](https://osu.ppy.sh/mp/19064573) |
-
-
 ### Semifinals
 
-**Saturday, 12\. September 2015**
+**[Download the mappack here!](https://www.mediafire.com/download/mwzkd8fx1hb8973/MWC_4K_2015_Semifinals.rar)**
 
-| Team A                                       | Score          | Team B                                            | History                        |
-|:---------------------------------------------|:--------------:|--------------------------------------------------:|--------------------------------|
-| ![][flag_BR] **Brazil**    | **6**  - 1     | South Korea ![][flag_KR]        | [#1](https://osu.ppy.sh/mp/18875865) |
-| ![][flag_JP] Japan         | 0      - **6** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/mp/18876734) |
-| ![][flag_CA] Canada        | 2      - **6** | **Philippines** ![][flag_PH]    | [#1](https://osu.ppy.sh/mp/18877878) |
-| ![][flag_ID] **Indonesia** | **6**  - 1     | France ![][flag_FR]             | [#1](https://osu.ppy.sh/mp/18884689) |
-| ![][flag_CN] China         | 0      - **6** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/mp/18885939) |
-| ![][flag_MY] **Malaysia**  | **6**  - 0     | Argentina ![][flag_AR]          | -- Win by default --           |
-
-**Sunday, 13\. September 2015**
-
-| Team A                                      | Score     | Team B                                     | History                        |
-|:--------------------------------------------|:---------:|-------------------------------------------:|--------------------------------|
-| ![][flag_MY] **Malaysia** | **6** - 5 | Philippines ![][flag_PH] | [#1](https://osu.ppy.sh/mp/18916080) |
-| ![][flag_BR] **Brazil**   | **6** - 3 | Indonesia ![][flag_ID]   | [#1](https://osu.ppy.sh/mp/18917606) |
+- FreeMod
+  - [you - Hold Angel (Shoegazer) \[Insane\]](https://osu.ppy.sh/b/763511)
+  - [COOL&CREATE - BEAT-NEW-WORLD (Feerum) \[Jinjin's GRAVITY Lv.16\]](https://osu.ppy.sh/b/716737)
+  - [3034 - NS18 (Fullerene-) \[EXTREME\]](https://osu.ppy.sh/b/777353)
+  - [ZiGZaG HACKER - V^3 (Hello World) (Quick Draw) \[4K SC\]](https://osu.ppy.sh/b/723816)
+  - [xi - Hesperides (Ichigaki) \[Master\]](https://osu.ppy.sh/b/735806)
+  - [Utsu-P feat.Kagamine Rin - Tokyo Teddy Bear (puxtu) \[SHD\]](https://osu.ppy.sh/b/747621)
+  - [Kaneko Chiharu - Yukionna (CannuJul) \[Jepetski's GRAVITY\]](https://osu.ppy.sh/b/772991)
+  - [siromaru - Absurd Gaff (arcwinolivirus) \[Assassination \[SC\]\]](https://osu.ppy.sh/b/766794)
+  - [xi - Quietus Ray (DE-CADE) \[Ichi's INFINITE Lv.16\]](https://osu.ppy.sh/b/517247)
+  - [Daiki Kasho - John Tanaka's Theme (Shoegazer) \[Astrofalcon\]](https://osu.ppy.sh/b/690803)
+  - [Hermit - Dysnomia (-Kamikaze-) \[Tidek's 4K Monochrome\]](https://osu.ppy.sh/b/763657)
+  - [LV.4 - Angel dust (LeiN-) \[Another\]](https://osu.ppy.sh/b/704844)
+  - [xi - Blue Zenith (Jepetski) \[Zen's Black Another\]](https://osu.ppy.sh/b/718163)
+  - [SD-501 - Cyberstorm (DJKurara Remix) (Quick Draw) \[4K SC\]](https://osu.ppy.sh/b/654145)
+  - [Nightmare - Dream To Nightmare (Shoegazer) \[Catatonia (SV)\]](https://osu.ppy.sh/b/775984)
+  - [The Quick Brown Fox - WANDERLUST (Nivrad00) \[Jinjin's 4K Extra\]](https://osu.ppy.sh/b/530698)
+- Tiebreaker
+  - [goreshit - burn this moment into the retina of my eye (Tidek) \[Fear\]](https://osu.ppy.sh/b/692640)
 
 ### Quarterfinals
 
-**Saturday, 5\. September 2015**
+**[Download the mappack here!](https://www.mediafire.com/download/0dhr36bhyp8lzwb/MWC_4K_2015_Quarter_Finals.rar)**
 
-| Team A                                     | Score          | Team B                                            | History                        |
-|:-------------------------------------------|:--------------:|--------------------------------------------------:|--------------------------------|
-| ![][flag_NL] Netherlands | 1      - **5** | **Malaysia** ![][flag_MY]       | [#1](https://osu.ppy.sh/mp/18735213) |
-| ![][flag_FR] France      | 0      - **5** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/18736038) |
-| ![][flag_CN] **China**   | **5**  - 1     | Philippines ![][flag_PH]        | [#1](https://osu.ppy.sh/mp/18737149) |
-| ![][flag_TW] Taiwan      | 0      - **5** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/mp/18739049) |
-| ![][flag_PL] Poland      | 0      - **5** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/18740464) |
-| ![][flag_AR] Argentina   | 0      - **5** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/mp/18741841) |
-
-**Sunday, 6\. September 2015**
-
-| Team A                                     | Score     | Team B                                           | History                        |
-|:-------------------------------------------|:---------:|-------------------------------------------------:|--------------------------------|
-| ![][flag_AU] Australia   | 0 - **5** | **Canada** ![][flag_CA]        | [#1](https://osu.ppy.sh/mp/18754356) |
-| ![][flag_KR] South Korea | 0 - **5** | **United States** ![][flag_US] | [#1](https://osu.ppy.sh/mp/18755307) |
+- FreeMod
+  - [xi - Garyou Tensei (LNP-) \[4K MX\]](https://osu.ppy.sh/b/530544)
+  - [Helblinde - Grief & Malice (Fullerene-) \[4K Kriemhild Gretchen\]](https://osu.ppy.sh/b/554655)
+  - [SasakureP - bokura no 16bit warz (CrazyStar) \[16bit\]](https://osu.ppy.sh/b/630173)
+  - [loz - Cinderella Cage -Trancecore Mix- (Jepetski) \[Lunatic\]](https://osu.ppy.sh/b/694425)
+  - [ZOGRAPHOS (Yu\_Asahina+Yamajet) - Verse IV (Ichigaki) \[EXHAUST\]](https://osu.ppy.sh/b/603737)
+  - [sun3 - ApolloN (bbu2) \[LeiN-'s 4K Insane\]](https://osu.ppy.sh/b/669917)
+  - [wa. remixed celas - Gin no Kaze (Marirose) \[4K Another\]](https://osu.ppy.sh/b/752775)
+  - [Izayoi Sak - Blue Planet (Shoegazer) \[Another\]](https://osu.ppy.sh/b/716960)
+  - [Soleily - Renatus (Tidek) \[Insane\]](https://osu.ppy.sh/b/552746)
+  - [xi - Wish upon Twin Stars (LNP-) \[EXHAUST Lv.15\]](https://osu.ppy.sh/b/540060)
+  - [Camellia - overcomplexification (Starry-) \[Lv.10\]](https://osu.ppy.sh/b/718998)
+  - [High Speed Music Team Sharpnel - M.A.M.A. (arcwinolivirus) \[MX\]](https://osu.ppy.sh/b/429550)
+  - [BlackY - Black Rose (Marirose) \[4K Another\]](https://osu.ppy.sh/b/668992)
+  - [xi - Aragami (Blocko) \[snover's 4K Another\]](https://osu.ppy.sh/b/760458)
+- Tiebreaker
+  - [Camellia - Lunatic Rough Party (Ichigaki) \[Lunatic\]](https://osu.ppy.sh/b/646319)
 
 ### Round of 16
 
-**Sunday, 30\. August 2015**
+**[Download the map pack here!](https://www.mediafire.com/download/a2deedhozg0wzcm/MWC_4K_2015_Round_of_16_.rar)**
 
-| Team A                                            | Score          | Team B                                         | History                        |
-|:--------------------------------------------------|:--------------:|-----------------------------------------------:|--------------------------------|
-| ![][flag_AU] Australia          | 1      - **5** | **South Korea** ![][flag_KR] | [#1](https://osu.ppy.sh/mp/18606478) |
-| ![][flag_CN] **China**          | **5**  - 1     | Taiwan ![][flag_TW]          | [#1](https://osu.ppy.sh/mp/18607469) |
-| ![][flag_MY] Malaysia           | 0      - **5** | **Japan** ![][flag_JP]       | [#1](https://osu.ppy.sh/mp/18608519) |
-| ![][flag_BR] Brazil             | 2      - **5** | **Philippines** ![][flag_PH] | [#1](https://osu.ppy.sh/mp/18609649) |
-| ![][flag_GB] **United Kingdom** | **5**  - 3     | Indonesia ![][flag_ID]       | [#1](https://osu.ppy.sh/mp/18612279) |
-| ![][flag_NL] Netherlands        | 1      - **5** | **France** ![][flag_FR]      | [#1](https://osu.ppy.sh/mp/18613709) |
-| ![][flag_PL] Poland             | 1      - **5** | **Argentina** ![][flag_AR]   | [#1](https://osu.ppy.sh/mp/18614619) |
-| ![][flag_US] **United States**  | **5**  - 0     | Canada ![][flag_CA]          | [#1](https://osu.ppy.sh/mp/18616004) |
+- FreeMod
+  - [Junk - Qualia (Mashiro-Fang) \[S.Star's 4K MX\]](https://osu.ppy.sh/b/432217)
+  - [ikaruga\_nex - gigadelic(m3rkAb4\# R3m!x) (Starry-) \[EXHAUST Lv.13\]](https://osu.ppy.sh/b/751036)
+  - [Soleily - Violet Soul (Spy) \[victorica's GRAVITY Lv.15\]](https://osu.ppy.sh/b/554742)
+  - [Orangestar - Asu no Yozora Shoukaihan (LovinYou) \[Insane\]](https://osu.ppy.sh/b/679332)
+  - [BlackY's BEATFLOOR - Creutz=Wilknare (Short Ver.) (SanadaYukimura) \[Insane\]](https://osu.ppy.sh/b/651992)
+  - [Hige Driver join. SELEN - Dadadadadadadadadada (victorica\_db) \[Lv.14\]](https://osu.ppy.sh/b/549360)
+  - [Tatsh - HEAVENLY MOON (Spy) \[EXTREME\]](https://osu.ppy.sh/b/561923)
+  - [Yooh - Shanghai Kouchakan ~ Chinese Tea Orchid Remix (SanadaYukimura) \[EXHAUST\]](https://osu.ppy.sh/b/590575)
+  - [Junk - Yellow Smile(bms edit) (Starry-) \[Another\]](https://osu.ppy.sh/b/678460)
+  - [C-Show - Invitation from Mr.C (\_FrEsH\_ChICkEn\_) \[EXHAUST\]](https://osu.ppy.sh/b/659683)
+  - [P\*Light - TRIGGER\*HAPPY (Kuo Kyoka) \[Spy's 4K EXHAUST Lv.20\]](https://osu.ppy.sh/b/323459)
+  - [S-C-U - Ambitious (\[ A v a l o n \]) \[Spy's Another\]](https://osu.ppy.sh/b/753220)
+  - [Seiryu - Water Horizon (Spy) \[victorica's 4K ExtrA\]](https://osu.ppy.sh/b/360805)
+  - [ETIA. - Nihonshiki Koukaku-OukaRanman- (Taiwan-NAK) \[Lv.15\]](https://osu.ppy.sh/b/602235)
+- Tiebreaker
+  - [Halozy - Kanshou no Matenrou (Feerum) \[World's End\]](https://osu.ppy.sh/b/577429)
+
+### Group Stage
+
+**[Download the map pack here!](https://www.mediafire.com/download/ea93b8bb99w1vt5/MWC_4K_2015_Group_Stage.rar)**
+
+- FreeMod
+  - [Qrispy Joybox - snow prism (LNP-) \[MX\]](https://osu.ppy.sh/b/487578)
+  - [yak\_won - Lucid (Critical\_Star) \[MX\]](https://osu.ppy.sh/b/476043)
+  - [Vospi - We Met Dat Night (Halogen-) \[MX\]](https://osu.ppy.sh/b/374172)
+  - [Ryu\* - We're so Happy (Spy) \[victorica's 4K HD+\]](https://osu.ppy.sh/b/314892)
+  - [Ryu\* - Sakura Mirage (Spy) \[ADVANCED Lv.12\]](https://osu.ppy.sh/b/439140)
+  - [Tokisawa Nao - Analyze (Heart of Bitch) \[ecafree2's 4K SC\]](https://osu.ppy.sh/b/429628)
+  - [nora2r - VISION (SanadaYukimura) \[ADVANCED\]](https://osu.ppy.sh/b/723147)
+  - [S-C-U feat. Qrispy Joybox - anemone (Starry-) \[Special\]](https://osu.ppy.sh/b/738032)
+  - [Celas - Azul (Remix) (Marirose) \[Bie' Hyper\]](https://osu.ppy.sh/b/714074)
+  - [SHK - Couple Breaking (Sky\_Demon) \[MX\]](https://osu.ppy.sh/b/376721)
+  - [Qrispy Joybox feat.mao - Good-bye Tears (LNP-) \[MX\]](https://osu.ppy.sh/b/637229)
+  - [3R2 - Beyond the Horizon (hokin1995) \[MX\]](https://osu.ppy.sh/b/505719)
+- Tiebreaker
+  - [Momobako & Aihara Kaori - Senbonzakura (victorica\_db) \[Insane\]](https://osu.ppy.sh/b/494045)
+
+------------------------------------------------------------------------
+
+## Match Results
+
+### Grand Finals
+
+| 2015-09-27 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **United States** ![][flag_US] | **7** | 0 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/19202583) |
+
+### Finals
+
+| 2015-09-19 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Malaysia ![][flag_MY]       | 0 | **6** | ![][flag_JP] **Japan**         | [#1](https://osu.ppy.sh/community/matches/19033684) |
+| China ![][flag_CN]          | 0 | **6** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/19035062) |
+| **Japan** ![][flag_JP]      | **6** | 1 | ![][flag_BR] Brazil            | [#1](https://osu.ppy.sh/community/matches/19036723) |
+| United Kingdom ![][flag_GB] | 0 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/19047914) |
+
+| 2015-09-20 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| United Kingdom ![][flag_GB] | 3 | **6** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/19064573) |
+
+### Semifinals
+
+| 2015-09-12 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **Brazil** ![][flag_BR]    | **6** | 1 | ![][flag_KR] South Korea        | [#1](https://osu.ppy.sh/community/matches/18875865) |
+| Japan ![][flag_JP]         | 0 | **6** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/18876734) |
+| Canada ![][flag_CA]        | 2 | **6** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/18877878) |
+| **Indonesia** ![][flag_ID] | **6** | 1 | ![][flag_FR] France             | [#1](https://osu.ppy.sh/community/matches/18884689) |
+| China ![][flag_CN]         | 0 | **6** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/18885939) |
+| **Malaysia** ![][flag_MY]  | **6** | 0 | ![][flag_AR] Argentina          | -Win by default- |
+
+| 2015-09-13 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| **Malaysia** ![][flag_MY] | **6** | 5 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/18916080) |
+| **Brazil** ![][flag_BR]   | **6** | 3 | ![][flag_ID] Indonesia   | [#1](https://osu.ppy.sh/community/matches/18917606) |
+
+### Quarterfinals
+
+| 2015-09-05 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Netherlands ![][flag_NL] | 1 | **5** | ![][flag_MY] **Malaysia**       | [#1](https://osu.ppy.sh/community/matches/18735213) |
+| France ![][flag_FR]      | 0 | **5** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/18736038) |
+| **China** ![][flag_CN]   | **5** | 1 | ![][flag_PH] Philippines        | [#1](https://osu.ppy.sh/community/matches/18737149) |
+| Taiwan ![][flag_TW]      | 0 | **5** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/18739049) |
+| Poland ![][flag_PL]      | 0 | **5** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/18740464) |
+| Argentina ![][flag_AR]   | 0 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/18741841) |
+
+| 2015-09-06 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Australia ![][flag_AU]   | 0 | **5** | ![][flag_CA] **Canada**        | [#1](https://osu.ppy.sh/community/matches/18754356) |
+| South Korea ![][flag_KR] | 0 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/18755307) |
+
+### Round of 16
+
+| 2015-08-30 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Australia ![][flag_AU]          | 1 | **5** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/18606478) |
+| **China** ![][flag_CN]          | **5** | 1 | ![][flag_TW] Taiwan          | [#1](https://osu.ppy.sh/community/matches/18607469) |
+| Malaysia ![][flag_MY]           | 0 | **5** | ![][flag_JP] **Japan**       | [#1](https://osu.ppy.sh/community/matches/18608519) |
+| Brazil ![][flag_BR]             | 2 | **5** | ![][flag_PH] **Philippines** | [#1](https://osu.ppy.sh/community/matches/18609649) |
+| **United Kingdom** ![][flag_GB] | **5** | 3 | ![][flag_ID] Indonesia       | [#1](https://osu.ppy.sh/community/matches/18612279) |
+| Netherlands ![][flag_NL]        | 1 | **5** | ![][flag_FR] **France**      | [#1](https://osu.ppy.sh/community/matches/18613709) |
+| Poland ![][flag_PL]             | 1 | **5** | ![][flag_AR] **Argentina**   | [#1](https://osu.ppy.sh/community/matches/18614619) |
+| **United States** ![][flag_US]  | **5** | 0 | ![][flag_CA] Canada          | [#1](https://osu.ppy.sh/community/matches/18616004) |
 
 ### Group Stage
 
 **[Find the Group Stage statistics here!](https://owc.nicarim.pw/results/view/6)**
 
-**Saturday, 22\. August 2015**
+| 2015-08-22 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Germany ![][flag_DE]                | 0 | **4** | ![][flag_AU] **Australia**      | [#1](https://osu.ppy.sh/community/matches/18414849) |
+| Denmark ![][flag_DK]                | 0 | **4** | ![][flag_MY] **Malaysia**       | [#1](https://osu.ppy.sh/community/matches/18414855) |
+| Netherlands ![][flag_NL]            | 1 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/18414897) |
+| Singapore ![][flag_SG]              | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/18414915) |
+| Poland ![][flag_PL]                 | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/18414935) |
+| Italy ![][flag_IT]                  | 1 | **4** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/18416078) |
+| **Vietnam** ![][flag_VN]            | **4** | 0 | ![][flag_CL] Chile              | -Win by default- |
+| Thailand ![][flag_TH]               | 0 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/18416085) |
+| **South Korea** ![][flag_KR]        | **4** | 0 | ![][flag_BR] Brazil             | [#1](https://osu.ppy.sh/community/matches/18416088) |
+| **Argentina** ![][flag_AR]          | **4** | 3 | ![][flag_MY] Malaysia           | [#1](https://osu.ppy.sh/community/matches/18417719) |
+| Israel ![][flag_IL]                 | 0 | **4** | ![][flag_GB] **United Kingdom** | -Win by default- |
+| Finland ![][flag_FI]                | 0 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/18417753) |
+| Norway ![][flag_NO]                 | 0 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/18417757) |
+| **Russian Federation** ![][flag_RU] | **4** | 2 | ![][flag_NO] Norway             | [#1](https://osu.ppy.sh/community/matches/18422906) |
+| Peru ![][flag_PE]                   | 0 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/18422912) |
+| Sweden ![][flag_SE]                 | 0 | **4** | ![][flag_AR] **Argentina**      | [#1](https://osu.ppy.sh/community/matches/18422917) |
+| Israel ![][flag_IL]                 | 0 | **4** | ![][flag_FR] **France**         | -Win by default- |
+| Venezuela ![][flag_VE]              | 0 | **4** | ![][flag_CA] **Canada**         | -Win by default- |
+| Chile ![][flag_CL]                  | 0 | **4** | ![][flag_US] **United States**  | -Win by default- |
 
-| Team A                                                | Score          | Team B                                            | History                        |
-|:------------------------------------------------------|:--------------:|--------------------------------------------------:|--------------------------------|
-| ![][flag_DE] Germany                | 0      - **4** | **Australia** ![][flag_AU]      | [#1](https://osu.ppy.sh/mp/18414849) |
-| ![][flag_DK] Denmark                | 0      - **4** | **Malaysia** ![][flag_MY]       | [#1](https://osu.ppy.sh/mp/18414855) |
-| ![][flag_NL] Netherlands            | 1      - **4** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/18414897) |
-| ![][flag_SG] Singapore              | 0      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/mp/18414915) |
-| ![][flag_PL] Poland                 | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/18414935) |
-| ![][flag_IT] Italy                  | 1      - **4** | **Philippines** ![][flag_PH]    | [#1](https://osu.ppy.sh/mp/18416078) |
-| ![][flag_VN] **Vietnam**            | **4**  - 0     | Chile ![][flag_CL]              | -- Win by default --           |
-| ![][flag_TH] Thailand               | 0      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/mp/18416085) |
-| ![][flag_KR] **South Korea**        | **4**  - 0     | Brazil ![][flag_BR]             | [#1](https://osu.ppy.sh/mp/18416088) |
-| ![][flag_AR] **Argentina**          | **4**  - 3     | Malaysia ![][flag_MY]           | [#1](https://osu.ppy.sh/mp/18417719) |
-| ![][flag_IL] Israel                 | 0      - **4** | **United Kingdom** ![][flag_GB] | -- Win by default --           |
-| ![][flag_FI] Finland                | 0      - **4** | **France** ![][flag_FR]         | [#1](https://osu.ppy.sh/mp/18417753) |
-| ![][flag_NO] Norway                 | 0      - **4** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/18417757) |
-| ![][flag_RU] **Russian Federation** | **4**  - 2     | Norway ![][flag_NO]             | [#1](https://osu.ppy.sh/mp/18422906) |
-| ![][flag_PE] Peru                   | 0      - **4** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/mp/18422912) |
-| ![][flag_SE] Sweden                 | 0      - **4** | **Argentina** ![][flag_AR]      | [#1](https://osu.ppy.sh/mp/18422917) |
-| ![][flag_IL] Israel                 | 0      - **4** | **France** ![][flag_FR]         | -- Win by default --           |
-| ![][flag_VE] Venezuela              | 0      - **4** | **Canada** ![][flag_CA]         | -- Win by default --           |
-| ![][flag_CL] Chile                  | 0      - **4** | **United States** ![][flag_US]  | -- Win by default --           |
-
-**Sunday, 23\. August 2015**
-
-| Team A                                            | Score          | Team B                                            | History                        |
-|:--------------------------------------------------|:--------------:|--------------------------------------------------:|--------------------------------|
-| ![][flag_MX] Mexico             | 0      - **4** | **New Zealand** ![][flag_NZ]    | [#1](https://osu.ppy.sh/mp/18432722) |
-| ![][flag_PE] Peru               | 0      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/mp/18432751) |
-| ![][flag_TW] Taiwan             | 0      - **4** | **United States** ![][flag_US]  | -- Win by default --           |
-| ![][flag_PE] Peru               | 1      - **4** | **Singapore** ![][flag_SG]      | [#1](https://osu.ppy.sh/mp/18433719) |
-| ![][flag_VE] Venezuela          | 0      - **4** | **China** ![][flag_CN]          | -- Win by default --           |
-| ![][flag_MX] Mexico             | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/18433722) |
-| ![][flag_TH] Thailand           | 0      - **4** | **Canada** ![][flag_CA]         | -- Win by default --           |
-| ![][flag_VN] Vietnam            | 0      - **4** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/mp/18434727) |
-| ![][flag_PH] **Philippines**    | **4**  - 1     | Australia ![][flag_AU]          | [#1](https://osu.ppy.sh/mp/18434735) |
-| ![][flag_CA] Canada             | 1      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/mp/18435863) |
-| ![][flag_NZ] New Zealand        | 0      - **4** | **Japan** ![][flag_JP]          | [#1](https://osu.ppy.sh/mp/18435867) |
-| ![][flag_FI] Finland            | 0      - **4** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/mp/18439906) |
-| ![][flag_NZ] New Zealand        | 0      - **4** | **Poland** ![][flag_PL]         | [#1](https://osu.ppy.sh/mp/18439907) |
-| ![][flag_VN] Vietnam            | 0      - **4** | **Taiwan** ![][flag_TW]         | -- Win by default --           |
-| ![][flag_IT] Italy              | 0      - **4** | **Australia** ![][flag_AU]      | [#1](https://osu.ppy.sh/mp/18439909) |
-| ![][flag_SE] Sweden             | 1      - **4** | **Malaysia** ![][flag_MY]       | [#1](https://osu.ppy.sh/mp/18440710) |
-| ![][flag_DE] Germany            | 0      - **4** | **Philippines** ![][flag_PH]    | [#1](https://osu.ppy.sh/mp/18440711) |
-| ![][flag_RU] Russian Federation | 0      - **4** | **Indonesia** ![][flag_ID]      | [#1](https://osu.ppy.sh/mp/18440713) |
-| ![][flag_CL] Chile              | 0      - **4** | **Taiwan** ![][flag_TW]         | -- Win by default --           |
-| ![][flag_SG] Singapore          | 3      - **4** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/mp/18444296) |
-| ![][flag_SE] Sweden             | 1      - **4** | **Denmark** ![][flag_DK]        | [#1](https://osu.ppy.sh/mp/18444297) |
-| ![][flag_RU] Russian Federation | 0      - **4** | **Netherlands** ![][flag_NL]    | [#1](https://osu.ppy.sh/mp/18444298) |
-| ![][flag_VE] Venezuela          | 0      - **4** | **Thailand** ![][flag_TH]       | -- Win by default --           |
-| ![][flag_IL] Israel             | 0      - **4** | **Finland** ![][flag_FI]        | -- Win by default --           |
-| ![][flag_IT] Italy              | 0      - **4** | **Germany** ![][flag_DE]        | [#1](https://osu.ppy.sh/mp/18446806) |
-| ![][flag_MX] Mexico             | 0      - **4** | **Poland** ![][flag_PL]         | -- Win by default --           |
-| ![][flag_NO] Norway             | 0      - **4** | **Netherlands** ![][flag_NL]    | [#1](https://osu.ppy.sh/mp/18447966) |
-| ![][flag_DK] Denmark            | 0      - **4** | **Argentina** ![][flag_AR]      | [#1](https://osu.ppy.sh/mp/18447967) |
-| ![][flag_FR] **France**         | **4**  - 1     | United Kingdom ![][flag_GB]     | [#1](https://osu.ppy.sh/mp/18447968) |
+| 2015-08-23 | | | | |
+|----:|:---:|:---:|:---|:---:|
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_NZ] **New Zealand**    | [#1](https://osu.ppy.sh/community/matches/18432722) |
+| Peru ![][flag_PE]               | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/18432751) |
+| Taiwan ![][flag_TW]             | 0 | **4** | ![][flag_US] **United States**  | -Win by default- |
+| Peru ![][flag_PE]               | 1 | **4** | ![][flag_SG] **Singapore**      | [#1](https://osu.ppy.sh/community/matches/18433719) |
+| Venezuela ![][flag_VE]          | 0 | **4** | ![][flag_CN] **China**          | -Win by default- |
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/18433722) |
+| Thailand ![][flag_TH]           | 0 | **4** | ![][flag_CA] **Canada**         | -Win by default- |
+| Vietnam ![][flag_VN]            | 0 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/18434727) |
+| **Philippines** ![][flag_PH]    | **4** | 1 | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/18434735) |
+| Canada ![][flag_CA]             | 1 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/18435863) |
+| New Zealand ![][flag_NZ]        | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/18435867) |
+| Finland ![][flag_FI]            | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/18439906) |
+| New Zealand ![][flag_NZ]        | 0 | **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/18439907) |
+| Vietnam ![][flag_VN]            | 0 | **4** | ![][flag_TW] **Taiwan**         | -Win by default- |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_AU] **Australia**      | [#1](https://osu.ppy.sh/community/matches/18439909) |
+| Sweden ![][flag_SE]             | 1 | **4** | ![][flag_MY] **Malaysia**       | [#1](https://osu.ppy.sh/community/matches/18440710) |
+| Germany ![][flag_DE]            | 0 | **4** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/18440711) |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/18440713) |
+| Chile ![][flag_CL]              | 0 | **4** | ![][flag_TW] **Taiwan**         | -Win by default- |
+| Singapore ![][flag_SG]          | 3 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/18444296) |
+| Sweden ![][flag_SE]             | 1 | **4** | ![][flag_DK] **Denmark**        | [#1](https://osu.ppy.sh/community/matches/18444297) |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_NL] **Netherlands**    | [#1](https://osu.ppy.sh/community/matches/18444298) |
+| Venezuela ![][flag_VE]          | 0 | **4** | ![][flag_TH] **Thailand**       | -Win by default- |
+| Israel ![][flag_IL]             | 0 | **4** | ![][flag_FI] **Finland**        | -Win by default- |
+| Italy ![][flag_IT]              | 0 | **4** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/18446806) |
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_PL] **Poland**         | -Win by default- |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_NL] **Netherlands**    | [#1](https://osu.ppy.sh/community/matches/18447966) |
+| Denmark ![][flag_DK]            | 0 | **4** | ![][flag_AR] **Argentina**      | [#1](https://osu.ppy.sh/community/matches/18447967) |
+| **France** ![][flag_FR]         | **4** | 1 | ![][flag_GB] United Kingdom     | [#1](https://osu.ppy.sh/community/matches/18447968) |
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/MWC/2017/4K/en.md
+++ b/wiki/Tournaments/MWC/2017/4K/en.md
@@ -9,21 +9,21 @@ The **osu!mania 4K World Cup 2017** (**_MWC 4K 2017_**) is a country-based osu!m
 
 | Event | Timestamp |
 | ---: | :--- |
-| Registration Phase | 10. - 23. July 2017 |
-| Drawings | 7. August 2017 (14:00 UTC+0) |
-| Group Stage | 12. - 13. August 2017 |
-| Round of 16 | 19. - 20. August 2017 |
-| Quarterfinals | 26. - 27. August 2017 |
-| Semifinals | 2. - 3. September 2017 |
-| Finals - Week 1 | 9. - 10. September 2017 |
-| Finals - Week 2 | 16. - 17. September 2017 |
+| Registration Phase | 2017-07-10/2017-07-23   |
+| Drawings           | 2017-08-07 14:00:00 UTC |
+| Group Stage        | 2017-08-12/2017-08-13   |
+| Round of 16        | 2017-08-19/2017-08-20   |
+| Quarterfinals      | 2017-08-26/2017-08-27   |
+| Semifinals         | 2017-09-02/2017-09-03   |
+| Finals             | 2017-09-09/2017-09-10   |
+| Grand Finals       | 2017-09-16/2017-09-17   |
 
 ## Prizes
 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
 | Placing | Prize(s) |
-| --- | :--- |
+| :---: | :--- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | $150 per team member, exclusive osu! pins and merchandise, profile badge, "osu!mania Champion" user title for one year |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | $80 per team member, exclusive osu! pins and merchandise, profile badge |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | $40 per team member, exclusive osu! pins and merchandise, profile badge |
@@ -32,8 +32,8 @@ In every world cup, people conquering a place on the podium are eligible to rece
 
 The osu!mania World Cup 2017 is run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Member |
-| ------------ | -------------- |
+| Position | Member(s) |
+|---|---|
 | Management | [![][flag_DE] Loctav](https://osu.ppy.sh/users/71366), [![][flag_DE] p3n](https://osu.ppy.sh/users/123703), [![][flag_ES] Deif](https://osu.ppy.sh/users/318565), [![][flag_FR] shARPII](https://osu.ppy.sh/users/776257) |
 | Map Selectors | [![][flag_US] Blocko](https://osu.ppy.sh/users/4075092), [![][flag_AR] juankristal](https://osu.ppy.sh/users/443656), [![][flag_GB] Pope Gadget](https://osu.ppy.sh/users/2288341) |
 | Commentators | [![][flag_BR] Guilhermeziat](https://osu.ppy.sh/users/3661387), [![][flag_US] Halogen-](https://osu.ppy.sh/users/169992), [![][flag_AR] juankristal](https://osu.ppy.sh/users/443656), [![][flag_AU] Lusty Platypus](https://osu.ppy.sh/users/2956184), [![][flag_AU] PotassiumF](https://osu.ppy.sh/users/4247722), [![][flag_US] TheToaphster](https://osu.ppy.sh/users/7616811), [![][flag_SE] \[ Vento \]](https://osu.ppy.sh/users/1612580), [![][flag_FR] XeoStyle](https://osu.ppy.sh/users/3377280), [![][flag_US] ztrot](https://osu.ppy.sh/users/6347) |
@@ -50,10 +50,8 @@ The osu!mania World Cup 2017 is run by various community members by distributing
 
 ## Participants
 
-### Confirmed Rosters
-
 | | Country | Member |
-| ---: | :---: | :--- |
+| :---: | :---: | :--- |
 | ![][flag_AR] | **Argentina** | **[lxLucasxl](https://osu.ppy.sh/users/3632846)**, [BossPlays_02](https://osu.ppy.sh/users/7341471), [aluuu](https://osu.ppy.sh/users/4585260), [Ezze](https://osu.ppy.sh/users/2887427), [Fisk-](https://osu.ppy.sh/users/5748843), [Juanvidrio](https://osu.ppy.sh/users/2628463) |
 | ![][flag_AU] | **Australia** | **[Kites](https://osu.ppy.sh/users/4922584)**, [Melt3dCheeze](https://osu.ppy.sh/users/634837), [PotassiumF](https://osu.ppy.sh/users/4247722), [Lusty Platypus](https://osu.ppy.sh/users/2956184), [Rek](https://osu.ppy.sh/users/4018184), [Zeppy-lin](https://osu.ppy.sh/users/7675859) |
 | ![][flag_BE] | **Belgium** | **[Kizunuko-P](https://osu.ppy.sh/users/6741014)**, [NightNarumi](https://osu.ppy.sh/users/4381142), [Yetified](https://osu.ppy.sh/users/6914714), [Podzel](https://osu.ppy.sh/users/7368776), [Ojily](https://osu.ppy.sh/users/6539319), [Pryme](https://osu.ppy.sh/users/6393309) |
@@ -99,90 +97,6 @@ The osu!mania World Cup 2017 is run by various community members by distributing
 
 ## Mappools
 
-### Group Stage
-
-**[Download the mappack here! (89 MB)](http://www.mediafire.com/file/cjk4f8ilwc2s7uv/MWC4K_2017_Group_Stage.rar)**
-
-- Freemod
-  - [Lifetheory - Daisy (Tidek) \[Life (Insane)\]](https://osu.ppy.sh/b/718401&m=3) 
-  - [Shawn Wasabi - Burnt Rice (855wa) \[Hard\]](https://osu.ppy.sh/b/1063205&m=3) 
-  - [YK. - Egg Of Life (Mwila Remix) (Paradoxq13) \[MX\]](https://osu.ppy.sh/b/741552&m=3) 
-  - [sakuzyo - Altale (Kuo Kyoka) \[Hyper Lv.22\]](https://osu.ppy.sh/b/767309&m=3) 
-  - [yuikonnu - Shinkai Shoujo (juankristal) \[Shoujo\]](https://osu.ppy.sh/b/1050663&m=3) 
-  - [Warak - REANIMATE (Mat) \[Complex LNs\]](https://osu.ppy.sh/b/1315761&m=3) 
-  - [Takemura Kiriko - Ninja Re Bang Bang (ecafree2) \[4K HD\]](https://osu.ppy.sh/b/816807&m=3) 
-  - [REDALiCE feat. anporin - Beautiful Dream (Dellvangel) \[CS' Challenge\]](https://osu.ppy.sh/b/908398&m=3) 
-  - [Niira Etsuko - Imaginary Waltz (-Troke-) \[Raccoon's MX\]](https://osu.ppy.sh/b/480148&m=3) 
-  - [Tim & Eric - Sports! (ilikexd) \[Hard\]](https://osu.ppy.sh/b/685357&m=3) 
-  - [Beltaine - Rockhill (Ryu Sei) \[Hard\]](https://osu.ppy.sh/b/994291&m=3) 
-  - [stereoberry - evangelize (blurry images) (Tidek) \[transparency (SV)\]](https://osu.ppy.sh/b/1222765&m=3) 
-- Tiebreaker
-  - [sakuraburst - sha (SitekX) \[dow\]](https://osu.ppy.sh/b/1258514&m=3) 
-
-### Round of 16
-
-**[Download the mappack here! (65 MB)](http://www.mediafire.com/file/z7pmbh632dy178j/MWC4K_2017_Round_of_16.rar)**
-
-- FreeMod
-  - [hyi - you can recover (Valedict) \[restoration\]](https://osu.ppy.sh/b/1199287&m=3) 
-  - [GIRAFFES? GIRAFFES! - I Am S/H(im)e[r] (XeoStyle) \[I Am Us\]](https://osu.ppy.sh/b/1259834&m=3) 
-  - [KOAN Sound + asa - Fuego (sakuraburst remix) (Couil) \[HD\]](https://osu.ppy.sh/b/1313120&m=3) 
-  - [Schubert - Introduction And Variations 'Trockne Blumen' Variation 5 Remix&Arrange (Feerum) \[4K Irrsinnig\]](https://osu.ppy.sh/b/1178997&m=3) 
-  - [Team Grimoire - Sheriruth (DoNotMess) \[Future\]](https://osu.ppy.sh/b/1295745&m=3) 
-  - [Helblinde - Heaven's Fall (Kaito-kun) \[Extra\]](https://osu.ppy.sh/b/1217314&m=3) 
-  - [q/stol - Re/Im (Lude) \[Re/Extreme\]](https://osu.ppy.sh/b/1245089&m=3) 
-  - [USAO - Showdown (Side) \[puxtu's MX\]](https://osu.ppy.sh/b/996693&m=3) 
-  - [Sonitus Vir ft. Emily Smith - Lune Noir (Bites) \[4K MX\]](https://osu.ppy.sh/b/225781&m=3) 
-  - [MINTi - So Fresh So Good (Leo137) \[Leo137's 4K\]](https://osu.ppy.sh/b/1097526&m=3) 
-  - [Edwin Starr vs. Justice - War vs. Waters of Nazareth (Raspberriel) \[Massacre Edit\]](https://osu.ppy.sh/b/1394983&m=3) 
-  - [The Flashbulb - Three Hundred CC (edit) (Blocko) \[Another\]](https://osu.ppy.sh/b/1368417&m=3) 
-  - [Alesana - The Artist (Tornspirit) \[Collapse\]](https://osu.ppy.sh/b/1280807&m=3) 
-- Tiebreaker
-  - [BABYMETAL - Tales of The Destinies (Couil) \[Endless Journey\]](https://osu.ppy.sh/b/1290602&m=3) 
-
-### Quarterfinals
-
-**[Download the mappack here! (88MB)](http://www.mediafire.com/file/7baxea9hafezhob/MWC4K_2017_Quarterfinals.rar)**
-
-- FreeMod
-  - [BABYMETAL - Road of Resistance (hi19hi19) \[Uprising\]](https://osu.ppy.sh/b/1375744&m=3) 
-  - [Caravan Palace - Clash (Hydria) \[Hard\]](https://osu.ppy.sh/b/1369706&m=3) 
-  - [goreshit - looming shadow of a tree long gone (Shoegazer) \[extra\]](https://osu.ppy.sh/b/792874&m=3) 
-  - [yst - The Lost Dedicated (DDMythical) \[Another\]](https://osu.ppy.sh/b/1302866&m=3) 
-  - [8284 - Connaextion (LeiN-) \[TIMED_OUT\]](https://osu.ppy.sh/b/1029033&m=3) 
-  - [Maika - Goldrop (Skorer) \[Yudaina LN\]](https://osu.ppy.sh/b/1243241&m=3) 
-  - [Getty vs. DJ DiA - Fox4-Raize- (Evening) \[GRAVITY VIP\]](https://osu.ppy.sh/b/1228388&m=3) 
-  - [Colorful Sounds Port - ETERNAL DRAIN (Wh1teh) \[Black Another\]](https://osu.ppy.sh/b/1104774&m=3) 
-  - [Blue Stahli - Shotgun Senorita (Zardonic Remix) (juankristal) \[Machine Gun\]](https://osu.ppy.sh/b/1341515&m=3) 
-  - [Dustvoxx - Trigger (Zekk Remix) (Wonki) \[Trigger\]](https://osu.ppy.sh/b/1174927&m=3) 
-  - [Akira Complex - Odyssey (Au5 Remix) (Shoegazer) \[Dreamless\]](https://osu.ppy.sh/b/1103630&m=3) 
-  - [YUC'e - Sengoku HOP (c/f Athenarium) (Hydria) \[Insane\]](https://osu.ppy.sh/b/1279175&m=3) 
-  - [NOISIA - Groundhog (Beat Juggle) (Raspberriel) \[Sorry, Am I Putting You Off?\]](https://osu.ppy.sh/b/1252742&m=3) 
-- Tiebreaker
-  - [DragonForce - The Warrior Inside (_underjoy) \[4K Collab Gladiator\]](https://osu.ppy.sh/b/1038662&m=3) 
-
-### Semifinals
-
-**[Download the mappack here! (90MB)](http://www.mediafire.com/file/7mxtjr3r9k4bi54/MWC4K_2017_Semifinals.rar)**
-
-- FreeMod
-  - [9mm Parabellum Bullet - Punishment (Valedict) \[Retribution\]](https://osu.ppy.sh/b/1128678&m=3) 
-  - [Kaneko Chiharu - Lachryma\<Re:Queen'M\> (Fresh Chicken) \[GRAVITY\]](https://osu.ppy.sh/b/901050&m=3) 
-  - [aaaa + yadorigi - Sakase natsuzora, koi no hana. (scissorsf) \[flnowers\]](https://osu.ppy.sh/b/993976&m=3) 
-  - [Ekcle - The Impulsive State (Parachor) \[Entropy_\]](https://osu.ppy.sh/b/1364765&m=3) 
-  - [The Flashbulb - Passage D (Jinjin) \[Delve\]](https://osu.ppy.sh/b/1016508&m=3) 
-  - [IOSYS - Endless Tewi-ma Park (arcwinolivirus) \[Arcwin Lost Tewicated\]](https://osu.ppy.sh/b/855471&m=3) 
-  - [USAO - Boss Rush (PiraTom) \[LN Rush\]](https://osu.ppy.sh/b/1259719&m=3) 
-  - [Fele - Peter on Crack (Cut) (Jole) \[this is brain surgery\]](https://osu.ppy.sh/b/1394763&m=3) 
-  - [Kidkanevil - Lantern 1 (Valedict) \[Fog\]](https://osu.ppy.sh/b/1331160&m=3) 
-  - [Kontinuum - Lost (feat. Savoi) \[Sunroof Remix\] (Otakujanai) \[Emotional Drift\]](https://osu.ppy.sh/b/1321781&m=3) 
-  - [Fractal Dreamers - Fortuna Redux (Kizunuko-P) \[Dream\]](https://osu.ppy.sh/b/1311355&m=3) 
-  - [Inferi - Those Who From the Heavens Came (XeoStyle) \[Investiture of the Gods\]](https://osu.ppy.sh/b/897408&m=3) 
-  - [C-Show - ERROR CODE (SpectorDG) \[SPE vs. ZEN's GRAVITY\]](https://osu.ppy.sh/b/1155393&m=3) 
-  - [Jeff Williams - Time to say Goodbye (feat. Casey Lee Williams) (juankristal) \[Team LNBY\]](https://osu.ppy.sh/b/1112725&m=3) 
-- Tiebreaker
-  - [Camellia - Dans la mer de son (TheToaphster) \[Abyss\]](https://osu.ppy.sh/b/1295025&m=3) 
-
 ### Finals
 
 **This mappool is played in Week 1 and Week 2 of the Finals.**
@@ -190,23 +104,107 @@ The osu!mania World Cup 2017 is run by various community members by distributing
 **[Download the mappack here! (123MB)](http://www.mediafire.com/file/jho7mgavbd8ktlo/MWC4K_2017_Finals.rar)**
 
 - FreeMod
-  - [Mick Gordon - The Mastermind (Pope Gadget) \[Brainstorm\]](https://osu.ppy.sh/b/1403911&m=3) 
-  - [Nine Inch Nails - March Of The Pigs (Valedict) \[OiNK\]](https://osu.ppy.sh/b/1153543&m=3) 
-  - [DJ Sharpnel - Lolit Speed (IcyWorld) \[Marathon\]](https://osu.ppy.sh/b/1366733&m=3) 
-  - [Hatsuki Yura - The Clockwork Rose -Tokei Shikake no Bara Shoujo- (Gekido-) \[LN Master\]](https://osu.ppy.sh/b/1349843&m=3) 
-  - [The Quick Brown Fox - Break (beary605) \[Smash\]](https://osu.ppy.sh/b/1066057&m=3) 
-  - [Makou - Hamsin (Wh1teh) \[!!\]](https://osu.ppy.sh/b/1404752&m=3) 
-  - [sakuraburst - descent (Ciel) \[delve\]](https://osu.ppy.sh/b/1405397&m=3) 
-  - [Camellia - K.Y.A.F.A. (Evening) \[UNSTOPPABLE DOMINATION\]](https://osu.ppy.sh/b/1076362&m=3) 
-  - [Miyu Tomita, Saori Oonishi, Naomi Ohzora, Kana Hanazawa - Hallelujah Essaim (JztCallMeRon) \[In the Name of God\]](https://osu.ppy.sh/b/1255764&m=3) 
-  - [Sound Horizon - Raijin no Hidariude (-Kamikaze-) \[Tempest w/ \_underjoy\]](https://osu.ppy.sh/b/1266238&m=3) 
-  - [Xanopticon - Psicicite (207bpm) (Shoegazer) \[Extreme\]](https://osu.ppy.sh/b/1398964&m=3) 
-  - [Camellia - Lunatic Rough Party!! (Fullerene-) \[Inspire\]](https://osu.ppy.sh/b/1052580&m=3) 
-  - [Behemoth - Daimonos (Wh1teh) \[Evangelion\]](https://osu.ppy.sh/b/1078837&m=3) 
-  - [Yuuyu - Scrap Syndrome (Halogen-) \[Manic Disassembly\]](https://osu.ppy.sh/b/1403908&m=3) 
-  - [Kairiki Bear - Inaiinai isonshou (feat. GUMI, Kagamine Rin) (juankristal) \[timing hell \[NSV\]\]](https://osu.ppy.sh/b/1404354&m=3) 
+  - [Mick Gordon - The Mastermind (Pope Gadget) \[Brainstorm\]](https://osu.ppy.sh/b/1403911&m=3)
+  - [Nine Inch Nails - March Of The Pigs (Valedict) \[OiNK\]](https://osu.ppy.sh/b/1153543&m=3)
+  - [DJ Sharpnel - Lolit Speed (IcyWorld) \[Marathon\]](https://osu.ppy.sh/b/1366733&m=3)
+  - [Hatsuki Yura - The Clockwork Rose -Tokei Shikake no Bara Shoujo- (Gekido-) \[LN Master\]](https://osu.ppy.sh/b/1349843&m=3)
+  - [The Quick Brown Fox - Break (beary605) \[Smash\]](https://osu.ppy.sh/b/1066057&m=3)
+  - [Makou - Hamsin (Wh1teh) \[!!\]](https://osu.ppy.sh/b/1404752&m=3)
+  - [sakuraburst - descent (Ciel) \[delve\]](https://osu.ppy.sh/b/1405397&m=3)
+  - [Camellia - K.Y.A.F.A. (Evening) \[UNSTOPPABLE DOMINATION\]](https://osu.ppy.sh/b/1076362&m=3)
+  - [Miyu Tomita, Saori Oonishi, Naomi Ohzora, Kana Hanazawa - Hallelujah Essaim (JztCallMeRon) \[In the Name of God\]](https://osu.ppy.sh/b/1255764&m=3)
+  - [Sound Horizon - Raijin no Hidariude (-Kamikaze-) \[Tempest w/ \_underjoy\]](https://osu.ppy.sh/b/1266238&m=3)
+  - [Xanopticon - Psicicite (207bpm) (Shoegazer) \[Extreme\]](https://osu.ppy.sh/b/1398964&m=3)
+  - [Camellia - Lunatic Rough Party!! (Fullerene-) \[Inspire\]](https://osu.ppy.sh/b/1052580&m=3)
+  - [Behemoth - Daimonos (Wh1teh) \[Evangelion\]](https://osu.ppy.sh/b/1078837&m=3)
+  - [Yuuyu - Scrap Syndrome (Halogen-) \[Manic Disassembly\]](https://osu.ppy.sh/b/1403908&m=3)
+  - [Kairiki Bear - Inaiinai isonshou (feat. GUMI, Kagamine Rin) (juankristal) \[timing hell \[NSV\]\]](https://osu.ppy.sh/b/1404354&m=3)
 - Tiebreaker  
-  - [Infected Mushroom - The Messenger 2012 (Sped Up Ver.) (Pope Gadget) \[Witness\]](https://osu.ppy.sh/b/1484095&m=3) 
+  - [Infected Mushroom - The Messenger 2012 (Sped Up Ver.) (Pope Gadget) \[Witness\]](https://osu.ppy.sh/b/1484095&m=3)
+
+### Semifinals
+
+**[Download the mappack here! (90MB)](http://www.mediafire.com/file/7mxtjr3r9k4bi54/MWC4K_2017_Semifinals.rar)**
+
+- FreeMod
+  - [9mm Parabellum Bullet - Punishment (Valedict) \[Retribution\]](https://osu.ppy.sh/b/1128678&m=3)
+  - [Kaneko Chiharu - Lachryma\<Re:Queen'M\> (Fresh Chicken) \[GRAVITY\]](https://osu.ppy.sh/b/901050&m=3)
+  - [aaaa + yadorigi - Sakase natsuzora, koi no hana. (scissorsf) \[flnowers\]](https://osu.ppy.sh/b/993976&m=3)
+  - [Ekcle - The Impulsive State (Parachor) \[Entropy_\]](https://osu.ppy.sh/b/1364765&m=3)
+  - [The Flashbulb - Passage D (Jinjin) \[Delve\]](https://osu.ppy.sh/b/1016508&m=3)
+  - [IOSYS - Endless Tewi-ma Park (arcwinolivirus) \[Arcwin Lost Tewicated\]](https://osu.ppy.sh/b/855471&m=3)
+  - [USAO - Boss Rush (PiraTom) \[LN Rush\]](https://osu.ppy.sh/b/1259719&m=3)
+  - [Fele - Peter on Crack (Cut) (Jole) \[this is brain surgery\]](https://osu.ppy.sh/b/1394763&m=3)
+  - [Kidkanevil - Lantern 1 (Valedict) \[Fog\]](https://osu.ppy.sh/b/1331160&m=3)
+  - [Kontinuum - Lost (feat. Savoi) \[Sunroof Remix\] (Otakujanai) \[Emotional Drift\]](https://osu.ppy.sh/b/1321781&m=3)
+  - [Fractal Dreamers - Fortuna Redux (Kizunuko-P) \[Dream\]](https://osu.ppy.sh/b/1311355&m=3)
+  - [Inferi - Those Who From the Heavens Came (XeoStyle) \[Investiture of the Gods\]](https://osu.ppy.sh/b/897408&m=3)
+  - [C-Show - ERROR CODE (SpectorDG) \[SPE vs. ZEN's GRAVITY\]](https://osu.ppy.sh/b/1155393&m=3)
+  - [Jeff Williams - Time to say Goodbye (feat. Casey Lee Williams) (juankristal) \[Team LNBY\]](https://osu.ppy.sh/b/1112725&m=3)
+- Tiebreaker
+  - [Camellia - Dans la mer de son (TheToaphster) \[Abyss\]](https://osu.ppy.sh/b/1295025&m=3)
+
+### Quarterfinals
+
+**[Download the mappack here! (88MB)](http://www.mediafire.com/file/7baxea9hafezhob/MWC4K_2017_Quarterfinals.rar)**
+
+- FreeMod
+  - [BABYMETAL - Road of Resistance (hi19hi19) \[Uprising\]](https://osu.ppy.sh/b/1375744&m=3)
+  - [Caravan Palace - Clash (Hydria) \[Hard\]](https://osu.ppy.sh/b/1369706&m=3)
+  - [goreshit - looming shadow of a tree long gone (Shoegazer) \[extra\]](https://osu.ppy.sh/b/792874&m=3)
+  - [yst - The Lost Dedicated (DDMythical) \[Another\]](https://osu.ppy.sh/b/1302866&m=3)
+  - [8284 - Connaextion (LeiN-) \[TIMED_OUT\]](https://osu.ppy.sh/b/1029033&m=3)
+  - [Maika - Goldrop (Skorer) \[Yudaina LN\]](https://osu.ppy.sh/b/1243241&m=3)
+  - [Getty vs. DJ DiA - Fox4-Raize- (Evening) \[GRAVITY VIP\]](https://osu.ppy.sh/b/1228388&m=3)
+  - [Colorful Sounds Port - ETERNAL DRAIN (Wh1teh) \[Black Another\]](https://osu.ppy.sh/b/1104774&m=3)
+  - [Blue Stahli - Shotgun Senorita (Zardonic Remix) (juankristal) \[Machine Gun\]](https://osu.ppy.sh/b/1341515&m=3)
+  - [Dustvoxx - Trigger (Zekk Remix) (Wonki) \[Trigger\]](https://osu.ppy.sh/b/1174927&m=3)
+  - [Akira Complex - Odyssey (Au5 Remix) (Shoegazer) \[Dreamless\]](https://osu.ppy.sh/b/1103630&m=3)
+  - [YUC'e - Sengoku HOP (c/f Athenarium) (Hydria) \[Insane\]](https://osu.ppy.sh/b/1279175&m=3)
+  - [NOISIA - Groundhog (Beat Juggle) (Raspberriel) \[Sorry, Am I Putting You Off?\]](https://osu.ppy.sh/b/1252742&m=3)
+- Tiebreaker
+  - [DragonForce - The Warrior Inside (\_underjoy) \[4K Collab Gladiator\]](https://osu.ppy.sh/b/1038662&m=3)
+
+### Round of 16
+
+**[Download the mappack here! (65 MB)](http://www.mediafire.com/file/z7pmbh632dy178j/MWC4K_2017_Round_of_16.rar)**
+
+- FreeMod
+  - [hyi - you can recover (Valedict) \[restoration\]](https://osu.ppy.sh/b/1199287&m=3)
+  - [GIRAFFES? GIRAFFES! - I Am S/H(im)e[r] (XeoStyle) \[I Am Us\]](https://osu.ppy.sh/b/1259834&m=3)
+  - [KOAN Sound + asa - Fuego (sakuraburst remix) (Couil) \[HD\]](https://osu.ppy.sh/b/1313120&m=3)
+  - [Schubert - Introduction And Variations 'Trockne Blumen' Variation 5 Remix&Arrange (Feerum) \[4K Irrsinnig\]](https://osu.ppy.sh/b/1178997&m=3)
+  - [Team Grimoire - Sheriruth (DoNotMess) \[Future\]](https://osu.ppy.sh/b/1295745&m=3)
+  - [Helblinde - Heaven's Fall (Kaito-kun) \[Extra\]](https://osu.ppy.sh/b/1217314&m=3)
+  - [q/stol - Re/Im (Lude) \[Re/Extreme\]](https://osu.ppy.sh/b/1245089&m=3)
+  - [USAO - Showdown (Side) \[puxtu's MX\]](https://osu.ppy.sh/b/996693&m=3)
+  - [Sonitus Vir ft. Emily Smith - Lune Noir (Bites) \[4K MX\]](https://osu.ppy.sh/b/225781&m=3)
+  - [MINTi - So Fresh So Good (Leo137) \[Leo137's 4K\]](https://osu.ppy.sh/b/1097526&m=3)
+  - [Edwin Starr vs. Justice - War vs. Waters of Nazareth (Raspberriel) \[Massacre Edit\]](https://osu.ppy.sh/b/1394983&m=3)
+  - [The Flashbulb - Three Hundred CC (edit) (Blocko) \[Another\]](https://osu.ppy.sh/b/1368417&m=3)
+  - [Alesana - The Artist (Tornspirit) \[Collapse\]](https://osu.ppy.sh/b/1280807&m=3)
+- Tiebreaker
+  - [BABYMETAL - Tales of The Destinies (Couil) \[Endless Journey\]](https://osu.ppy.sh/b/1290602&m=3)
+
+### Group Stage
+
+**[Download the mappack here! (89 MB)](http://www.mediafire.com/file/cjk4f8ilwc2s7uv/MWC4K_2017_Group_Stage.rar)**
+
+- Freemod
+  - [Lifetheory - Daisy (Tidek) \[Life (Insane)\]](https://osu.ppy.sh/b/718401&m=3)
+  - [Shawn Wasabi - Burnt Rice (855wa) \[Hard\]](https://osu.ppy.sh/b/1063205&m=3)
+  - [YK. - Egg Of Life (Mwila Remix) (Paradoxq13) \[MX\]](https://osu.ppy.sh/b/741552&m=3)
+  - [sakuzyo - Altale (Kuo Kyoka) \[Hyper Lv.22\]](https://osu.ppy.sh/b/767309&m=3)
+  - [yuikonnu - Shinkai Shoujo (juankristal) \[Shoujo\]](https://osu.ppy.sh/b/1050663&m=3)
+  - [Warak - REANIMATE (Mat) \[Complex LNs\]](https://osu.ppy.sh/b/1315761&m=3)
+  - [Takemura Kiriko - Ninja Re Bang Bang (ecafree2) \[4K HD\]](https://osu.ppy.sh/b/816807&m=3)
+  - [REDALiCE feat. anporin - Beautiful Dream (Dellvangel) \[CS' Challenge\]](https://osu.ppy.sh/b/908398&m=3)
+  - [Niira Etsuko - Imaginary Waltz (-Troke-) \[Raccoon's MX\]](https://osu.ppy.sh/b/480148&m=3)
+  - [Tim & Eric - Sports! (ilikexd) \[Hard\]](https://osu.ppy.sh/b/685357&m=3)
+  - [Beltaine - Rockhill (Ryu Sei) \[Hard\]](https://osu.ppy.sh/b/994291&m=3)
+  - [stereoberry - evangelize (blurry images) (Tidek) \[transparency (SV)\]](https://osu.ppy.sh/b/1222765&m=3)
+- Tiebreaker
+  - [sakuraburst - sha (SitekX) \[dow\]](https://osu.ppy.sh/b/1258514&m=3)
 
 ------------------------------------------------------------------------
 
@@ -214,123 +212,123 @@ The osu!mania World Cup 2017 is run by various community members by distributing
 
 ### Grand Finals
 
-| Saturday, 16. September 2017 | | | | |
+| 2017-09-16 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| United States ![][flag_US] | 0 | 7 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/36111799) |
+| United States ![][flag_US] | 0 | **7** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/36111799) |
 
-### Finals - Week 1
+### Finals
 
-| Saturday, 9. September 2017 | | | | |
+| 2017-09-09 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Japan ![][flag_JP] | 6 | 0 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35952218) |
-| United Kingdom ![][flag_GB] | 0 | 6 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/35955973) |
+| **Japan** ![][flag_JP]      | **6** | 0 | ![][flag_CL] Chile      | [#1](https://osu.ppy.sh/community/matches/35952218) |
+| United Kingdom ![][flag_GB] | 0 | **6** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/35955973) |
 
-| Sunday, 10. September 2017 | | | | |
+| 2017-09-10 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | 6 | 0 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35972975) |
-| Brazil ![][flag_BR] | 6 | 1 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35974418) |
-| Brazil ![][flag_BR] | 5 | 6 | ![][flag_US] Unites States | [#1](https://osu.ppy.sh/community/matches/35998794) |
+| **South Korea** ![][flag_KR] | **6** | 0 | ![][flag_US] United States     | [#1](https://osu.ppy.sh/community/matches/35972975) |
+| **Brazil** ![][flag_BR]      | **6** | 1 | ![][flag_JP] Japan             | [#1](https://osu.ppy.sh/community/matches/35974418) |
+| Brazil ![][flag_BR]          | 5 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/35998794) |
 
 ### Semifinals
 
-| Saturday, 2. September 2017 | | | | |
+| 2017-09-02 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Sweden ![][flag_SE] | 1 | 6 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35769761) |
-| China ![][flag_CN] | 6 | 2 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/35771726) |
-| Brazil ![][flag_BR] | 0 | 6 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/35774130) |
-| Poland ![][flag_PL] | 1 | 6 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35777392) |
-| United Kingdom ![][flag_GB] | 6 | 3 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/35779902) |
-| United States ![][flag_US] | 6 | 0 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35783065) |
+| Sweden ![][flag_SE]             | 1 | **6** | ![][flag_JP] **Japan**       | [#1](https://osu.ppy.sh/community/matches/35769761) |
+| **China** ![][flag_CN]          | **6** | 2 | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/35771726) |
+| Brazil ![][flag_BR]             | 0 | **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/35774130) |
+| Poland ![][flag_PL]             | 1 | **6** | ![][flag_ID] **Indonesia**   | [#1](https://osu.ppy.sh/community/matches/35777392) |
+| **United Kingdom** ![][flag_GB] | **6** | 3 | ![][flag_CA] Canada          | [#1](https://osu.ppy.sh/community/matches/35779902) |
+| **United States** ![][flag_US]  | **6** | 0 | ![][flag_CL] Chile           | [#1](https://osu.ppy.sh/community/matches/35783065) |
 
-| Sunday, 3. September 2017 | | | | |
+| 2017-09-03 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Japan ![][flag_JP] | 6 | 3 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35804308) |
-| China ![][flag_CN] | 2 | 6 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/35807134) |
+| **Japan** ![][flag_JP] | **6** | 3 | ![][flag_ID] Indonesia          | [#1](https://osu.ppy.sh/community/matches/35804308) |
+| China ![][flag_CN]     | 2 | **6** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/35807134) |
 
 ### Quarterfinals
 
-| Saturday, 26. August 2017 | | | | |
+| 2017-08-26 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| France ![][flag_FR] | 4 | 5 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35585664) |
-| Argentina ![][flag_AR] | 1 | 5 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/35588367) |
-| Canada ![][flag_CA] | 0 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35590366) |
+| France ![][flag_FR]    | 4 | **5** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/35585664) |
+| Argentina ![][flag_AR] | 1 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/35588367) |
+| Canada ![][flag_CA]    | 0 | **5** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/35590366) |
 
-| Sunday, 27. August 2017 | | | | |
+| 2017-08-27 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | 5 | 0 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35601021) |
-| New Zealand ![][flag_NZ] | 0 | 5 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/35602514) |
-| Singapore ![][flag_SG] | 1 | 5 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/35604433) |
-| Hong Kong ![][flag_HK] | 0 | 5 | ![][flag_SE] Sweden | -WIN BY DEFAULT- |
-| Brazil ![][flag_BR] | 5 | 1 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35608732) |
+| **South Korea** ![][flag_KR] | **5** | 0 | ![][flag_JP] Japan         | [#1](https://osu.ppy.sh/community/matches/35601021) |
+| New Zealand ![][flag_NZ]     | 0 | **5** | ![][flag_PL] **Poland**    | [#1](https://osu.ppy.sh/community/matches/35602514) |
+| Singapore ![][flag_SG]       | 1 | **5** | ![][flag_CN] **China**     | [#1](https://osu.ppy.sh/community/matches/35604433) |
+| Hong Kong ![][flag_HK]       | 0 | **5** | ![][flag_SE] **Sweden**    | -Win by default- |
+| **Brazil** ![][flag_BR]      | **5** | 1 | ![][flag_ID] Indonesia     | [#1](https://osu.ppy.sh/community/matches/35608732) |
 
 ### Round of 16
 
-| Sunday, 20. August 2017 | | | | |
+| 2017-08-20 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| New Zealand ![][flag_NZ] | 1 | 5 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/35418105) |
-| Indonesia ![][flag_ID] | 5 | 1 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/35419189) |
-| United Kingdom ![][flag_GB] | 3 | 5 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35420314) |
-| South Korea ![][flag_KR] | 5 | 0 | ![][flag_AR] Argentina | [#1](https://osu.ppy.sh/community/matches/35421542) |
-| Brazil ![][flag_BR] | 5 | 0 | ![][flag_SG] Singapore | [#1](https://osu.ppy.sh/community/matches/35423100) |
-| Hong Kong ![][flag_HK] | 4 | 5 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/35424487) |
-| Poland ![][flag_PL] | 0 | 5 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35429710) |
-| Sweden ![][flag_SE] | 0 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35431890) |
+| New Zealand ![][flag_NZ]     | 1 | **5** | ![][flag_FR] **France**        | [#1](https://osu.ppy.sh/community/matches/35418105) |
+| **Indonesia** ![][flag_ID]   | **5** | 1 | ![][flag_CN] China             | [#1](https://osu.ppy.sh/community/matches/35419189) |
+| United Kingdom ![][flag_GB]  | 3 | **5** | ![][flag_JP] **Japan**         | [#1](https://osu.ppy.sh/community/matches/35420314) |
+| **South Korea** ![][flag_KR] | **5** | 0 | ![][flag_AR] Argentina         | [#1](https://osu.ppy.sh/community/matches/35421542) |
+| **Brazil** ![][flag_BR]      | **5** | 0 | ![][flag_SG] Singapore         | [#1](https://osu.ppy.sh/community/matches/35423100) |
+| Hong Kong ![][flag_HK]       | 4 | **5** | ![][flag_CA] **Canada**        | [#1](https://osu.ppy.sh/community/matches/35424487) |
+| Poland ![][flag_PL]          | 0 | **5** | ![][flag_CL] **Chile**         | [#1](https://osu.ppy.sh/community/matches/35429710) |
+| Sweden ![][flag_SE]          | 0 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/35431890) |
 
 ### Group Stage
 
-| Saturday, 12. August 2017 | | | | |
+| 2017-08-12 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Taiwan ![][flag_TW] | 2 | 4 | ![][flag_AU] Australia | [#1](https://osu.ppy.sh/community/matches/35209765) |
-| Russian Federation ![][flag_RU] | 0 | 4 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/35209716) |
-| New Zealand ![][flag_NZ] | 1 | 4 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35209719) |
-| Philippines ![][flag_PH] | 1 | 4 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/35210698) |
-| Norway ![][flag_NO] | 3 | 4 | ![][flag_HK] Hong Kong | [#1](https://osu.ppy.sh/community/matches/35210701) |
-| Malaysia ![][flag_MY] | 0 | 4 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/35210711) |
-| Switzerland ![][flag_CH] | 0 | 4 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35210713) |
-| Norway ![][flag_NO] | 0 | 4 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/35211634) |
-| Australia ![][flag_AU] | 1 | 4 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/35211644) |
-| Finland ![][flag_FI] | 4 | 2 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/35211647) |
-| Singapore ![][flag_SG] | 4 | 1 | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/35211655) |
-| France ![][flag_FR] | 4 | 1 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/35212839) |
-| Russian Federation ![][flag_RU] | 0 | 4 | ![][flag_SE] Sweden | [#1](https://osu.ppy.sh/community/matches/35212859) |
-| Belgium ![][flag_BE] | 3 | 4 | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/35212861) |
-| Singapore ![][flag_SG] | 0 | 4 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35212866) |
-| Venezuela ![][flag_VE] | 2 | 4 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/35214348) |
-| Finland ![][flag_FI] | 0 | 4 | ![][flag_SE] Sweden | [#1](https://osu.ppy.sh/community/matches/35214425) |
-| Spain ![][flag_ES] | 3 | 4 | ![][flag_IT] Italy | [#1](https://osu.ppy.sh/community/matches/35214428) |
-| Belgium ![][flag_BE] | 0 | 4 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35214432) |
-| Poland ![][flag_PL] | 0 | 4 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/35218496) |
-| Germany ![][flag_DE] | 0 | 4 | ![][flag_MX] Mexico | [#1](https://osu.ppy.sh/community/matches/35219133) |
-| Argentina ![][flag_AR] | 1 | 4 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35218503) |
-| Netherlands ![][flag_NL] | 1 | 4 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/35218508) |
-| Venezuela ![][flag_VE] | 0 | 4 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/35219912) |
-| Germany ![][flag_DE] | 0 | 4 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35219931) |
-| Mexico ![][flag_MX] | 0 | 4 | ![][flag_AR] Argentina | [#1](https://osu.ppy.sh/community/matches/35219934) |
-| Switzerland ![][flag_CH] | 0 | 4 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/35219940) |
+| Taiwan ![][flag_TW]             | 2 | **4** | ![][flag_AU] **Australia**      | [#1](https://osu.ppy.sh/community/matches/35209765) |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/35209716) |
+| New Zealand ![][flag_NZ]        | 1 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/35209719) |
+| Philippines ![][flag_PH]        | 1 | **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/35210698) |
+| Norway ![][flag_NO]             | 3 | **4** | ![][flag_HK] **Hong Kong**      | [#1](https://osu.ppy.sh/community/matches/35210701) |
+| Malaysia ![][flag_MY]           | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/35210711) |
+| Switzerland ![][flag_CH]        | 0 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/35210713) |
+| Norway ![][flag_NO]             | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/35211634) |
+| Australia ![][flag_AU]          | 1 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/35211644) |
+| **Finland** ![][flag_FI]        | **4** | 2 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/35211647) |
+| **Singapore** ![][flag_SG]      | **4** | 1 | ![][flag_TH] Thailand           | [#1](https://osu.ppy.sh/community/matches/35211655) |
+| **France** ![][flag_FR]         | **4** | 1 | ![][flag_CN] China              | [#1](https://osu.ppy.sh/community/matches/35212839) |
+| Russian Federation ![][flag_RU] | 0 | **4** | ![][flag_SE] **Sweden**         | [#1](https://osu.ppy.sh/community/matches/35212859) |
+| Belgium ![][flag_BE]            | 3 | **4** | ![][flag_TH] **Thailand**       | [#1](https://osu.ppy.sh/community/matches/35212861) |
+| Singapore ![][flag_SG]          | 0 | **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/35212866) |
+| Venezuela ![][flag_VE]          | 2 | **4** | ![][flag_PH] **Philippines**    | [#1](https://osu.ppy.sh/community/matches/35214348) |
+| Finland ![][flag_FI]            | 0 | **4** | ![][flag_SE] **Sweden**         | [#1](https://osu.ppy.sh/community/matches/35214425) |
+| Spain ![][flag_ES]              | 3 | **4** | ![][flag_IT] **Italy**          | [#1](https://osu.ppy.sh/community/matches/35214428) |
+| Belgium ![][flag_BE]            | 0 | **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/35214432) |
+| Poland ![][flag_PL]             | 0 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/35218496) |
+| Germany ![][flag_DE]            | 0 | **4** | ![][flag_MX] **Mexico**         | [#1](https://osu.ppy.sh/community/matches/35219133) |
+| Argentina ![][flag_AR]          | 1 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/35218503) |
+| Netherlands ![][flag_NL]        | 1 | **4** | ![][flag_CA] **Canada**         | [#1](https://osu.ppy.sh/community/matches/35218508) |
+| Venezuela ![][flag_VE]          | 0 | **4** | ![][flag_PL] **Poland**         | [#1](https://osu.ppy.sh/community/matches/35219912) |
+| Germany ![][flag_DE]            | 0 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/35219931) |
+| Mexico ![][flag_MX]             | 0 | **4** | ![][flag_AR] **Argentina**      | [#1](https://osu.ppy.sh/community/matches/35219934) |
+| Switzerland ![][flag_CH]        | 0 | **4** | ![][flag_CA] **Canada**         | [#1](https://osu.ppy.sh/community/matches/35219940) |
 
-| Sunday, 13. August 2017 | | | | |
+| 2017-08-13 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| New Zealand ![][flag_NZ] | 4 | 2 | ![][flag_ES] Spain | [#1](https://osu.ppy.sh/community/matches/35236072) |
-| Italy ![][flag_IT] | 0 | 4 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35236074) |
-| Netherlands ![][flag_NL] | 1 | 4 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35236084) |
-| New Zealand ![][flag_NZ] | 4 | 0 | ![][flag_IT] Italy | [#1](https://osu.ppy.sh/community/matches/35237009) |
-| Australia ![][flag_AU] | 1 | 4 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/35237013) |
-| Belgium ![][flag_BE] | 0 | 4 | ![][flag_SG] Singapore | -Win by default- |
-| Spain ![][flag_ES] | 0 | 4 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/35237019) |
-| Norway ![][flag_NO] | 2 | 4 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/35237818) |
-| Hong Kong ![][flag_HK] | 0 | 4 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/35237821) |
-| Sweden ![][flag_SE] | 2 | 4 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/35237888) |
-| Hong Kong ![][flag_HK] | 4 | 2 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/35238975) |
-| Taiwan ![][flag_TW] | 2 | 4 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/35238978) |
-| Finland ![][flag_FI] | 0 | 4 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/35238983) |
-| Philippines ![][flag_PH] | 1 | 4 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/35240162) |
-| Taiwan ![][flag_TW] | 1 | 4 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/35240166) |
-| Canada ![][flag_CA] | 4 | 1 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/35240169) |
-| Thailand ![][flag_TH] | 2 | 4 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/35240175) |
-| Netherlands ![][flag_NL] | 1 | 4 | ![][flag_CH] Switzerland | [#1](https://osu.ppy.sh/community/matches/35241555) |
-| Venezuela ![][flag_VE] | 0 | 4 | ![][flag_BR] Brazil | -Win by default- |
-| Germany ![][flag_DE] | 0 | 4 | ![][flag_AR] Argentina | [#1](https://osu.ppy.sh/community/matches/35241635) |
-| Mexico ![][flag_MX] | 0 | 4 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/35241640) |
+| New Zealand ![][flag_NZ]     | **4** | 2 | ![][flag_ES] Spain              | [#1](https://osu.ppy.sh/community/matches/35236072) |
+| Italy ![][flag_IT]           | 0 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/35236074) |
+| Netherlands ![][flag_NL]     | 1 | **4** | ![][flag_JP] **Japan**          | [#1](https://osu.ppy.sh/community/matches/35236084) |
+| **New Zealand** ![][flag_NZ] | **4** | 0 | ![][flag_IT] Italy              | [#1](https://osu.ppy.sh/community/matches/35237009) |
+| Australia ![][flag_AU]       | 1 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/35237013) |
+| Belgium ![][flag_BE]         | 0 | **4** | ![][flag_SG] **Singapore**      | -Win by default- |
+| Spain ![][flag_ES]           | 0 | **4** | ![][flag_ID] **Indonesia**      | [#1](https://osu.ppy.sh/community/matches/35237019) |
+| Norway ![][flag_NO]          | 2 | **4** | ![][flag_MY] **Malaysia**       | [#1](https://osu.ppy.sh/community/matches/35237818) |
+| Hong Kong ![][flag_HK]       | 0 | **4** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/35237821) |
+| Sweden ![][flag_SE]          | 2 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/35237888) |
+| **Hong Kong** ![][flag_HK]   | **4** | 2 | ![][flag_MY] Malaysia           | [#1](https://osu.ppy.sh/community/matches/35238975) |
+| Taiwan ![][flag_TW]          | 2 | **4** | ![][flag_CN] **China**          | [#1](https://osu.ppy.sh/community/matches/35238978) |
+| Finland ![][flag_FI]         | 0 | **4** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/35238983) |
+| Philippines ![][flag_PH]     | 1 | **4** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/35240162) |
+| Taiwan ![][flag_TW]          | 1 | **4** | ![][flag_FR] **France**         | [#1](https://osu.ppy.sh/community/matches/35240166) |
+| **Canada** ![][flag_CA]      | **4** | 1 | ![][flag_JP] Japan              | [#1](https://osu.ppy.sh/community/matches/35240169) |
+| Thailand ![][flag_TH]        | 2 | **4** | ![][flag_CL] **Chile**          | [#1](https://osu.ppy.sh/community/matches/35240175) |
+| Netherlands ![][flag_NL]     | 1 | **4** | ![][flag_CH] **Switzerland**    | [#1](https://osu.ppy.sh/community/matches/35241555) |
+| Venezuela ![][flag_VE]       | 0 | **4** | ![][flag_BR] **Brazil**         | -Win by default- |
+| Germany ![][flag_DE]         | 0 | **4** | ![][flag_AR] **Argentina**      | [#1](https://osu.ppy.sh/community/matches/35241635) |
+| Mexico ![][flag_MX]          | 0 | **4** | ![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/35241640) |
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/MWC/2017/4K/fr.md
+++ b/wiki/Tournaments/MWC/2017/4K/fr.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 osu!mania 4K World Cup 2017
 =============================
 
@@ -20,7 +24,7 @@ La **osu!mania 4K World Cup 2017** (**_MWC 4K 2017_**) est un tournoi de osu!man
 
 ## Récompenses
 
-Dans chaque coupe du monde, les joueurs qui réussissent à obtenir une place sur le podium reçoivent des prix uniques créés spécialement pour les gagnants de la coupe du monde. Il est possible que ces récompenses changent entre plusieurs coupe du monde. 
+Dans chaque coupe du monde, les joueurs qui réussissent à obtenir une place sur le podium reçoivent des prix uniques créés spécialement pour les gagnants de la coupe du monde. Il est possible que ces récompenses changent entre plusieurs coupe du monde.
 
 | Place | Récompenses |
 | --- | :--- |
@@ -134,85 +138,85 @@ La coupe du monde osu!mania 2017 est organisée par divers membres de la communa
 **[Téléchargez le pack de maps ici ! (89 MB)](http://www.mediafire.com/file/cjk4f8ilwc2s7uv/MWC4K_2017_Group_Stage.rar)**
 
 - Freemod
-  - [Lifetheory - Daisy (Tidek) \[Life (Insane)\]](http://osu.ppy.sh/b/718401&m=3) 
-  - [Shawn Wasabi - Burnt Rice (855wa) \[Hard\]](https://osu.ppy.sh/b/1063205&m=3) 
-  - [YK. - Egg Of Life (Mwila Remix) (Paradoxq13) \[MX\]](http://osu.ppy.sh/b/741552&m=3) 
-  - [sakuzyo - Altale (Kuo Kyoka) \[Hyper Lv.22\]](http://osu.ppy.sh/b/767309&m=3) 
-  - [yuikonnu - Shinkai Shoujo (juankristal) \[Shoujo\]](http://osu.ppy.sh/b/1050663&m=3) 
-  - [Warak - REANIMATE (Mat) \[Complex LNs\]](http://osu.ppy.sh/b/1315761&m=3) 
-  - [Takemura Kiriko - Ninja Re Bang Bang (ecafree2) \[4K HD\]](http://osu.ppy.sh/b/816807&m=3) 
-  - [REDALiCE feat. anporin - Beautiful Dream (Dellvangel) \[CS' Challenge\]](http://osu.ppy.sh/b/908398&m=3) 
-  - [Niira Etsuko - Imaginary Waltz (-Troke-) \[Raccoon's MX\]](http://osu.ppy.sh/b/480148&m=3) 
-  - [Tim & Eric - Sports! (ilikexd) \[Hard\]](http://osu.ppy.sh/b/685357&m=3) 
-  - [Beltaine - Rockhill (Ryu Sei) \[Hard\]](http://osu.ppy.sh/b/994291&m=3) 
-  - [stereoberry - evangelize (blurry images) (Tidek) \[transparency (SV)\]](http://osu.ppy.sh/b/1222765&m=3) 
+  - [Lifetheory - Daisy (Tidek) \[Life (Insane)\]](http://osu.ppy.sh/b/718401&m=3)
+  - [Shawn Wasabi - Burnt Rice (855wa) \[Hard\]](https://osu.ppy.sh/b/1063205&m=3)
+  - [YK. - Egg Of Life (Mwila Remix) (Paradoxq13) \[MX\]](http://osu.ppy.sh/b/741552&m=3)
+  - [sakuzyo - Altale (Kuo Kyoka) \[Hyper Lv.22\]](http://osu.ppy.sh/b/767309&m=3)
+  - [yuikonnu - Shinkai Shoujo (juankristal) \[Shoujo\]](http://osu.ppy.sh/b/1050663&m=3)
+  - [Warak - REANIMATE (Mat) \[Complex LNs\]](http://osu.ppy.sh/b/1315761&m=3)
+  - [Takemura Kiriko - Ninja Re Bang Bang (ecafree2) \[4K HD\]](http://osu.ppy.sh/b/816807&m=3)
+  - [REDALiCE feat. anporin - Beautiful Dream (Dellvangel) \[CS' Challenge\]](http://osu.ppy.sh/b/908398&m=3)
+  - [Niira Etsuko - Imaginary Waltz (-Troke-) \[Raccoon's MX\]](http://osu.ppy.sh/b/480148&m=3)
+  - [Tim & Eric - Sports! (ilikexd) \[Hard\]](http://osu.ppy.sh/b/685357&m=3)
+  - [Beltaine - Rockhill (Ryu Sei) \[Hard\]](http://osu.ppy.sh/b/994291&m=3)
+  - [stereoberry - evangelize (blurry images) (Tidek) \[transparency (SV)\]](http://osu.ppy.sh/b/1222765&m=3)
 - Tiebreaker
-  - [sakuraburst - sha (SitekX) \[dow\]](http://osu.ppy.sh/b/1258514&m=3) 
+  - [sakuraburst - sha (SitekX) \[dow\]](http://osu.ppy.sh/b/1258514&m=3)
 
 ### Huitièmes de finale
 
 **[Téléchargez le pack de maps ici ! (65 MB)](http://www.mediafire.com/file/z7pmbh632dy178j/MWC4K_2017_Round_of_16.rar)**
 
 - FreeMod
-  - [hyi - you can recover (Valedict) \[restoration\]](http://osu.ppy.sh/b/1199287&m=3) 
-  - [GIRAFFES? GIRAFFES! - I Am S/H(im)e[r] (XeoStyle) \[I Am Us\]](http://osu.ppy.sh/b/1259834&m=3) 
-  - [KOAN Sound + asa - Fuego (sakuraburst remix) (Couil) \[HD\]](http://osu.ppy.sh/b/1313120&m=3) 
-  - [Schubert - Introduction And Variations 'Trockne Blumen' Variation 5 Remix&Arrange (Feerum) \[4K Irrsinnig\]](http://osu.ppy.sh/b/1178997&m=3) 
-  - [Team Grimoire - Sheriruth (DoNotMess) \[Future\]](https://osu.ppy.sh/b/1295745&m=3) 
-  - [Helblinde - Heaven's Fall (Kaito-kun) \[Extra\]](http://osu.ppy.sh/b/1217314&m=3) 
-  - [q/stol - Re/Im (Lude) \[Re/Extreme\]](http://osu.ppy.sh/b/1245089&m=3) 
-  - [USAO - Showdown (Side) \[puxtu's MX\]](http://osu.ppy.sh/b/996693&m=3) 
-  - [Sonitus Vir ft. Emily Smith - Lune Noir (Bites) \[4K MX\]](http://osu.ppy.sh/b/225781&m=3) 
-  - [MINTi - So Fresh So Good (Leo137) \[Leo137's 4K\]](http://osu.ppy.sh/b/1097526&m=3) 
-  - [Edwin Starr vs. Justice - War vs. Waters of Nazareth (Raspberriel) \[Massacre Edit\]](http://osu.ppy.sh/b/1372839&m=3) 
-  - [The Flashbulb - Three Hundred CC (edit) (Blocko) \[Another\]](http://osu.ppy.sh/b/1368417&m=3) 
-  - [Alesana - The Artist (Tornspirit) \[Collapse\]](http://osu.ppy.sh/b/1280807&m=3) 
+  - [hyi - you can recover (Valedict) \[restoration\]](http://osu.ppy.sh/b/1199287&m=3)
+  - [GIRAFFES? GIRAFFES! - I Am S/H(im)e[r] (XeoStyle) \[I Am Us\]](http://osu.ppy.sh/b/1259834&m=3)
+  - [KOAN Sound + asa - Fuego (sakuraburst remix) (Couil) \[HD\]](http://osu.ppy.sh/b/1313120&m=3)
+  - [Schubert - Introduction And Variations 'Trockne Blumen' Variation 5 Remix&Arrange (Feerum) \[4K Irrsinnig\]](http://osu.ppy.sh/b/1178997&m=3)
+  - [Team Grimoire - Sheriruth (DoNotMess) \[Future\]](https://osu.ppy.sh/b/1295745&m=3)
+  - [Helblinde - Heaven's Fall (Kaito-kun) \[Extra\]](http://osu.ppy.sh/b/1217314&m=3)
+  - [q/stol - Re/Im (Lude) \[Re/Extreme\]](http://osu.ppy.sh/b/1245089&m=3)
+  - [USAO - Showdown (Side) \[puxtu's MX\]](http://osu.ppy.sh/b/996693&m=3)
+  - [Sonitus Vir ft. Emily Smith - Lune Noir (Bites) \[4K MX\]](http://osu.ppy.sh/b/225781&m=3)
+  - [MINTi - So Fresh So Good (Leo137) \[Leo137's 4K\]](http://osu.ppy.sh/b/1097526&m=3)
+  - [Edwin Starr vs. Justice - War vs. Waters of Nazareth (Raspberriel) \[Massacre Edit\]](http://osu.ppy.sh/b/1372839&m=3)
+  - [The Flashbulb - Three Hundred CC (edit) (Blocko) \[Another\]](http://osu.ppy.sh/b/1368417&m=3)
+  - [Alesana - The Artist (Tornspirit) \[Collapse\]](http://osu.ppy.sh/b/1280807&m=3)
 - Tiebreaker
-  - [BABYMETAL - Tales of The Destinies (Couil) \[Endless Journey\]](http://osu.ppy.sh/b/1290602&m=3) 
+  - [BABYMETAL - Tales of The Destinies (Couil) \[Endless Journey\]](http://osu.ppy.sh/b/1290602&m=3)
 
 ### Quarts de finale
 
 **[Téléchargez le pack de maps ici ! (88 MB)](http://www.mediafire.com/file/7baxea9hafezhob/MWC4K_2017_Quarterfinals.rar)**
 
 - FreeMod
-  - [BABYMETAL - Road of Resistance (hi19hi19) \[Uprising\]](http://osu.ppy.sh/b/1375744&m=3) 
-  - [Caravan Palace - Clash (Hydria) \[Hard\]](http://osu.ppy.sh/b/1369706&m=3) 
-  - [goreshit - looming shadow of a tree long gone (Shoegazer) \[extra\]](http://osu.ppy.sh/b/792874&m=3) 
-  - [yst - The Lost Dedicated (DDMythical) \[Another\]](http://osu.ppy.sh/b/1302866&m=3) 
-  - [8284 - Connaextion (LeiN-) \[TIMED_OUT\]](http://osu.ppy.sh/b/1029033&m=3) 
-  - [Maika - Goldrop (Skorer) \[Yudaina LN\]](http://osu.ppy.sh/b/1243241&m=3) 
-  - [Getty vs. DJ DiA - Fox4-Raize- (Evening) \[GRAVITY VIP\]](http://osu.ppy.sh/b/1228388&m=3) 
-  - [Colorful Sounds Port - ETERNAL DRAIN (Wh1teh) \[Black Another\]](http://osu.ppy.sh/b/1104774&m=3) 
-  - [Blue Stahli - Shotgun Senorita (Zardonic Remix) (juankristal) \[Machine Gun\]](http://osu.ppy.sh/b/1341515&m=3) 
-  - [Dustvoxx - Trigger (Zekk Remix) (Wonki) \[Trigger\]](http://osu.ppy.sh/b/1174927&m=3) 
-  - [Akira Complex - Odyssey (Au5 Remix) (Shoegazer) \[Dreamless\]](http://osu.ppy.sh/b/1103630&m=3) 
-  - [YUC'e - Sengoku HOP (c/f Athenarium) (Hydria) \[Insane\]](http://osu.ppy.sh/b/1279175&m=3) 
-  - [NOISIA - Groundhog (Beat Juggle) (Raspberriel) \[Sorry, Am I Putting You Off?\]](http://osu.ppy.sh/b/1252742&m=3) 
+  - [BABYMETAL - Road of Resistance (hi19hi19) \[Uprising\]](http://osu.ppy.sh/b/1375744&m=3)
+  - [Caravan Palace - Clash (Hydria) \[Hard\]](http://osu.ppy.sh/b/1369706&m=3)
+  - [goreshit - looming shadow of a tree long gone (Shoegazer) \[extra\]](http://osu.ppy.sh/b/792874&m=3)
+  - [yst - The Lost Dedicated (DDMythical) \[Another\]](http://osu.ppy.sh/b/1302866&m=3)
+  - [8284 - Connaextion (LeiN-) \[TIMED_OUT\]](http://osu.ppy.sh/b/1029033&m=3)
+  - [Maika - Goldrop (Skorer) \[Yudaina LN\]](http://osu.ppy.sh/b/1243241&m=3)
+  - [Getty vs. DJ DiA - Fox4-Raize- (Evening) \[GRAVITY VIP\]](http://osu.ppy.sh/b/1228388&m=3)
+  - [Colorful Sounds Port - ETERNAL DRAIN (Wh1teh) \[Black Another\]](http://osu.ppy.sh/b/1104774&m=3)
+  - [Blue Stahli - Shotgun Senorita (Zardonic Remix) (juankristal) \[Machine Gun\]](http://osu.ppy.sh/b/1341515&m=3)
+  - [Dustvoxx - Trigger (Zekk Remix) (Wonki) \[Trigger\]](http://osu.ppy.sh/b/1174927&m=3)
+  - [Akira Complex - Odyssey (Au5 Remix) (Shoegazer) \[Dreamless\]](http://osu.ppy.sh/b/1103630&m=3)
+  - [YUC'e - Sengoku HOP (c/f Athenarium) (Hydria) \[Insane\]](http://osu.ppy.sh/b/1279175&m=3)
+  - [NOISIA - Groundhog (Beat Juggle) (Raspberriel) \[Sorry, Am I Putting You Off?\]](http://osu.ppy.sh/b/1252742&m=3)
 - Tiebreaker
-  - [DragonForce - The Warrior Inside (_underjoy) \[4K Collab Gladiator\]](http://osu.ppy.sh/b/1038662&m=3) 
- 
+  - [DragonForce - The Warrior Inside (\_underjoy) \[4K Collab Gladiator\]](http://osu.ppy.sh/b/1038662&m=3) 
+
 ### Demi-finales
 
 **[Téléchargez le pack de maps ici ! (90 MB)](http://www.mediafire.com/file/7mxtjr3r9k4bi54/MWC4K_2017_Semifinals.rar)**
 
 - FreeMod
-  - [9mm Parabellum Bullet - Punishment (Valedict) \[Retribution\]](http://osu.ppy.sh/b/1128678&m=3) 
-  - [Kaneko Chiharu - Lachryma\<Re:Queen'M\> (Fresh Chicken) \[GRAVITY\]](http://osu.ppy.sh/b/901050&m=3) 
-  - [aaaa + yadorigi - Sakase natsuzora, koi no hana. (scissorsf) \[flnowers\]](http://osu.ppy.sh/b/993976&m=3) 
-  - [Ekcle - The Impulsive State (Parachor) \[Entropy_\]](http://osu.ppy.sh/b/1364765&m=3) 
-  - [The Flashbulb - Passage D (Jinjin) \[Delve\]](http://osu.ppy.sh/b/1016508&m=3) 
-  - [IOSYS - Endless Tewi-ma Park (arcwinolivirus) \[Arcwin Lost Tewicated\]](http://osu.ppy.sh/b/855471&m=3) 
-  - [USAO - Boss Rush (PiraTom) \[LN Rush\]](http://osu.ppy.sh/b/1259719&m=3) 
-  - [Fele - Peter on Crack (Cut) (Jole) \[this is brain surgery\]](http://osu.ppy.sh/b/1394763&m=3) 
-  - [Kidkanevil - Lantern 1 (Valedict) \[Fog\]](http://osu.ppy.sh/b/1331160&m=3) 
-  - [Kontinuum - Lost (feat. Savoi) \[Sunroof Remix\] (Otakujanai) \[Emotional Drift\]](http://osu.ppy.sh/b/1321781&m=3) 
-  - [Fractal Dreamers - Fortuna Redux (Kizunuko-P) \[Dream\]](http://osu.ppy.sh/b/1311355&m=3) 
-  - [Inferi - Those Who From the Heavens Came (XeoStyle) \[Investiture of the Gods\]](http://osu.ppy.sh/b/897408&m=3) 
-  - [C-Show - ERROR CODE (SpectorDG) \[SPE vs. ZEN's GRAVITY\]](http://osu.ppy.sh/b/1155393&m=3) 
-  - [Jeff Williams - Time to say Goodbye (feat. Casey Lee Williams) (juankristal) \[Team LNBY\]](http://osu.ppy.sh/b/1112725&m=3) 
+  - [9mm Parabellum Bullet - Punishment (Valedict) \[Retribution\]](http://osu.ppy.sh/b/1128678&m=3)
+  - [Kaneko Chiharu - Lachryma\<Re:Queen'M\> (Fresh Chicken) \[GRAVITY\]](http://osu.ppy.sh/b/901050&m=3)
+  - [aaaa + yadorigi - Sakase natsuzora, koi no hana. (scissorsf) \[flnowers\]](http://osu.ppy.sh/b/993976&m=3)
+  - [Ekcle - The Impulsive State (Parachor) \[Entropy_\]](http://osu.ppy.sh/b/1364765&m=3)
+  - [The Flashbulb - Passage D (Jinjin) \[Delve\]](http://osu.ppy.sh/b/1016508&m=3)
+  - [IOSYS - Endless Tewi-ma Park (arcwinolivirus) \[Arcwin Lost Tewicated\]](http://osu.ppy.sh/b/855471&m=3)
+  - [USAO - Boss Rush (PiraTom) \[LN Rush\]](http://osu.ppy.sh/b/1259719&m=3)
+  - [Fele - Peter on Crack (Cut) (Jole) \[this is brain surgery\]](http://osu.ppy.sh/b/1394763&m=3)
+  - [Kidkanevil - Lantern 1 (Valedict) \[Fog\]](http://osu.ppy.sh/b/1331160&m=3)
+  - [Kontinuum - Lost (feat. Savoi) \[Sunroof Remix\] (Otakujanai) \[Emotional Drift\]](http://osu.ppy.sh/b/1321781&m=3)
+  - [Fractal Dreamers - Fortuna Redux (Kizunuko-P) \[Dream\]](http://osu.ppy.sh/b/1311355&m=3)
+  - [Inferi - Those Who From the Heavens Came (XeoStyle) \[Investiture of the Gods\]](http://osu.ppy.sh/b/897408&m=3)
+  - [C-Show - ERROR CODE (SpectorDG) \[SPE vs. ZEN's GRAVITY\]](http://osu.ppy.sh/b/1155393&m=3)
+  - [Jeff Williams - Time to say Goodbye (feat. Casey Lee Williams) (juankristal) \[Team LNBY\]](http://osu.ppy.sh/b/1112725&m=3)
 - Tiebreaker
-  - [Camellia - Dans la mer de son (TheToaphster) \[Abyss\]](http://osu.ppy.sh/b/1295025&m=3) 
- 
+  - [Camellia - Dans la mer de son (TheToaphster) \[Abyss\]](http://osu.ppy.sh/b/1295025&m=3)
+
 ------------------------------------------------------------------------
 
 ## Résultats des matchs

--- a/wiki/Tournaments/MWC/2017/7K/en.md
+++ b/wiki/Tournaments/MWC/2017/7K/en.md
@@ -9,13 +9,13 @@ The **osu!mania 7K World Cup 2017** (**_MWC 7K 2017_**) is a country-based osu!m
 
 | Event | Timestamp |
 | ---: | :--- |
-| Registration Phase | 12. - 25. December 2016 | 
-| Drawings | 8. January 2017 (14:00 UTC+0) | 
-| Group Stage | 14. - 15. January 2017 | 
-| Quarterfinals | 21. - 22. January 2017 | 
-| Semifinals | 28. - 29. January 2017 | 
-| Finals - Week 1 | 04. - 05. February 2017 | 
-| Finals - Week 2 | 11. - 12. February 2017 | 
+| Registration Phase | 2016-12-12/2016-12-25   |
+| Drawings           | 2017-01-08 14:00:00 UTC |
+| Group Stage        | 2017-01-14/2017-01-15   |
+| Quarterfinals      | 2017-01-21/2017-01-22   |
+| Semifinals         | 2017-01-28/2017-01-29   |
+| Finals             | 2017-02-04/2017-02-05   |
+| Grand Finals       | 2017-02-11/2017-02-12   |
 
 ## Prizes
 
@@ -31,8 +31,8 @@ In every world cup, people conquering a place on the podium are eligible to rece
 
 The osu!mania World Cup 2017 is run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Member |
-| ------------ | -------------- |
+| Position | Member(s) |
+|---|---|
 | Management | [![][flag_DE] Loctav](https://osu.ppy.sh/users/71366), [![][flag_DE] p3n](https://osu.ppy.sh/users/123703), [![][flag_ES] Deif](https://osu.ppy.sh/users/318565), [![][flag_FR] shARPII](https://osu.ppy.sh/users/776257) |
 | Map Selectors | [![][flag_US] Blocko](https://osu.ppy.sh/users/4075092), [![][flag_PL] -Kamikaze-](https://osu.ppy.sh/users/2124783), [![][flag_SG] Evening](https://osu.ppy.sh/users/2193881) |
 | Commentators | [![][flag_US] Daikyi](https://osu.ppy.sh/users/811832), [![][flag_NZ] deadbeat](https://osu.ppy.sh/users/128370), [![][flag_SG] Evening](https://osu.ppy.sh/users/2193881), [![][flag_US] Halogen-](https://osu.ppy.sh/users/169992), [![][flag_AR] juankristal](https://osu.ppy.sh/users/443656), [![][flag_GB] -Konner-](https://osu.ppy.sh/users/6108644), [![][flag_US] Nivrad00](https://osu.ppy.sh/users/1984634), [![][flag_FR] Slainv](https://osu.ppy.sh/users/4823843), [![][flag_US] ztrot](https://osu.ppy.sh/users/6347) |
@@ -78,167 +78,167 @@ The osu!mania World Cup 2017 is run by various community members by distributing
 
 ## Mappools
 
-### Group Stage
+### Finals
 
-**[Download the mappack here! (88 MB)](http://www.mediafire.com/file/zztlm72z3ngh1ha/MWC_7K_2017_Group_Stage.rar)**
+**This mappool will be used in Finals and Grand Finals**
 
-- FreeMod
-  - [WALKUERE - Ikenai Borderline (SanadaYukimura) \[Emiria's 7K G\]](http://osu.ppy.sh/b/1030861&m=3) 
-  - [The Flashbulb - Who You Evidently Thought Was Me (-Kamikaze-)](http://osu.ppy.sh/b/1158709&m=3) \[Pope's Anfractuous Derivative\]
-  - [penoreri - Everlasting Message (Julie) \[EXHAUST\]](http://osu.ppy.sh/b/687322&m=3) 
-  - [Sawano Hiroyuki - Blowin' (ArcherLove) \[Hard\]](http://osu.ppy.sh/b/426032&m=3) 
-  - [Ayana - freak of nature: start (richardfeder) \[Freak Out\]](http://osu.ppy.sh/b/362574&m=3) 
-  - [Sasaki Sayaka - My Dear Girl (short Ver) (shionelove) \[yoshilove's 7K HD\]](http://osu.ppy.sh/b/787134&m=3) 
-  - [Helblinde - Above the Clouds (Level 51) \[Hymn\]](http://osu.ppy.sh/b/1074573&m=3) 
-  - [KANON NAKAGAWA starring Nao Toyama - Natsuiro Surprise (HanzeR) \[Insane\]](http://osu.ppy.sh/b/255968&m=3) 
-  - [Tsukasa Yatoki - 2A-Attack (Reikosaka) \[Maximum\]](http://osu.ppy.sh/b/359560&m=3) 
-  - [Hatsuki Yura - Izayoi Warabeuta (Elementaires) \[HD\]](http://osu.ppy.sh/b/712126&m=3) 
-  - [Toni Leys - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci) (LordRaika) \[Insane\]](http://osu.ppy.sh/b/841216&m=3) 
-  - [Misawa Sachika - Links (TV Size) (17VA) \[MX\]](http://osu.ppy.sh/b/320510&m=3) 
-  - [Junk - Aihana (Love+ Edit) (richardfeder) \[S.Star's Another\]](http://osu.ppy.sh/b/468795&m=3) 
-- Tiebreaker
-  - [Nhato - Magic (Tear) \[Enchanted\]](http://osu.ppy.sh/b/427993&m=3) 
-
-### Quarterfinals
-
-**[Download the mappack here! (61 MB)](http://www.mediafire.com/file/19768v0uxatm433/MWC_7K_2017_Quarterfinals.rar)**
+**[Download the mappack here! (124 MB)](http://www.mediafire.com/file/6xjcb99fb7z1vrz/MWC_7K_2017_Finals.rar)**
 
 - FreeMod
-  - [Rob Zombie - What Lurks on Channel X? (Pope Gadget) \[VII\]](http://osu.ppy.sh/b/1150224&m=3) 
-  - [SHK - Milky Way (ExPew) \[SC\]](http://osu.ppy.sh/b/305675&m=3) 
-  - [xi - Hesperides (ExKagii-) \[Another\]](http://osu.ppy.sh/b/1035076&m=3) 
-  - [S.I.D Sound - Pink Gold (Reikosaka) \[Happiness\]](http://osu.ppy.sh/b/525686&m=3) 
-  - [STN - The Limbo (Alumetorz) \[Rumi's MX\]](http://osu.ppy.sh/b/405715&m=3) 
-  - [DJ SHIMAMURA - Move Real Slow (Agka) \[Slow\]](http://osu.ppy.sh/b/412973&m=3) 
-  - [TAG - Romancing Layer (\_S u w a k o\_) \[Lv.34\]](http://osu.ppy.sh/b/543414&m=3) 
-  - [Nakamura Meiko - reverb (richardfeder) \[Another\]](http://osu.ppy.sh/b/509575&m=3) 
-  - [YUZU - Hyori Ittai (ArcherLove) \[Lv.25\]](http://osu.ppy.sh/b/516758&m=3) 
-  - [LeaF - Doppelganger (Jinjin) \[Zen's Insane\]](http://osu.ppy.sh/b/1025646&m=3) 
-  - [Shibayan - X-D-A-T (Jole) \[Lv.12 Another\]](http://osu.ppy.sh/b/440089&m=3) 
-  - [Iced Blade - Sora no Senritsu -the melody of the cosmos- feat.lily-an (OP Cut) (arcwinolivirus) \[7K Awakened\]](http://osu.ppy.sh/b/941427&m=3) 
-  - [M2U - Promise (Jinjin) \[Yaksok\]](http://osu.ppy.sh/b/869223&m=3) 
+  - [Alon Mor - Demons (-Kamikaze-) \[Evening's ritual (preview)\]](http://osu.ppy.sh/b/1188811&m=3)
+  - [uma vs. Morimori Atsushi - Re End of a Dream (qodtjr) \[Dreaming of square\]](http://osu.ppy.sh/b/1104259&m=3)
+  - [Suzumu - Kakumeisei ousama densenbyou (Zenonia) \[ZenoCORE!\]](http://osu.ppy.sh/b/993185&m=3)
+  - [Blitz Lunar - Mathsma Attack (Blocko) \[Shockwave\]](http://osu.ppy.sh/b/1060566&m=3)
+  - [Falcom Sound Team jdk - SILENT DESERT (Evening) \[BEGINNING\]](http://osu.ppy.sh/b/1146187&m=3)
+  - [The Algorithm - floating point (Drumcorps Remix) (\_underjoy) \[Approximation\]](http://osu.ppy.sh/b/1154859&m=3)
+  - [EZFG - cloud (Ciel) \[High (nerfed)\]](http://osu.ppy.sh/b/1178427&m=3)
+  - [xi - Angelic Party (Jinjin) \[Evening & Jinjin's Collaborative Party!\]](http://osu.ppy.sh/b/1185659&m=3)
+  - [Demetori - Wind God Girl (TBSM) \[BMS 21\]](http://osu.ppy.sh/b/766085&m=3)
+  - [Sakuzyo - Imprinting (Zenonia) \[Impression\]](http://osu.ppy.sh/b/908448&m=3)
+  - [Carl Maria von Weber - Perpetuum Mobile (Gekido-) \[Nivrad00's Virtuoso\]](http://osu.ppy.sh/b/1185947&m=3)
+  - [Helblinde - Memoria Reborn (sankansuki) \[Reincarnation\]](http://osu.ppy.sh/b/982489&m=3)
+  - [Camellia - Dans la mer de son (Jinjin) \[Calm Before the Storm\]](http://osu.ppy.sh/b/1178316&m=3)
+  - [hino isuika - Dreamin' attraction!!(Extended) (qodtjr) \[CRASH KBD\]](http://osu.ppy.sh/b/1099040&m=3)
+  - [xi - PEACE BREAKER (Evening) \[Marathon/Fallout.\]](http://osu.ppy.sh/b/837107&m=3)
 - Tiebreaker
-  - [niki feat. Reol - WAVE (KafuuChino) \[WAVE\]](http://osu.ppy.sh/b/1017922&m=3) 
+  - [Camellia - Fastest Crash (Gekido-) \[Fastest\]](http://osu.ppy.sh/b/767979&m=3)
 
 ### Semifinals
 
 **[Download the mappack here! (99 MB)](http://www.mediafire.com/file/ko6380yoov9455x/MWC7K_2017_Semifinals.rar)**
 
 - FreeMod
-  - [Pegboard Nerds - Swamp Thing (Da Tweekaz Edit) (Evening) \[Expert\]](http://osu.ppy.sh/b/1042544&m=3) 
-  - [HHHxMMxST - oboro (Yooh) \[Hisoka\]](http://osu.ppy.sh/b/519264&m=3) 
-  - [DJ MRYM - Monotune \~Respect\~ (Pope Gadget) \[whasgoinon\]](http://osu.ppy.sh/b/1082251&m=3) 
-  - [orangentle / Yu_Asahina - HAELEQUINZ -the clown of 24stairs- (AncuL) \[Black Another\]](http://osu.ppy.sh/b/909107&m=3) 
-  - [sun3 - Morgenglut 2012 (arcwinolivirus) \[7K 'Morgen Mugen' Arc\]](http://osu.ppy.sh/b/1083582&m=3) 
-  - [goreshit - o'er the flood (Blocko) \[torrent\]](http://osu.ppy.sh/b/974969&m=3) 
-  - [Miku (Vocal by Nobunaga) - Shinkai Shoujou (Cuppp) \[SHD\]](http://osu.ppy.sh/b/368423&m=3) 
-  - [DJ Sharpnel - Tactical railroad (qodtjr) \[Destruction\]](http://osu.ppy.sh/b/1072967&m=3) 
-  - [Nero's Day At Disneyland - No Money Down, Low Monthly Payments (Ciel) \[Tick Tock\]](http://osu.ppy.sh/b/1165581&m=3) 
-  - [yuikonnu - Chikyuu Saigo no Kokuhaku wo (Zenonia) \[ZenoCORE!\]](http://osu.ppy.sh/b/580759&m=3) 
-  - [Forte Escape remixed by gmtn. - Extreme Z4 (Agressive HC mix) (spoonguy) \[sp5\]](http://osu.ppy.sh/b/1015428&m=3) 
-  - [sky-fi - sakura sweets (keii bootleg) (Agka) \[Sweet\]](http://osu.ppy.sh/b/725614&m=3) 
-  - [Tool - Right in Two (Pope Gadget) \[The Chasm\]](http://osu.ppy.sh/b/1157119&m=3) 
-  - [Yuikonnu & Ayaponzu - Kimi to watashi no hitorigoto (\_S h i r o\_) \[Relax\]](http://osu.ppy.sh/b/895160&m=3) 
+  - [Pegboard Nerds - Swamp Thing (Da Tweekaz Edit) (Evening) \[Expert\]](http://osu.ppy.sh/b/1042544&m=3)
+  - [HHHxMMxST - oboro (Yooh) \[Hisoka\]](http://osu.ppy.sh/b/519264&m=3)
+  - [DJ MRYM - Monotune \~Respect\~ (Pope Gadget) \[whasgoinon\]](http://osu.ppy.sh/b/1082251&m=3)
+  - [orangentle / Yu_Asahina - HAELEQUINZ -the clown of 24stairs- (AncuL) \[Black Another\]](http://osu.ppy.sh/b/909107&m=3)
+  - [sun3 - Morgenglut 2012 (arcwinolivirus) \[7K 'Morgen Mugen' Arc\]](http://osu.ppy.sh/b/1083582&m=3)
+  - [goreshit - o'er the flood (Blocko) \[torrent\]](http://osu.ppy.sh/b/974969&m=3)
+  - [Miku (Vocal by Nobunaga) - Shinkai Shoujou (Cuppp) \[SHD\]](http://osu.ppy.sh/b/368423&m=3)
+  - [DJ Sharpnel - Tactical railroad (qodtjr) \[Destruction\]](http://osu.ppy.sh/b/1072967&m=3)
+  - [Nero's Day At Disneyland - No Money Down, Low Monthly Payments (Ciel) \[Tick Tock\]](http://osu.ppy.sh/b/1165581&m=3)
+  - [yuikonnu - Chikyuu Saigo no Kokuhaku wo (Zenonia) \[ZenoCORE!\]](http://osu.ppy.sh/b/580759&m=3)
+  - [Forte Escape remixed by gmtn. - Extreme Z4 (Agressive HC mix) (spoonguy) \[sp5\]](http://osu.ppy.sh/b/1015428&m=3)
+  - [sky-fi - sakura sweets (keii bootleg) (Agka) \[Sweet\]](http://osu.ppy.sh/b/725614&m=3)
+  - [Tool - Right in Two (Pope Gadget) \[The Chasm\]](http://osu.ppy.sh/b/1157119&m=3)
+  - [Yuikonnu & Ayaponzu - Kimi to watashi no hitorigoto (\_S h i r o\_) \[Relax\]](http://osu.ppy.sh/b/895160&m=3)
 - Tiebreaker
-  - [Camellia - Glitch Nerds (Evening) \[overloaded\_.\]](http://osu.ppy.sh/b/991010&m=3) 
+  - [Camellia - Glitch Nerds (Evening) \[overloaded\_.\]](http://osu.ppy.sh/b/991010&m=3)
 
-### Finals
+### Quarterfinals
 
-**This mappool will be used in Finals - Week 1 and Finals - Week 2**
-
-**[Download the mappack here! (124 MB)](http://www.mediafire.com/file/6xjcb99fb7z1vrz/MWC_7K_2017_Finals.rar)**
+**[Download the mappack here! (61 MB)](http://www.mediafire.com/file/19768v0uxatm433/MWC_7K_2017_Quarterfinals.rar)**
 
 - FreeMod
-  - [Alon Mor - Demons (-Kamikaze-) \[Evening's ritual (preview)\]](http://osu.ppy.sh/b/1188811&m=3) 
-  - [uma vs. Morimori Atsushi - Re End of a Dream (qodtjr) \[Dreaming of square\]](http://osu.ppy.sh/b/1104259&m=3) 
-  - [Suzumu - Kakumeisei ousama densenbyou (Zenonia) \[ZenoCORE!\]](http://osu.ppy.sh/b/993185&m=3) 
-  - [Blitz Lunar - Mathsma Attack (Blocko) \[Shockwave\]](http://osu.ppy.sh/b/1060566&m=3) 
-  - [Falcom Sound Team jdk - SILENT DESERT (Evening) \[BEGINNING\]](http://osu.ppy.sh/b/1146187&m=3) 
-  - [The Algorithm - floating point (Drumcorps Remix) (\_underjoy) \[Approximation\]](http://osu.ppy.sh/b/1154859&m=3) 
-  - [EZFG - cloud (Ciel) \[High (nerfed)\]](http://osu.ppy.sh/b/1178427&m=3) 
-  - [xi - Angelic Party (Jinjin) \[Evening & Jinjin's Collaborative Party!\]](http://osu.ppy.sh/b/1185659&m=3) 
-  - [Demetori - Wind God Girl (TBSM) \[BMS 21\]](http://osu.ppy.sh/b/766085&m=3) 
-  - [Sakuzyo - Imprinting (Zenonia) \[Impression\]](http://osu.ppy.sh/b/908448&m=3) 
-  - [Carl Maria von Weber - Perpetuum Mobile (Gekido-) \[Nivrad00's Virtuoso\]](http://osu.ppy.sh/b/1185947&m=3) 
-  - [Helblinde - Memoria Reborn (sankansuki) \[Reincarnation\]](http://osu.ppy.sh/b/982489&m=3) 
-  - [Camellia - Dans la mer de son (Jinjin) \[Calm Before the Storm\]](http://osu.ppy.sh/b/1178316&m=3) 
-  - [hino isuika - Dreamin' attraction!!(Extended) (qodtjr) \[CRASH KBD\]](http://osu.ppy.sh/b/1099040&m=3) 
-  - [xi - PEACE BREAKER (Evening) \[Marathon/Fallout.\]](http://osu.ppy.sh/b/837107&m=3) 
+  - [Rob Zombie - What Lurks on Channel X? (Pope Gadget) \[VII\]](http://osu.ppy.sh/b/1150224&m=3)
+  - [SHK - Milky Way (ExPew) \[SC\]](http://osu.ppy.sh/b/305675&m=3)
+  - [xi - Hesperides (ExKagii-) \[Another\]](http://osu.ppy.sh/b/1035076&m=3)
+  - [S.I.D Sound - Pink Gold (Reikosaka) \[Happiness\]](http://osu.ppy.sh/b/525686&m=3)
+  - [STN - The Limbo (Alumetorz) \[Rumi's MX\]](http://osu.ppy.sh/b/405715&m=3)
+  - [DJ SHIMAMURA - Move Real Slow (Agka) \[Slow\]](http://osu.ppy.sh/b/412973&m=3)
+  - [TAG - Romancing Layer (\_S u w a k o\_) \[Lv.34\]](http://osu.ppy.sh/b/543414&m=3)
+  - [Nakamura Meiko - reverb (richardfeder) \[Another\]](http://osu.ppy.sh/b/509575&m=3)
+  - [YUZU - Hyori Ittai (ArcherLove) \[Lv.25\]](http://osu.ppy.sh/b/516758&m=3)
+  - [LeaF - Doppelganger (Jinjin) \[Zen's Insane\]](http://osu.ppy.sh/b/1025646&m=3)
+  - [Shibayan - X-D-A-T (Jole) \[Lv.12 Another\]](http://osu.ppy.sh/b/440089&m=3)
+  - [Iced Blade - Sora no Senritsu -the melody of the cosmos- feat.lily-an (OP Cut) (arcwinolivirus) \[7K Awakened\]](http://osu.ppy.sh/b/941427&m=3)
+  - [M2U - Promise (Jinjin) \[Yaksok\]](http://osu.ppy.sh/b/869223&m=3)
 - Tiebreaker
-  - [Camellia - Fastest Crash (Gekido-) \[Fastest\]](http://osu.ppy.sh/b/767979&m=3) 
-  
+  - [niki feat. Reol - WAVE (KafuuChino) \[WAVE\]](http://osu.ppy.sh/b/1017922&m=3)
+
+### Group Stage
+
+**[Download the mappack here! (88 MB)](http://www.mediafire.com/file/zztlm72z3ngh1ha/MWC_7K_2017_Group_Stage.rar)**
+
+- FreeMod
+  - [WALKUERE - Ikenai Borderline (SanadaYukimura) \[Emiria's 7K G\]](http://osu.ppy.sh/b/1030861&m=3)
+  - [The Flashbulb - Who You Evidently Thought Was Me (-Kamikaze-) \[Pope's Anfractuous Derivative\]](http://osu.ppy.sh/b/1158709&m=3)
+  - [penoreri - Everlasting Message (Julie) \[EXHAUST\]](http://osu.ppy.sh/b/687322&m=3)
+  - [Sawano Hiroyuki - Blowin' (ArcherLove) \[Hard\]](http://osu.ppy.sh/b/426032&m=3)
+  - [Ayana - freak of nature: start (richardfeder) \[Freak Out\]](http://osu.ppy.sh/b/362574&m=3)
+  - [Sasaki Sayaka - My Dear Girl (short Ver) (shionelove) \[yoshilove's 7K HD\]](http://osu.ppy.sh/b/787134&m=3)
+  - [Helblinde - Above the Clouds (Level 51) \[Hymn\]](http://osu.ppy.sh/b/1074573&m=3)
+  - [KANON NAKAGAWA starring Nao Toyama - Natsuiro Surprise (HanzeR) \[Insane\]](http://osu.ppy.sh/b/255968&m=3)
+  - [Tsukasa Yatoki - 2A-Attack (Reikosaka) \[Maximum\]](http://osu.ppy.sh/b/359560&m=3)
+  - [Hatsuki Yura - Izayoi Warabeuta (Elementaires) \[HD\]](http://osu.ppy.sh/b/712126&m=3)
+  - [Toni Leys - Dragon Valley (Toni Leys Remix feat. Esteban Bellucci) (LordRaika) \[Insane\]](http://osu.ppy.sh/b/841216&m=3)
+  - [Misawa Sachika - Links (TV Size) (17VA) \[MX\]](http://osu.ppy.sh/b/320510&m=3)
+  - [Junk - Aihana (Love+ Edit) (richardfeder) \[S.Star's Another\]](http://osu.ppy.sh/b/468795&m=3)
+- Tiebreaker
+  - [Nhato - Magic (Tear) \[Enchanted\]](http://osu.ppy.sh/b/427993&m=3)
+
 ------------------------------------------------------------------------
 
 ## Match Results
 
 ### Grand Finals
 
-| Sunday, 12. February 2017 | | | | |
+| 2017-02-12 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | **7** | 1 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/31033827) |
+| **South Korea** ![][flag_KR] | **7** | 1 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/31033827) |
 
-### Finals: Week 1
+### Finals
 
-| Saturday, 4. February 2017 | | | | |
+| 2017-02-04 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| United States ![][flag_US] | 2 | **6** | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/30827217) |
-| China ![][flag_CN] | 0 | **6** | ![][flag_KR] South Korea | -win by default- |
-| Thailand ![][flag_TH] | 4 | **6** | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/30830208) |
+| United States ![][flag_US] | 2 | **6** | ![][flag_ID] **Indonesia**   | [#1](https://osu.ppy.sh/community/matches/30827217) |
+| China ![][flag_CN]         | 0 | **6** | ![][flag_KR] **South Korea** | -Win by default- |
+| Thailand ![][flag_TH]      | 4 | **6** | ![][flag_PH] **Philippines** | [#1](https://osu.ppy.sh/community/matches/30830208) |
 
-| Sunday, 5. February 2017 | | | | |
+| 2017-02-05 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Indonesia ![][flag_ID] | **6** | 0 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/30858348) |
-| China ![][flag_CN] | **6** | 0 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/30861745) |
+| **Indonesia** ![][flag_ID] | **6** | 0 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/30858348) |
+| **China** ![][flag_CN]     | **6** | 0 | ![][flag_ID] Indonesia   | [#1](https://osu.ppy.sh/community/matches/30861745) |
 
 ### Semifinals
 
-| Saturday, 29. January 2017 | | | | |
+| 2017-01-29 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Indonesia ![][flag_ID] | 0 | **6** | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/30699733) |
-| Philippines ![][flag_PH] | 0 | **6** | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/30701653) |
-| Chile ![][flag_CL] | 0 | **6** | ![][flag_TH] Thailand | -win by default- |
-| United States ![][flag_US] | **6** | 0 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/30705988) |
+| Indonesia ![][flag_ID]         | 0 | **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/30699733) |
+| Philippines ![][flag_PH]       | 0 | **6** | ![][flag_CN] **China**       | [#1](https://osu.ppy.sh/community/matches/30701653) |
+| Chile ![][flag_CL]             | 0 | **6** | ![][flag_TH] **Thailand**    | -Win by default- |
+| **United States** ![][flag_US] | **6** | 0 | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/30705988) |
 
 ### Quarterfinals
 
-| Saturday, 21. January 2017 | | | | |
+| 2017-01-21 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | **5** | 0 | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/30507247) |
-| China ![][flag_CN] | **5** | 0 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/30508461) |
-| Chile ![][flag_CL] | 2 | **5** | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/30510203) |
-| United States ![][flag_US] | 2 | **5** | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/30510203) |
+| **South Korea** ![][flag_KR]   | **5** | 0 | ![][flag_TH] Thailand        | [#1](https://osu.ppy.sh/community/matches/30507247) |
+| **China** ![][flag_CN]         | **5** | 0 | ![][flag_FR] France          | [#1](https://osu.ppy.sh/community/matches/30508461) |
+| Chile ![][flag_CL]             | 2 | **5** | ![][flag_ID] **Indonesia**   | [#1](https://osu.ppy.sh/community/matches/30510203) |
+| United States ![][flag_US]     | 2 | **5** | ![][flag_PH] **Philippines** | [#1](https://osu.ppy.sh/community/matches/30510203) |
 
 ### Group Stage
 
-| Saturday, 14. January 2017 | | | | |
+| 2017-01-14 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Indonesia ![][flag_ID] | 1 | **5** | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/30338922) |
-| Philippines ![][flag_PH] | 0 | **5** | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/30338925) |
-| Australia ![][flag_AU] | 0 | **5** | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/30338930) |
-| Russian Federation ![][flag_RU] | **5** | 2 | ![][flag_AU] Australia | [#1](https://osu.ppy.sh/community/matches/30340143) |
-| France ![][flag_FR] | **5** | 1 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/30340147) |
-| United Kingdom ![][flag_GB] | 0 | **5** | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/30340152) |
-| Philippines ![][flag_PH] | **5** | 2 | ![][flag_SG] Singapore | [#1](https://osu.ppy.sh/community/matches/30340157) |
-| Malaysia ![][flag_MY] | **5** | 3 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/30341742) |
-| Argentina ![][flag_AR] | 0 | **5** | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/30341746) |
-| Singapore ![][flag_SG] | 1 | **5** | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/30341751) |
-| France ![][flag_FR] | 1 | **5** | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/30348053) |
-| Russian Federation ![][flag_RU] | 2 | **5** | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/30348061) |
-| Chile ![][flag_CL] | 4 | **5** | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/30350044) |
+| Indonesia ![][flag_ID]              | 1 | **5** | ![][flag_CN] **China**         | [#1](https://osu.ppy.sh/community/matches/30338922) |
+| Philippines ![][flag_PH]            | 0 | **5** | ![][flag_KR] **South Korea**   | [#1](https://osu.ppy.sh/community/matches/30338925) |
+| Australia ![][flag_AU]              | 0 | **5** | ![][flag_TH] **Thailand**      | [#1](https://osu.ppy.sh/community/matches/30338930) |
+| **Russian Federation** ![][flag_RU] | **5** | 2 | ![][flag_AU] Australia         | [#1](https://osu.ppy.sh/community/matches/30340143) |
+| **France** ![][flag_FR]             | **5** | 1 | ![][flag_MY] Malaysia          | [#1](https://osu.ppy.sh/community/matches/30340147) |
+| United Kingdom ![][flag_GB]         | 0 | **5** | ![][flag_KR] **South Korea**   | [#1](https://osu.ppy.sh/community/matches/30340152) |
+| **Philippines** ![][flag_PH]        | **5** | 2 | ![][flag_SG] Singapore         | [#1](https://osu.ppy.sh/community/matches/30340157) |
+| **Malaysia** ![][flag_MY]           | **5** | 3 | ![][flag_BR] Brazil            | [#1](https://osu.ppy.sh/community/matches/30341742) |
+| Argentina ![][flag_AR]              | 0 | **5** | ![][flag_CN] **China**         | [#1](https://osu.ppy.sh/community/matches/30341746) |
+| Singapore ![][flag_SG]              | 1 | **5** | ![][flag_KR] **South Korea**   | [#1](https://osu.ppy.sh/community/matches/30341751) |
+| France ![][flag_FR]                 | 1 | **5** | ![][flag_CL] **Chile**         | [#1](https://osu.ppy.sh/community/matches/30348053) |
+| Russian Federation ![][flag_RU]     | 2 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/30348061) |
+| Chile ![][flag_CL]                  | 4 | **5** | ![][flag_BR] **Brazil**        | [#1](https://osu.ppy.sh/community/matches/30350044) |
 
-| Sunday, 15. January 2017 | | | | |
+| 2017-01-15 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Australia ![][flag_AU] | 0 | **5** | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/30362455) |
-| United States ![][flag_US] | **5** | 1 | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/30363554) |
-| Russian Federation ![][flag_RU] | 1 | **5** | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/30373030) |
-| Argentina ![][flag_AR] | 1 | **5** | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/30373052) |
-| Poland ![][flag_PL] | 1 | **5** | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/30373084) |
-| United Kingdom ![][flag_GB] | 0 | **5** | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/30373170) |
-| Poland ![][flag_PL] | 2 | **5** | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/30374278) |
-| Malaysia ![][flag_MY] | 0 | **5** | ![][flag_CL] Chile  | -win by default- |
-| United Kingdom ![][flag_GB] | **5** | 0 | ![][flag_SG] Singapore | -win by default- |
-| France ![][flag_FR] | **5** | 2 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/30375970) |
-| Argentina ![][flag_AR] | 0 | **5** | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/30375979) |
+| Australia ![][flag_AU]              | 0 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/30362455) |
+| **United States** ![][flag_US]      | **5** | 1 | ![][flag_TH] Thailand          | [#1](https://osu.ppy.sh/community/matches/30363554) |
+| Russian Federation ![][flag_RU]     | 1 | **5** | ![][flag_TH] **Thailand**      | [#1](https://osu.ppy.sh/community/matches/30373030) |
+| Argentina ![][flag_AR]              | 1 | **5** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/30373052) |
+| Poland ![][flag_PL]                 | 1 | **5** | ![][flag_CN] **China**         | [#1](https://osu.ppy.sh/community/matches/30373084) |
+| United Kingdom ![][flag_GB]         | 0 | **5** | ![][flag_PH] **Philippines**   | [#1](https://osu.ppy.sh/community/matches/30373170) |
+| Poland ![][flag_PL]                 | 2 | **5** | ![][flag_ID] **Indonesia**     | [#1](https://osu.ppy.sh/community/matches/30374278) |
+| Malaysia ![][flag_MY]               | 0 | **5** | ![][flag_CL] **Chile**         | -Win by default- |
+| **United Kingdom** ![][flag_GB]     | **5** | 0 | ![][flag_SG] Singapore         | -Win by default- |
+| **France** ![][flag_FR]             | **5** | 2 | ![][flag_BR] Brazil            | [#1](https://osu.ppy.sh/community/matches/30375970) |
+| Argentina ![][flag_AR]              | 0 | **5** | ![][flag_PL] **Poland**        | [#1](https://osu.ppy.sh/community/matches/30375979) |
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

Updates, cleans and fixes the MWC 2015, MWC 2017 4K and 7K articles

### Status

Finished; Pending Review

### Changelog

- Changing date format
- Editing table format for participants
- Changing order of mappools and results from more recent to oldest
- Editing and fixing results tables
- Changing links to follow the ASC
- Marking MWC 4K 2017 FR translation as outdated.

### Related Issues 

Related to #350 
