### PR TITLE
Fix owc 2017 redirect

### DIFF
--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -1454,9 +1454,6 @@
 "owc2017":                     "Tournaments/OWC/2017"
 "owc_2017":                    "Tournaments/OWC/2017"
 "owc/2017":                    "Tournaments/OWC/2017"
-"owc2017":                     "Tournaments/OWC/2017"
-"owc_2017":                    "Tournaments/OWC/2017"
-"owc/2017":                    "Tournaments/OWC/2017"
 
 "tournaments/twc":             "Tournaments/#-taiko-world-cup"
 "twc":                         "Tournaments/#-taiko-world-cup"


### PR DESCRIPTION
Remove duplicated owc2017 entries which caused parse errors.