### PR TITLE
Update .db file format

### DIFF
--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -68,7 +68,7 @@ Some data types specific to osu!.db are defined below.
 | String | Audio file name |
 | String | MD5 hash of the beatmap |
 | String | Name of the .osu file corresponding to this beatmap |
-| Byte | Ranked status (4 = ranked, 5 = approved, 2 = pending/graveyard) |
+| Byte | Ranked status (4 = ranked, 5 = approved, 2 = pending/graveyard, 7 = loved, 1 = unsubmitted) |
 | Short | Number of hitcircles |
 | Short | Number of sliders (note: this will be present in every mode) |
 | Short | Number of spinners (note: this will be present in every mode) |

--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -179,6 +179,4 @@ This database contains the scores achieved locally.
 | Int | Should always be 0xffffffff (-1). |
 | Long | Online Score ID |
 
-Apart from the online score ID, the individual score format is the same as the replay format. [Osr (file format)][Osr Link]. This explains the empty string and -1 int.
-[Osr Link]: /wiki/osu!_File_Formats/Osr_(file_format)
-[Osu Link]: /wiki/osu!_File_Formats/Osu_(file_format)
+Apart from the online score ID, the individual score format is the same as the replay format. This explains the empty string and -1 int. See [this](/wiki/osu!_File_Formats/Osr_(file_format)).


### PR DESCRIPTION
Update article about the .db file format by adding "loved" and "unsubmitted" rank status identifiers. Fixed link at bottom of the article targeting the .osr file format article.

Found out about the missing identifiers while writing an API that wraps around the database file formats in the osu directory.

![Identifier for /b/545076](https://user-images.githubusercontent.com/22560425/42170288-6365d42a-7e16-11e8-8491-ed0a64f8bbab.png)
See above, identifier for [/b/545076](https://osu.ppy.sh/beatmapsets/545076/) (loved).

![Identifier for local beatmap](https://user-images.githubusercontent.com/22560425/42170395-b179d526-7e16-11e8-94fc-198cc83bd754.png)
See above, identifier for a local, unsubmitted beatmap.

There used to be a link to the .osu file format as well but it wasn't evident how it correlated with the section it was mentioned in. Can add again if desired. Otherwise ready for review.