### PR TITLE
Remove "Article of the month" section on Welcome page

### DIFF
--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -20,12 +20,6 @@ Welcome to osu!, a free-to-win rhythm game developed by peppy with four game mod
   - ![osu!catch icon](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## Article of the month
-
-*Main page: [Mascots](/wiki/Mascots).*
-
-Meet pippi, Yuzu, Maria, and Mocha; the four mascots of osu!standard, osu!catch, osu!mania, and osu!taiko respectively.
-
 ## Beatmapping
 
 *Main page: [Beatmapping](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/es.md
+++ b/wiki/Welcome/es.md
@@ -20,11 +20,6 @@ Bienvenidos a osu!, un juego de ritmo gratis creado por peppy el cual tiene cuat
   - ![icono de osu!catch](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![icono de osu!mania](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## Artículo del mes.
-
-*Pagina principal: [Mascotas](/wiki/Mascots).*
-Conoce a pippi, Yuzu, Maria y Mocha; las cuatro mascotas de osu!standard, osu!catch, osu!mania y osu!taiko, respectivamente.
-
 ## Beatmapping
 
 *Pagina principal: [Beatmapping](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/id.md
+++ b/wiki/Welcome/id.md
@@ -23,12 +23,6 @@ Selamat datang di osu!, game ritme free-to-win yang dikembangkan oleh peppy yang
   - ![Ikon osu!catch](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![Ikon osu!mania](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## Artikel bulan ini
-
-*Lihat juga: [Maskot](/wiki/Mascots).*
-
-Temui pippi, Yuzu, Maria, dan Mocha; empat maskot dari mode osu!standard, osu!catch, osu!mania, dan osu!taiko.
-
 ## Beatmapping
 
 *Lihat juga: [Beatmapping](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/it.md
+++ b/wiki/Welcome/it.md
@@ -20,12 +20,6 @@ Benvenuto su osu!, un gioco musicale free-to-win sviluppato da peppy con 4 modal
   - ![osu!catch icon](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## Articolo del mese
-
-*Pagina principale: [Mascotte](/wiki/Mascots).*
-
-Incontra pippi, Yuzu, Maria, e Mocha; rispettivamente le quattro mascotte di osu!standard, osu!catch, osu!mania, and osu!taiko.
-
 ## Beatmapping
 
 *Pagina principale: [Beatmapping](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/ko.md
+++ b/wiki/Welcome/ko.md
@@ -18,12 +18,6 @@ osu! 에 오신 것을 환영합니다! osu! 는 peppy가 개발한 동그라미
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/osu!mania/#getting-started)
 - [멀티플레이](/wiki/Multi/#getting-started)
 
-## 이번 달의 기사
-
-*같이 보기: [랭킹 기준](/wiki/Ranking_Criteria).*
-
-랭킹 기준은 QAT가 정한 규칙 및 지침으로, 모든 플레이어가 모든 비트맵에서 비슷한 게임을 기대할 수 있도록 합니다.
-
 ## 비트맵핑
 
 *같이 보기: [비트맵 제작](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/pl.md
+++ b/wiki/Welcome/pl.md
@@ -18,12 +18,6 @@ Witaj w osu!, darmowej grze rytmicznej rozwijanej przez peppy'ego, która posiad
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/osu!mania)
 - [Tryb wieloosobowy](/wiki/Multi)
 
-## Artykuł miesiąca
-
-*Zobacz także: [Kryteria rankingowe](/wiki/Ranking_Criteria).*
-
-Kryteria rankingowe to zbiór zasad i porad napisanych przez członków zespołu [QAT](/wiki/People/Quality_Assurance_Team) w celu zapewnienia standardu jakości wszystkim rankingowym beatmapom.
-
 ## Mapowanie
 
 *Zobacz także: [Mapowanie](/wiki/Beatmapping).*

--- a/wiki/Welcome/pt-br.md
+++ b/wiki/Welcome/pt-br.md
@@ -18,12 +18,6 @@ Bem-vindo ao osu!, um jogo de ritmo free-to-win desenvolvido pelo peppy com quat
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/osu!mania/#getting-started)
 - [Multi](/wiki/Multi/#getting-started)
 
-## Artigo do mês
-
-*Veja também: [Critérios de Classificação](/wiki/Ranking_Criteria).*
-
-Critérios de Classificação são um conjunto de regras e condutas definidas pela QAT para assegurar que todos os jogadores possam esperar por uma jogabilidade similar em todos os beatmaps.
-
 ## Beatmapping
 
 *Veja também: [Beatmapping](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/ru.md
+++ b/wiki/Welcome/ru.md
@@ -23,12 +23,6 @@ outdated: true
   - ![значок osu!catch](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![значок osu!mania](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## Статья месяца
-
-*Подробнее: [Маскоты (персонажи-талисманы)](/wiki/Mascots).*
-
-Встречайте pippi, Yuzu, Maria и Mocha — полюбившихся всем маскотов osu!standard, osu!catch, osu!mania и osu!taiko.
-
 ## Маппинг
 
 *Подробнее: [Маппинг](/wiki/Beatmapping/#getting-started).*

--- a/wiki/Welcome/zh.md
+++ b/wiki/Welcome/zh.md
@@ -20,10 +20,6 @@
   - ![osu!catch icon](/wiki/shared/mode/catch.png) [osu!catch](/wiki/Ranking_Criteria/osu!catch)
   - ![osu!mania icon](/wiki/shared/mode/mania.png) [osu!mania](/wiki/Ranking_Criteria/osu!mania)
 
-## 本月推荐文章
-
-[点此查看](/wiki/Welcome?locale=en#article-of-the-month)
-
 ## 作图
 
 *参考：[作图](/wiki/Beatmapping/#开始)。*


### PR DESCRIPTION
Closes #1448.

I came to a conclusion to myself that this isn't working. First off, the English page isn't getting monthly updates. That's bad enough, and then these translations. They have to updated monthly which is not happening.

*Note: This PR is purely at removing the AotM, nothing more. After this gets merge, I will make another one regarding to the ASC.*