### PR TITLE
Updates to BN/QAT Information and Table

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -55,6 +55,13 @@ Modders that aim to apply to the Beatmap Nominators must fulfil the following cr
   + Modding abilities: Knowledge of the general [Ranking Criteria](/wiki/Ranking_Criteria) and specific criteria of each game mode. Additional abilities like Metadata, Timing, and some others will also be taken into consideration.
 + After evaluating each modder, a discussion will be made on whether the modder will join the Beatmap Nominators.
 
+Quality Assurance Helpers
+-------------------------
+
+The Quality Assurance Helpers are volunteers inside of the Beatmap Nominators who assist the Quality Assurance Team at checking every single qualified beatmap for issues. They do so by reporting maps on the [Report a Qualified beatmap here!](https://osu.ppy.sh/forum/p/5075934) thread. 
+
+Quality Assurance Helpers are free to choose whatever maps they like to check as long as they check at least four qualified maps per month. If they are not able to fulfill these activity standards, they will be removed and can only rejoin after a cooldown of one month. Beatmap Nominators who are not on their probationary period or in the cooldown period mentioned above may join the Quality Assurance Helpers at any time. 
+
 Team Members
 ------------
 
@@ -75,7 +82,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [celerih](https://osu.ppy.sh/users/4696296)           | French                   |
 | [Cerulean Veyron](https://osu.ppy.sh/users/1886524)   | Arabic                   |
 | [Delis](https://osu.ppy.sh/users/1603923)             | Japanese                 |
-| [Deramok](https://osu.ppy.sh/users/1428455)           |                          |
 | [DeRandom Otaku](https://osu.ppy.sh/users/5156153)    | Urdu                     |
 | [Doormat](https://osu.ppy.sh/users/3230571)           |                          |
 | [Electoz](https://osu.ppy.sh/users/6485263)           | Thai                     |
@@ -85,7 +91,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Hailie](https://osu.ppy.sh/users/5226970)            |                          |
 | [Halfslashed](https://osu.ppy.sh/users/4598899)       |                          |
 | [Hobbes2](https://osu.ppy.sh/users/8157492)           |                          |
-| [hypercyte](https://osu.ppy.sh/users/9155377)         | Bangla, some Arabic      |
 | [iYiyo](https://osu.ppy.sh/users/3919785)             | Spanish, some German     |
 | [jonathanlfj](https://osu.ppy.sh/users/270377)        | Chinese, some French     |
 | [Kagetsu](https://osu.ppy.sh/users/6203841)           | Spanish                  |
@@ -93,7 +98,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Karen](https://osu.ppy.sh/users/3143784)             | Chinese                  |
 | [Kibbleru](https://osu.ppy.sh/users/3193504)          |                          |
 | [Kuron-kun](https://osu.ppy.sh/users/2697284)         | Portuguese               |
-| [kwk](https://osu.ppy.sh/users/365586)                |                          |
 | [Lafayla](https://osu.ppy.sh/users/5312547)           |                          |
 | [mancuso_JM_](https://osu.ppy.sh/users/521568)        | Spanish, Portuguese      |
 | [MaridiuS](https://osu.ppy.sh/users/4496961)          | Serbian                  |
@@ -115,7 +119,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Ryuusei Aika](https://osu.ppy.sh/users/7777875)      | Chinese, some French     |
 | [sahuang](https://osu.ppy.sh/users/5318910)           | Chinese                  |
 | [Sieg](https://osu.ppy.sh/users/1404615)              | Russian                  |
-| [Sinnoh](https://osu.ppy.sh/users/4236057)            | Some French              |
 | [smallboat](https://osu.ppy.sh/users/243049)          | Chinese                  |
 | [Sonnyc](https://osu.ppy.sh/users/11771)              | Korean                   |
 | [squirrelpascals](https://osu.ppy.sh/users/6151332)   |                          |

--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -58,7 +58,7 @@ Modders that aim to apply to the Beatmap Nominators must fulfil the following cr
 Quality Assurance Helpers
 -------------------------
 
-The Quality Assurance Helpers are volunteers inside of the Beatmap Nominators who assist the Quality Assurance Team at checking every single qualified beatmap for issues. They do so by reporting maps on the [Report a Qualified beatmap here!](https://osu.ppy.sh/forum/p/5075934) thread. 
+The Quality Assurance Helpers are volunteers inside of the Beatmap Nominators who assist the Quality Assurance Team at checking every single qualified beatmap for issues. They do so by reporting maps on the [Report a Qualified beatmap here!](https://osu.ppy.sh/forum/t/447428) thread. 
 
 Quality Assurance Helpers are free to choose whatever maps they like to check as long as they check at least four qualified maps per month. If they are not able to fulfill these activity standards, they will be removed and can only rejoin after a cooldown of one month. Beatmap Nominators who are not on their probationary period or in the cooldown period mentioned above may join the Quality Assurance Helpers at any time. 
 

--- a/wiki/People/Quality_Assurance_Team/en.md
+++ b/wiki/People/Quality_Assurance_Team/en.md
@@ -4,11 +4,11 @@
 Quality Assurance Team
 ======================
 
-The **Quality Assurance Team**, commonly referred to as QAT, are the judges of quality control who will check recently qualified beatmaps for quality and playability, retracting their qualified status as a disqualification notice where appropriate. They form the bulwark of standard control and enforce the basic expectation of quality for all beatmaps that enter the ranking process.
+The Quality Assurance Team, commonly referred to as QAT, form the last line of defense for standard control and enforce the basic expectation of quality for all beatmaps that enter the ranking process. Along with the [Quality Assurance Helpers](https://osu.ppy.sh/community/forums/topics/764134), they check recently Qualified beatmaps for any issues that may have slipped past the nomination and modding processes. Mapsets that contain issues have their Qualified status revoked through disqualification where necessary.
 
-QAT members will be held to strict activity standards as their role requires them to be regularly involved in assessing beatmap quality.
+In addition to assuring the basic expectation of quality, the QAT also manage the [Beatmap Nominators](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators) and ensure the enforcement of various rulesets surrounding the ranking process, for example the [Code of Conduct](https://osu.ppy.sh/help/wiki/Ranking_Criteria/Code_of_Conduct), [Ranking Criteria](https://osu.ppy.sh/help/wiki/Ranking_Criteria) and [Beatmap Nominator Rules](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators/Rules). This requires them to be regularly involved in assessing beatmap quality and overseeing the activity of the Beatmap Nominators.
 
-Members of this team will be promoted from [BNs](/wiki/People/Beatmap_Nominators/), should they accept the new role offered. Members of QAT have a red name on the in-game chat and on the forums, whereas BNs only have a purple name on the forums.
+Members of this team are generally promoted from well-behaved, active and willing members of the Quality Assurance Helpers, whom are also deemed to work well with the team. Members of the QAT have a red name in the game's chat and on the forums, whereas BNs have a purple name only on the forums.
 
 Team Members
 ------------
@@ -19,16 +19,12 @@ Link to [user group page](https://osu.ppy.sh/groups/7)
 |---------------------------------------------------|:------------:|:------------:|:------------:|:------------:|:----------------------------|
 | [-Mo-](https://osu.ppy.sh/users/2202163)              | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Aloda](https://osu.ppy.sh/users/1190127)             | ![No][false] | ![Yes][true] | ![No][false] | ![No][false] |                         |
-| [Asherz007](https://osu.ppy.sh/users/9014047)         | ![No][false] | ![No][false] | ![No][false] | ![Yes][true] |                         |
 | [Chaoslitz](https://osu.ppy.sh/users/3621552)         | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Cantonese, Chinese      |
 | [Deif](https://osu.ppy.sh/users/318565)               | ![No][false] | ![No][false] | ![Yes][true] | ![No][false] | Spanish, German         |
-| [Doyak](https://osu.ppy.sh/users/2046893)             | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Korean                  |
 | [Feerum](https://osu.ppy.sh/users/4815717)            | ![No][false] | ![No][false] | ![No][false] | ![Yes][true] | German, Polish          |
 | [Fycho](https://osu.ppy.sh/users/1876867)             | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Chinese                 |
 | [Gabe](https://osu.ppy.sh/users/654108)               | ![Yes][true] | ![Yes][true] | ![No][false] | ![No][false] | French                  |
 | [JBHyperion](https://osu.ppy.sh/users/4879508)        | ![No][false] | ![No][false] | ![Yes][true] | ![No][false] |                         |
-| [Kurai](https://osu.ppy.sh/users/77089)               | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | French                  |
-| [Kurokami](https://osu.ppy.sh/users/260933)           | ![No][false] | ![No][false] | ![Yes][true] | ![No][false] | Hungarian               |
 | [Lanturn](https://osu.ppy.sh/users/1446665)           | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Lasse](https://osu.ppy.sh/users/896613)              | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | German                  |
 | [Mao](https://osu.ppy.sh/users/2204515)               | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | German                  |

--- a/wiki/People/Quality_Assurance_Team/en.md
+++ b/wiki/People/Quality_Assurance_Team/en.md
@@ -4,7 +4,7 @@
 Quality Assurance Team
 ======================
 
-The Quality Assurance Team, commonly referred to as QAT, form the last line of defense for standard control and enforce the basic expectation of quality for all beatmaps that enter the ranking process. Along with the [Quality Assurance Helpers](https://osu.ppy.sh/community/forums/topics/764134), they check recently Qualified beatmaps for any issues that may have slipped past the nomination and modding processes. Mapsets that contain issues have their Qualified status revoked through disqualification where necessary.
+The Quality Assurance Team, commonly referred to as QAT, form the last line of defense for standard control and enforce the basic expectation of quality for all beatmaps that enter the ranking process. Along with the [Quality Assurance Helpers](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators/#quality-assurance-helpers), they check recently Qualified beatmaps for any issues that may have slipped past the nomination and modding processes. Mapsets that contain issues have their Qualified status revoked through disqualification where necessary.
 
 In addition to assuring the basic expectation of quality, the QAT also manage the [Beatmap Nominators](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators) and ensure the enforcement of various rulesets surrounding the ranking process, for example the [Code of Conduct](https://osu.ppy.sh/help/wiki/Ranking_Criteria/Code_of_Conduct), [Ranking Criteria](https://osu.ppy.sh/help/wiki/Ranking_Criteria) and [Beatmap Nominator Rules](https://osu.ppy.sh/help/wiki/People/Beatmap_Nominators/Rules). This requires them to be regularly involved in assessing beatmap quality and overseeing the activity of the Beatmap Nominators.
 


### PR DESCRIPTION
quality assurance team page was outdated:
 - table had old info
 - explanations for what the qat does and how to join were not accurate

as part of the latest commit, this updates the BN info/table as well