### PR TITLE
Welcome: add Skinning Section and change the AotM

### DIFF
--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -17,9 +17,9 @@ Welcome to _osu!_, a free-to-win rhythm game developed by peppy with four game m
 
 ## Article of the month
 
-_See also: [Ranking Criteria](/wiki/Ranking_Criteria)._
+_See also: [Performance Points](/wiki/Performance_Points)._
 
-Ranking Criteria is a set of rules and guidelines set by the QAT to ensure that every player can expect similar game play throughout every beatmap.
+Performance Points is a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like *osu!*. It tries to do this by shifting the focus of skill progression from the amount of time played to the actual representation of the player's skill.
 
 ## Beatmapping
 
@@ -33,8 +33,14 @@ _See also: [Modding](/wiki/Modding/#getting-started)._
 
 Modding is the process of users reviewing (or commonly called "modding") a creator's beatmap in the pending (or work in progress/help) stage. Modding plays a big role in quality control because this allows creators to fix issues with their beatmap.
 
+## Skinning
+
+*See also: [Skinning](/wiki/Skinning) and [Skinning Tutorial](/wiki/Skinning_Tutorial).*
+
+Skinning allows anyone to change the way osu! looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all of the game modes.
+
 ## osu!wiki - How you can help!
 
-Since 26. August 2016, the osu!wiki has moved to a GitHub repository. After this change, the workflow has drastically changed. All contributions now go through the [osu-wiki GitHub repository](https://github.com/ppy/osu-wiki) and are reviewed before being approved and merged to the osu!wiki.
+Since 2016-08-26, the osu!wiki has moved to a GitHub repository. After this change, the workflow has drastically changed. All contributions now go through the [osu-wiki GitHub repository](https://github.com/ppy/osu-wiki) and are reviewed before being approved and merged to the osu!wiki.
 
 To get started, see the [osu!wiki Contribution Guide](/wiki/owcg).

--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -31,13 +31,13 @@ Beatmapping is the process of a creator creating a beatmap. This process include
 
 _See also: [Modding](/wiki/Modding/#getting-started)._
 
-Modding is the process of users reviewing (or commonly called "modding") a creator's beatmap in the pending (or work in progress/help) stage. Modding plays a big role in quality control because this allows creators to fix issues with their beatmap.
+Modding is the process of users reviewing (or commonly called "modders") a creator's beatmap in the pending (or work in progress/help) stage. Modding plays a big role in quality control because this allows creators to fix issues with their beatmap.
 
 ## Skinning
 
 *See also: [Skinning](/wiki/Skinning) and [Skinning Tutorial](/wiki/Skinning_Tutorial).*
 
-Skinning allows anyone to change the way osu! looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all of the game modes.
+Skinning allows anyone to change the way *osu!* looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all the game modes and interface.
 
 ## osu!wiki - How you can help!
 

--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -19,7 +19,7 @@ Welcome to osu!, a free-to-win rhythm game developed by peppy with four game mod
 
 _See also: [Performance Points](/wiki/Performance_Points)._
 
-Performance Points is a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like osu!. It tries to do this by shifting the focus of skill progression from the amount of time played to the actual representation of the player's skill.
+Performance Points are a value from a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like osu!. It tries to do this by shifting the focus of skill progression from the amount of time played to the actual representation of the player's skill.
 
 ## Beatmapping
 

--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -1,6 +1,6 @@
 # Welcome
 
-Welcome to _osu!_, a free-to-win rhythm game developed by peppy with four game modes: osu!standard, a circle clicking simulator; osu!taiko, a drumming emulator; osu!catch, a fruit salad catcher; osu!mania, a key smashing mania.
+Welcome to osu!, a free-to-win rhythm game developed by peppy with four game modes: osu!standard, a circle clicking simulator; osu!taiko, a drumming emulator; osu!catch, a fruit salad catcher; osu!mania, a key smashing mania.
 
 ## Common points of interest
 
@@ -19,7 +19,7 @@ Welcome to _osu!_, a free-to-win rhythm game developed by peppy with four game m
 
 _See also: [Performance Points](/wiki/Performance_Points)._
 
-Performance Points is a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like *osu!*. It tries to do this by shifting the focus of skill progression from the amount of time played to the actual representation of the player's skill.
+Performance Points is a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like osu!. It tries to do this by shifting the focus of skill progression from the amount of time played to the actual representation of the player's skill.
 
 ## Beatmapping
 
@@ -37,7 +37,7 @@ Modding is the process of users reviewing (or commonly called "modders") a creat
 
 *See also: [Skinning](/wiki/Skinning) and [Skinning Tutorial](/wiki/Skinning_Tutorial).*
 
-Skinning allows anyone to change the way *osu!* looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all the game modes and interface.
+Skinning allows anyone to change the way osu! looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all the game modes and interface.
 
 ## osu!wiki - How you can help!
 

--- a/wiki/Welcome/es.md
+++ b/wiki/Welcome/es.md
@@ -1,3 +1,6 @@
+---
+outdated: true
+---
 # Bienvenido
 
 Bienvenidos a osu!, un juego rítmico de categoría "libre para ganar" creado por peppy con cuatro modos de juego: osu!standard, un simulador para dar clics en los círculos, osu!taiko, un emulador de tambores, osu!catch, un atrapador de ensalada de frutas, osu!mania, una mania de golpear teclas.

--- a/wiki/Welcome/pl.md
+++ b/wiki/Welcome/pl.md
@@ -1,3 +1,6 @@
+---
+outdated: true
+---
 # Na początek
 
 Witaj w _osu!_, darmowej grze rytmicznej rozwijanej przez peppy'ego, która posiada cztery tryby gry: osu!standard - klikanie kółek, osu!taiko - uderzanie bębenków, osu!catch - łapanie owoców oraz osu!mania - naciskanie klawiszy.
@@ -31,7 +34,7 @@ Mapowanie jest to proces tworzenia beatmap. Uwzględnia on: wybór piosenki, ust
 
 _Zobacz także: [Modowanie](/wiki/Modding)._
 
-Modowanie jest to proces sprawdzania i oceniania nierankingowej beatmapy przez różnych użytkowników. Modowanie odgrywa dużą rolę w kontroli jakości, ponieważ pozwala twórcom na naniesienie niezbędnych poprawek na ich mapy. 
+Modowanie jest to proces sprawdzania i oceniania nierankingowej beatmapy przez różnych użytkowników. Modowanie odgrywa dużą rolę w kontroli jakości, ponieważ pozwala twórcom na naniesienie niezbędnych poprawek na ich mapy.
 
 ## osu!wiki - Jak możesz pomóc!
 

--- a/wiki/Welcome/zh.md
+++ b/wiki/Welcome/zh.md
@@ -1,3 +1,6 @@
+---
+outdated: true
+---
 # 欢迎
 
 欢迎来到 osu! ， 一款由 peppy 开发的有着以下四个模式的音乐游戏： osu!standard ——戳泡泡、 osu!taiko ——打太鼓、 osu!catch ——接水果、 osu!mania ——敲键盘。


### PR DESCRIPTION
## Status: Pending Review

> Welcome:

The `/wiki/Welcome` article.

> add Skinning Section

Part of what @RockRoller01 and I were talking about in a DM. I told him to do it (just add a link to CPoI), but I thought that it probably should have it's own section.

> and

and...

> change the AotM

Picked by RNG\*. Basically, copy/paste the lead section the first few sentences with some modifications.

\* well... sorta, it was going to be `/wiki/People` but I didn't want to try and write something for that yet. So `/wiki/Performance_Points`, the next one over, got the short end of the stick