### PR TITLE
Replaced osu!wiki with osu! wiki in HOO

### DIFF
--- a/wiki/History_of_osu!/2011/en.md
+++ b/wiki/History_of_osu!/2011/en.md
@@ -8,4 +8,4 @@ The osu! wiki was announced, allowing users to add all sorts of information abou
 
 Links:
 
-- [osu! wiki project](https://osu.ppy.sh/community/forums/topics/68479)
+- [osu!wiki project](https://osu.ppy.sh/community/forums/topics/68479)

--- a/wiki/History_of_osu!/2011/en.md
+++ b/wiki/History_of_osu!/2011/en.md
@@ -4,8 +4,8 @@
 
 ## December
 
-The osu!wiki was announced, allowing users to add all sorts of information about everything osu! related.
+The osu! wiki was announced, allowing users to add all sorts of information about everything osu! related.
 
 Links:
 
-- [osu!wiki project](https://osu.ppy.sh/community/forums/topics/68479)
+- [osu! wiki project](https://osu.ppy.sh/community/forums/topics/68479)

--- a/wiki/History_of_osu!/2013/en.md
+++ b/wiki/History_of_osu!/2013/en.md
@@ -15,7 +15,7 @@ Links:
 
 ## February
 
-A new version of the osu!mania editor was being worked on. Taiko mode skinning now has a "metadata" bar (song title and artist below the playfield), taiko playfield was no longer transparent and fades in and out of kiai time. The original [FAQ](http://osu.ppy.sh/p/faq) has been superseded by the [osu!wiki](/wiki/FAQ).
+A new version of the osu!mania editor was being worked on. Taiko mode skinning now has a "metadata" bar (song title and artist below the playfield), taiko playfield was no longer transparent and fades in and out of kiai time. The original [FAQ](http://osu.ppy.sh/p/faq) has been superseded by the [osu! wiki](/wiki/FAQ).
 
 BanchoBot's `!faq` command has been open to public for [translation](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdHhUUjNSa19QendtcTdYUjE2S2hnVHc#gid=24). The legendary [BanchoBot](/wiki/BanchoBot) finally has a [profile](/users/3)! The user panels display now adjusts to display four columns on all widescreen modes.
 

--- a/wiki/History_of_osu!/en.md
+++ b/wiki/History_of_osu!/en.md
@@ -19,4 +19,4 @@ Records of osu!'s history, all in the osu! wiki.
 
 On a side note, the osu! wiki has a bit of its own detailed history in and of itself.
 
-- [osu! wiki](/wiki/HOO/osu!_wiki)
+- [osu! wiki](/wiki/HOO/osu!wiki)

--- a/wiki/History_of_osu!/en.md
+++ b/wiki/History_of_osu!/en.md
@@ -17,6 +17,6 @@ Records of osu!'s history, all in the osu! wiki.
 
 ---
 
-On a side note, the osu!wiki has a bit of its own detailed history in and of itself.
+On a side note, the osu! wiki has a bit of its own detailed history in and of itself.
 
 - [osu! wiki](/wiki/HOO/osu!_wiki)

--- a/wiki/History_of_osu!/en.md
+++ b/wiki/History_of_osu!/en.md
@@ -1,17 +1,17 @@
 # History of osu!
 
-Records of osu!'s history, all in the osu!wiki.
+Records of osu!'s history, all in the osu! wiki.
 
 - [2007](/wiki/HOO/2007) - Initial game build
 - [2008](/wiki/HOO/2008) - Taiko and Catch the Beat, more mods, and major improvements
 - [2009](/wiki/HOO/2009) - osu! iPhone
 - 2010
-- [2011](/wiki/HOO/2011) - osu!wiki
+- [2011](/wiki/HOO/2011) - osu! wiki
 - [2012](/wiki/HOO/2012) - Five years of osu!, osu!mania, widescreen support, and visual settings
 - [2013](/wiki/HOO/2013) - UI overhaul, HD skins, (more) widescreen support, osu!mania editor, in-game collections, moddingV2 was introduced, Disqus, osu!api, accuracy overlays, Comic Fiesta 2013, downloads unrestricted\*, and osu!cuttingedge (osu!supporters only)
 - [2014](/wiki/HOO/2014) - BPM scrolling, in-game intro/outro sequences, osu!cuttingedge (for everyone\*), and snow!
 - [2015](/wiki/HOO/2015) - jizz (redesigned osu!web), osu!weekly, and osu!coins
-- [2016](/wiki/HOO/2016) - scorev2, open-source osu! announced (osu!lazer), and osu!wiki (overhaul)
+- [2016](/wiki/HOO/2016) - scorev2, open-source osu! announced (osu!lazer), and osu! wiki (overhaul)
 - [2017](/wiki/HOO/2017) - first osu!lazer build release, and Discord integration
 - [2018](/wiki/HOO/2018) - ?
 
@@ -19,4 +19,4 @@ Records of osu!'s history, all in the osu!wiki.
 
 On a side note, the osu!wiki has a bit of its own detailed history in and of itself.
 
-- [osu!wiki](/wiki/HOO/osu!wiki)
+- [osu! wiki](/wiki/HOO/osu!_wiki)


### PR DESCRIPTION
A few articles in History of osu! still used the old wiki name. Complete folder should use the new name now.