### PR TITLE
Fix broken links in beatmap veto articles

### DIFF
--- a/wiki/People/Beatmap_Nominators/Beatmap_Veto/en.md
+++ b/wiki/People/Beatmap_Nominators/Beatmap_Veto/en.md
@@ -8,7 +8,7 @@ Any Beatmap Nominator may place a beatmap veto, provided they are formally quali
 
 Each beatmap veto must be discussed by both parties - the mapper as well as the Nominator placing the beatmap veto - in an attempt to reach an agreed compromise.
 
-In cases where discussion does not take place or is inconclusive, members of the [QAT](/wiki/Quality_Assurance_Team) (Quality Assurance Team) disqualification branch will mediate to either uphold or dismiss the veto.
+In cases where discussion does not take place or is inconclusive, members of the [QAT](/wiki/People/Quality_Assurance_Team) (Quality Assurance Team) disqualification branch will mediate to either uphold or dismiss the veto.
 
 ## Performing a beatmap veto
 

--- a/wiki/People/Beatmap_Nominators/General_Information/en.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/en.md
@@ -6,13 +6,15 @@ Are you a Beatmap Nominator, or are interested in becoming one? Then you have co
 
 ## Useful Information
 
-First off, take note of the [Beatmap Nominator Rules](/wiki/Beatmap_Nominator_Rules), which outlines both how to undertake various actions such as iconing maps, as well as how not to do things - you would want to avoid breaking these in any situation, so be sure to read them carefully! You can always ask a member of the [Quality Assurance Team](/wiki/Quality_Assurance_Team) if you are unsure about something, and we will be happy to help.
+First off, take note of the [Beatmap Nominator Rules](/wiki/Beatmap_Nominator_Rules), which outlines both how to undertake various actions such as iconing maps, as well as how not to do things - you would want to avoid breaking these in any situation, so be sure to read them carefully! You can always ask a member of the [Quality Assurance Team](/wiki/People/Quality_Assurance_Team) if you are unsure about something, and we will be happy to help.
 
 Next, there's the [Code of Conduct for Mapping and Modding](/wiki/CoC). As a Beatmap Nominator, you are expected to be an exemplary figure of the community, someone others look up to and respect, so misconduct may get you reprimanded or even expelled. This also includes parts of the ranking process as well - do not go around nominating maps in which the mapper has ignored mods, for example.
 
 Moreover, as a Beatmap Nominator, you have the opportunity to join a Nominator Subdivision. These provide an opportunity to collaborate in small groups, discuss potential problems with your peers, or gain a fresh perspective. Joining a Subdivision is highly recommended for new Beatmap Nominators to ensure you can always ask for help and guidance when necessary. You can find more information on how these work in this document.
 
 Lastly, the information you will probably be referencing the most, the Ranking Criteria. If you are already a Beatmap Nominator, then you should be familiar with this. Essentially, it serves to explain what aspects of mapping are and are not allowed in the Ranked section, as well as including some general guidelines that people should try to follow in most cases. If you see a Qualified map breaking one of the rules, or feel that it could still use substantial improvement for whatever reason, feel free to report it in this thread, giving a brief outline of the problems you see.
+
+For beatmaps with subjective quality concerns that don't necessarily break the rules and guidelines of the Ranking Criteria, but which you feel which make the beatmap in question unfit for the Ranked section, the [_beatmap veto_](/wiki/People/Beatmap_Nominators/Beatmap_Veto) allows you to withhold a beatmap from Qualification.
 
 ## Beatmap Nominator Icons
 


### PR DESCRIPTION
### Description

Links to the QAT page in the new beatmap veto articles were broken, hopefully this fixes them
Also added a missing paragraph to the BN Information page regarding how new beatmap vetoes work

### Status

Pending Review - 2018-04-13

### Additional Notes 

None