### PR TITLE
History of osu!: additions to April in 2013 and add January section in 2018

### DIFF
--- a/wiki/History_of_osu!/2013/en.md
+++ b/wiki/History_of_osu!/2013/en.md
@@ -39,12 +39,13 @@ Links:
 
 ## April
 
-This month's updates were mostly made up of patching up the previous major update, but that doesn't mean that was the end! First, it was the initial implementation of "Collections" support that will replace the long-standing "Favourites A/B", making it simple for player to put in their favourite beatmaps in one "Collections" and able to share it with others by transferring the "Collections" rather than "Favourites A/B". Game modes can now be easily switched at song selection by using `Ctrl` + `1`, `2`, `3`, or `4`. A new game modifier was added specially for osu!mania, [Random](/wiki/RD). Some adjustment has been made on Multi's "Quick Join" button behaviour to direct you to a room with respect to your average pp against the room pp's deviation. For beatmap replays, stale-standing comment has been switched to moving [nico-style](http://en.wikipedia.org/wiki/Nico_Nico_Douga) comment style and comment colour can now be customised (for osu!supporters only). In the beatmapping side, all MAT members have became BAT members and MAT has been officially dissolved as the power boundary between MAT and BAT members were too close to each other.
+This month's updates were mostly made up of patching up the previous major update, but that doesn't mean that was the end! First, it was the initial implementation of "Collections" support that will replace the long-standing "Favourites A/B", making it simple for player to put in their favourite beatmaps in one "Collections" and able to share it with others by transferring the "Collections" rather than "Favourites A/B". Game modes can now be easily switched at song selection by using `Ctrl` + `1`, `2`, `3`, or `4`. A new game modifier was added specially for osu!mania, [Random](/wiki/RD). Some adjustment has been made on Multi's "Quick Join" button behaviour to direct you to a room with respect to your average pp against the room pp's deviation. For beatmap replays, stale-standing comment has been switched to moving [nico-style](http://en.wikipedia.org/wiki/Nico_Nico_Douga) comment style and comment colour can now be customised (for osu!supporters only). In the beatmapping side, all MAT members have became BAT members and MAT has been officially dissolved as the power boundary between MAT and BAT members were too close to each other. peppy released one of the initial osu! builds from 2007 to 2009 (the one he had hoped to release for the 5th anniversary of osu!).
 
 Links:
 
 - [This week (month) in osu! – ppy blog](https://blog.ppy.sh/post/46924535831/this-week-month-in-osu-13)
 - [The end of the MAT](https://osu.ppy.sh/forum/t/129165)
+- [osu! Public Release (2007-09)](https://osu.ppy.sh/forum/t/130144)
 
 ## May
 

--- a/wiki/History_of_osu!/2013/en.md
+++ b/wiki/History_of_osu!/2013/en.md
@@ -15,7 +15,13 @@ Links:
 
 ## February
 
-A new version of the osu!mania editor was being worked on. Taiko mode skinning now has a "metadata" bar (song title and artist below the playfield), taiko playfield was no longer transparent and fades in and out of kiai time. The original [FAQ](http://osu.ppy.sh/p/faq) has been superseded by the [osu!wiki](/wiki/FAQ). BanchoBot's `!faq` command has been open to public for [translation](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdHhUUjNSa19QendtcTdYUjE2S2hnVHc#gid=24). The legendary [BanchoBot](/wiki/BanchoBot) finally has a [profile](/u/3)! The user panels display now adjusts to display four columns on all widescreen modes. osu!mania now support vertical flip (upside-down), making gameplay similar to that of DDR/o2jam. Skinning now supports double-resolution sprites when the window width was greater than 1600 pixels. To add support to a skin, add images with double the width/height containing the `@2x` suffix before the file extension (eg: `cursor@2x.png`). Ranking support for [Hidden](/wiki/HD) and [FadeIn](/wiki/FI) mods in osu!mania and lastly, less widescreen limitations in the editor when it comes to placement and selection.
+A new version of the osu!mania editor was being worked on. Taiko mode skinning now has a "metadata" bar (song title and artist below the playfield), taiko playfield was no longer transparent and fades in and out of kiai time. The original [FAQ](http://osu.ppy.sh/p/faq) has been superseded by the [osu!wiki](/wiki/FAQ).
+
+BanchoBot's `!faq` command has been open to public for [translation](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdHhUUjNSa19QendtcTdYUjE2S2hnVHc#gid=24). The legendary [BanchoBot](/wiki/BanchoBot) finally has a [profile](/users/3)! The user panels display now adjusts to display four columns on all widescreen modes.
+
+osu!mania now support vertical flip (upside-down), making gameplay similar to that of DDR/o2jam. Skinning now supports double-resolution sprites when the window width was greater than 1600 pixels. To add support to a skin, add images with double the width/height containing the `@2x` suffix before the file extension (eg: `cursor@2x.png`).
+
+Ranking support for [Hidden](/wiki/HD) and [FadeIn](/wiki/FI) mods in osu!mania and lastly, less widescreen limitations in the editor when it comes to placement and selection.
 
 Links:
 
@@ -26,9 +32,15 @@ Links:
 
 ## March
 
-osu! received a complete overhaul of the UI (User Interface)! osu!standard received a new leitmotif symbol (previously, it was a circle with "osu!", was now a circle with a "1"). Buttons on the editor has been updated. Special mode has been combined with Song Selection menu (named under "Mods"), allowing players to switch modes quicker and hassle-free. All [Game Modifiers](/wiki/Game_Modifiers) buttons received their respective image overhaul. The result screen now shows the beatmap's background image rather than user skin's result background. Hit-Offset can now be known by hovering to the Accuracy from the result screen. Do note that it will disappear and can't be saved. Online Results was now hidden below the result screen rather than forcing you to see it. You can scroll down to see or you can just click the button and you will be directed to the Online Results screen. In terms of skin, "osu!default by peppy" was replaced by "osu! by peppy" (art by [RBRat3](/u/RBRat3)). Since osu! now can support both widescreen HD and standard size, a new button was added to the "Skins" tab under "Options". By default, old skin behaviour was used for compatibility and enabling the button will force the new skin behaviour to be in effect instead. [Combo fire](/wiki/Combo_fire) was removed due to performance concerns. At the Multi side, hosts have a new special command called "Free Mods" and the "Game Style" was removed (Host can adjust the Game Style in Song Selection now under "Mods"). `#userlog` was introduced to showcase your recent playing achievement privately.
+osu! received a complete overhaul of the UI (User Interface)! osu!standard received a new leitmotif symbol (previously, it was a circle with "osu!", was now a circle with a "1"). Buttons on the editor has been updated. Special mode has been combined with Song Selection menu (named under "Mods"), allowing players to switch modes quicker and hassle-free. All [Game Modifiers](/wiki/Game_Modifiers) buttons received their respective image overhaul. The result screen now shows the beatmap's background image rather than user skin's result background.
 
-Ranking scoreboard, on the other hand, received two revisions in a single month. The first revision was "unified scoreboards", where the scoreboard the separated into four parts (Mods, Friends, Personal Best, Local) with score difference given below the accuracy of the layer, the removal of local scoreboard and the inability to scroll to see more of the later Top score players. Despite it was limited to osu!supporters only, it received much criticism and as such, a second revision has been issued at the near end of the month. The scoreboard was basically revered back to how it was previously, keeping the score difference gap. The prominent addition was the tabbed drop-down menu, where it house various types of ranking scoreboard. However, the new types of scoreboard \[Country, Global (Selected Mod), and Friend\] were still limited to osu!supporters only. Lastly, player's profile picture has been added beside the grade mark of their place in the ranking scoreboard. When hovered to the tab, the placement can be known as the profile picture was darken to show the placement number. Please note that this simple addition does not affect Local scoreboard in any way, as it will most likely to be flooded with your own play results with minimum to no intrusion from other players (unless the beatmap was received from other players in folder form).
+Hit-Offset can now be known by hovering to the Accuracy from the result screen. Do note that it will disappear and can't be saved. Online Results was now hidden below the result screen rather than forcing you to see it. You can scroll down to see or you can just click the button and you will be directed to the Online Results screen.
+
+In terms of skin, "osu!default by peppy" was replaced by "osu! by peppy" (art by [RBRat3](/users/307202)). Since osu! now can support both widescreen HD and standard size, a new button was added to the "Skins" tab under "Options". By default, old skin behaviour was used for compatibility and enabling the button will force the new skin behaviour to be in effect instead. [Combo fire](/wiki/Combo_fire) was removed due to performance concerns. At the Multi side, hosts have a new special command called "Free Mods" and the "Game Style" was removed (Host can adjust the Game Style in Song Selection now under "Mods"). `#userlog` was introduced to showcase your recent playing achievement privately.
+
+Ranking scoreboard, on the other hand, received two revisions in a single month. The first revision was "unified scoreboards", where the scoreboard the separated into four parts (Mods, Friends, Personal Best, Local) with score difference given below the accuracy of the layer, the removal of local scoreboard and the inability to scroll to see more of the later Top score players. Despite it was limited to osu!supporters only, it received much criticism and as such, a second revision has been issued at the near end of the month. The scoreboard was basically revered back to how it was previously, keeping the score difference gap. The prominent addition was the tabbed drop-down menu, where it house various types of ranking scoreboard. However, the new types of scoreboard \[Country, Global (Selected Mod), and Friend\] were still limited to osu!supporters only.
+
+Lastly, player's profile picture has been added beside the grade mark of their place in the ranking scoreboard. When hovered to the tab, the placement can be known as the profile picture was darken to show the placement number. Please note that this simple addition does not affect Local scoreboard in any way, as it will most likely to be flooded with your own play results with minimum to no intrusion from other players (unless the beatmap was received from other players in folder form).
 
 Links:
 
@@ -39,24 +51,46 @@ Links:
 
 ## April
 
-This month's updates were mostly made up of patching up the previous major update, but that doesn't mean that was the end! First, it was the initial implementation of "Collections" support that will replace the long-standing "Favourites A/B", making it simple for player to put in their favourite beatmaps in one "Collections" and able to share it with others by transferring the "Collections" rather than "Favourites A/B". Game modes can now be easily switched at song selection by using `Ctrl` + `1`, `2`, `3`, or `4`. A new game modifier was added specially for osu!mania, [Random](/wiki/RD). Some adjustment has been made on Multi's "Quick Join" button behaviour to direct you to a room with respect to your average pp against the room pp's deviation. For beatmap replays, stale-standing comment has been switched to moving [nico-style](http://en.wikipedia.org/wiki/Nico_Nico_Douga) comment style and comment colour can now be customised (for osu!supporters only). In the beatmapping side, all MAT members have became BAT members and MAT has been officially dissolved as the power boundary between MAT and BAT members were too close to each other. peppy released one of the initial osu! builds from 2007 to 2009 (the one he had hoped to release for the 5th anniversary of osu!).
+This month's updates were mostly made up of patching up the previous major update, but that doesn't mean that was the end! First, it was the initial implementation of "Collections" support that will replace the long-standing "Favourites A/B", making it simple for player to put in their favourite beatmaps in one "Collections" and able to share it with others by transferring the "Collections" rather than "Favourites A/B".
+
+Game modes can now be easily switched at song selection by using `Ctrl` + `1`, `2`, `3`, or `4`. A new game modifier was added specially for osu!mania, [Random](/wiki/RD). Some adjustment has been made on Multi's "Quick Join" button behaviour to direct you to a room with respect to your average pp against the room pp's deviation.
+
+For beatmap replays, stale-standing comment has been switched to moving [nico-style](http://en.wikipedia.org/wiki/Nico_Nico_Douga) comment style and comment colour can now be customised (for osu!supporters only).
+
+In the beatmapping side of things, all MAT members became BAT members as MAT has been officially dissolved since the power boundary between MAT and BAT members were too close to each other.
+
+peppy released one of the initial osu! builds from 2007 to 2009 (the one he had hoped to release for the 5th anniversary of osu!).
 
 Links:
 
 - [This week (month) in osu! – ppy blog](https://blog.ppy.sh/post/46924535831/this-week-month-in-osu-13)
-- [The end of the MAT](https://osu.ppy.sh/forum/t/129165)
-- [osu! Public Release (2007-09)](https://osu.ppy.sh/forum/t/130144)
+- [The end of the MAT](/community/forums/topics/129165)
+- [osu! Public Release (2007-09)](/community/forums/topics/130144)
 
 ## May
 
-Game modifiers naming in results has been shorten (e.g. "Hard Rock" to "HR") to decease the limited space usage. *Most* of the broken replays in the past have been fixed. A new spectator system where you can follow the spectator target if they were spectating someone else. The update system has been reworked, most notably it will no longer force restarts unless required. During replays, half-speed replay has been added (after pressing `2x` Speed, it will show `0.5x` Speed). The playfield will not flash out the background at 100% dim. [Catch the Beat](/wiki/Catch the Beat) received joystick support (Up/Down: change song, Right: select, Left: exit). [A new ranking/modding system is in development](https://osu.ppy.sh/forum/t/129625) (will replace the ancient forum-styled modding threads). For Multi mode, players can now use Special mod (Relax/Autopilot/SpunOut/ManiaKeys) when Free Mod is enabled by the host. At the skinning side of things, widescreen taiko (taiko `@2x`) default sprites have been added. Favourite A/B have removed completely and superseded by the Collections. Three brand new Dedication [achievements](/wiki/achievements) for osu!mania have been released (40,000 / 400,000 / 4,000,000 keys pressed). User profile design has been reworked and your "last visit" will be based on connection to Bancho (that was, in-game login) rather than visits to the forum. Finally, osu! hit the milestone of having 10,000 users connected simultaneously!
+Game modifiers naming in results has been shorten (e.g. "Hard Rock" to "HR") to decease the limited space usage. *Most* of the broken replays in the past have been fixed. A new spectator system where you can follow the spectator target if they were spectating someone else. The update system has been reworked, most notably it will no longer force restarts unless required.
 
-- [osu! Public Release (b20130509)](https://osu.ppy.sh/forum/t/131611)
+During replays, half-speed replay has been added (after pressing `2x` Speed, it will show `0.5x` Speed). The playfield will not flash out the background at 100% dim. [Catch the Beat](/wiki/Catch_the_Beat) received joystick support (Up/Down: change song, Right: select, Left: exit).
+
+[A new ranking/modding system is in development](/community/forums/topics/129625) which will replace the ancient forum-styled modding threads.
+
+For Multi mode, players can now use Special mod (Relax/Autopilot/SpunOut/ManiaKeys) when Free Mod is enabled by the host. At the skinning side of things, widescreen taiko (taiko `@2x`) default sprites have been added. Favourite A/B have removed completely and superseded by the Collections.
+
+Three brand new Dedication [achievements](/wiki/achievements) for osu!mania have been released (40,000 / 400,000 / 4,000,000 keys pressed). User profile design has been reworked and your "last visit" will be based on connection to Bancho (that was, in-game login) rather than visits to the forum. Finally, osu! hit the milestone of having 10,000 users connected simultaneously!
+
+- [osu! Public Release (b20130509)](/community/forums/topics/131611)
 - [May 2013 Highlights + Map of the Month](https://osu.ppy.sh/forum/p/2334705)
 
 ## June
 
-[osu! Beatmapping Contest \#4](https://osu.ppy.sh/forum/p/2324098) has started and will end at 2013-07-01. As a counter-measure against players creating lots of accounts, clarity of messaging during account registration was improved and infographic showing that you can't register from phones/tablets has been added to prevent players creating more accounts for personal reasons. Away with the security measures, users allowed to choose which game mode their profile defaults to (such as [osu!mania](/wiki/osu!mania), [Taiko](/wiki/Taiko)) and [last.fm](http://www.last.fm/) support to profiles. User profiles now have country performance rank on their profile and a new pp graph. In-game wise, the main menu gets a new visualisation, with a blazing flare around the osu! symbol dependent on intensity of currently playing song's BPM. Performance have been optimised in song selection with many (more than ten-thousand) maps. Update process robustness and performance have been improved. Gameplay-wise, lead-in time was automatically add to any beatmaps which start abruptly to allow enough time to adjust [Visual Settings](/wiki/Visual_Settings) and total press counts for each key on the input overlay was added. For online results storages, personal best rank was show on beatmap info pages besides the \#1 player. Score submission from mania charts was allowed and Top 50 replays was stored rather than the usual Top 40. Quick repeat sliders not reaching their maximum combo has been fixed. Disqus comments added to beatmap pages. Finally, prototype testing of score meter for all modes was underway for osu!test.
+[osu! Beatmapping Contest \#4](https://osu.ppy.sh/forum/p/2324098) has started. As a counter-measure against players creating lots of accounts, clarity of messaging during account registration was improved and infographic showing that you can't register from phones/tablets has been added to prevent players creating more accounts for personal reasons.
+
+Away with the security measures, users allowed to choose which game mode their profile defaults to (such as [osu!mania](/wiki/osu!mania), [Taiko](/wiki/Taiko)) and [last.fm](http://www.last.fm/) support to profiles. User profiles now have country performance rank on their profile and a new pp graph.
+
+In-game wise, the main menu gets a new visualisation, with a blazing flare around the osu! symbol dependent on intensity of currently playing song's BPM. Performance have been optimised in song selection with many (more than ten-thousand) maps. Update process robustness and performance have been improved.
+
+Gameplay-wise, lead-in time was automatically add to any beatmaps which start abruptly to allow enough time to adjust [Visual Settings](/wiki/Visual_Settings) and total press counts for each key on the input overlay was added. For online results storages, personal best rank was show on beatmap info pages besides the \#1 player. Score submission from mania charts was allowed and Top 50 replays was stored rather than the usual Top 40. Quick repeat sliders not reaching their maximum combo has been fixed. Disqus comments added to beatmap pages. Finally, prototype testing of score meter for all modes was underway for osu!test.
 
 ![](img/2013-06_01.jpg "Account creation process")
 
@@ -73,11 +107,13 @@ Game modifiers naming in results has been shorten (e.g. "Hard Rock" to "HR") to 
 Links:
 
 - [June 2013 Highlights + Map of the Month](https://osu.ppy.sh/forum/p/2400775)
-- [Regional Team Management](https://osu.ppy.sh/forum/t/132667)
+- [Regional Team Management](/community/forums/topics/132667)
 
 ## July
 
-[The new regional BATmanagers](https://osu.ppy.sh/forum/t/132667) began their first major recruitment of new BAT in to the team with the [Summer 2013 NewBAT Applications](https://osu.ppy.sh/forum/t/142864). This provided a chance for the new managers to adequately handle new applications. The new regional managers were [NatsumeRin](/u/151679) representing Asia/Oceania, [Kurai](/u/77089) representing Europe, and [Garven](/u/244216) representing America. On 2013-07-02, peppy made the [osu!api](https://osu.ppy.sh/forum/t/141240) open to the public (previously available only through private requests). This allowed independent developers to work on third party services for osu!. On 2013-07-11, the previously broken "forgot password" page has been fixed. 2013-07-18 brought updates to Bancho's fallback connectivity. On 2013-07-21, widescreen support for storyboards was added in the song setup dialog. Two new in-game overlays were added to track accuracy as you play or watch others play. Refer to [Options](/wiki/Options) page for further information.
+[The new regional BATmanagers](/community/forums/topics/132667) began their first major recruitment of new BAT in to the team with the [Summer 2013 NewBAT Applications](/community/forums/topics/142864). This provided a chance for the new managers to adequately handle new applications. The new regional managers were [NatsumeRin](/users/151679) representing Asia/Oceania, [Kurai](/users/77089) representing Europe, and [Garven](/users/244216) representing America.
+
+On 2013-07-02, peppy made the [osu!api](/community/forums/topics/141240) open to the public (previously available only through private requests). This allowed independent developers to work on third party services for osu!. On 2013-07-11, the previously broken "forgot password" page has been fixed. 2013-07-18 brought updates to Bancho's fallback connectivity. On 2013-07-21, widescreen support for storyboards was added in the song setup dialog. Two new in-game overlays were added to track accuracy as you play or watch others play. Refer to [Options](/wiki/Options) page for further information.
 
 ![](img/2013-07_01.jpg "Hit-error overlay")
 
@@ -85,18 +121,20 @@ Links:
 
 Links:
 
-- [Summer 2013 NewBAT Applications](https://osu.ppy.sh/forum/t/142864)
-- [osu!api open beta](https://osu.ppy.sh/forum/t/141240)
+- [Summer 2013 NewBAT Applications](/community/forums/topics/142864)
+- [osu!api open beta](/community/forums/topics/141240)
 
 ## December
 
 ![](img/2013-12_01.jpg "Guest appearance at Comic Fiesta 2013")
 
-[peppy was confirmed for Comic Fiesta 2013 in Malaysia at 21st and 22nd of December in Kuala Lumpur City Center](https://osu.ppy.sh/forum/t/163121). For day 1 (2013-12-21), osu! was shown as a stage event, demonstrating the game in four different game modes (osu!standard, Taiko, Catch the Beat, and osu!mania). For day 2 (2013-12-22), peppy gives an insight of osu! along with his future update plans at the panel room and showcased osu!tablet for the public to try it out. One of the current hot-topic for debate right now was that peppy was making a new game mode and was testing it as a proof-in-concept (testing if it's playable, competitive or flexible enough). Some players speculate it was [Tohousu!](https://osu.ppy.sh/forum/t/19307) (dodging the bullet-hell, that was, inverse of [Catch the Beat](/wiki/Catch_the_Beat)). By time of writing, not much information was discovered about the new game mode. [A video clip about the talk was in ppy's blog](http://blog.ppy.sh/post/71405880656/i-have-a-few-posts-waiting-for-some-final-touches)
+[peppy was confirmed for Comic Fiesta 2013 in Malaysia at 21st and 22nd of December in Kuala Lumpur City Center](/community/forums/topics/163121). For day 1 (2013-12-21), osu! was shown as a stage event, demonstrating the game in four different game modes (osu!standard, Taiko, Catch the Beat, and osu!mania). For day 2 (2013-12-22), peppy gives an insight of osu! along with his future update plans at the panel room and showcased osu!tablet for the public to try it out.
+
+One of the current hot-topic for debate right now was that peppy was making a new game mode and was testing it as a proof-in-concept (testing if it's playable, competitive or flexible enough). Some players speculate it was [Tohousu!](/community/forums/topics/19307) (dodging the bullet-hell, that was, inverse of [Catch the Beat](/wiki/Catch_the_Beat)). By time of writing, not much information was discovered about the new game mode. [A video clip about the talk was in ppy's blog](http://blog.ppy.sh/post/71405880656/i-have-a-few-posts-waiting-for-some-final-touches)
 
 Links:
 
-- [I will be in malaysia (December)](https://osu.ppy.sh/forum/t/163121)
+- [I will be in malaysia (December)](/community/forums/topics/163121)
 - [Schedule | Comic Fiesta 2013](http://comicfiesta.org/2013/info/event/schedule/)
-- [New osu! mode announced on CF2013?](https://osu.ppy.sh/forum/t/176000)
+- [New osu! mode announced on CF2013?](/community/forums/topics/176000)
 - [Comic Fiesta 2013 Impressions & osu! Q&A Panel Session with peppy (ppy) | INFONOCHIKARA 「インフォノチカラ」 Blogotopia](https://infonochikara.wordpress.com/2013/12/30/comic-fiesta-2013-impressions-osu-qa-panel-session-with-peppy-ppy/)

--- a/wiki/History_of_osu!/2018/en.md
+++ b/wiki/History_of_osu!/2018/en.md
@@ -3,3 +3,19 @@
 *Main page: [History of osu!](/wiki/HOO).*
 
 ## January
+
+After a six-month long hiatus, flyte posted on the [osu!next](http://osunext.tumblr.com) blog with some teaser pictures for the next website design. He explained that the current state of the website had many UX problems, from various functionality specs to user feedback, that wasn't considered at the time when designing. Since then, he had been taking some time to redesign the website's redesign from scratch. ([osu!next](http://osunext.tumblr.com/post/169336245023/hi-its-been-6-months-since-my-last-post-rest))
+
+The osu!mania 7K World Cup 2018 registrations opened. ([osu!mania 7K World Cup 2018: Registrations now open!](https://osu.ppy.sh/home/news/2018-01-10-MWC7K-2018-registrations-open))
+
+osu!lazer's osu!catch game mode was vastly improved. ([Dean Herbert on Twitter](https://twitter.com/ppy/status/951884503122784257))
+
+Community Choice 2017 (previously known as the "Best of" series) voting was opened. ([Community Choice 2017](https://osu.ppy.sh/home/news/2018-01-18-community-choice-2017))
+
+In osu!lazer, background blurring and the hidden mod were added. In osu!web, pagination improvements for beatmap pack listings, hype and nomination counters were visible on the beatmap listings. Obtaining a permalink to beatmap discussion post was now easier to copy, localisations now resize the menu upon hovering over the locales, star ratings can be seen in the beatmap listing via hovering the difficulty icon, and sorting of beatmap discussions were added. A limit to only load 250 forum threads and unload others was implemented to avoid heavy memory consumption. ([dev changelog 20180120 – ppy blog](https://blog.ppy.sh/dev-changelog-20180120/))
+
+[peppy tweeted](https://twitter.com/ppy/status/956058435845611521) that the new t-shirt inventory (along with their new designs) has arrived. Six days later, they were up on the osu!store. ([Dean Herbet on Twitter](https://twitter.com/ppy/status/958185268258865152))
+
+Thanks to nekodex, the beatmap leaderboards were revamped. ([ppy/osu-web#2292](https://github.com/ppy/osu-web/pull/2292))
+
+## February

--- a/wiki/History_of_osu!/2018/en.md
+++ b/wiki/History_of_osu!/2018/en.md
@@ -18,4 +18,8 @@ In osu!lazer, background blurring and the hidden mod were added. In osu!web, pag
 
 The ability to see star ratings in the osu!direct was backported from osu!lazer. ([Dean Herbert on Twitter](https://twitter.com/ppy/status/958220599783866368)) Lastly, thanks to nekodex, the beatmap leaderboards were revamped. ([ppy/osu-web#2292](https://github.com/ppy/osu-web/pull/2292))
 
+peppy opened a GitHub issue thread to discuss about *passive HP*. ([ppy/osu#1990](https://github.com/ppy/osu/issues/1990))
+
+In osu!lazer, osu!mania scrolling speed was implemented. Thanks to cYsmix, a fresh set of default hit sounds were added. osu!catch's autoplay was fixed to be more human-like. ([dev changelog 20180128 – ppy blog](https://blog.ppy.sh/dev-changelog-20180128/))
+
 ## February

--- a/wiki/History_of_osu!/2018/en.md
+++ b/wiki/History_of_osu!/2018/en.md
@@ -14,8 +14,8 @@ Community Choice 2017 (previously known as the "Best of" series) voting was open
 
 In osu!lazer, background blurring and the hidden mod were added. In osu!web, pagination improvements for beatmap pack listings, hype and nomination counters were visible on the beatmap listings. Obtaining a permalink to beatmap discussion post was now easier to copy, localisations now resize the menu upon hovering over the locales, star ratings can be seen in the beatmap listing via hovering the difficulty icon, and sorting of beatmap discussions were added. A limit to only load 250 forum threads and unload others was implemented to avoid heavy memory consumption. ([dev changelog 20180120 – ppy blog](https://blog.ppy.sh/dev-changelog-20180120/))
 
-[peppy tweeted](https://twitter.com/ppy/status/956058435845611521) that the new t-shirt inventory (along with their new designs) has arrived. Six days later, they were up on the osu!store. ([Dean Herbet on Twitter](https://twitter.com/ppy/status/958185268258865152))
+[peppy tweeted](https://twitter.com/ppy/status/956058435845611521) that the new t-shirt inventory (along with their new designs) has arrived. Six days later, they were up on the osu!store. ([Dean Herbert on Twitter](https://twitter.com/ppy/status/958185268258865152))
 
-Thanks to nekodex, the beatmap leaderboards were revamped. ([ppy/osu-web#2292](https://github.com/ppy/osu-web/pull/2292))
+The ability to see star ratings in the osu!direct was backported from osu!lazer. ([Dean Herbert on Twitter](https://twitter.com/ppy/status/958220599783866368)) Lastly, thanks to nekodex, the beatmap leaderboards were revamped. ([ppy/osu-web#2292](https://github.com/ppy/osu-web/pull/2292))
 
 ## February


### PR DESCRIPTION
- add peppy's osu! from 2007-09 release forum post (2013)
- add January (2018)
  - ~~I wish I took a photo of the previous leaderboards to show the before and after looks :(~~