### PR TITLE
Create April QAT Gazette

### DIFF
--- a/news/2018-05-02-the-qat-gazette-april-2018.md
+++ b/news/2018-05-02-the-qat-gazette-april-2018.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title: "The QAT Gazette: April 2018"
+date: 2018-05-02 09:00:00 +0000
+---
+
+New rules on beatmap vetoing and disqualifications, contributor badges for long-serving Beatmap Nominators, the introduction of public QAT meetings and so much more in store for the busiest month of 2018 yet! Sound interesting? Of course it does! Read on to find out more!
+
+![](/wiki/shared/news/banners/qat-blog-logo.png)
+
+## Opening
+by [JBHyperion](https://osu.ppy.sh/users/4879508)
+
+Hello once again! It’s time for some mapping and modding news you don’t want to lose!
+
+I know I say this every issue, but this time especially so - April was a *busy* month. We’ve seen it all, from rule changes, rewards, restructuring and all this with more transparency™ than ever before! Once again I’m joined by some new Gazette friends who will be more than happy to walk you through all the juicy details below, so let’s get stuck in!
+
+## Within the Beatmap Nominators
+by [Protastic101](https://osu.ppy.sh/users/6712747)
+
+This month, we welcome an additional wave of new members to the Beatmap Nominators for the osu! game mode. All the while, the current Beatmap Nominators show no signs of slowing down, continuing the steady growth we saw last month.
+
+In addition to our regular BN addition updates, we’re pleased to announce incoming (and long-overdue) rewards in recognition of the Beatmap Nominators’ vital role within the mapping and modding communities.
+
+### Beatmap Nominator Badges
+After it was first mentioned back in September’s Upheaval discussion, Beatmap Nominator rewards are finally becoming more than just mere rumor. In appreciation of the service our hard working team of esteemed modders have contributed to the osu! community over the years, we’re happy to announce the introduction of **Beatmap Nominator badges** for those have served in the team for two or more years in total.
+
+These badges will be incremental in nature, with slight variations to the design flair indicating the number of years served, up to 5 years. They will also apply retroactively to currently retired members of either the Beatmap Nominators or former Beatmap Appreciation Team (BAT) as well! Expect to see these beauties popping up on the profile pages of our most dedicated community servants very soon!
+
+### New Beatmap Nominator Promotions
+After much deliberation and discussion among members of the applications branch of the QAT, over an astounding 94 applicants in the recent osu! round, we finally have results, and are proud to welcome **19 new and returning Beatmap Nominators** to the team! Please give a warm welcome to the following:
+
+[Mirash](https://osu.ppy.sh/users/2841009), [Kyuukai](https://osu.ppy.sh/users/5337374), [Net0](https://osu.ppy.sh/users/5099768), [Ultima Fox](https://osu.ppy.sh/users/3198109), [Deramok](https://osu.ppy.sh/users/1428455), [hypercyte](https://osu.ppy.sh/users/9155377), [Smokeman](https://osu.ppy.sh/users/2140676), [Trynna](https://osu.ppy.sh/users/2652951), [Ryuusei Aika](https://osu.ppy.sh/users/7777875), [SnowNiNo_](https://osu.ppy.sh/users/2506267), [kwk](https://osu.ppy.sh/users/365586), [Sonnyc](https://osu.ppy.sh/users/11771), [Lafayla](https://osu.ppy.sh/users/5312547), [bossandy](https://osu.ppy.sh/users/360437), [Andrea](https://osu.ppy.sh/users/33599), [Sieg](https://osu.ppy.sh/users/1404615), [Mordred](https://osu.ppy.sh/users/7265097), [Kalibe](https://osu.ppy.sh/users/3376777), and [Nao Tomori](https://osu.ppy.sh/users/5364763)!
+
+### Beatmap Nominator Retirements
+As the month draws to a close though, we must also say goodbye to familiar faces within the Beatmap Nominators who have moved on from circle and fruit modding to pursue other paths. Please extend gratitude to the following members who have worked hard to bring new and refreshing content to the Ranked section:
+
+[Voli](https://osu.ppy.sh/users/2522275), [Sanyi](https://osu.ppy.sh/users/7496029), [ezek](https://osu.ppy.sh/users/180241), [Hareimu](https://osu.ppy.sh/users/4138746), [Kencho](https://osu.ppy.sh/users/3178411) and [Chromoxx](https://osu.ppy.sh/users/1881639)
+
+While we are sad to see you all go, your efforts will be remembered and we wish you luck in your future endeavors!
+
+## Within the Quality Assurance Team
+by [Asherz007](https://osu.ppy.sh/users/9014047)
+
+This month has seen a fair amount of change for the Quality Assurance Team, as far as operations are concerned at least. There have been plenty of tweaks here and there that have added up to result in a huge impact on how the team works as a collective unit.
+
+### Changes to vetoing
+Beatmap vetoes have always been something that mappers have feared in the past. But fear no more (or at least a little less)! The beatmap veto system has been reworked this month to include an extra step, aiming to prevent maps from being stopped completely in their tracks for all eternity. Say hello to **mediation**, operated by members of the Quality Assurance Team disqualification branch.
+
+The process of mediation will be performed on any vetoed beatmap, after 48 hours by the request of the mappers or Nominator upholding the veto if no compromise can be made between the two parties, or after 7 days automatically. From there, the arguments for and against the veto will be discussed to determine if the proposed changes are deemed necessary, detrimental, or anything in between.
+
+After discussion concludes, a decision is made amongst the disqualification branch members on whether to uphold the veto, or to dismiss it and allow the ranking process to continue. If you want to look a little more into the details in mediation, or just for a reminder of what vetoes are and how they work, head on over to the new [Beatmap Veto wiki page](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators/Beatmap_Veto).
+
+### Changes to disqualifications
+Last-minute disqualifications have seen a lot of controversy in the past, delaying the Ranking process of a beatmap significantly; something a fair number of mappers wish to avoid at all costs. This month, however, sees a change to this process which will hopefully make these disqualifications a little less daunting and discouraging.
+
+Disqualifications from maps nominated through modding discussions will now have their **qualified timer “frozen”** - that is, if a map gets disqualified whilst 4 days from reaching Ranked status, when it is requalified once more, the map will only spend those 4 days in Qualified before reaching the Ranked section. If this period is less than a day, then the timer will be reset to 24 hours, to ensure an adequate amount of time for the community to suggest further changes if necessary.
+
+Hopefully with this change, mappers will be more positive towards accepting changes during the qualification process, knowing that they won’t need to start from square one - or rather, day one - any longer.
+
+### Public QAT meeting
+As part of the transition to have more transparency, the first **public QAT meeting** was held on the osu!dev Discord server on Sunday 24th April, where everyone was free to watch on and share their thoughts as we discussed the operation of the newly formed QAT branch-system, aforementioned BN badges and more. This provided community members a previously inaccessible insight as to how the QAT functioned as a whole, as each of the branches reported their progress, problems and future plans.
+
+For a detailed run-down of all the discussion, feel free to peruse the [meeting summary thread](https://osu.ppy.sh/community/forums/topics/735472).
+
+Whilst this presents landmark progress in making the operation and decision making process of the QAT more freely accessible than ever before, there is still room for refinement. A lot of interested community members were unable to attend this time around due to the short notice of announcement, so we’ll make an effort to disclose details of future public meetings more in advance.
+
+These meetings will always share their location in common though - head on over to the [osu!dev public Discord server](https://discord.gg/ppy) to follow our discussion, as well as contribute to the osu!wiki, osu!lazer, modding discussions, Beatmap Spotlights, Project Loved, and so much more if you are inclined!
+
+### New Quality Assurance Team additions
+With the enormous amount of osu!taiko maps reaching the Ranked section, it is no surprise that more and more people are needed to ensure that their fellow drum bashers are enjoying beatmaps of the highest quality. With that said, give a warm welcome to [Aloda](https://osu.ppy.sh/users/1190127), who joins the disqualification branch!
+
+### QAT Interviews
+One final thing to note: since his return to the Quality Assurance Team last month, [Feerum](https://osu.ppy.sh/users/4815717) has expressed interest in reviving an old feature that never quite made it to our previous issues - **QAT Interviews**. These will essentially take the form of a short Q&A with interested team members, similar to the “Ask Me Anything!” feature from the previous tumblr blog.
+
+If you’d like a chance to get to know your Quality Assurance Team better, or get a more personal insight as to our work and how we came to be, head on over to the [QAT Interview discussion & poll](https://osu.ppy.sh/community/forums/topics/739410) and share your thoughts!
+
+## Summary
+by [JBHyperion](https://osu.ppy.sh/users/4879508) 
+
+If you managed to make it through all that, thanks for staying with us! I have a sneaking suspicion that if past history is anything to go by, next month will be just as chaotic - but that makes it all the more interesting! One thing you can count on though is that we’ll be back again next month to share it all with you!
+
+On behalf of the Gazette team, thank you all for reading and wherever you are, enjoy the rest of your day!
+
+—JBHyperion, Protastic101, Asherz007


### PR DESCRIPTION
### Description

Adds the April edition of the QAT Gazette blog

### Status

Pending Review 2018-05-01

### Additional Notes 

Self-reminder that QAT Interview thread needs to be moved to a visible forum before/as the announcement goes live.
