### PR TITLE
Unify the style of the OWC articles

### DIFF
--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -5,10 +5,10 @@ tags:
 - OWC#1
 - OWC1
 ---
-osu! World Cup #1
-=====================
 
-![osu! World Cup #1](logo.png)
+# osu! World Cup #1
+
+![osu! World Cup #1 logo](logo.png)
 
 The **osu! World Cup #1** (***OWC #1***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 1st installment of the osu! World Cup.
 
@@ -21,14 +21,14 @@ The **osu! World Cup #1** (***OWC #1***) is a country-based osu! tournament host
 
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
-| Place | Prize(s) |
-| ----- | -------- |
+| Placing | Prize(s) |
+| ----- | :------- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, special profile badge |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 1 month supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
 | *Special* | 1 month supporter tag (won by ![][flag_JP] Japan) |
 
-## Organization
+## Organisation
 
 The osu! World Cup #1 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
@@ -47,10 +47,6 @@ The osu! World Cup #1 was run by various community members by distributing the m
 - [Finals recap](https://www.mediafire.com/file/ab6j6k4ihtp25o2) - provided by [dvorak](https://osu.ppy.sh/users/271359)
 
 ------------------------------------------------------------
-
-![osu! World Cup #1 Brackets](brackets.png)
-
-----------------------------------------------------
 
 ## Participants
 
@@ -85,6 +81,8 @@ The osu! World Cup #1 was run by various community members by distributing the m
 | ![][flag_GB] | **United Kingdom** | **Doomsday**, Natteke, aevv, Jericho2442, DiamondCrash |
 | ![][flag_US] | **United States** | **Lybydose**, Mafiamaster, Cyclone, ebacho, naptime |
 
+## Groups
+
 | Asia/Oceania | Europe | America |
 | ------------ | ------ | ------- |
 | ![][flag_CN] China       | ![][flag_AT] Austria | ![][flag_AR] Argentina |  
@@ -101,9 +99,13 @@ The osu! World Cup #1 was run by various community members by distributing the m
 | | ![][flag_UA] Ukraine | |
 | | ![][flag_GB] United Kingdom | |
 
+------------------------------------------------------------
+
+![osu! World Cup #1 Brackets](brackets.png)
+
 ---------------------------------------------------
 
-## Mappool
+## Mappools
 
 ### Finals
 

--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -117,7 +117,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
   - [DJ YOSHITAKA - Bloody Tears(IIDX EDITION) (Gabi) \[Insane\]](https://osu.ppy.sh/beatmapsets/6598#osu/29731)
   - [Betwixt & Between - I think we can go to the moon (AngelHoney) \[Another\]](https://osu.ppy.sh/beatmapsets/13728#osu/50658)
 - Tiebreaker
-  - [Renard - Banned Forever (Blue Dragon) \[Nogard\]](https://osu.ppy.sh/beatmapsets/16349#osu/64267)
+  - **[Renard - Banned Forever (Blue Dragon) \[Nogard\]](https://osu.ppy.sh/beatmapsets/16349#osu/64267)**
 
 ### Semifinals
 
@@ -129,7 +129,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
   - [Tachibana Miya - Miya to Tengoku to Jigoku (AngelHoney) \[Hentai\]](https://osu.ppy.sh/beatmapsets/17450#osu/62269)
   - [Nobuo Uematsu - The Fierce Battle (mtmcl) \[Omega\]](https://osu.ppy.sh/beatmapsets/5727#osu/27466)
 - Tiebreaker
-  - [Rhapsody - Emerald Sword (Reikin) \[Extreme\]](https://osu.ppy.sh/beatmapsets/3198#osu/25580)
+  - **[Rhapsody - Emerald Sword (Reikin) \[Extreme\]](https://osu.ppy.sh/beatmapsets/3198#osu/25580)**
 
 ### Quarterfinals
 
@@ -150,7 +150,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
   - [sun3 - Higan Retour (saymun) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/14464#osu/54373)
   - [Susumu Hirasawa - Amor Buffer (Real1) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/11702#osu/44526)
 - Tiebreaker
-  - [DJ Mars - Lemon Tree (MetalMario201) \[Hard\]](https://osu.ppy.sh/beatmapsets/8229#osu/34045)
+  - **[DJ Mars - Lemon Tree (MetalMario201) \[Hard\]](https://osu.ppy.sh/beatmapsets/8229#osu/34045)**
 
 ### Round of 16
 
@@ -171,7 +171,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
   - [Tatsh - Cruel Moon (Shinxyn) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/13584#osu/50148)
   - [The Mighty Mighty Bosstones - The Impression That I Get (lesjuh) \[Hard\]](https://osu.ppy.sh/beatmapsets/14912#osu/54329)
 - Tiebreaker
-  - [Seiryu - Time to Air (Alace) \[DaRRi MIx\]](https://osu.ppy.sh/beatmapsets/4597#osu/24594)
+  - **[Seiryu - Time to Air (Alace) \[DaRRi MIx\]](https://osu.ppy.sh/beatmapsets/4597#osu/24594)**
 
 ### Group Stage 
 
@@ -192,7 +192,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
   - [The Gregory Brothers - Auto-Tune the News \#9 (MetalMario201) \[Angry Gorilla\]](https://osu.ppy.sh/beatmapsets/12155#osu/45825)
   - [Weird Al Yankovic - Hardware Store (kingcobra52) \[Impossible\]](https://osu.ppy.sh/beatmapsets/2042#osu/18682)
 - Tiebreaker
-  - [Hyadain - Battle with the Four Fiends (mtmcl) \[Sinistro\]](https://osu.ppy.sh/beatmapsets/2619#osu/20019)
+  - **[Hyadain - Battle with the Four Fiends (mtmcl) \[Sinistro\]](https://osu.ppy.sh/beatmapsets/2619#osu/20019)**
 
 --------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -22,7 +22,7 @@ The **osu! World Cup #1** (***OWC #1***) is a country-based osu! tournament host
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
 | Placing | Prize(s) |
-| ----- | :------- |
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, special profile badge |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 1 month supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
@@ -51,7 +51,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
 ## Participants
 
 | | Country | Members |
-| --- | :-------: | ------------ |
+| :-: | :-: | :-- |
 | ![][flag_AT] | **Austria** | **TouhouNerd**, Snowball, Hanyuu, Nharox, unbelievable |
 | ![][flag_AR] | **Argentina** | **Wishy22**, RocknRolla, Grisuh, Vivere, lota78, violentt |
 | ![][flag_BR] | **Brazil** | **fabriciorby**, Coy, Blue Dragon, Poisonchan, Antsu, Guerra |

--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -8,7 +8,7 @@ tags:
 
 # osu! World Cup #1
 
-![osu! World Cup #1 logo](logo.png)
+![OWC #1 Logo](logo.png)
 
 The **osu! World Cup #1** (***OWC #1***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 1st installment of the osu! World Cup.
 
@@ -101,7 +101,7 @@ The osu! World Cup #1 was run by various community members by distributing the m
 
 ------------------------------------------------------------
 
-![osu! World Cup #1 Brackets](brackets.png)
+![OWC #1 Brackets](brackets.png)
 
 ---------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -8,7 +8,7 @@ tags:
 
 # osu! World Cup #2
 
-![osu! World Cup #2 logo](logo.png)
+![OWC #2 Logo](logo.png)
 
 The **osu! World Cup #2** (***OWC #2***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 2nd installment of the osu! World Cup.
 
@@ -34,8 +34,8 @@ The osu! World Cup #2 was run by various community members by distributing the m
 
 ## Links
 
-- [Tournament Schedule](https://docs.google.com/document/d/1aYgninqJ6OolEvkynUsirJMpt8ZcV4Eksb7p4xuU2Jg/edit)
-- [Pre-tournament Interviews](https://docs.google.com/document/d/1xgR7cfCf1yZD1j90_ObGKccS_9OMA6rDHhYJy8uRxNE/edit)
+- [Tournament schedule](https://docs.google.com/document/d/1aYgninqJ6OolEvkynUsirJMpt8ZcV4Eksb7p4xuU2Jg/edit)
+- [Pre-tournament interviews](https://docs.google.com/document/d/1xgR7cfCf1yZD1j90_ObGKccS_9OMA6rDHhYJy8uRxNE/edit)
 
 ------------------------------------------
 
@@ -87,7 +87,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
 
 ------------------------------------
 
-![osu! World Cup #2 Brackets](brackets.png)
+![OWC #2 Brackets](brackets.png)
 
 ------------------------------------------
 

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -17,7 +17,7 @@ The **osu! World Cup #2** (***OWC #2***) is a country-based osu! tournament host
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
 | Placing | Prize(s) |
-| ----- | :------- |
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, special profile badge |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 1 month supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
@@ -42,7 +42,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
 ## Participants
 
 | | Country | Members |
-| -- |:---------:|---------|
+| :-: | :-: | :-- |
 | ![][flag_AR] | **Argentina** | **Wishy22**, [Metro](https://osu.ppy.sh/users/306737), Ever17, [Darksonic](https://osu.ppy.sh/users/570042), [Salvage](https://osu.ppy.sh/users/242119), [Glazbom](https://osu.ppy.sh/users/608277) |
 | ![][flag_AU] | **Australia** | **Mizorex**, damiaanzx, [Hark](https://osu.ppy.sh/users/43265), [Frankcons](https://osu.ppy.sh/users/594006), [Mikey](https://osu.ppy.sh/users/979780), [Neko_Lover](https://osu.ppy.sh/users/596535) |
 | ![][flag_AT] |**Austria** | **[-Lennox-](https://osu.ppy.sh/users/489103)**, [Snowball](https://osu.ppy.sh/users/152238), [Hanyuu](https://osu.ppy.sh/users/73480), HakkeroHakkero, [novaaa](https://osu.ppy.sh/users/953405), [M A R I O](https://osu.ppy.sh/users/594424) |

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -112,7 +112,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Nanamori-chu * Goraku-bu - My Pace de Ikimashou \[Yuri\]](https://osu.ppy.sh/beatmaps/118226)
     - [DJ Fresh - Gold Dust \[Insane\]](https://osu.ppy.sh/beatmaps/93842)
 - Tiebreaker:
-    - [Loathing in Las Vegas - Just Awake \[Insane\]](https://osu.ppy.sh/beatmaps/139446)
+    - **[Loathing in Las Vegas - Just Awake \[Insane\]](https://osu.ppy.sh/beatmaps/139446)**
 
 ### Semifinals
     
@@ -132,7 +132,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Hatsune Miku - Kagerou Days \[mizuki\]](https://osu.ppy.sh/beatmaps/128668)
     - [Paramore - Looking Up \[Hard\]](https://osu.ppy.sh/beatmaps/66662)
 - Tiebreaker:
-    - [DJ Fresh - Gold Dust \[Insane\]](https://osu.ppy.sh/beatmaps/93842)
+    - **[DJ Fresh - Gold Dust \[Insane\]](https://osu.ppy.sh/beatmaps/93842)**
 
 ### Quarterfinals
 
@@ -152,7 +152,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Lou Bega - Mambo No.5 \[Insane\]](https://osu.ppy.sh/beatmaps/108936)
     - [Pizuya's Cell x MyonMyon - Romantic Children \[Lunatic\]](https://osu.ppy.sh/beatmaps/68431)
 - Tiebreaker:
-    - [Nanamori-chu * Goraku-bu - My Pace de Ikimashou \[Yuri\]](https://osu.ppy.sh/beatmaps/118226)
+    - **[Nanamori-chu * Goraku-bu - My Pace de Ikimashou \[Yuri\]](https://osu.ppy.sh/beatmaps/118226)**
 
 ### Round of 16
 
@@ -172,7 +172,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Megpoid GUMI - Chocolate \[Insane\]](https://osu.ppy.sh/beatmaps/89721)
     - [DCX - Flying High (DJ Splash Remix) \[InoSane\]](https://osu.ppy.sh/beatmaps/76663)
 - Tiebreaker:
-    - [Hatsune Miku - Rubik's Cube \[7x7x7\]](https://osu.ppy.sh/beatmaps/114635)
+    - **[Hatsune Miku - Rubik's Cube \[7x7x7\]](https://osu.ppy.sh/beatmaps/114635)**
 
 ### Group Stage (Round 3)
 
@@ -192,7 +192,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Pendulum - The Vulture \[Insane\]](https://osu.ppy.sh/beatmaps/82249)
     - [Hatsune Miku - Kusaregedou to Chocolate \[Insane\]](https://osu.ppy.sh/beatmaps/85494)
 - Tiebreaker:
-    - [Hommarju feat. R.Cena - Chousai Kenbo Sengen \[Insane\]](https://osu.ppy.sh/beatmaps/99342)
+    - **[Hommarju feat. R.Cena - Chousai Kenbo Sengen \[Insane\]](https://osu.ppy.sh/beatmaps/99342)**
 
 ### Group Stage (Round 2)
 
@@ -212,7 +212,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Aizawa - Flutter Girl \[Insane\]](https://osu.ppy.sh/beatmaps/61124)
     - [Mutsuhiko Izumi - Russian Snowy Dance \[Insane\]](https://osu.ppy.sh/beatmaps/124275)
 - Tiebreaker:
-    - [Okui Masami - God Speed \[Insane\]](https://osu.ppy.sh/beatmaps/93947)
+    - **[Okui Masami - God Speed \[Insane\]](https://osu.ppy.sh/beatmaps/93947)**
 
 ### Group Stage (Round 1)
 
@@ -232,7 +232,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
     - [Lia - Kokoro ni Todoku Uta \[Holo\]](https://osu.ppy.sh/beatmaps/89428)
     - [nomico - Bad Apple!! \[Hard\]](https://osu.ppy.sh/beatmaps/28755)
 - Tiebreaker:
-    - [supercell - Rock 'n' Roll Nan Desu no \[Insane\]](https://osu.ppy.sh/beatmaps/93021)
+    - **[supercell - Rock 'n' Roll Nan Desu no \[Insane\]](https://osu.ppy.sh/beatmaps/93021)**
 
 ------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -5,8 +5,8 @@ tags:
 - OWC#2
 - OWC2
 ---
-osu! World Cup #2
-========================
+
+# osu! World Cup #2
 
 ![osu! World Cup #2 logo](logo.png)
 
@@ -16,17 +16,17 @@ The **osu! World Cup #2** (***OWC #2***) is a country-based osu! tournament host
 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
-| Place | Prize(s) |
-| ----- | -------- |
+| Placing | Prize(s) |
+| ----- | :------- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, special profile badge |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 1 month supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
 
-## Organization
+## Organisation
 
 The osu! World Cup #2 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917), ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) |
 | Map Selectors | ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993), ![][flag_DE] [Dangaard](https://osu.ppy.sh/users/19488), ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917), ![][flag_SE] [Gabi](https://osu.ppy.sh/users/57057), ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679), ![][flag_US] [SapphireGhost](https://osu.ppy.sh/users/388602) |
@@ -36,10 +36,6 @@ The osu! World Cup #2 was run by various community members by distributing the m
 
 - [Tournament Schedule](https://docs.google.com/document/d/1aYgninqJ6OolEvkynUsirJMpt8ZcV4Eksb7p4xuU2Jg/edit)
 - [Pre-tournament Interviews](https://docs.google.com/document/d/1xgR7cfCf1yZD1j90_ObGKccS_9OMA6rDHhYJy8uRxNE/edit)
-
-------------------------------------------
-
-![osu! World Cup #2 Brackets](brackets.png)
 
 ------------------------------------------
 
@@ -80,6 +76,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
 | ![][flag_UY] | **Uruguay** | **[maay](https://osu.ppy.sh/users/160970)**, Z e o n, [GonixZ](https://osu.ppy.sh/users/612622), [H1ko](https://osu.ppy.sh/users/58710), Snepif, [AlrdyExists](https://osu.ppy.sh/users/407022) |
 | ![][flag_VN] | **Vietnam** | **[Misuzu-san](https://osu.ppy.sh/users/358563)**, [JerryC](https://osu.ppy.sh/users/279278), [Shin1801](https://osu.ppy.sh/users/604492), [BridgetteLSatellizer](https://osu.ppy.sh/users/854083), [xLightningx](https://osu.ppy.sh/users/1007806), [kira\_lacus1995](https://osu.ppy.sh/users/996435) |
 
+## Groups
 
 | Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H |
 | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
@@ -90,7 +87,11 @@ The osu! World Cup #2 was run by various community members by distributing the m
 
 ------------------------------------
 
-## Mappool
+![osu! World Cup #2 Brackets](brackets.png)
+
+------------------------------------------
+
+## Mappools
 
 ### Finals
 

--- a/wiki/Tournaments/OWC/2013/en.md
+++ b/wiki/Tournaments/OWC/2013/en.md
@@ -112,7 +112,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 ### Finals
 
-**[Download the mappack here! (194.7MB)](https://www.mediafire.com/download/igx08rvp8g5502v/Final%20Map%20Pool.rar)**
+**[Download the mappack here! (194 MB)](https://www.mediafire.com/download/igx08rvp8g5502v/Final%20Map%20Pool.rar)**
 
 - NoMod
   - [Ryu\* vs. kors k - Force of Wind (Jenny) \[Extra\]](https://osu.ppy.sh/beatmaps/142239)
@@ -146,7 +146,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 ### Semifinals
 
-**[Download the mappack here! (209.3MB)](https://www.mediafire.com/?pn3yxce7m6v4j13)**
+**[Download the mappack here! (209 MB)](https://www.mediafire.com/?pn3yxce7m6v4j13)**
 
 - NoMod
   - [CON - Cruel Clocks (Amamiya Yuko) \[Skystar\]](https://osu.ppy.sh/beatmaps/216272)
@@ -180,7 +180,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 ### Quarterfinals
 
-**[Download the mappack here! (184MB)](https://www.mediafire.com/download/i2umf8lrethjzoj/Quarter-finals.rar)**
+**[Download the mappack here! (184 MB)](https://www.mediafire.com/download/i2umf8lrethjzoj/Quarter-finals.rar)**
 
 - NoMod
   - [xi - Time files (gowww) \[Another\]](https://osu.ppy.sh/beatmaps/153484)
@@ -214,7 +214,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 ### Round of 16
 
-**[Download the mappack here! (143MB)](https://www.mediafire.com/download/e62iav4kb90981b/Round_of_16_Pack.rar)**
+**[Download the mappack here! (143 MB)](https://www.mediafire.com/download/e62iav4kb90981b/Round_of_16_Pack.rar)**
 
 - NoMod
   - [DECO\*27 feat. marina - Aimai Elegy (val0108) \[0108\]](https://osu.ppy.sh/beatmaps/135804)
@@ -248,7 +248,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 ### Group Stage
 
-**[Download the mappack here! (215.9MB)](https://www.mediafire.com/?jn0c8p6wqfrtfhb)**
+**[Download the mappack here! (215 MB)](https://www.mediafire.com/?jn0c8p6wqfrtfhb)**
 
 - NoMod
   - [Mikami Shiori & Ookubo Rumi - Onna to Onna no Yuri-Game (eg91022a71w) \[YuruYuri\]](https://osu.ppy.sh/beatmaps/153418)

--- a/wiki/Tournaments/OWC/2013/en.md
+++ b/wiki/Tournaments/OWC/2013/en.md
@@ -13,9 +13,9 @@ The **osu! World Cup 2013** (***OWC 2013***) is a country-based osu! tournament 
 ## Tournament Schedule
 
 | Event | Timestamp  |
-|-----------------------:|-------------------------|
+|------:|:-----------|
 | Registration Phase | 2013-10-15/2013-10-28 |
-| Drawings  | 2013-10-31 (16:00 UTC+0)|
+| Live Drawings  | 2013-10-31 (16:00 UTC+0)|
 | Group Stage | 2013-11-08/2013-11-10 |
 | Round of 16 | 2013-11-16/2013-11-17 |
 | Quarterfinals  | 2013-11-23/2013-11-24 |
@@ -26,17 +26,17 @@ The **osu! World Cup 2013** (***OWC 2013***) is a country-based osu! tournament 
 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
-| Place | Prize(s) |
-| ----- | -------- |
+| Placing | Prize(s) |
+| ----- | :------- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | 6 months supporter tag, special profile badge, OWC trophy, [osu!tablet](https://osu.ppy.sh/forum/t/169139) |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 months supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
 
-## Organization
+## Organisation
 
 The osu! World Cup 2013 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_US] [dkun](https://osu.ppy.sh/users/154400) |
 | Map Selectors | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_AR] [Wishy](https://osu.ppy.sh/users/495477), ![][flag_IT] [Chewin](https://osu.ppy.sh/users/617323) |
@@ -48,13 +48,9 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 - [Discussion thread](https://osu.ppy.sh/forum/t/160181/start=0)
 - [Livestream](https://www.twitch.tv/osulive/profile/pastBroadcasts)
-- **[Statistics Sheet](https://docs.google.com/spreadsheet/ccc?key=0AsjrK0nkPsOfdGZmZ2VKZ05KV1pjdUE5VlpHYVlwZWc&usp=drive_web#gid=17)**
+- **[Statistics sheet](https://docs.google.com/spreadsheet/ccc?key=0AsjrK0nkPsOfdGZmZ2VKZ05KV1pjdUE5VlpHYVlwZWc&usp=drive_web#gid=17)**
 
 -------------------------------------------
-
-![osu! World Cup 2013 Brackets](brackets.jpg)
-
--------------------------------
 
 ## Participants
 
@@ -93,6 +89,8 @@ The osu! World Cup 2013 was run by various community members by distributing the
 | ![][flag_US] | United States | **Kaoru**, Floks, Kyou-kun, Thatgooey, pielak213, Silynn, pooptartsonas, SapphireGhost |
 | ![][flag_VE] | Venezuela | **MeowinTurtle**, S4suk3, CrymynaL, Baozis, Livean, Roli |
 
+## Groups
+
 | Top-seeded | High-seeded | Low-seeded | Unseeded |
 | ---------- | ----------- | ---------- | -------- |
 | ![][flag_CN] China | ![][flag_AR] Argentina | ![][flag_AU] Australia | ![][flag_BE] Belgium |
@@ -106,12 +104,15 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 --------------------------------
 
-Mappool
--------------
+![osu! World Cup 2013 Brackets](brackets.jpg)
+
+-------------------------------
+
+## Mappools
 
 ### Finals
 
-**[Download the mappack here!](https://www.mediafire.com/download/igx08rvp8g5502v/Final%20Map%20Pool.rar)**
+**[Download the mappack here! (194.7MB)](https://www.mediafire.com/download/igx08rvp8g5502v/Final%20Map%20Pool.rar)**
 
 - NoMod
   - [Ryu\* vs. kors k - Force of Wind (Jenny) \[Extra\]](https://osu.ppy.sh/beatmaps/142239)
@@ -145,7 +146,7 @@ Mappool
 
 ### Semifinals
 
-**[Download the mappack here!](https://www.mediafire.com/?pn3yxce7m6v4j13)**
+**[Download the mappack here! (209.3MB)](https://www.mediafire.com/?pn3yxce7m6v4j13)**
 
 - NoMod
   - [CON - Cruel Clocks (Amamiya Yuko) \[Skystar\]](https://osu.ppy.sh/beatmaps/216272)
@@ -179,7 +180,7 @@ Mappool
 
 ### Quarterfinals
 
-**[Download the mappack here!](https://www.mediafire.com/download/i2umf8lrethjzoj/Quarter-finals.rar)**
+**[Download the mappack here! (184MB)](https://www.mediafire.com/download/i2umf8lrethjzoj/Quarter-finals.rar)**
 
 - NoMod
   - [xi - Time files (gowww) \[Another\]](https://osu.ppy.sh/beatmaps/153484)
@@ -213,7 +214,7 @@ Mappool
 
 ### Round of 16
 
-**[Download the mappack here!](https://www.mediafire.com/download/e62iav4kb90981b/Round_of_16_Pack.rar)**
+**[Download the mappack here! (143MB)](https://www.mediafire.com/download/e62iav4kb90981b/Round_of_16_Pack.rar)**
 
 - NoMod
   - [DECO\*27 feat. marina - Aimai Elegy (val0108) \[0108\]](https://osu.ppy.sh/beatmaps/135804)
@@ -247,7 +248,7 @@ Mappool
 
 ### Group Stage
 
-**[Download the mappack here!](https://www.mediafire.com/?jn0c8p6wqfrtfhb)**
+**[Download the mappack here! (215.9MB)](https://www.mediafire.com/?jn0c8p6wqfrtfhb)**
 
 - NoMod
   - [Mikami Shiori & Ookubo Rumi - Onna to Onna no Yuri-Game (eg91022a71w) \[YuruYuri\]](https://osu.ppy.sh/beatmaps/153418)
@@ -279,6 +280,8 @@ Mappool
 - Tiebreaker
   - **[DJ Okawari - Luv Letter (nold\_1702) \[Posthumous\]](https://osu.ppy.sh/beatmaps/127363)**
 
+--------------------------------
+
 ## Match Results
 
 ### Finals
@@ -292,14 +295,14 @@ Mappool
 | ---: | :---: | :---: | :--- | :---: |
 |  United Kingdom ![][flag_GB] | 1 | **6** | **Poland** ![][flag_PL] | [#1](https://osu.ppy.sh/community/matches/3272199) |
 
-### Semi-finals
+### Semifinals
 
 | Saturday, 2013-11-30 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
 |  **Korea** ![][flag_KR] | **6** | 1 | United Kingdom ![][flag_GB] | [#1](https://osu.ppy.sh/community/matches/3088440) |
 |  **Taiwan** ![][flag_TW]| **6** | 0 | Poland ![][flag_PL] | [#1](https://osu.ppy.sh/community/matches/3091169) |
 
-### Quarter-finals
+### Quarterfinals
 
 | Sunday, 2013-11-24 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
@@ -308,7 +311,7 @@ Mappool
 |  China ![][flag_CN]| 4 | **5** | **Poland** ![][flag_PL] | [#1](https://osu.ppy.sh/community/matches/2966197) |
 | **United Kingdom** ![][flag_GB] | **5** | 3 | Germany ![][flag_DE]  | [#1](https://osu.ppy.sh/community/matches/2969031) [#A](https://puu.sh/5rT5F/9b2a7bfa74.jpg) |
 
-### Round 16
+### Round of 16
 
 | Saturday, 2013-11-16 | | | | |
 | ---: | :---: | :---: | :--- | :---: |

--- a/wiki/Tournaments/OWC/2013/en.md
+++ b/wiki/Tournaments/OWC/2013/en.md
@@ -6,7 +6,7 @@ tags:
 
 # osu! World Cup 2013
 
-![osu! World Cup 2013 logo](logo.png)
+![OWC 2013 Logo](logo.png)
 
 The **osu! World Cup 2013** (***OWC 2013***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 4th installment of the osu! World Cup.
 
@@ -104,7 +104,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 
 --------------------------------
 
-![osu! World Cup 2013 Brackets](brackets.jpg)
+![OWC 2013 Brackets](brackets.jpg)
 
 -------------------------------
 

--- a/wiki/Tournaments/OWC/2013/en.md
+++ b/wiki/Tournaments/OWC/2013/en.md
@@ -27,7 +27,7 @@ The **osu! World Cup 2013** (***OWC 2013***) is a country-based osu! tournament 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
 | Placing | Prize(s) |
-| ----- | :------- |
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | 6 months supporter tag, special profile badge, OWC trophy, [osu!tablet](https://osu.ppy.sh/forum/t/169139) |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 months supporter tag |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag |
@@ -55,7 +55,7 @@ The osu! World Cup 2013 was run by various community members by distributing the
 ## Participants
 
 | | Country | Members |
-| - | :---: | -------- |
+| :-: | :-: | :-- |
 | ![][flag_AR] | Argentina | **Metro**, Glazbom, Salvage, Hernan, Fabi, druidxd, CBA-ES-CAB, Mikumiku97 |
 | ![][flag_AU] | Australia | **JappyBabes**, kamiyo-sama, flow, TimmyTimTims, Lach, Bauxe, Melt3dCheeze, smoogipooo |
 | ![][flag_AT] | Austria  | **Omgforz**, WhitePhoenixLP, M3tr01d, Alumetorz, Jin\_Back7, SunBurn |

--- a/wiki/Tournaments/OWC/2014/en.md
+++ b/wiki/Tournaments/OWC/2014/en.md
@@ -11,10 +11,10 @@ The **osu! World Cup 2014** (***OWC 2014***) is a country-based osu! tournament 
 
 ## Tournament Schedule
 
-| Event| Timestamp  |
-|-------------------:|--------------------------|
+| Event | Timestamp  |
+|------:|:-----------|
 | Registration Phase | 2014-10-02/2014-10-26    |
-| Drawings    | 2014-11-01  (14:00 UTC+0)|
+| Live Drawings  | 2014-11-01 (14:00 UTC+0)|
 | Group Stage | 2014-11-08/2014-11-09    |
 | Round of 16 | 2014-11-15/2014-11-16    |
 | Quarterfinals | 2014-11-22/2014-11-23    |
@@ -26,17 +26,17 @@ The **osu! World Cup 2014** (***OWC 2014***) is a country-based osu! tournament 
 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
-| Place | Prize(s) |
-| ----- | -------- |
+| Placing | Prize(s) |
+| ----- | :------- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, profile badge, "osu! Champion" user title, osu! merchandise |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 months supporter tag  |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag  |
 
-## Organization
+## Organisation
 
 The osu! World Cup 2014 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565)  |
 | Map Selectors | ![][flag_NL] [GladiOol](https://osu.ppy.sh/users/23326), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236)  |
@@ -46,13 +46,9 @@ The osu! World Cup 2014 was run by various community members by distributing the
 
 ## Links
 
--   [Discussion Thread](https://osu.ppy.sh/forum/p/3410198)
+-   [Discussion thread](https://osu.ppy.sh/forum/p/3410198)
 -   [Livestream](https://www.twitch.tv/osulive/)
--   **[Statistics Sheet](https://owc.nicarim.pw/results/view/3)**
-
-------------------------------------------------------------------------
-
-![OWC 2014 brackets](brackets.jpg)
+-   **[Statistics sheet](https://owc.nicarim.pw/results/view/3)**
 
 ------------------------------------------------------------------------
 
@@ -93,6 +89,8 @@ The osu! World Cup 2014 was run by various community members by distributing the
 | ![][flag_GB] |United Kingdom | **[jesus1412](https://osu.ppy.sh/users/230116)**, [Doomsday](https://osu.ppy.sh/users/18983), [Raiku](https://osu.ppy.sh/users/1525538), [lovu](https://osu.ppy.sh/users/846235), [PortalLife](https://osu.ppy.sh/users/929134), [bahamete](https://osu.ppy.sh/users/960620), [Kardet](https://osu.ppy.sh/users/1438509), [Jameslike](https://osu.ppy.sh/users/2415743)|
 | ![][flag_US] |United States  | **[pooptartsonas](https://osu.ppy.sh/users/1334453)**, [Kaoru](https://osu.ppy.sh/users/492699), [kittehcommando](https://osu.ppy.sh/users/2162669), [pielak](https://osu.ppy.sh/users/310455), [Xilver15](https://osu.ppy.sh/users/3099689), [SapphireGhost](https://osu.ppy.sh/users/388602), [Horo](https://osu.ppy.sh/users/992439), [-Soba-](https://osu.ppy.sh/users/663657) |
 
+## Groups
+
 | Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H | 
 | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
 | ![][flag_DE] Germany | ![][flag_AR] Argentina | ![][flag_AU] Australia | ![][flag_BR] Brazil  | ![][flag_LT] Lithuania | ![][flag_CA] Canada | ![][flag_FI] Finland | ![][flag_CN] China |
@@ -102,12 +100,15 @@ The osu! World Cup 2014 was run by various community members by distributing the
 
 ------------------------------------------------------------------------
 
-Mappool
-----------
+![OWC 2014 brackets](brackets.jpg)
+
+------------------------------------------------------------------------
+
+## Mappools
 
 ### Finals
 
-**[Download the mappack here!](https://www.mediafire.com/download/hd8njp8cvqad5yq/OWC_Finals.rar)**
+**[Download the mappack here! (130.7MB)](https://www.mediafire.com/download/hd8njp8cvqad5yq/OWC_Finals.rar)**
 
 - NoMod
   - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume wo Miru (Strawberry) \[BakaNA\]](https://osu.ppy.sh/beatmaps/214248)
@@ -137,7 +138,7 @@ Mappool
 
 ### Semifinals
 
-**[Download the mappack here!](https://www.mediafire.com/download/31bm61ol9wip0y4/OWC_SemiFinals.rar)**
+**[Download the mappack here! (187.8MB)](https://www.mediafire.com/download/31bm61ol9wip0y4/OWC_SemiFinals.rar)**
 
 - NoMod
   - [Hanatan - Airman ga Taosenai (SOUND HOLIC Ver.) (Natsu) \[CRN's Extra\]](https://osu.ppy.sh/beatmaps/338682)
@@ -167,7 +168,7 @@ Mappool
 
 ### Quarterfinals
 
-**[Download the mappack here!](https://www.mediafire.com/download/gh0da1ahgxiogka/OWC_Quarter_Finals.rar)**
+**[Download the mappack here! (164.1MB)](https://www.mediafire.com/download/gh0da1ahgxiogka/OWC_Quarter_Finals.rar)**
 
 - NoMod
   - [Himeringo - Yotsuya-san ni Yoroshiku (RLC) \[Winber1's Extreme\]](https://osu.ppy.sh/beatmaps/378781)
@@ -197,7 +198,7 @@ Mappool
 
 ### Round of 16
 
-**[Download the mappack here!](https://www.mediafire.com/download/eav4oeg33eax8w9/OWC_Round_of_16.rar)**
+**[Download the mappack here! (144.2MB)](https://www.mediafire.com/download/eav4oeg33eax8w9/OWC_Round_of_16.rar)**
 
 - NoMod
   - [yuikonnu - Kakushigoto (jonathanlfj) \[Insane\]](https://osu.ppy.sh/beatmaps/315260)
@@ -227,7 +228,7 @@ Mappool
 
 ### Group Stage
 
-**[Download the mappack here!](https://www.mediafire.com/download/p2fxdt67qlsakn3/OWC_Group_Stage.rar)**
+**[Download the mappack here! (206.6MB)](https://www.mediafire.com/download/p2fxdt67qlsakn3/OWC_Group_Stage.rar)**
 
 - NoMod
   - [Toyosaki Aki - MORE&MORE (Fycho) \[Insane\]](https://osu.ppy.sh/beatmaps/318975)
@@ -417,7 +418,7 @@ Mappool
 -   Captains will get notified in case their roster has been accepted or rejected.
 12.  Mapset selectors must not participate as a player in this tournament.
 
-### Stage instructions
+### Stage Instructions
 
 1.  In the first stage (Group Stage), the teams will be divided into 8 groups of 4 teams.
 2.  All the teams from each group will face each other.
@@ -475,7 +476,7 @@ Mappool
 12.  The size of the NoMod bracket will be 6 in all stages.
 13. The size of the mod-specific brackets will be 3 in all stages.
 
-### Scheduling instructions
+### Scheduling Instructions
 
 1.  Each stage will be held on **a single weekend**.
 2.  Matches in Group Stage may overlap.

--- a/wiki/Tournaments/OWC/2014/en.md
+++ b/wiki/Tournaments/OWC/2014/en.md
@@ -27,7 +27,7 @@ The **osu! World Cup 2014** (***OWC 2014***) is a country-based osu! tournament 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. As these items may change with every installment of the World Cups, it is only possible to give an estimate prize list for each World Cup.
 
 | Placing | Prize(s) |
-| ----- | :------- |
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 6 months supporter tag, profile badge, "osu! Champion" user title, osu! merchandise |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 3 months supporter tag  |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 1 month supporter tag  |
@@ -55,7 +55,7 @@ The osu! World Cup 2014 was run by various community members by distributing the
 ## Participants
 
 | | Country | Members |
-| -- | :---: | ----- |
+| :-: | :-: | :-- |
 | ![][flag_AR] | Argentina   | **[Glazbom](https://osu.ppy.sh/users/608277)**, [Enhu](https://osu.ppy.sh/users/2840499), [benjacala](https://osu.ppy.sh/users/1625740), [Fr0th](https://osu.ppy.sh/users/3458870), [Graphite Edge](https://osu.ppy.sh/users/825712), [Peingod](https://osu.ppy.sh/users/2212941), [GaTu](https://osu.ppy.sh/users/3583351)    |
 | ![][flag_AU] |Australia | **[Bauxe](https://osu.ppy.sh/users/1881685)**, [Melt3dCheeze](https://osu.ppy.sh/users/634837), [gimly32](https://osu.ppy.sh/users/3448993), [FluxVanes](https://osu.ppy.sh/users/655267), [uyghti](https://osu.ppy.sh/users/3641404), [Happyjon](https://osu.ppy.sh/users/5543), [Rivastyx](https://osu.ppy.sh/users/2719307), [Jaybladezz](https://osu.ppy.sh/users/3725492)  |
 | ![][flag_AT] |Austria| **[Omgforz](https://osu.ppy.sh/users/578943)**, [WhitePhoenixLP](https://osu.ppy.sh/users/1426098), [Alumetorz](https://osu.ppy.sh/users/1145984), [Elscar](https://osu.ppy.sh/users/2253511), [Hakkero](https://osu.ppy.sh/users/177913), [BlueFlameZ](https://osu.ppy.sh/users/3506191), [Jin_Back7](https://osu.ppy.sh/users/1238524)|

--- a/wiki/Tournaments/OWC/2014/en.md
+++ b/wiki/Tournaments/OWC/2014/en.md
@@ -108,7 +108,7 @@ The osu! World Cup 2014 was run by various community members by distributing the
 
 ### Finals
 
-**[Download the mappack here! (130.7MB)](https://www.mediafire.com/download/hd8njp8cvqad5yq/OWC_Finals.rar)**
+**[Download the mappack here! (130 MB)](https://www.mediafire.com/download/hd8njp8cvqad5yq/OWC_Finals.rar)**
 
 - NoMod
   - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume wo Miru (Strawberry) \[BakaNA\]](https://osu.ppy.sh/beatmaps/214248)
@@ -134,11 +134,11 @@ The osu! World Cup 2014 was run by various community members by distributing the
   - [LeaF - Calamity Fortune (Flower) \[Extra\]](https://osu.ppy.sh/beatmaps/257793)
   - [Awake - Supernova (DoKoLP) \[DoKo\]](https://osu.ppy.sh/beatmaps/138008)
 - Tiebreaker
-  - [onoken - P8107 (Kloyd) \[KA071\]](https://osu.ppy.sh/beatmaps/457061)
+  - **[onoken - P8107 (Kloyd) \[KA071\]](https://osu.ppy.sh/beatmaps/457061)**
 
 ### Semifinals
 
-**[Download the mappack here! (187.8MB)](https://www.mediafire.com/download/31bm61ol9wip0y4/OWC_SemiFinals.rar)**
+**[Download the mappack here! (187 MB)](https://www.mediafire.com/download/31bm61ol9wip0y4/OWC_SemiFinals.rar)**
 
 - NoMod
   - [Hanatan - Airman ga Taosenai (SOUND HOLIC Ver.) (Natsu) \[CRN's Extra\]](https://osu.ppy.sh/beatmaps/338682)
@@ -164,11 +164,11 @@ The osu! World Cup 2014 was run by various community members by distributing the
   - [Mind Vortex - Arc (Natteke) \[Nsane\]](https://osu.ppy.sh/beatmaps/239037)
   - [Amatsuki - Higurashi Moratorium (HelloSCV) \[Frobe's Extra\]](https://osu.ppy.sh/beatmaps/254370)
 - Tiebreaker
-  - [sweet ARMS - Installation (Cherry Blossom) \[Nightmare\]](https://osu.ppy.sh/beatmaps/444356)
+  - **[sweet ARMS - Installation (Cherry Blossom) \[Nightmare\]](https://osu.ppy.sh/beatmaps/444356)**
 
 ### Quarterfinals
 
-**[Download the mappack here! (164.1MB)](https://www.mediafire.com/download/gh0da1ahgxiogka/OWC_Quarter_Finals.rar)**
+**[Download the mappack here! (164 MB)](https://www.mediafire.com/download/gh0da1ahgxiogka/OWC_Quarter_Finals.rar)**
 
 - NoMod
   - [Himeringo - Yotsuya-san ni Yoroshiku (RLC) \[Winber1's Extreme\]](https://osu.ppy.sh/beatmaps/378781)
@@ -194,11 +194,11 @@ The osu! World Cup 2014 was run by various community members by distributing the
   - [8284 vs wa. - Adularescence (Cherry Blossom) \[Extra\]](https://osu.ppy.sh/beatmaps/306669)
   - [yuikonnu - Hatsukoi no Ehon (litoluna) \[Insane\]](https://osu.ppy.sh/beatmaps/288660)
 - Tiebreaker
-  - [Halozy - Kanshou no Matenrou (captin1) \[Eternal\]](https://osu.ppy.sh/beatmaps/431957)
+  - **[Halozy - Kanshou no Matenrou (captin1) \[Eternal\]](https://osu.ppy.sh/beatmaps/431957)**
 
 ### Round of 16
 
-**[Download the mappack here! (144.2MB)](https://www.mediafire.com/download/eav4oeg33eax8w9/OWC_Round_of_16.rar)**
+**[Download the mappack here! (144 MB)](https://www.mediafire.com/download/eav4oeg33eax8w9/OWC_Round_of_16.rar)**
 
 - NoMod
   - [yuikonnu - Kakushigoto (jonathanlfj) \[Insane\]](https://osu.ppy.sh/beatmaps/315260)
@@ -224,11 +224,11 @@ The osu! World Cup 2014 was run by various community members by distributing the
   - [Memme - NEW Astronomas (Charles445) \[Extra\]](https://osu.ppy.sh/beatmaps/238265)
   - [Hatsune Miku - Dance of many (LKs) \[Dance\]](https://osu.ppy.sh/beatmaps/140805)
 - Tiebreaker
-  - [Dark PHOENiX - The Primal Scene of Japan the Girl Saw (sjoy) \[Extra\]](https://osu.ppy.sh/beatmaps/311573)
+  - **[Dark PHOENiX - The Primal Scene of Japan the Girl Saw (sjoy) \[Extra\]](https://osu.ppy.sh/beatmaps/311573)**
 
 ### Group Stage
 
-**[Download the mappack here! (206.6MB)](https://www.mediafire.com/download/p2fxdt67qlsakn3/OWC_Group_Stage.rar)**
+**[Download the mappack here! (206 MB)](https://www.mediafire.com/download/p2fxdt67qlsakn3/OWC_Group_Stage.rar)**
 
 - NoMod
   - [Toyosaki Aki - MORE&MORE (Fycho) \[Insane\]](https://osu.ppy.sh/beatmaps/318975)
@@ -254,7 +254,7 @@ The osu! World Cup 2014 was run by various community members by distributing the
   - [Knife Party - Bonfire (inverness) \[Rage\]](https://osu.ppy.sh/beatmaps/281918)
   - [Sana - Terekakushi Shishunki (litoluna) \[Insane\]](https://osu.ppy.sh/beatmaps/479354)
 - Tiebreaker
-  - [Okui Masami - God Speed (ykcarrot) \[Insane\]](https://osu.ppy.sh/beatmaps/93947)
+  - **[Okui Masami - God Speed (ykcarrot) \[Insane\]](https://osu.ppy.sh/beatmaps/93947)**
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2014/en.md
+++ b/wiki/Tournaments/OWC/2014/en.md
@@ -5,7 +5,7 @@ tags:
 ---
 # osu! World Cup 2014
 
-![osu! World Cup 2014 logo](logo.png)
+![OWC 2014 logo](logo.png)
 
 The **osu! World Cup 2014** (***OWC 2014***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 5th installment of the osu! World Cup.
 
@@ -100,7 +100,7 @@ The osu! World Cup 2014 was run by various community members by distributing the
 
 ------------------------------------------------------------------------
 
-![OWC 2014 brackets](brackets.jpg)
+![OWC 2014 Brackets](brackets.jpg)
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2015/en.md
+++ b/wiki/Tournaments/OWC/2015/en.md
@@ -115,7 +115,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 **This mappool will be used in Finals - Week 1 and Finals - Week 2**
 
-**[Download the mappack here! (206.6MB)](https://www.mediafire.com/download/22q8exrnwiyxfn1/OWC_2015_Finals.rar)**
+**[Download the mappack here! (206 MB)](https://www.mediafire.com/download/22q8exrnwiyxfn1/OWC_2015_Finals.rar)**
 
 - NoMod
   - [Reol - Asymmetry (Skystar) \[Asphewin's Expert\]](https://osu.ppy.sh/beatmaps/698249)
@@ -145,7 +145,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ### Semifinals
 
-**[Download the mappack here! (183.9MB)](https://www.mediafire.com/download/rm2w6we4i90dhc5/OWC_2015_Semifinals.rar)**
+**[Download the mappack here! (183 MB)](https://www.mediafire.com/download/rm2w6we4i90dhc5/OWC_2015_Semifinals.rar)**
 
 - NoMod
   - [Reol - Streaming Heart (sukiNathan) \[Extra\]](https://osu.ppy.sh/beatmaps/760466)
@@ -175,7 +175,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ### Quarterfinals
 
-**[Download the mappack here! (160.8MB)](https://www.mediafire.com/download/l4zdsy0ujeq8xz3/OWC_2015_Quarterfinals.rar)**
+**[Download the mappack here! (160 MB)](https://www.mediafire.com/download/l4zdsy0ujeq8xz3/OWC_2015_Quarterfinals.rar)**
 
 - NoMod
   - [ALiCE'S EMOTiON - Dark Flight Dreamer (Sakaue Nachi) \[Dreamer\]](https://osu.ppy.sh/beatmaps/676172)
@@ -205,7 +205,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ### Round of 16
 
-**[Download the mappack here! (187MB)](https://www.mediafire.com/download/r21yp0iu2zgkkln/OWC_2015_Round_of_16.rar)**
+**[Download the mappack here! (187 MB)](https://www.mediafire.com/download/r21yp0iu2zgkkln/OWC_2015_Round_of_16.rar)**
 
 - NoMod
   - [Sharlo & yealina - Kakushigoto (Sharlo) \[RLC's Extra\]](https://osu.ppy.sh/beatmaps/495899)
@@ -235,7 +235,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ### Group Stage
 
-**[Download the mappack here! (155.8MB)](https://www.mediafire.com/download/4mmsagzc3mg6g13/OWC_2015_Group_Stage.rar)**
+**[Download the mappack here! (155 MB)](https://www.mediafire.com/download/4mmsagzc3mg6g13/OWC_2015_Group_Stage.rar)**
 
 - NoMod
   - [Duca - COLD BUTTERFLY (Zweib) \[Insane\]](https://osu.ppy.sh/beatmaps/363063)

--- a/wiki/Tournaments/OWC/2015/en.md
+++ b/wiki/Tournaments/OWC/2015/en.md
@@ -11,10 +11,10 @@ The **osu! World Cup 2015** (***OWC 2015***) is a country-based osu! tournament 
 
 ## Tournament Schedule
 
-| Event              | Timestamp                |
-|-------------------:|--------------------------|
+| Event   | Timestamp   |
+|--------:|-------------|
 | Registration Phase | 2015-10-01/2015-10-18    |
-| Drawings           | 2015-11-01 (14:00 UTC+0) |
+| Live Drawings      | 2015-11-01 (14:00 UTC+0) |
 | Group Stage        | 2015-11-07/2015-11-08    |
 | Round of 16        | 2015-11-14/2015-11-15    |
 | Quarterfinals      | 2015-11-21/2015-11-22    |
@@ -26,30 +26,78 @@ The **osu! World Cup 2015** (***OWC 2015***) is a country-based osu! tournament 
 
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
-| Place                                                    | Prize(s)                                                                  |
-|------------------------------------------------------------|-------------------------------------------------------------------------|
+| Placing   | Prize(s)      |
+|---------|---------------|
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 50% of the raised prize pool, profile badge, "osu! Champion" user title |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge                             |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge                             |
 
-## Organization
+## Organisation
 
 The osu! World Cup 2015 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257)  |
 | Map Selectors         | ![][flag_FR] [Cherry Blossom](https://osu.ppy.sh/users/1156742), ![][flag_HK] [Skystar](https://osu.ppy.sh/users/873961), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236)  |
-| Streamers             | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
-| Commentators          | ![][flag_US] [Chippy](https://osu.ppy.sh/users/2314115), ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_GB] [Raiku](https://osu.ppy.sh/users/1525538), ![][flag_US] [rfandomization](https://osu.ppy.sh/users/3716999), ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
-| Statistician          | ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665)  |
+| Streamers  | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) |
+| Commentators  | ![][flag_US] [Chippy](https://osu.ppy.sh/users/2314115), ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370), ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_GB] [Raiku](https://osu.ppy.sh/users/1525538), ![][flag_US] [rfandomization](https://osu.ppy.sh/users/3716999), ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955), ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) |
+| Statistician  | ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665)  |
 
 ## Links
 
-
--   [Discussion Thread](https://osu.ppy.sh/forum/p/4550383)
+-   [Discussion thread](https://osu.ppy.sh/forum/p/4550383)
 -   [Livestream](https://www.twitch.tv/osulive/)
--   **[Group Stage Statistics overview](https://docs.google.com/spreadsheets/d/1QGI7BxI7fOMhXSdgYbFqPGCTUUwfSrsAiUhibWu4xUk/pubhtml)**
+-   **[Group Stage statistics overview](https://docs.google.com/spreadsheets/d/1QGI7BxI7fOMhXSdgYbFqPGCTUUwfSrsAiUhibWu4xUk/pubhtml)**
+
+------------------------------------------------------------------------
+
+## Participants
+
+| | Country | Members |
+|:-:|:---:|-----------|
+| ![][flag_AR] | **Argentina** | **[GaTu](https://osu.ppy.sh/users/3583351 "GaTu")**, [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [Graphite Edge](https://osu.ppy.sh/users/825712 "Graphite Edge"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Fr0th](https://osu.ppy.sh/users/3458870 "Fr0th"), [Peingod](https://osu.ppy.sh/users/2212941 "Peingod"), [chucentry](https://osu.ppy.sh/users/2498731 "chucentry"), [Dreamcast](https://osu.ppy.sh/users/1565577 "Dreamcast") |
+| ![][flag_AU] | **Australia** | **[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [Tokichii](https://osu.ppy.sh/users/557197 "Tokichii"), [JappyBabes](https://osu.ppy.sh/users/697783 "JappyBabes"), [Meowt3dCheeze](https://osu.ppy.sh/users/634837 "Meowt3dCheeze"), [[ ZhengS ]](https://osu.ppy.sh/users/2671317 "[ ZhengS ]"), [Hexicate](https://osu.ppy.sh/users/2171562 "Hexicate"), [Jaybladezz](https://osu.ppy.sh/users/3725492 "Jaybladezz"), [Aloha](https://osu.ppy.sh/users/792176 "Aloha") | 
+| ![][flag_AT] | **Austria** | **[Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [Alumetorz](https://osu.ppy.sh/users/1145984 "Alumetorz"), [BlueFlame](https://osu.ppy.sh/users/3506191 "BlueFlame"), [Shirone](https://osu.ppy.sh/users/1426098 "Shirone"), [Elscar](https://osu.ppy.sh/users/2253511 "Elscar"), [Hakkero](https://osu.ppy.sh/users/177913 "Hakkero"), [skritsch](https://osu.ppy.sh/users/3323141 "skritsch") |
+| ![][flag_BR] | **Brazil** | **[fabriciorby](https://osu.ppy.sh/users/209664 "fabriciorby")**, [MouseEasy](https://osu.ppy.sh/users/1558603 "MouseEasy"), [Tio Fenrir](https://osu.ppy.sh/users/2644700 "Tio Fenrir"), [Sooki](https://osu.ppy.sh/users/1451811 "Sooki"), [Shott](https://osu.ppy.sh/users/965354 "Shott"), [Polaco](https://osu.ppy.sh/users/1057782 "Polaco"), [HideZ](https://osu.ppy.sh/users/504657 "HideZ"), [Miyazono](https://osu.ppy.sh/users/529036 "Miyazono") |
+| ![][flag_CA] | **Canada** | **[TrickMirror](https://osu.ppy.sh/users/2138739 "TrickMirror")**, [Azer](https://osu.ppy.sh/users/2155578 "Azer"), [Bowlglet](https://osu.ppy.sh/users/622485 "Bowlglet"), [Xenbo](https://osu.ppy.sh/users/1895489 "Xenbo"), [Ciao](https://osu.ppy.sh/users/2674642 "Ciao"), [MiruHong](https://osu.ppy.sh/users/2866814 "MiruHong"), [Ignite](https://osu.ppy.sh/users/3122948 "Ignite"), [Shina Kokomi](https://osu.ppy.sh/users/980956 "Shina Kokomi") | 
+| ![][flag_CN] | **China** | **[MatsumotoRise](https://osu.ppy.sh/users/672726 "MatsumotoRise")**, [rustbell](https://osu.ppy.sh/users/227717 "rustbell"), [SpringLane](https://osu.ppy.sh/users/1343504 "SpringLane"), [Dsan](https://osu.ppy.sh/users/1266166 "Dsan"), [GGBY](https://osu.ppy.sh/users/629717 "GGBY"), [[ZN]](https://osu.ppy.sh/users/1030696 "[ZN]"), [Rixia Mao](https://osu.ppy.sh/users/3314431 "Rixia Mao"), [Toshinou Kyouko](https://osu.ppy.sh/users/560228 "Toshinou Kyouko") |
+| ![][flag_FI] | **Finland** | **[Sanze](https://osu.ppy.sh/users/3110552 "Sanze")**, [isokasapupuja](https://osu.ppy.sh/users/1770462 "isokasapupuja"), [huono_tuuri](https://osu.ppy.sh/users/1432954 "huono_tuuri"), [Poofie](https://osu.ppy.sh/users/3517198 "Poofie"), [nycto](https://osu.ppy.sh/users/2867764 "nycto"), [Hyppyri](https://osu.ppy.sh/users/3123423 "Hyppyri"), [Winner](https://osu.ppy.sh/users/3437263 "Winner"), [Incera](https://osu.ppy.sh/users/2159415 "Incera") |
+| ![][flag_FR] | **France** | **[Musty](https://osu.ppy.sh/users/251683 "Musty")**, [NerO](https://osu.ppy.sh/users/1545031 "NerO"), [Elysion](https://osu.ppy.sh/users/106269 "Elysion"), [Kynan](https://osu.ppy.sh/users/1093361 "Kynan"), [mrzomb](https://osu.ppy.sh/users/1694887 "mrzomb"), [filsdelama](https://osu.ppy.sh/users/2831793 "filsdelama"), [Shapy](https://osu.ppy.sh/users/2705769 "Shapy"), [FayeurS](https://osu.ppy.sh/users/3105416 "FayeurS") |
+| ![][flag_DE] | **Germany** | **[Dustice](https://osu.ppy.sh/users/754565 "Dustice")**, [BDDav](https://osu.ppy.sh/users/1164526 "BDDav"), [Neliel](https://osu.ppy.sh/users/1500305 "Neliel"), [Beafowl](https://osu.ppy.sh/users/2438122 "Beafowl"), [Jonimay](https://osu.ppy.sh/users/1118341 "Jonimay"), [TobiGH3](https://osu.ppy.sh/users/3341040 "TobiGH3"), [W3SON](https://osu.ppy.sh/users/2070822 "W3SON"), [cptnXn](https://osu.ppy.sh/users/495272 "cptnXn") |
+| ![][flag_GR] | **Greece** | **[Riven](https://osu.ppy.sh/users/3638005 "Riven")**, [ThePainG7](https://osu.ppy.sh/users/3478000 "ThePainG7"), [Tofas](https://osu.ppy.sh/users/2755584 "Tofas"), [SutiBu](https://osu.ppy.sh/users/2633472 "SutiBu"), [I Like Kimas](https://osu.ppy.sh/users/2490195 "I Like Kimas"), [JohnyZ](https://osu.ppy.sh/users/4508048 "JohnyZ") |
+| ![][flag_HK] | **Hong Kong** | **[- G I D Z -](https://osu.ppy.sh/users/2286528 "- G I D Z -")**, [Chaoslitz](https://osu.ppy.sh/users/3621552 "Chaoslitz"), [shAe1eck](https://osu.ppy.sh/users/1553672 "shAe1eck"), [MinG3012](https://osu.ppy.sh/users/1583218 "MinG3012"), [-N a n a k o-](https://osu.ppy.sh/users/1407516 "-N a n a k o-"), [clp012345](https://osu.ppy.sh/users/126144 "clp012345") |
+| ![][flag_IT] | **Italy** | **[xiAmME](https://osu.ppy.sh/users/1428960 "xiAmME")**, [Nemis](https://osu.ppy.sh/users/1635091 "Nemis"), [Kirin](https://osu.ppy.sh/users/1852356 "Kirin"), [DT-sama](https://osu.ppy.sh/users/3525018 "DT-sama"), [- Croma -](https://osu.ppy.sh/users/1752181 "- Croma -"), [Gian](https://osu.ppy.sh/users/2105981 "Gian"), [LLoyd-chan](https://osu.ppy.sh/users/2849149 "LLoyd-chan"), [umii](https://osu.ppy.sh/users/2538695 "umii") |
+| ![][flag_JP] | **Japan** | **[Mercurius](https://osu.ppy.sh/users/589550 "Mercurius")**, [Poruteri](https://osu.ppy.sh/users/1379576 "Poruteri"), [OhAHO](https://osu.ppy.sh/users/1066760 "OhAHO"), [Roro Rosset](https://osu.ppy.sh/users/673214 "Roro Rosset"), [Super Arrow](https://osu.ppy.sh/users/1970239 "Super Arrow"), [NeruL](https://osu.ppy.sh/users/2497197 "NeruL"), [1o-chak](https://osu.ppy.sh/users/1401004 "1o-chak") |
+| ![][flag_LV] | **Latvia** | **[LoGo](https://osu.ppy.sh/users/750382 "LoGo")**, [Forseen](https://osu.ppy.sh/users/556012 "Forseen"), [Emula](https://osu.ppy.sh/users/2891792 "Emula"), [Vmx](https://osu.ppy.sh/users/967501 "Vmx"), [Jesus[Krists]](https://osu.ppy.sh/users/2842992 "Jesus[Krists]"), [Edijs](https://osu.ppy.sh/users/2799835 "Edijs"), [xoho](https://osu.ppy.sh/users/3647897 "xoho") |
+| ![][flag_LT] | **Lithuania** | **[QonQuest](https://osu.ppy.sh/users/988503 "QonQuest")**, [Mazzerin](https://osu.ppy.sh/users/2942381 "Mazzerin"), [Auji](https://osu.ppy.sh/users/4114438 "Auji"), [PainSinger](https://osu.ppy.sh/users/697843 "PainSinger"), [Zinkon](https://osu.ppy.sh/users/85043 "Zinkon"), [Shelbis](https://osu.ppy.sh/users/2639159 "Shelbis"), [Midget](https://osu.ppy.sh/users/4141635 "Midget"), [Azerite](https://osu.ppy.sh/users/2562987 "Azerite") |
+| ![][flag_MY] | **Malaysia** | **[ClawViper](https://osu.ppy.sh/users/2681361 "ClawViper")**, [xsrsbsns](https://osu.ppy.sh/users/414427 "xsrsbsns"), [Gon](https://osu.ppy.sh/users/583765 "Gon"), [Rumia-](https://osu.ppy.sh/users/1787171 "Rumia-"), [Ex6TenZ](https://osu.ppy.sh/users/2676512 "Ex6TenZ"), [caleb123456](https://osu.ppy.sh/users/2205376 "caleb123456"), [Rampax](https://osu.ppy.sh/users/3995630 "Rampax"), [Amane-](https://osu.ppy.sh/users/2276847 "Amane-") | 
+| ![][flag_MX] | **Mexico** | **[Broodich](https://osu.ppy.sh/users/2484629 "Broodich")**, [Id_Beat](https://osu.ppy.sh/users/3431380 "Id_Beat"), [Atheneon](https://osu.ppy.sh/users/2164627 "Atheneon"), [lndex](https://osu.ppy.sh/users/2038320 "lndex"), [Psycopath-](https://osu.ppy.sh/users/3233957 "Psycopath-"), [Eiikon](https://osu.ppy.sh/users/2553519 "Eiikon"), [KevEz](https://osu.ppy.sh/users/2271558 "KevEz"), [Atsuro](https://osu.ppy.sh/users/2279351 "Atsuro") |
+| ![][flag_NL] | **Netherlands** | **[taku](https://osu.ppy.sh/users/684433 "taku")**, [jackylam5](https://osu.ppy.sh/users/1540807 "jackylam5"), [Pittigbaasje](https://osu.ppy.sh/users/2167433 "Pittigbaasje"), [HappyStick](https://osu.ppy.sh/users/256802 "HappyStick"), [Synchrostar](https://osu.ppy.sh/users/419705 "Synchrostar"), [Chidori](https://osu.ppy.sh/users/5258565 "Chidori"), [Menthuthuyoupi](https://osu.ppy.sh/users/2715937 "Menthuthuyoupi"), [Kyshiro](https://osu.ppy.sh/users/640611 "Kyshiro") |
+| ![][flag_NZ] | **New Zealand** | **[shortpotato](https://osu.ppy.sh/users/1266102 "shortpotato")**, [kiyumi](https://osu.ppy.sh/users/3701898 "kiyumi"), [a loli](https://osu.ppy.sh/users/1488796 "a loli"), [momochan](https://osu.ppy.sh/users/4827310 "momochan"), [[ Pustules ]](https://osu.ppy.sh/users/2419478 "[ Pustules ]"), [Tang](https://osu.ppy.sh/users/2162609 "Tang"), [yellowy246](https://osu.ppy.sh/users/3833980 "yellowy246"), [Grimacee](https://osu.ppy.sh/users/2352484 "Grimacee") |
+| ![][flag_NO] | **Norway** | **[Tobi](https://osu.ppy.sh/users/2970667 "Tobi")**, [-GN](https://osu.ppy.sh/users/895581 "-GN"), [-PC](https://osu.ppy.sh/users/2916414 "-PC"), [Sebu](https://osu.ppy.sh/users/3990173 "Sebu"), [HundurThePanda](https://osu.ppy.sh/users/3145033 "HundurThePanda"), [warrock](https://osu.ppy.sh/users/2841744 "warrock"), [Liqh](https://osu.ppy.sh/users/3409838 "Liqh"), [CXu](https://osu.ppy.sh/users/84841 "CXu") |
+| ![][flag_PH] | **Philippines** | **[Takane Enomoto](https://osu.ppy.sh/users/1208491 "Takane Enomoto")**, [-Ryo](https://osu.ppy.sh/users/3113141 "-Ryo"), [KouNue](https://osu.ppy.sh/users/4180036 "KouNue"), [ededed028](https://osu.ppy.sh/users/3932796 "ededed028"), [Marika](https://osu.ppy.sh/users/1679638 "Marika"), [konawiki](https://osu.ppy.sh/users/4003979 "konawiki"), [---Mikoto](https://osu.ppy.sh/users/2911062 "---Mikoto"), [Gio](https://osu.ppy.sh/users/1795827 "Gio") |
+| ![][flag_PL] | **Poland** | **[Wilchq](https://osu.ppy.sh/users/2021758 "Wilchq")**, [Rafis](https://osu.ppy.sh/users/2558286 "Rafis"), [WubWoofWolf](https://osu.ppy.sh/users/39828 "WubWoofWolf"), [AmaiHachimitsu](https://osu.ppy.sh/users/844815 "AmaiHachimitsu"), [r0ck](https://osu.ppy.sh/users/1549620 "r0ck"), [fartownik](https://osu.ppy.sh/users/56917 "fartownik"), [SpajdeR](https://osu.ppy.sh/users/3446664 "SpajdeR"), [Lucid Astray](https://osu.ppy.sh/users/1773225 "Lucid Astray") |
+| ![][flag_PT] | **Portugal** | **[kek](https://osu.ppy.sh/users/2148013 "kek")**, [Osama](https://osu.ppy.sh/users/799218 "Osama"), [Mizuru](https://osu.ppy.sh/users/4495871 "Mizuru"), [AA00AA](https://osu.ppy.sh/users/2928612 "AA00AA"), [Zenden](https://osu.ppy.sh/users/3070694 "Zenden"), [PedroLipton](https://osu.ppy.sh/users/3272012 "PedroLipton") |
+| ![][flag_RU] | **Russian Federation** | **[talala](https://osu.ppy.sh/users/1389663 "talala")**, [KoTo](https://osu.ppy.sh/users/1382805 "KoTo"), [_index](https://osu.ppy.sh/users/652457 "_index"), [Shiawase](https://osu.ppy.sh/users/989489 "Shiawase"), [SoMad](https://osu.ppy.sh/users/637168 "SoMad"), [xantic](https://osu.ppy.sh/users/1897386 "xantic"), [Kert](https://osu.ppy.sh/users/119933 "Kert"), [Red_Pixel](https://osu.ppy.sh/users/4170932 "Red_Pixel") |
+| ![][flag_SG] | **Singapore** | **[plaatinum](https://osu.ppy.sh/users/3385566 "plaatinum")**, [GSBlank](https://osu.ppy.sh/users/2312106 "GSBlank"), [Rtyzen](https://osu.ppy.sh/users/2439822 "Rtyzen"), [oneplusone](https://osu.ppy.sh/users/1843447 "oneplusone"), [Clyine](https://osu.ppy.sh/users/1275211 "Clyine"), [jcjc](https://osu.ppy.sh/users/1200275 "jcjc"), [-LeeP-](https://osu.ppy.sh/users/1143744 "-LeeP-"), [Tatch](https://osu.ppy.sh/users/2390650 "Tatch") |
+| ![][flag_KR] | **South Korea** | **[Neta](https://osu.ppy.sh/users/832084 "Neta")**, [Cinia Pacifica](https://osu.ppy.sh/users/1414625 "Cinia Pacifica"), [[Chiyo]](https://osu.ppy.sh/users/2000416 "[Chiyo]"), [- Hakurei Reimu-](https://osu.ppy.sh/users/948713 "- Hakurei Reimu-"), [Meltina](https://osu.ppy.sh/users/946990 "Meltina"), [Enon](https://osu.ppy.sh/users/2043401 "Enon"), [Gomo Pslvarh](https://osu.ppy.sh/users/1206417 "Gomo Pslvarh"), [eoehd1ek](https://osu.ppy.sh/users/3938876 "eoehd1ek") |
+| ![][flag_SE] | **Sweden** | **[Xytox](https://osu.ppy.sh/users/2229274 "Xytox")**, [Slizzer](https://osu.ppy.sh/users/809983 "Slizzer"), [SnickarN](https://osu.ppy.sh/users/3258429 "SnickarN"), [AntoN](https://osu.ppy.sh/users/2538562 "AntoN"), [Bubba](https://osu.ppy.sh/users/2330524 "Bubba"), [IVo one](https://osu.ppy.sh/users/3623465 "IVo one"), [Sebbe](https://osu.ppy.sh/users/3181965 "Sebbe"), [Xiniox](https://osu.ppy.sh/users/5233691 "Xiniox") |
+| ![][flag_TW] | **Taiwan** | **[Rucker](https://osu.ppy.sh/users/147515 "Rucker")**, [hvick225](https://osu.ppy.sh/users/50265 "hvick225"), [Small K](https://osu.ppy.sh/users/952751 "Small K"), [YuyuKo sama](https://osu.ppy.sh/users/234788 "YuyuKo sama"), [Uan](https://osu.ppy.sh/users/147623 "Uan"), [dabanlong](https://osu.ppy.sh/users/624254 "dabanlong"), [zxxzxxz](https://osu.ppy.sh/users/1646474 "zxxzxxz"), [RedLeaf](https://osu.ppy.sh/users/2703742 "RedLeaf") |
+| ![][flag_TH] | **Thailand** | **[FrostxE](https://osu.ppy.sh/users/199669 "FrostxE")**, [- Phantasma -](https://osu.ppy.sh/users/1427407 "- Phantasma -"), [bossm](https://osu.ppy.sh/users/654123 "bossm"), [Mikkuri](https://osu.ppy.sh/users/317494 "Mikkuri"), [NonxE](https://osu.ppy.sh/users/319312 "NonxE"), [Romantic](https://osu.ppy.sh/users/1592894 "Romantic") |
+| ![][flag_UA] | **Ukraine** | **[Aka](https://osu.ppy.sh/users/1307553 "Aka")**, [wasisdasS](https://osu.ppy.sh/users/1999698 "wasisdasS"), [FllareA](https://osu.ppy.sh/users/1163931 "FllareA"), [Granje](https://osu.ppy.sh/users/496387 "Granje"), [-Ranndom-](https://osu.ppy.sh/users/5022536 "-Ranndom-"), [Yoru-hide](https://osu.ppy.sh/users/791121 "Yoru-hide"), [blednak](https://osu.ppy.sh/users/912627 "blednak") |
+| ![][flag_GB] | **United Kingdom** | **[jesus1412](https://osu.ppy.sh/users/230116 "jesus1412")**, [Doomsday](https://osu.ppy.sh/users/18983 "Doomsday"), [Tasty Beverage](https://osu.ppy.sh/users/960620 "Tasty Beverage"), [Xim](https://osu.ppy.sh/users/2083664 "Xim"), [Raiku](https://osu.ppy.sh/users/1525538 "Raiku"), [Bubbleman](https://osu.ppy.sh/users/5182050 "Bubbleman"), [Run-Cat](https://osu.ppy.sh/users/4361729 "Run-Cat") |
+| ![][flag_US] | **United States** | **[Xilver](https://osu.ppy.sh/users/3099689 "Xilver")**, [Natalia](https://osu.ppy.sh/users/2162669 "Natalia"), [Axarious](https://osu.ppy.sh/users/2614511 "Axarious"), [Ritzeh](https://osu.ppy.sh/users/1028387 "Ritzeh"), [Seouless](https://osu.ppy.sh/users/3328676 "Seouless"), [0120](https://osu.ppy.sh/users/1901534 "0120"), [Zodiaack](https://osu.ppy.sh/users/3096229 "Zodiaack"), [[Toy]](https://osu.ppy.sh/users/2757689 "[Toy]") |
+
+
+## Groups 
+
+| Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H |
+| ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
+| ![][flag_AU] Australia | ![][flag_FR] France | ![][flag_CA] Canada | ![][flag_CN] China | ![][flag_AR] Argentina | ![][flag_BR] Brazil | ![][flag_DE] Germany | ![][flag_AT] Austria |
+| ![][flag_MY] Malaysia | ![][flag_HK] Hong Kong  | ![][flag_LV] Latvia | ![][flag_JP] Japan | ![][flag_FI] Finland | ![][flag_GR] Greece | ![][flag_NL] Netherlands | ![][flag_PT] Portugal |
+| ![][flag_MX] Mexico | ![][flag_IT] Italy | ![][flag_PL] Poland | ![][flag_PH] Philippines | ![][flag_NZ] New Zealand | ![][flag_NO] Norway | ![][flag_SG] Singapore | ![][flag_SE] Sweden |
+| ![][flag_US] United States | ![][flag_LT] Lithuania | ![][flag_UA] Ukraine | ![][flag_GB] United Kingdom  | ![][flag_KR] South Korea | ![][flag_RU] Russian Federation | ![][flag_TH] Thailand | ![][flag_TW] Taiwan |
 
 ------------------------------------------------------------------------
 
@@ -61,102 +109,13 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ------------------------------------------------------------------------
 
-Participants
----------------
-
-| Top Seed                                          | High Seed                                     | Low Seed                                 | No Seed                                    |
-|---------------------------------------------------|-----------------------------------------------|------------------------------------------|--------------------------------------------|
-| ![][flag_CN] China              | ![][flag_AU] Australia      | ![][flag_AR] Argentina | ![][flag_GR] Greece      |
-| ![][flag_FR] France             | ![][flag_AT] Austria        | ![][flag_JP] Japan     | ![][flag_IT] Italy       |
-| ![][flag_DE] Germany            | ![][flag_BR] Brazil         | ![][flag_LV] Latvia    | ![][flag_MX] Mexico      |
-| ![][flag_PL] Poland             | ![][flag_CA] Canada         | ![][flag_LT] Lithuania | ![][flag_NZ] New Zealand |
-| ![][flag_RU] Russian Federation | ![][flag_FI] Finland        | ![][flag_MY] Malaysia  | ![][flag_PH] Philippines |
-| ![][flag_KR] South Korea        | ![][flag_HK] Hong Kong      | ![][flag_NO] Norway    | ![][flag_PT] Portugal    |
-| ![][flag_TW] Taiwan             | ![][flag_NL] Netherlands    | ![][flag_SE] Sweden    | ![][flag_SG] Singapore   |
-| ![][flag_US] United States      | ![][flag_GB] United Kingdom | ![][flag_TH] Thailand  | ![][flag_UA] Ukraine     |
-
-### Group A
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Mx.gif][flag_MX]|**Mexico**|**[Broodich](https://osu.ppy.sh/users/2484629 "Broodich")**, [Id_Beat](https://osu.ppy.sh/users/3431380 "Id_Beat"), [Atheneon](https://osu.ppy.sh/users/2164627 "Atheneon"), [lndex](https://osu.ppy.sh/users/2038320 "lndex"), [Psycopath-](https://osu.ppy.sh/users/3233957 "Psycopath-"), [Eiikon](https://osu.ppy.sh/users/2553519 "Eiikon"), [KevEz](https://osu.ppy.sh/users/2271558 "KevEz"), [Atsuro](https://osu.ppy.sh/users/2279351 "Atsuro")|
-|![My.gif][flag_MY]|**Malaysia**|**[ClawViper](https://osu.ppy.sh/users/2681361 "ClawViper")**, [xsrsbsns](https://osu.ppy.sh/users/414427 "xsrsbsns"), [Gon](https://osu.ppy.sh/users/583765 "Gon"), [Rumia-](https://osu.ppy.sh/users/1787171 "Rumia-"), [Ex6TenZ](https://osu.ppy.sh/users/2676512 "Ex6TenZ"), [caleb123456](https://osu.ppy.sh/users/2205376 "caleb123456"), [Rampax](https://osu.ppy.sh/users/3995630 "Rampax"), [Amane-](https://osu.ppy.sh/users/2276847 "Amane-")| 
-|![Au.gif][flag_AU]|**Australia**|**[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [Tokichii](https://osu.ppy.sh/users/557197 "Tokichii"), [JappyBabes](https://osu.ppy.sh/users/697783 "JappyBabes"), [Meowt3dCheeze](https://osu.ppy.sh/users/634837 "Meowt3dCheeze"), [[ ZhengS ]](https://osu.ppy.sh/users/2671317 "[ ZhengS ]"), [Hexicate](https://osu.ppy.sh/users/2171562 "Hexicate"), [Jaybladezz](https://osu.ppy.sh/users/3725492 "Jaybladezz"), [Aloha](https://osu.ppy.sh/users/792176 "Aloha")| 
-|![Us.gif][flag_US]|**United States**|**[Xilver](https://osu.ppy.sh/users/3099689 "Xilver")**, [Natalia](https://osu.ppy.sh/users/2162669 "Natalia"), [Axarious](https://osu.ppy.sh/users/2614511 "Axarious"), [Ritzeh](https://osu.ppy.sh/users/1028387 "Ritzeh"), [Seouless](https://osu.ppy.sh/users/3328676 "Seouless"), [0120](https://osu.ppy.sh/users/1901534 "0120"), [Zodiaack](https://osu.ppy.sh/users/3096229 "Zodiaack"), [[Toy]](https://osu.ppy.sh/users/2757689 "[Toy]")|
-
-### Group B
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![It.gif][flag_IT]|**Italy**|**[xiAmME](https://osu.ppy.sh/users/1428960 "xiAmME")**, [Nemis](https://osu.ppy.sh/users/1635091 "Nemis"), [Kirin](https://osu.ppy.sh/users/1852356 "Kirin"), [DT-sama](https://osu.ppy.sh/users/3525018 "DT-sama"), [- Croma -](https://osu.ppy.sh/users/1752181 "- Croma -"), [Gian](https://osu.ppy.sh/users/2105981 "Gian"), [LLoyd-chan](https://osu.ppy.sh/users/2849149 "LLoyd-chan"), [umii](https://osu.ppy.sh/users/2538695 "umii")|
-|![Lt.gif][flag_LT]|**Lithuania**|**[QonQuest](https://osu.ppy.sh/users/988503 "QonQuest")**, [Mazzerin](https://osu.ppy.sh/users/2942381 "Mazzerin"), [Auji](https://osu.ppy.sh/users/4114438 "Auji"), [PainSinger](https://osu.ppy.sh/users/697843 "PainSinger"), [Zinkon](https://osu.ppy.sh/users/85043 "Zinkon"), [Shelbis](https://osu.ppy.sh/users/2639159 "Shelbis"), [Midget](https://osu.ppy.sh/users/4141635 "Midget"), [Azerite](https://osu.ppy.sh/users/2562987 "Azerite")|
-|![Hk.gif][flag_HK]|**Hong Kong**|**[- G I D Z -](https://osu.ppy.sh/users/2286528 "- G I D Z -")**, [Chaoslitz](https://osu.ppy.sh/users/3621552 "Chaoslitz"), [shAe1eck](https://osu.ppy.sh/users/1553672 "shAe1eck"), [MinG3012](https://osu.ppy.sh/users/1583218 "MinG3012"), [-N a n a k o-](https://osu.ppy.sh/users/1407516 "-N a n a k o-"), [clp012345](https://osu.ppy.sh/users/126144 "clp012345")|
-|![Fr.gif][flag_FR]|**France**|**[Musty](https://osu.ppy.sh/users/251683 "Musty")**, [NerO](https://osu.ppy.sh/users/1545031 "NerO"), [Elysion](https://osu.ppy.sh/users/106269 "Elysion"), [Kynan](https://osu.ppy.sh/users/1093361 "Kynan"), [mrzomb](https://osu.ppy.sh/users/1694887 "mrzomb"), [filsdelama](https://osu.ppy.sh/users/2831793 "filsdelama"), [Shapy](https://osu.ppy.sh/users/2705769 "Shapy"), [FayeurS](https://osu.ppy.sh/users/3105416 "FayeurS")|
-
-### Group C
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Ua.gif][flag_UA]|**Ukraine**|**[Aka](https://osu.ppy.sh/users/1307553 "Aka")**, [wasisdasS](https://osu.ppy.sh/users/1999698 "wasisdasS"), [FllareA](https://osu.ppy.sh/users/1163931 "FllareA"), [Granje](https://osu.ppy.sh/users/496387 "Granje"), [-Ranndom-](https://osu.ppy.sh/users/5022536 "-Ranndom-"), [Yoru-hide](https://osu.ppy.sh/users/791121 "Yoru-hide"), [blednak](https://osu.ppy.sh/users/912627 "blednak")|
-|![Lv.gif][flag_LV]|**Latvia**|**[LoGo](https://osu.ppy.sh/users/750382 "LoGo")**, [Forseen](https://osu.ppy.sh/users/556012 "Forseen"), [Emula](https://osu.ppy.sh/users/2891792 "Emula"), [Vmx](https://osu.ppy.sh/users/967501 "Vmx"), [Jesus[Krists]](https://osu.ppy.sh/users/2842992 "Jesus[Krists]"), [Edijs](https://osu.ppy.sh/users/2799835 "Edijs"), [xoho](https://osu.ppy.sh/users/3647897 "xoho")|
-|![Ca.gif][flag_CA]|**Canada**|**[TrickMirror](https://osu.ppy.sh/users/2138739 "TrickMirror")**, [Azer](https://osu.ppy.sh/users/2155578 "Azer"), [Bowlglet](https://osu.ppy.sh/users/622485 "Bowlglet"), [Xenbo](https://osu.ppy.sh/users/1895489 "Xenbo"), [Ciao](https://osu.ppy.sh/users/2674642 "Ciao"), [MiruHong](https://osu.ppy.sh/users/2866814 "MiruHong"), [Ignite](https://osu.ppy.sh/users/3122948 "Ignite"), [Shina Kokomi](https://osu.ppy.sh/users/980956 "Shina Kokomi")| 
-|![Pl.gif][flag_PL]|**Poland**|**[Wilchq](https://osu.ppy.sh/users/2021758 "Wilchq")**, [Rafis](https://osu.ppy.sh/users/2558286 "Rafis"), [WubWoofWolf](https://osu.ppy.sh/users/39828 "WubWoofWolf"), [AmaiHachimitsu](https://osu.ppy.sh/users/844815 "AmaiHachimitsu"), [r0ck](https://osu.ppy.sh/users/1549620 "r0ck"), [fartownik](https://osu.ppy.sh/users/56917 "fartownik"), [SpajdeR](https://osu.ppy.sh/users/3446664 "SpajdeR"), [Lucid Astray](https://osu.ppy.sh/users/1773225 "Lucid Astray")|
-
-### Group D
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Ph.gif][flag_PH]|**Philippines**|**[Takane Enomoto](https://osu.ppy.sh/users/1208491 "Takane Enomoto")**, [-Ryo](https://osu.ppy.sh/users/3113141 "-Ryo"), [KouNue](https://osu.ppy.sh/users/4180036 "KouNue"), [ededed028](https://osu.ppy.sh/users/3932796 "ededed028"), [Marika](https://osu.ppy.sh/users/1679638 "Marika"), [konawiki](https://osu.ppy.sh/users/4003979 "konawiki"), [---Mikoto](https://osu.ppy.sh/users/2911062 "---Mikoto"), [Gio](https://osu.ppy.sh/users/1795827 "Gio")|
-|![Jp.gif][flag_JP]|**Japan**|**[Mercurius](https://osu.ppy.sh/users/589550 "Mercurius")**, [Poruteri](https://osu.ppy.sh/users/1379576 "Poruteri"), [OhAHO](https://osu.ppy.sh/users/1066760 "OhAHO"), [Roro Rosset](https://osu.ppy.sh/users/673214 "Roro Rosset"), [Super Arrow](https://osu.ppy.sh/users/1970239 "Super Arrow"), [NeruL](https://osu.ppy.sh/users/2497197 "NeruL"), [1o-chak](https://osu.ppy.sh/users/1401004 "1o-chak")|
-|![Gb.gif][flag_GB]|**United Kingdom**|**[jesus1412](https://osu.ppy.sh/users/230116 "jesus1412")**, [Doomsday](https://osu.ppy.sh/users/18983 "Doomsday"), [Tasty Beverage](https://osu.ppy.sh/users/960620 "Tasty Beverage"), [Xim](https://osu.ppy.sh/users/2083664 "Xim"), [Raiku](https://osu.ppy.sh/users/1525538 "Raiku"), [Bubbleman](https://osu.ppy.sh/users/5182050 "Bubbleman"), [Run-Cat](https://osu.ppy.sh/users/4361729 "Run-Cat")|
-|![Cn.gif][flag_CN]|**China**|**[MatsumotoRise](https://osu.ppy.sh/users/672726 "MatsumotoRise")**, [rustbell](https://osu.ppy.sh/users/227717 "rustbell"), [SpringLane](https://osu.ppy.sh/users/1343504 "SpringLane"), [Dsan](https://osu.ppy.sh/users/1266166 "Dsan"), [GGBY](https://osu.ppy.sh/users/629717 "GGBY"), [[ZN]](https://osu.ppy.sh/users/1030696 "[ZN]"), [Rixia Mao](https://osu.ppy.sh/users/3314431 "Rixia Mao"), [Toshinou Kyouko](https://osu.ppy.sh/users/560228 "Toshinou Kyouko")|
-
-### Group E
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Nz.gif][flag_NZ]|**New Zealand**|**[shortpotato](https://osu.ppy.sh/users/1266102 "shortpotato")**, [kiyumi](https://osu.ppy.sh/users/3701898 "kiyumi"), [a loli](https://osu.ppy.sh/users/1488796 "a loli"), [momochan](https://osu.ppy.sh/users/4827310 "momochan"), [[ Pustules ]](https://osu.ppy.sh/users/2419478 "[ Pustules ]"), [Tang](https://osu.ppy.sh/users/2162609 "Tang"), [yellowy246](https://osu.ppy.sh/users/3833980 "yellowy246"), [Grimacee](https://osu.ppy.sh/users/2352484 "Grimacee")|
-|![Ar.gif][flag_AR]|**Argentina**|**[GaTu](https://osu.ppy.sh/users/3583351 "GaTu")**, [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [Graphite Edge](https://osu.ppy.sh/users/825712 "Graphite Edge"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Fr0th](https://osu.ppy.sh/users/3458870 "Fr0th"), [Peingod](https://osu.ppy.sh/users/2212941 "Peingod"), [chucentry](https://osu.ppy.sh/users/2498731 "chucentry"), [Dreamcast](https://osu.ppy.sh/users/1565577 "Dreamcast")|
-|![Fi.gif][flag_FI]|**Finland**|**[Sanze](https://osu.ppy.sh/users/3110552 "Sanze")**, [isokasapupuja](https://osu.ppy.sh/users/1770462 "isokasapupuja"), [huono_tuuri](https://osu.ppy.sh/users/1432954 "huono_tuuri"), [Poofie](https://osu.ppy.sh/users/3517198 "Poofie"), [nycto](https://osu.ppy.sh/users/2867764 "nycto"), [Hyppyri](https://osu.ppy.sh/users/3123423 "Hyppyri"), [Winner](https://osu.ppy.sh/users/3437263 "Winner"), [Incera](https://osu.ppy.sh/users/2159415 "Incera")|
-|![Kr.gif][flag_KR]|**South Korea**|**[Neta](https://osu.ppy.sh/users/832084 "Neta")**, [Cinia Pacifica](https://osu.ppy.sh/users/1414625 "Cinia Pacifica"), [[Chiyo]](https://osu.ppy.sh/users/2000416 "[Chiyo]"), [- Hakurei Reimu-](https://osu.ppy.sh/users/948713 "- Hakurei Reimu-"), [Meltina](https://osu.ppy.sh/users/946990 "Meltina"), [Enon](https://osu.ppy.sh/users/2043401 "Enon"), [Gomo Pslvarh](https://osu.ppy.sh/users/1206417 "Gomo Pslvarh"), [eoehd1ek](https://osu.ppy.sh/users/3938876 "eoehd1ek")|
-
-### Group F
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Gr.gif][flag_GR]|**Greece**|**[Riven](https://osu.ppy.sh/users/3638005 "Riven")**, [ThePainG7](https://osu.ppy.sh/users/3478000 "ThePainG7"), [Tofas](https://osu.ppy.sh/users/2755584 "Tofas"), [SutiBu](https://osu.ppy.sh/users/2633472 "SutiBu"), [I Like Kimas](https://osu.ppy.sh/users/2490195 "I Like Kimas"), [JohnyZ](https://osu.ppy.sh/users/4508048 "JohnyZ")|
-|![No.gif][flag_NO]|**Norway**|**[Tobi](https://osu.ppy.sh/users/2970667 "Tobi")**, [-GN](https://osu.ppy.sh/users/895581 "-GN"), [-PC](https://osu.ppy.sh/users/2916414 "-PC"), [Sebu](https://osu.ppy.sh/users/3990173 "Sebu"), [HundurThePanda](https://osu.ppy.sh/users/3145033 "HundurThePanda"), [warrock](https://osu.ppy.sh/users/2841744 "warrock"), [Liqh](https://osu.ppy.sh/users/3409838 "Liqh"), [CXu](https://osu.ppy.sh/users/84841 "CXu")|
-|![Br.gif][flag_BR]|**Brazil**|**[fabriciorby](https://osu.ppy.sh/users/209664 "fabriciorby")**, [MouseEasy](https://osu.ppy.sh/users/1558603 "MouseEasy"), [Tio Fenrir](https://osu.ppy.sh/users/2644700 "Tio Fenrir"), [Sooki](https://osu.ppy.sh/users/1451811 "Sooki"), [Shott](https://osu.ppy.sh/users/965354 "Shott"), [Polaco](https://osu.ppy.sh/users/1057782 "Polaco"), [HideZ](https://osu.ppy.sh/users/504657 "HideZ"), [Miyazono](https://osu.ppy.sh/users/529036 "Miyazono")|
-|![Ru.gif][flag_RU]|**Russian Federation**|**[talala](https://osu.ppy.sh/users/1389663 "talala")**, [KoTo](https://osu.ppy.sh/users/1382805 "KoTo"), [_index](https://osu.ppy.sh/users/652457 "_index"), [Shiawase](https://osu.ppy.sh/users/989489 "Shiawase"), [SoMad](https://osu.ppy.sh/users/637168 "SoMad"), [xantic](https://osu.ppy.sh/users/1897386 "xantic"), [Kert](https://osu.ppy.sh/users/119933 "Kert"), [Red_Pixel](https://osu.ppy.sh/users/4170932 "Red_Pixel")|
-
-### Group G
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Sg.gif][flag_SG]|**Singapore**|**[plaatinum](https://osu.ppy.sh/users/3385566 "plaatinum")**, [GSBlank](https://osu.ppy.sh/users/2312106 "GSBlank"), [Rtyzen](https://osu.ppy.sh/users/2439822 "Rtyzen"), [oneplusone](https://osu.ppy.sh/users/1843447 "oneplusone"), [Clyine](https://osu.ppy.sh/users/1275211 "Clyine"), [jcjc](https://osu.ppy.sh/users/1200275 "jcjc"), [-LeeP-](https://osu.ppy.sh/users/1143744 "-LeeP-"), [Tatch](https://osu.ppy.sh/users/2390650 "Tatch")|
-|![Th.gif][flag_TH]|**Thailand**|**[FrostxE](https://osu.ppy.sh/users/199669 "FrostxE")**, [- Phantasma -](https://osu.ppy.sh/users/1427407 "- Phantasma -"), [bossm](https://osu.ppy.sh/users/654123 "bossm"), [Mikkuri](https://osu.ppy.sh/users/317494 "Mikkuri"), [NonxE](https://osu.ppy.sh/users/319312 "NonxE"), [Romantic](https://osu.ppy.sh/users/1592894 "Romantic")|
-|![Nl.gif][flag_NL]|**Netherlands**|**[taku](https://osu.ppy.sh/users/684433 "taku")**, [jackylam5](https://osu.ppy.sh/users/1540807 "jackylam5"), [Pittigbaasje](https://osu.ppy.sh/users/2167433 "Pittigbaasje"), [HappyStick](https://osu.ppy.sh/users/256802 "HappyStick"), [Synchrostar](https://osu.ppy.sh/users/419705 "Synchrostar"), [Chidori](https://osu.ppy.sh/users/5258565 "Chidori"), [Menthuthuyoupi](https://osu.ppy.sh/users/2715937 "Menthuthuyoupi"), [Kyshiro](https://osu.ppy.sh/users/640611 "Kyshiro")|
-|![De.gif][flag_DE]|**Germany**|**[Dustice](https://osu.ppy.sh/users/754565 "Dustice")**, [BDDav](https://osu.ppy.sh/users/1164526 "BDDav"), [Neliel](https://osu.ppy.sh/users/1500305 "Neliel"), [Beafowl](https://osu.ppy.sh/users/2438122 "Beafowl"), [Jonimay](https://osu.ppy.sh/users/1118341 "Jonimay"), [TobiGH3](https://osu.ppy.sh/users/3341040 "TobiGH3"), [W3SON](https://osu.ppy.sh/users/2070822 "W3SON"), [cptnXn](https://osu.ppy.sh/users/495272 "cptnXn")|
-
-### Group H
-
-|F|Country name|Team|
-|:---:|:---:|:---|
-|![Pt.gif][flag_PT]|**Portugal**|**[kek](https://osu.ppy.sh/users/2148013 "kek")**, [Osama](https://osu.ppy.sh/users/799218 "Osama"), [Mizuru](https://osu.ppy.sh/users/4495871 "Mizuru"), [AA00AA](https://osu.ppy.sh/users/2928612 "AA00AA"), [Zenden](https://osu.ppy.sh/users/3070694 "Zenden"), [PedroLipton](https://osu.ppy.sh/users/3272012 "PedroLipton")|
-|![Se.gif][flag_SE]|**Sweden**|**[Xytox](https://osu.ppy.sh/users/2229274 "Xytox")**, [Slizzer](https://osu.ppy.sh/users/809983 "Slizzer"), [SnickarN](https://osu.ppy.sh/users/3258429 "SnickarN"), [AntoN](https://osu.ppy.sh/users/2538562 "AntoN"), [Bubba](https://osu.ppy.sh/users/2330524 "Bubba"), [IVo one](https://osu.ppy.sh/users/3623465 "IVo one"), [Sebbe](https://osu.ppy.sh/users/3181965 "Sebbe"), [Xiniox](https://osu.ppy.sh/users/5233691 "Xiniox")|
-|![At.gif][flag_AT]|**Austria**|**[Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [Alumetorz](https://osu.ppy.sh/users/1145984 "Alumetorz"), [BlueFlame](https://osu.ppy.sh/users/3506191 "BlueFlame"), [Shirone](https://osu.ppy.sh/users/1426098 "Shirone"), [Elscar](https://osu.ppy.sh/users/2253511 "Elscar"), [Hakkero](https://osu.ppy.sh/users/177913 "Hakkero"), [skritsch](https://osu.ppy.sh/users/3323141 "skritsch")|
-|![Tw.gif][flag_TW]|**Taiwan**|**[Rucker](https://osu.ppy.sh/users/147515 "Rucker")**, [hvick225](https://osu.ppy.sh/users/50265 "hvick225"), [Small K](https://osu.ppy.sh/users/952751 "Small K"), [YuyuKo sama](https://osu.ppy.sh/users/234788 "YuyuKo sama"), [Uan](https://osu.ppy.sh/users/147623 "Uan"), [dabanlong](https://osu.ppy.sh/users/624254 "dabanlong"), [zxxzxxz](https://osu.ppy.sh/users/1646474 "zxxzxxz"), [RedLeaf](https://osu.ppy.sh/users/2703742 "RedLeaf")|
-
-------------------------------------------------------------------------
-
-Mappools
-------------
+## Mappools
 
 ### Finals
 
 **This mappool will be used in Finals - Week 1 and Finals - Week 2**
 
-**[Download the mappack here!](https://www.mediafire.com/download/22q8exrnwiyxfn1/OWC_2015_Finals.rar)**
+**[Download the mappack here! (206.6MB)](https://www.mediafire.com/download/22q8exrnwiyxfn1/OWC_2015_Finals.rar)**
 
 - NoMod
   - [Reol - Asymmetry (Skystar) \[Asphewin's Expert\]](https://osu.ppy.sh/beatmaps/698249)
@@ -182,11 +141,11 @@ Mappools
   - [LEAF XCEED Music Division - YuYu Metal (DoKoLP) \[DoKo\]](https://osu.ppy.sh/beatmaps/142145)
   - [Suzumu - Kakumeisei ousama densenbyou (tutuhaha) \[AngelHoney's Extra\]](https://osu.ppy.sh/beatmaps/701528)
 - Tiebreaker
-  - [gmtn. (witch's slave) - furioso melodia (Alumetorz) \[Wrath\]](https://osu.ppy.sh/beatmaps/633993)
+  - **[gmtn. (witch's slave) - furioso melodia (Alumetorz) \[Wrath\]](https://osu.ppy.sh/beatmaps/633993)**
 
 ### Semifinals
 
-**[Download the mappack here!](https://www.mediafire.com/download/rm2w6we4i90dhc5/OWC_2015_Semifinals.rar)**
+**[Download the mappack here! (183.9MB)](https://www.mediafire.com/download/rm2w6we4i90dhc5/OWC_2015_Semifinals.rar)**
 
 - NoMod
   - [Reol - Streaming Heart (sukiNathan) \[Extra\]](https://osu.ppy.sh/beatmaps/760466)
@@ -212,11 +171,11 @@ Mappools
   - [Cutline - Die For You (Shock One Remix) (Regou) \[Insane\]](https://osu.ppy.sh/beatmaps/404550)
   - [HoneyWorks - Akatsuki Zukuyo (Fast) \[Twilight\]](https://osu.ppy.sh/beatmaps/736729)
 - Tiebreaker
-  - [Ohka - Nanairo Anniversary (Rizia) \[Kaleidoscope\]](https://osu.ppy.sh/beatmaps/541044)
+  - **[Ohka - Nanairo Anniversary (Rizia) \[Kaleidoscope\]](https://osu.ppy.sh/beatmaps/541044)**
 
 ### Quarterfinals
 
-**[Download the mappack here!](https://www.mediafire.com/download/l4zdsy0ujeq8xz3/OWC_2015_Quarterfinals.rar)**
+**[Download the mappack here! (160.8MB)](https://www.mediafire.com/download/l4zdsy0ujeq8xz3/OWC_2015_Quarterfinals.rar)**
 
 - NoMod
   - [ALiCE'S EMOTiON - Dark Flight Dreamer (Sakaue Nachi) \[Dreamer\]](https://osu.ppy.sh/beatmaps/676172)
@@ -242,11 +201,11 @@ Mappools
   - [APG550 - NEVERLAND (Natsu) \[Yuny\]](https://osu.ppy.sh/beatmaps/776749)
   - [Rita - Dream Walker (Amamiya Yuko) \[Ethereal\]](https://osu.ppy.sh/beatmaps/722934)
 - Tiebreaker
-  - [Our Stolen Theory - United (L.A.O.S Remix) (Asphyxia) \[Infinity\]](https://osu.ppy.sh/beatmaps/550235)
+  - **[Our Stolen Theory - United (L.A.O.S Remix) (Asphyxia) \[Infinity\]](https://osu.ppy.sh/beatmaps/550235)**
 
 ### Round of 16
 
-**[Download the mappack here!](https://www.mediafire.com/download/r21yp0iu2zgkkln/OWC_2015_Round_of_16.rar)**
+**[Download the mappack here! (187MB)](https://www.mediafire.com/download/r21yp0iu2zgkkln/OWC_2015_Round_of_16.rar)**
 
 - NoMod
   - [Sharlo & yealina - Kakushigoto (Sharlo) \[RLC's Extra\]](https://osu.ppy.sh/beatmaps/495899)
@@ -272,11 +231,11 @@ Mappools
   - [senya - Kanjou Chemistry (Drum 'n' Bass Remix) (Satellite) \[Exw\]](https://osu.ppy.sh/beatmaps/255700)
   - [yuikonnu - Chikyuu Saigo no Kokuhaku o (Fycho) \[Insane\]](https://osu.ppy.sh/beatmaps/494798)
 - Tiebreaker
-  - [Wakeshima Kanon - World's End, Girl's Rondo(Asterisk DnB Remix) (Meg) \[We cry "OPEN"\]](https://osu.ppy.sh/beatmaps/734339)
+  - **[Wakeshima Kanon - World's End, Girl's Rondo(Asterisk DnB Remix) (Meg) \[We cry "OPEN"\]](https://osu.ppy.sh/beatmaps/734339)**
 
 ### Group Stage
 
-**[Download the mappack here!](https://www.mediafire.com/download/4mmsagzc3mg6g13/OWC_2015_Group_Stage.rar)**
+**[Download the mappack here! (155.8MB)](https://www.mediafire.com/download/4mmsagzc3mg6g13/OWC_2015_Group_Stage.rar)**
 
 - NoMod
   - [Duca - COLD BUTTERFLY (Zweib) \[Insane\]](https://osu.ppy.sh/beatmaps/363063)
@@ -302,158 +261,136 @@ Mappools
   - [yuikonnu - Natsu no Owari, Koi no Hajimari (xChippy) \[Insane\]](https://osu.ppy.sh/beatmaps/486613) 
   - [Jin - Outer Science (tutuhaha) \[Insane\]](https://osu.ppy.sh/beatmaps/313025)
 - Tiebreaker
-  - [Sawai Miku - Colorful. (Asterisk DnB Remix) (Amamiya Yuko) \[Megumi\]](https://osu.ppy.sh/beatmaps/722224)
+  - **[Sawai Miku - Colorful. (Asterisk DnB Remix) (Amamiya Yuko) \[Megumi\]](https://osu.ppy.sh/beatmaps/722224)**
 
 ------------------------------------------------------------------------
 
-Match Results
------------------
+## Match Results
 
 ### Grand Finals
 
-**Sunday. 13\. December 2015**
+| Sunday, 2015-12-13 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  China        ![][flag_CN]     | 2       | **7** |![][flag_US] **United States**  | [#1](https://osu.ppy.sh/community/matches/20910697) |
+|  **United States** ![][flag_US]| **7**   | 6     |![][flag_CN]   China            | [#1](https://osu.ppy.sh/community/matches/20912739) |
 
-| Team A                                           | Score           | Team B                                           | History                        |
-|:-------------------------------------------------|:---------------:|-------------------------------------------------:|--------------------------------|
-| ![][flag_CN] China             | 2       - **7** | **United States** ![][flag_US] | [#1](https://osu.ppy.sh/community/matches/20910697) |
-| ![][flag_US] **United States** | **7**   - 6     | China ![][flag_CN]             | [#1](https://osu.ppy.sh/community/matches/20912739) |
+### Finals
 
-### Finals: Week 1
+| Saturday, 2015-12-05 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  United States ![][flag_US]| 3      | **6** |![][flag_CN] **China**        | [#1](https://osu.ppy.sh/community/matches/20711754) |
+|  Hong Kong  ![][flag_HK]   | 0      | **6** |![][flag_KR] **South Korea**  | [#1](https://osu.ppy.sh/community/matches/20713615) |
+|  Germany  ![][flag_DE]     | 2      | **6** |![][flag_PL]  **Poland**      | [#1](https://osu.ppy.sh/community/matches/20717055) |
+|  **Poland** ![][flag_PL]   | **6**  | 3     |![][flag_KR] South Korea      | [#1](https://osu.ppy.sh/community/matches/20719563) |
 
-**Saturday, 5\. December 2015**
-
-| Team A                                       | Score          | Team B                                         | History                        |
-|:---------------------------------------------|:--------------:|-----------------------------------------------:|--------------------------------|
-| ![][flag_US] United States | 3      - **6** | **China** ![][flag_CN]       | [#1](https://osu.ppy.sh/community/matches/20711754) |
-| ![][flag_HK] Hong Kong     | 0      - **6** | **South Korea** ![][flag_KR] | [#1](https://osu.ppy.sh/community/matches/20713615) |
-| ![][flag_DE] Germany       | 2      - **6** | **Poland** ![][flag_PL]      | [#1](https://osu.ppy.sh/community/matches/20717055) |
-| ![][flag_PL] **Poland**    | **6**  - 3     | South Korea ![][flag_KR]     | [#1](https://osu.ppy.sh/community/matches/20719563) |
-
-**Sunday, 6\. December 2015**
-
-| Team A                                           | Score      | Team B                                | History                        |
-|:-------------------------------------------------|:----------:|--------------------------------------:|--------------------------------|
-| ![][flag_US] **United States** | **6**  - 3 | Poland ![][flag_PL] | [#1](https://osu.ppy.sh/community/matches/20762171) |
+| Sunday, 2015-12-06 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **United States** ![][flag_US]| **6**  | 3 |![][flag_PL] Poland  | [#1](https://osu.ppy.sh/community/matches/20762171) |
 
 ### Semifinals
 
-**Saturday, 28\. November 2015**
+| Saturday, 2015-11-28 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **United States** ![][flag_US]| **6** | 2     |![][flag_KR] South Korea    | [#1](https://osu.ppy.sh/community/matches/20553676) |
+|  Thailand   ![][flag_TH]       | 2     | **6** |![][flag_HK] **Hong Kong**  | [#1](https://osu.ppy.sh/community/matches/20555273) |
+| **China**   ![][flag_CN]       | **6** | 2     |![][flag_PL] Poland         | [#1](https://osu.ppy.sh/community/matches/20556916) |
+|  **Germany**  ![][flag_DE]     | **6** | 2     |![][flag_FR] France         | [#1](https://osu.ppy.sh/community/matches/20558712) |
+|  **Norway**  ![][flag_NO]      | **6** | 2     |![][flag_BR]  Brazil        | [#1](https://osu.ppy.sh/community/matches/20561290) |
+|  **Germany** ![][flag_DE]      | **6** | 3     |![][flag_NO]   Norway       | [#1](https://osu.ppy.sh/community/matches/20570952) |
+|  Canada ![][flag_CA]           | 5     | **6** |![][flag_AT] **Austria**    | [#1](https://osu.ppy.sh/community/matches/20574246) |
 
-| Team A                                           | Score         | Team B                                       | History                        |
-|:-------------------------------------------------|:-------------:|---------------------------------------------:|--------------------------------|
-| ![][flag_US] **United States** | **6** - 2     | South Korea ![][flag_KR]   | [#1](https://osu.ppy.sh/community/matches/20553676) |
-| ![][flag_TH] Thailand          | 2     - **6** | **Hong Kong** ![][flag_HK] | [#1](https://osu.ppy.sh/community/matches/20555273) |
-| ![][flag_CN] **China**         | **6** - 2     | Poland ![][flag_PL]        | [#1](https://osu.ppy.sh/community/matches/20556916) |
-| ![][flag_DE] **Germany**       | **6** - 2     | France ![][flag_FR]        | [#1](https://osu.ppy.sh/community/matches/20558712) |
-| ![][flag_NO] **Norway**        | **6** - 2     | Brazil ![][flag_BR]        | [#1](https://osu.ppy.sh/community/matches/20561290) |
-| ![][flag_DE] **Germany**       | **6** - 3     | Norway ![][flag_NO]        | [#1](https://osu.ppy.sh/community/matches/20570952) |
-| ![][flag_CA] Canada            | 5     - **6** | **Austria** ![][flag_AT]   | [#1](https://osu.ppy.sh/community/matches/20574246) |
-
-**Sunday, 29\. November 2015**
-
-| Team A                                 | Score          | Team B                                       | History                        |
-|:---------------------------------------|:--------------:|---------------------------------------------:|--------------------------------|
-| ![][flag_AT] Austria | 4      - **6** | **Hong Kong** ![][flag_HK] | [#1](https://osu.ppy.sh/community/matches/20591359) |
+| Sunday, 2015-11-29 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  Austria ![][flag_AT]| 4      | **6** |![][flag_HK] **Hong Kong**  | [#1](https://osu.ppy.sh/community/matches/20591359) |
 
 ### Quarterfinals
 
-**Saturday, 21\. November 2015**
+| Saturday, 2015-11-21 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **United States** ![][flag_US]| **5** | 2 |![][flag_BR] Brazil  | [#1](https://osu.ppy.sh/community/matches/20411352) |
 
-| Team A                                           | Score     | Team B                                | History                        |
-|:-------------------------------------------------|:---------:|--------------------------------------:|--------------------------------|
-| ![][flag_US] **United States** | **5** - 2 | Brazil ![][flag_BR] | [#1](https://osu.ppy.sh/community/matches/20411352) |
-
-**Sunday, 22. November 2015**
-
-| Team A                                         | Score          | Team B                                      | History                        |
-|:-----------------------------------------------|:--------------:|--------------------------------------------:|--------------------------------|
-| ![][flag_TW] Taiwan          | 4      - **5** | **Canada** ![][flag_CA]   | [#1](https://osu.ppy.sh/community/matches/20423117) |
-| ![][flag_HK] Hong Kong       | 2      - **5** | **China** ![][flag_CN]    | [#1](https://osu.ppy.sh/community/matches/20424826) |
-| ![][flag_KR] **South Korea** | **5**  - 3     | France ![][flag_FR]       | [#1](https://osu.ppy.sh/community/matches/20426594) |
-| ![][flag_NO] **Norway**      | **5**  - 2     | Malaysia ![][flag_MY]     | [#1](https://osu.ppy.sh/community/matches/20427714) |
-| ![][flag_GB] United Kingdom  | 3      - **5** | **Thailand** ![][flag_TH] | [#1](https://osu.ppy.sh/community/matches/20429267) |
-| ![][flag_DE] **Germany**     | **5**  - 1     | Finland ![][flag_FI]      | [#1](https://osu.ppy.sh/community/matches/20430864) |
-| ![][flag_PL] **Poland**      | **5**  - 0     | Austria ![][flag_AT]      | [#1](https://osu.ppy.sh/community/matches/20432995) |
+| Sunday, 2015-11-22 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  Taiwan  ![][flag_TW]        | 4      | **5** |![][flag_CA] **Canada**    | [#1](https://osu.ppy.sh/community/matches/20423117) |
+| !Hong Kong  [][flag_HK]      | 2      | **5** |![][flag_CN]  **China**    | [#1](https://osu.ppy.sh/community/matches/20424826) |
+|  **South Korea** ![][flag_KR]| **5**  | 3     |![][flag_FR] France        | [#1](https://osu.ppy.sh/community/matches/20426594) |
+|  **Norway**  ![][flag_NO]    | **5**  | 2     |![][flag_MY] Malaysia      | [#1](https://osu.ppy.sh/community/matches/20427714) |
+| United Kingdom ![][flag_GB]  | 3      | **5** |![][flag_TH] **Thailand**  | [#1](https://osu.ppy.sh/community/matches/20429267) |
+| **Germany** ![][flag_DE]     | **5**  | 1     |![][flag_FI] Finland       | [#1](https://osu.ppy.sh/community/matches/20430864) |
+|  **Poland** ![][flag_PL]     | **5**  | 0     |![][flag_AT] Austria       | [#1](https://osu.ppy.sh/community/matches/20432995) |
 
 ### Round of 16
 
-**Sunday, 15\. November 2015**
-
-| Team A                                           | Score          | Team B                                         | History                        |
-|:-------------------------------------------------|:--------------:|-----------------------------------------------:|--------------------------------|
-| ![][flag_US] **United States** | **5**  - 4     | Taiwan ![][flag_TW]          | [#1](https://osu.ppy.sh/community/matches/20269690) |
-| ![][flag_FI] Finland           | 0      - **5** | **China** ![][flag_CN]       | [#1](https://osu.ppy.sh/community/matches/20273790) |
-| ![][flag_AT] **Austria**       | **5**  - 0     | Malaysia ![][flag_MY]        | [#1](https://osu.ppy.sh/community/matches/20275097) |
-| ![][flag_HK] **Hong Kong**     | **5**  - 3     | Germany ![][flag_DE]         | [#1](https://osu.ppy.sh/community/matches/20276700) |
-| ![][flag_GB] United Kingdom    | 2      - **5** | **South Korea** ![][flag_KR] | [#1](https://osu.ppy.sh/community/matches/20278584) |
-| ![][flag_TH] Thailand          | 2      - **5** | **France** ![][flag_FR]      | [#1](https://osu.ppy.sh/community/matches/20280529) |
-| ![][flag_NO] Norway            | 0      - **5** | **Poland** ![][flag_PL]      | [#1](https://osu.ppy.sh/community/matches/20285332) |
-| ![][flag_CA] Canada            | 1      - **5** | **Brazil** ![][flag_BR]      | [#1](https://osu.ppy.sh/community/matches/20287601) |
+| Sunday, 2015-11-15 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **United States** ![][flag_US]| **5**  | 4     |![][flag_TW] Taiwan           | [#1](https://osu.ppy.sh/community/matches/20269690) |
+|  Finland  ![][flag_FI]         | 0      | **5** |![][flag_CN] **China**        | [#1](https://osu.ppy.sh/community/matches/20273790) |
+|  **Austria**  ![][flag_AT]     | **5**  | 0     |![][flag_MY] Malaysia         | [#1](https://osu.ppy.sh/community/matches/20275097) |
+|  **Hong Kong** ![][flag_HK]    | **5**  | 3     |![][flag_DE] Germany          | [#1](https://osu.ppy.sh/community/matches/20276700) |
+|  United Kingdom ![][flag_GB]   | 2      | **5** |![][flag_KR] **South Korea**  | [#1](https://osu.ppy.sh/community/matches/20278584) |
+| Thailand   ![][flag_TH]        | 2      | **5** |![][flag_FR] **France**       | [#1](https://osu.ppy.sh/community/matches/20280529) |
+|  Norway   ![][flag_NO]         | 0      | **5** |![][flag_PL] **Poland**       | [#1](https://osu.ppy.sh/community/matches/20285332) |
+|  Canada   ![][flag_CA]         | 1      | **5** |![][flag_BR] **Brazil**       | [#1](https://osu.ppy.sh/community/matches/20287601) |
 
 ### Group Stage
 
-**Saturday, 8\. November 2015**
+| Saturday, 2015-11-08 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **Austria** ![][flag_AT]   | **4** | 1     |![][flag_TW] Taiwan                  | [#1](https://osu.ppy.sh/community/matches/20091839) |
+| New Zealand ![][flag_NZ]    | 3     | **4** |![][flag_FI] **Finland**             | [#1](https://osu.ppy.sh/community/matches/20091841) |
+|  **Malaysia** ![][flag_MY]  | **4** | 1     |![][flag_AU]  Australia              | [#1](https://osu.ppy.sh/community/matches/20091844) |
+|  Philippines ![][flag_PH]   | 1     | **4** |![][flag_JP] **Japan**               | [#1](https://osu.ppy.sh/community/matches/20091847) |
+| Singapore ![][flag_SG]      | 0     | **4** |![][flag_DE] **Germany**             | [#1](https://osu.ppy.sh/community/matches/20092909) |
+|  Thailand  ![][flag_TH]     | 1     | **4** |![][flag_NL] **Netherlands**         | [#1](https://osu.ppy.sh/community/matches/20092910) |
+|  United Kingdom ![][flag_GB]| 1     | **4** |![][flag_CN] **China**               | [#1](https://osu.ppy.sh/community/matches/20092912) |
+|  Lithuania  ![][flag_LT]    | 1     | **4** |![][flag_FR] **France**              | [#1](https://osu.ppy.sh/community/matches/20094037) |
+|  Italy   ![][flag_IT]       | 1     | **4** |![][flag_HK] **Hong Kong**           | [#1](https://osu.ppy.sh/community/matches/20094040) |
+|  Portugal  ![][flag_PT]     | 3     | **4** |![][flag_TW] **Taiwan**              | [#1](https://osu.ppy.sh/community/matches/20094042) |
+|  Singapore  ![][flag_SG]    | 3     | **4** |![][flag_TH] **Thailand**            | [#1](https://osu.ppy.sh/community/matches/20095460) |
+| Philippines ![][flag_PH]    | 0     | **4** |![][flag_GB]  **United Kingdom**     | [#1](https://osu.ppy.sh/community/matches/20095461) |
+| Argentina ![][flag_AR]      | 0     | **4** |![][flag_KR]  **South Korea**        | [#1](https://osu.ppy.sh/community/matches/20095462) |
+|  Greece  ![][flag_GR]       | 0     | **4** |![][flag_RU] **Russian Federation**  | [#1](https://osu.ppy.sh/community/matches/20105876) |
+|  Canada ![][flag_CA]        | 0     | **4** |![][flag_PL] **Poland**              | [#1](https://osu.ppy.sh/community/matches/20105877) |
+|  Portugal ![][flag_PT]      | 1     | **4** |![][flag_AT] **Austria**             | [#1](https://osu.ppy.sh/community/matches/20105878) |
+|  **Ukraine**  ![][flag_UA]  | **4** | 1     |![][flag_LV] Latvia                  | [#1](https://osu.ppy.sh/community/matches/20107684) |
+| Argentina ![][flag_AR]      | 3     | **4** |![][flag_FI] **Finland**             | [#1](https://osu.ppy.sh/community/matches/20107685) |
+|  Norway  ![][flag_NO]       | 2     | **4** |![][flag_BR] **Brazil**              | [#1](https://osu.ppy.sh/community/matches/20109708) |
+| Sweden ![][flag_SE]         | 2     | **4** |![][flag_AT] **Austria**             | [#1](https://osu.ppy.sh/community/matches/20109709) |
 
-| Team A                                        | Score         | Team B                                                | History                        |
-|:----------------------------------------------|:-------------:|------------------------------------------------------:|--------------------------------|
-| ![][flag_AT] **Austria**    | **4** - 1     | Taiwan ![][flag_TW]                 | [#1](https://osu.ppy.sh/community/matches/20091839) |
-| ![][flag_NZ] New Zealand    | 3     - **4** | **Finland** ![][flag_FI]            | [#1](https://osu.ppy.sh/community/matches/20091841) |
-| ![][flag_MY] **Malaysia**   | **4** - 1     | Australia ![][flag_AU]              | [#1](https://osu.ppy.sh/community/matches/20091844) |
-| ![][flag_PH] Philippines    | 1     - **4** | **Japan** ![][flag_JP]              | [#1](https://osu.ppy.sh/community/matches/20091847) |
-| ![][flag_SG] Singapore      | 0     - **4** | **Germany** ![][flag_DE]            | [#1](https://osu.ppy.sh/community/matches/20092909) |
-| ![][flag_TH] Thailand       | 1     - **4** | **Netherlands** ![][flag_NL]        | [#1](https://osu.ppy.sh/community/matches/20092910) |
-| ![][flag_GB] United Kingdom | 1     - **4** | **China** ![][flag_CN]              | [#1](https://osu.ppy.sh/community/matches/20092912) |
-| ![][flag_LT] Lithuania      | 1     - **4** | **France** ![][flag_FR]             | [#1](https://osu.ppy.sh/community/matches/20094037) |
-| ![][flag_IT] Italy          | 1     - **4** | **Hong Kong** ![][flag_HK]          | [#1](https://osu.ppy.sh/community/matches/20094040) |
-| ![][flag_PT] Portugal       | 3     - **4** | **Taiwan** ![][flag_TW]             | [#1](https://osu.ppy.sh/community/matches/20094042) |
-| ![][flag_SG] Singapore      | 3     - **4** | **Thailand** ![][flag_TH]           | [#1](https://osu.ppy.sh/community/matches/20095460) |
-| ![][flag_PH] Philippines    | 0     - **4** | **United Kingdom** ![][flag_GB]     | [#1](https://osu.ppy.sh/community/matches/20095461) |
-| ![][flag_AR] Argentina      | 0     - **4** | **South Korea** ![][flag_KR]        | [#1](https://osu.ppy.sh/community/matches/20095462) |
-| ![][flag_GR] Greece         | 0     - **4** | **Russian Federation** ![][flag_RU] | [#1](https://osu.ppy.sh/community/matches/20105876) |
-| ![][flag_CA] Canada         | 0     - **4** | **Poland** ![][flag_PL]             | [#1](https://osu.ppy.sh/community/matches/20105877) |
-| ![][flag_PT] Portugal       | 1     - **4** | **Austria** ![][flag_AT]            | [#1](https://osu.ppy.sh/community/matches/20105878) |
-| ![][flag_UA] **Ukraine**    | **4** - 1     | Latvia ![][flag_LV]                 | [#1](https://osu.ppy.sh/community/matches/20107684) |
-| ![][flag_AR] Argentina      | 3     - **4** | **Finland** ![][flag_FI]            | [#1](https://osu.ppy.sh/community/matches/20107685) |
-| ![][flag_NO] Norway         | 2     - **4** | **Brazil** ![][flag_BR]             | [#1](https://osu.ppy.sh/community/matches/20109708) |
-| ![][flag_SE] Sweden         | 2     - **4** | **Austria** ![][flag_AT]            | [#1](https://osu.ppy.sh/community/matches/20109709) |
-
-**Sunday, 9\. November 2015**
-
-| Team A                                         | Score          | Team B                                            | History                        |
-|:-----------------------------------------------|:--------------:|--------------------------------------------------:|--------------------------------|
-| ![][flag_NZ] **New Zealand** | **4**  - 0     | Argentina ![][flag_AR]          | [#1](https://osu.ppy.sh/community/matches/20115243) |
-| ![][flag_MX] Mexico          | 1      - **4** | **Australia** ![][flag_AU]      | [#1](https://osu.ppy.sh/community/matches/20114985) |
-| ![][flag_MY] Malaysia        | 1      - **4** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/community/matches/20116482) |
-| ![][flag_JP] Japan           | 1      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/community/matches/20116483) |
-| ![][flag_NZ] New Zealand     | 1      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/community/matches/20117565) |
-| ![][flag_MX] Mexico          | 0      - **4** | **Malaysia** ![][flag_MY]       | [#1](https://osu.ppy.sh/community/matches/20117566) |
-| ![][flag_AU] Australia       | 1      - **4** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/community/matches/20117569) |
-| ![][flag_SE] Sweden          | 1      - **4** | **Taiwan** ![][flag_TW]         | [#1](https://osu.ppy.sh/community/matches/20125092) |
-| ![][flag_PH] Philippines     | 1      - **4** | **China** ![][flag_CN]          | [#1](https://osu.ppy.sh/community/matches/20125093) |
-| ![][flag_HK] Hong Kong       | 2      - **4** | **France** ![][flag_FR]         | [#1](https://osu.ppy.sh/community/matches/20126344) |
-| ![][flag_FI] Finland         | 1      - **4** | **South Korea** ![][flag_KR]    | [#1](https://osu.ppy.sh/community/matches/20126352) |
-| ![][flag_TH] **Thailand**    | **4**  - 0     | Germany ![][flag_DE]            | [#1](https://osu.ppy.sh/community/matches/20126358) |
-| ![][flag_JP] Japan           | 0      - **4** | **United Kingdom** ![][flag_GB] | [#1](https://osu.ppy.sh/community/matches/20127886) |
-| ![][flag_UA] Ukraine         | 0      - **4** | **Poland** ![][flag_PL]         | [#1](https://osu.ppy.sh/community/matches/20127887) |
-| ![][flag_SG] Singapore       | 2      - **4** | **Netherlands** ![][flag_NL]    | [#1](https://osu.ppy.sh/community/matches/20127888) |
-| ![][flag_LT] Lithuania       | 2      - **4** | **Hong Kong** ![][flag_HK]      | [#1](https://osu.ppy.sh/community/matches/20129481) |
-| ![][flag_PT] **Portugal**    | **4**  - 3     | Sweden ![][flag_SE]             | [#1](https://osu.ppy.sh/community/matches/20129484) |
-| ![][flag_IT] Italy           | 2      - **4** | **France** ![][flag_FR]         | [#1](https://osu.ppy.sh/community/matches/20133656) |
-| ![][flag_GR] Greece          | 0      - **4** | **Brazil** ![][flag_BR]         | [#1](https://osu.ppy.sh/community/matches/20133657) |
-| ![][flag_NO] **Norway**      | **4**  - 2     | Russian Federation ![][flag_RU] | [#1](https://osu.ppy.sh/community/matches/20133658) |
-| ![][flag_NL] Netherlands     | 0      - **4** | **Germany** ![][flag_DE]        | [#1](https://osu.ppy.sh/community/matches/20135079) |
-| ![][flag_LV] Latvia          | 1      - **4** | **Canada** ![][flag_CA]         | [#1](https://osu.ppy.sh/community/matches/20135084) |
-| ![][flag_IT] Italy           | 3      - **4** | **Lithuania** ![][flag_LT]      | [#1](https://osu.ppy.sh/community/matches/20136741) |
-| ![][flag_BR] **Brazil**      | **4**  - 3     | Russian Federation ![][flag_RU] | [#1](https://osu.ppy.sh/community/matches/20136742) |
-| ![][flag_GR] Greece          | 0      - **4** | **Norway** ![][flag_NO]         | [#1](https://osu.ppy.sh/community/matches/20136743) |
-| ![][flag_MX] Mexico          | 0      - **4** | **United States** ![][flag_US]  | [#1](https://osu.ppy.sh/community/matches/20138453) |
-| ![][flag_UA] Ukraine         | 1      - **4** | **Canada** ![][flag_CA]         | [#1](https://osu.ppy.sh/community/matches/20138457) |
-| ![][flag_LV] Latvia          | 0      - **4** | **Poland** ![][flag_PL]         | [#1](https://osu.ppy.sh/community/matches/20138460) |
+| Sunday, 2015-11-09 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **New Zealand** ![][flag_NZ]| **4**  | 0     |![][flag_AR]  Argentina          | [#1](https://osu.ppy.sh/community/matches/20115243) |
+|  Mexico ![][flag_MX]         | 1      | **4** |![][flag_AU] **Australia**       | [#1](https://osu.ppy.sh/community/matches/20114985) |
+| Malaysia ![][flag_MY]        | 1      | **4** |![][flag_US] **United States**   | [#1](https://osu.ppy.sh/community/matches/20116482) |
+|  Japan  ![][flag_JP]         | 1      | **4** |![][flag_CN] **China**           | [#1](https://osu.ppy.sh/community/matches/20116483) |
+|  New Zealand ![][flag_NZ]    | 1      | **4** |![][flag_KR] **South Korea**     | [#1](https://osu.ppy.sh/community/matches/20117565) |
+|  Mexico ![][flag_MX]         | 0      | **4** |![][flag_MY]  **Malaysia**       | [#1](https://osu.ppy.sh/community/matches/20117566) |
+|  Australia ![][flag_AU]      | 1      | **4** |![][flag_US] **United States**   | [#1](https://osu.ppy.sh/community/matches/20117569) |
+| Sweden ![][flag_SE]          | 1      | **4** |![][flag_TW] **Taiwan**          | [#1](https://osu.ppy.sh/community/matches/20125092) |
+|  Philippines ![][flag_PH]    | 1      | **4** |![][flag_CN] **China**           | [#1](https://osu.ppy.sh/community/matches/20125093) |
+|  Hong Kong  ![][flag_HK]     | 2      | **4** |![][flag_FR]  **France**         | [#1](https://osu.ppy.sh/community/matches/20126344) |
+|  Finland ![][flag_FI]        | 1      | **4** |![][flag_KR] **South Korea**     | [#1](https://osu.ppy.sh/community/matches/20126352) |
+|  **Thailand** ![][flag_TH]   | **4**  | 0     |![][flag_DE] Germany             | [#1](https://osu.ppy.sh/community/matches/20126358) |
+|  Japan  ![][flag_JP]         | 0      | **4** |![][flag_GB] **United Kingdom**  | [#1](https://osu.ppy.sh/community/matches/20127886) |
+| Ukraine ![][flag_UA]         | 0      | **4** |![][flag_PL] **Poland**          | [#1](https://osu.ppy.sh/community/matches/20127887) |
+|  Singapore ![][flag_SG]      | 2      | **4** |![][flag_NL] **Netherlands**     | [#1](https://osu.ppy.sh/community/matches/20127888) |
+| Lithuania ![][flag_LT]       | 2      | **4** |![][flag_HK] **Hong Kong**       | [#1](https://osu.ppy.sh/community/matches/20129481) |
+|  **Portugal** ![][flag_PT]   | **4**  | 3     |![][flag_SE] Sweden              | [#1](https://osu.ppy.sh/community/matches/20129484) |
+| Italy   ![][flag_IT]         | 2      | **4** |![][flag_FR]  **France**         | [#1](https://osu.ppy.sh/community/matches/20133656) |
+| Greece  ![][flag_GR]         | 0      | **4** |![][flag_BR] **Brazil**          | [#1](https://osu.ppy.sh/community/matches/20133657) |
+|  **Norway** ![][flag_NO]     | **4**  | 2     |![][flag_RU] Russian Federation  | [#1](https://osu.ppy.sh/community/matches/20133658) |
+|  Netherlands ![][flag_NL]    | 0      | **4** |![][flag_DE] **Germany**         | [#1](https://osu.ppy.sh/community/matches/20135079) |
+|  Latvia  ![][flag_LV]        | 1      | **4** |![][flag_CA] **Canada**          | [#1](https://osu.ppy.sh/community/matches/20135084) |
+|  Italy   ![][flag_IT]        | 3      | **4** |![][flag_LT] **Lithuania**       | [#1](https://osu.ppy.sh/community/matches/20136741) |
+|  **Brazil** ![][flag_BR]     | **4**  | 3     |![][flag_RU] Russian Federation  | [#1](https://osu.ppy.sh/community/matches/20136742) |
+| Greece   ![][flag_GR]        | 0      | **4** |![][flag_NO]  **Norway**         | [#1](https://osu.ppy.sh/community/matches/20136743) |
+| Mexico   ![][flag_MX]        | 0      | **4** |![][flag_US] **United States**   | [#1](https://osu.ppy.sh/community/matches/20138453) |
+|  Ukraine   ![][flag_UA]      | 1      | **4** |![][flag_CA] **Canada**          | [#1](https://osu.ppy.sh/community/matches/20138457) |
+| Latvia  ![][flag_LV]         | 0      | **4** |![][flag_PL] **Poland**          | [#1](https://osu.ppy.sh/community/matches/20138460) |
 
 ------------------------------------------------------------------------
 
-Ruleset
----------
+## Ruleset
 
 ### Tournament Rules
 
@@ -510,7 +447,7 @@ Ruleset
 4.  Rejected players may appeal this decision by contacting tournaments@ppy.sh.
 5.  Mapset selectors may not participate as a player in this tournament.
 
-### Stage instructions
+### Stage Instructions
 
 1.  In the first stage (Group Stage), the teams will be divided into 8 groups of 4 teams.
 2.  All the teams from each group will face each other.
@@ -579,7 +516,7 @@ Ruleset
 9.  The size of the NoMod bracket will be 6 in all stages.
 10. The size of the mod-specific brackets will be 3 in all stages.
 
-### Scheduling instructions
+### Scheduling Instructions
 
 1.  Each stage will be held on **a single weekend**.
 2.  Matches in Group Stage may overlap.

--- a/wiki/Tournaments/OWC/2015/en.md
+++ b/wiki/Tournaments/OWC/2015/en.md
@@ -5,7 +5,7 @@ tags:
 ---
 # osu! World Cup 2015
 
-![osu! World Cup 2015 logo](logo.jpg)
+![OWC 2015 Logo](logo.jpg)
 
 The **osu! World Cup 2015** (***OWC 2015***) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 6th installment of the osu! World Cup.
 
@@ -101,11 +101,11 @@ The osu! World Cup 2015 was run by various community members by distributing the
 
 ------------------------------------------------------------------------
 
-![OWC 2015 podium](podium.jpg)
+![OWC 2015 Podium](podium.jpg)
 
 ------------------------------------------------------------------------
 
-![OWC 2015 brackets](brackets.jpg)
+![OWC 2015 Brackets](brackets.jpg)
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2015/en.md
+++ b/wiki/Tournaments/OWC/2015/en.md
@@ -12,7 +12,7 @@ The **osu! World Cup 2015** (***OWC 2015***) is a country-based osu! tournament 
 ## Tournament Schedule
 
 | Event   | Timestamp   |
-|--------:|-------------|
+| --: | :-- |
 | Registration Phase | 2015-10-01/2015-10-18    |
 | Live Drawings      | 2015-11-01 (14:00 UTC+0) |
 | Group Stage        | 2015-11-07/2015-11-08    |
@@ -27,7 +27,7 @@ The **osu! World Cup 2015** (***OWC 2015***) is a country-based osu! tournament 
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
 | Placing   | Prize(s)      |
-|---------|---------------|
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | 50% of the raised prize pool, profile badge, "osu! Champion" user title |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | 38% of the raised prize pool, profile badge                             |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | 12% of the raised prize pool, profile badge                             |
@@ -55,7 +55,7 @@ The osu! World Cup 2015 was run by various community members by distributing the
 ## Participants
 
 | | Country | Members |
-|:-:|:---:|-----------|
+| :-: | :-: | :-- |
 | ![][flag_AR] | **Argentina** | **[GaTu](https://osu.ppy.sh/users/3583351 "GaTu")**, [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [Graphite Edge](https://osu.ppy.sh/users/825712 "Graphite Edge"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Fr0th](https://osu.ppy.sh/users/3458870 "Fr0th"), [Peingod](https://osu.ppy.sh/users/2212941 "Peingod"), [chucentry](https://osu.ppy.sh/users/2498731 "chucentry"), [Dreamcast](https://osu.ppy.sh/users/1565577 "Dreamcast") |
 | ![][flag_AU] | **Australia** | **[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [Tokichii](https://osu.ppy.sh/users/557197 "Tokichii"), [JappyBabes](https://osu.ppy.sh/users/697783 "JappyBabes"), [Meowt3dCheeze](https://osu.ppy.sh/users/634837 "Meowt3dCheeze"), [[ ZhengS ]](https://osu.ppy.sh/users/2671317 "[ ZhengS ]"), [Hexicate](https://osu.ppy.sh/users/2171562 "Hexicate"), [Jaybladezz](https://osu.ppy.sh/users/3725492 "Jaybladezz"), [Aloha](https://osu.ppy.sh/users/792176 "Aloha") | 
 | ![][flag_AT] | **Austria** | **[Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [Alumetorz](https://osu.ppy.sh/users/1145984 "Alumetorz"), [BlueFlame](https://osu.ppy.sh/users/3506191 "BlueFlame"), [Shirone](https://osu.ppy.sh/users/1426098 "Shirone"), [Elscar](https://osu.ppy.sh/users/2253511 "Elscar"), [Hakkero](https://osu.ppy.sh/users/177913 "Hakkero"), [skritsch](https://osu.ppy.sh/users/3323141 "skritsch") |

--- a/wiki/Tournaments/OWC/2016/en.md
+++ b/wiki/Tournaments/OWC/2016/en.md
@@ -5,7 +5,7 @@ tags:
 ---
 # osu! World Cup 2016
 
-![osu! World Cup 2016 logo](logo.jpg)
+![OWC 2016 Logo](logo.jpg)
 
 The **osu! World Cup 2016** (_**OWC 2016**_) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 7th installment of the osu! World Cup.
 

--- a/wiki/Tournaments/OWC/2016/en.md
+++ b/wiki/Tournaments/OWC/2016/en.md
@@ -11,10 +11,10 @@ The **osu! World Cup 2016** (_**OWC 2016**_) is a country-based osu! tournament 
 
 ## Tournament Schedule
 
-| Event              | Timestamp                |
-|-------------------:|--------------------------|
+| Event    | Timestamp |
+|---------:|:----------|
 | Registration Phase | 2016-10-02/2016-10-16    |
-| Drawings           | 2016-11-04 (12:00 UTC+0) |
+| Live Drawings      | 2016-11-04 (12:00 UTC+0) |
 | Group Stage        | 2016-11-12/2016-11-13    |
 | Round of 16        | 2016-11-19/2016-11-20    |
 | Quarterfinals      | 2016-11-26/2016-11-27    |
@@ -26,17 +26,17 @@ The **osu! World Cup 2016** (_**OWC 2016**_) is a country-based osu! tournament 
 
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
-| Place                                               | Prize(s)                                                                    |
-|------------------------------------------------------|----------------------------------------------------------------------------|
+| Placing    | Prize(s)    |
+|------------|:------------|
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | exclusive and unique merchandise, profile badge, "osu! Champion" user title |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | exclusive and unique merchandise, profile badge                             |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | exclusive and unique merchandise, profile badge                             |
 
-## Organization
+## Organisation
 
 The osu! World Cup 2016 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366 "Loctav"), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703 "p3n"), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565 "Deif"), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257 "shARPII") |
 | Map Selectors | ![][flag_JP] [Asahina Momoko](https://osu.ppy.sh/users/3650145 "Asahina Momoko"), ![][flag_DE] [Okorin](https://osu.ppy.sh/users/1623405 "Okorin"), ![][flag_HK] [Skystar](https://osu.ppy.sh/users/873961 "Skystar") |
@@ -45,192 +45,105 @@ The osu! World Cup 2016 was run by various community members by distributing the
 
 ## Links
 
-- [Discussion Thread](https://osu.ppy.sh/forum/t/507270)
+- [Discussion thread](https://osu.ppy.sh/forum/t/507270)
 - [Livestream](https://www.twitch.tv/osulive)
-- [Stage Recaps](https://www.youtube.com/playlist?list=PLqJuZKl72XH_El27Es8RsxW5NXDUVeRRl) (by Feurigel)
-- **[Statistics Sheet](https://docs.google.com/spreadsheets/users/1/d/1rvVSjmdHIb-h8pekmVfIIPDPivrD5fACjNRYGo1U9to/pubhtml)**
+- [Stage recaps](https://www.youtube.com/playlist?list=PLqJuZKl72XH_El27Es8RsxW5NXDUVeRRl) (by Feurigel)
+- **[Statistics sheet](https://docs.google.com/spreadsheets/users/1/d/1rvVSjmdHIb-h8pekmVfIIPDPivrD5fACjNRYGo1U9to/pubhtml)**
+
+-----------------------
+
+## Participants
+
+| | Country | Members |
+| - | :---: | -------- |
+| ![][flag_AR] | Argentina | **[Glazbom](https://osu.ppy.sh/users/608277 "Glazbom")**, [GaTu](https://osu.ppy.sh/users/3583351 "GaTu"), [Pein](https://osu.ppy.sh/users/2212941 "Pein"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [nicogame14](https://osu.ppy.sh/users/3812213 "nicogame14"), [Catalysis](https://osu.ppy.sh/users/5958063 "Catalysis"), [Toushi](https://osu.ppy.sh/users/2367825 "Toushi")  |
+| ![][flag_AU] | Australia | **[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [uyghti](https://osu.ppy.sh/users/3641404 "uyghti"), [ithgyu](https://osu.ppy.sh/users/5113781 "ithgyu"), [Dumii](https://osu.ppy.sh/users/3068044 "Dumii"), [Korilak](https://osu.ppy.sh/users/7260014 "Korilak"), [Weber](https://osu.ppy.sh/users/6410432 "Weber"), [Lunirs](https://osu.ppy.sh/users/2118945 "Lunirs"), [Peekamoo](https://osu.ppy.sh/users/2337263 "Peekamoo") |
+| ![][flag_AT] | Austria       | **[Akane-Yuki](https://osu.ppy.sh/users/3656589 "Akane-Yuki")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [LWMF](https://osu.ppy.sh/users/3632402 "LWMF"), [Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose"), [Myst1k](https://osu.ppy.sh/users/5302223 "Myst1k")  |
+| ![][flag_BR] | Brazil         | **[Fenrir](https://osu.ppy.sh/users/2644700 "Fenrir")**, [Idealism](https://osu.ppy.sh/users/3869519 "Idealism"), [Texats](https://osu.ppy.sh/users/1638293 "Texats"), [Mirtrax](https://osu.ppy.sh/users/2290888 "Mirtrax"), [Zekker](https://osu.ppy.sh/users/4663554 "Zekker"), [MouseEasy](https://osu.ppy.sh/users/1558603 "MouseEasy"), [fabriciorby](https://osu.ppy.sh/users/209664 "fabriciorby"), [Miyazono](https://osu.ppy.sh/users/529036 "Miyazono")                          |
+| ![][flag_CA] | Canada | **[Azer](https://osu.ppy.sh/users/2155578 "Azer")**, [TrickMirror](https://osu.ppy.sh/users/2138739 "TrickMirror"), [MiruHong](https://osu.ppy.sh/users/2866814 "MiruHong"), [Kaifin](https://osu.ppy.sh/users/2596942 "Kaifin"), [Ignite](https://osu.ppy.sh/users/3122948 "Ignite"), [Kyle](https://osu.ppy.sh/users/2694475 "Kyle"), [karalis](https://osu.ppy.sh/users/3146018 "karalis"), [VINXIS](https://osu.ppy.sh/users/4323406 "VINXIS")  |
+| ![][flag_CL] | Chile  | **[kafaN](https://osu.ppy.sh/users/1489743 "kafaN")**, [DanyL](https://osu.ppy.sh/users/3069354 "DanyL"), [Neab](https://osu.ppy.sh/users/916693 "Neab"), [etejuano](https://osu.ppy.sh/users/2243537 "etejuano"), [allives](https://osu.ppy.sh/users/3951781 "allives"), [-Dylson-](https://osu.ppy.sh/users/6315784 "-Dylson-"), [DPL](https://osu.ppy.sh/users/3024454 "DPL"), [Criss](https://osu.ppy.sh/users/3188017 "Criss")  |
+| ![][flag_CN] | China  | **[Crystal](https://osu.ppy.sh/users/1646397 "Crystal")**, [Totori](https://osu.ppy.sh/users/227717 "Totori"), [Dsan](https://osu.ppy.sh/users/1266166 "Dsan"), [Totoki](https://osu.ppy.sh/users/557197 "Totoki"), [ArtxE](https://osu.ppy.sh/users/954557 "ArtxE"), [SpringLane](https://osu.ppy.sh/users/1343504 "SpringLane"), [GGBY](https://osu.ppy.sh/users/629717 "GGBY"), [MatsumotoRise](https://osu.ppy.sh/users/672726 "MatsumotoRise") |
+| ![][flag_DK] | Denmark       | **[Spork Lover](https://osu.ppy.sh/users/3417469 "Spork Lover")**, [waefwerf](https://osu.ppy.sh/users/3868653 "waefwerf"), [iamVill](https://osu.ppy.sh/users/6295380 "iamVill"), [Zog](https://osu.ppy.sh/users/3722715 "Zog"), [Hudda](https://osu.ppy.sh/users/4103629 "Hudda"), [Crylizhy](https://osu.ppy.sh/users/3023138 "Crylizhy"), [Lemmen](https://osu.ppy.sh/users/6090254 "Lemmen"), [teamplayer51](https://osu.ppy.sh/users/3084508 "teamplayer51") |
+| ![][flag_FI] | Finland     | **[Sanze](https://osu.ppy.sh/users/3110552 "Sanze")**, [thelewa](https://osu.ppy.sh/users/475021 "thelewa"), [Hyppyri](https://osu.ppy.sh/users/3123423 "Hyppyri"), [Subbie](https://osu.ppy.sh/users/1590138 "Subbie"), [Maffe](https://osu.ppy.sh/users/4773855 "Maffe"), [huono_tuuri](https://osu.ppy.sh/users/1432954 "huono_tuuri"), [Sonoda-Umi](https://osu.ppy.sh/users/2197711 "Sonoda-Umi"), [Multtari](https://osu.ppy.sh/users/1097352 "Multtari")      |
+| ![][flag_FR] | France      | **[Musty](https://osu.ppy.sh/users/251683 "Musty")**, [filsdelama](https://osu.ppy.sh/users/2831793 "filsdelama"), [ThePooN](https://osu.ppy.sh/users/718454 "ThePooN"), [Flaven](https://osu.ppy.sh/users/3213239 "Flaven"), [NerO](https://osu.ppy.sh/users/1545031 "NerO"), [mrzomb](https://osu.ppy.sh/users/1694887 "mrzomb"), [FayeurS](https://osu.ppy.sh/users/3105416 "FayeurS"), [Elysion](https://osu.ppy.sh/users/106269 "Elysion")                      |
+| ![][flag_DE] | Germany   | **[Dustice](https://osu.ppy.sh/users/754565 "Dustice")**, [DoKito](https://osu.ppy.sh/users/537084 "DoKito"), [Beafowl](https://osu.ppy.sh/users/2438122 "Beafowl"), [Neliel](https://osu.ppy.sh/users/1500305 "Neliel"), [imagaK](https://osu.ppy.sh/users/2022445 "imagaK"), [Firstus](https://osu.ppy.sh/users/1856829 "Firstus"), [BDDav](https://osu.ppy.sh/users/1164526 "BDDav"), [W3SON](https://osu.ppy.sh/users/2070822 "W3SON")                 |
+| ![][flag_GR] | Greece    | **[Riven](https://osu.ppy.sh/users/3638005 "Riven")**, [JohnyZ](https://osu.ppy.sh/users/4508048 "JohnyZ"), [ThePainG7](https://osu.ppy.sh/users/3478000 "ThePainG7"), [kYorineN](https://osu.ppy.sh/users/4131515 "kYorineN"), [Grapheon](https://osu.ppy.sh/users/2415008 "Grapheon"), [ThOmAstr](https://osu.ppy.sh/users/2793537 "ThOmAstr"), [Tofas](https://osu.ppy.sh/users/2755584 "Tofas"), [xDarxen](https://osu.ppy.sh/users/4625954 "xDarxen") |
+| ![][flag_HK] | Hong Kong      | **[- G I D Z -](https://osu.ppy.sh/users/2286528 "- G I D Z -")**, [-N a n a k o-](https://osu.ppy.sh/users/1407516 "-N a n a k o-"), [Chaoslitz](https://osu.ppy.sh/users/3621552 "Chaoslitz"), [Rizia](https://osu.ppy.sh/users/1367570 "Rizia"), [DenierNezzar](https://osu.ppy.sh/users/126144 "DenierNezzar"), [MinG3012](https://osu.ppy.sh/users/1583218 "MinG3012"), [StarrStyx](https://osu.ppy.sh/users/4600383 "StarrStyx"), [YoonA-](https://osu.ppy.sh/users/1639250 "YoonA-") |
+| ![][flag_ID] | Indonesia          | **[Mood Breaker](https://osu.ppy.sh/users/692065 "Mood Breaker")**, [LongExistence](https://osu.ppy.sh/users/2380426 "LongExistence"), [Rinzler](https://osu.ppy.sh/users/2133381 "Rinzler"), [Genjitsu](https://osu.ppy.sh/users/3531490 "Genjitsu"), [lolimastah](https://osu.ppy.sh/users/3207112 "lolimastah"), [Rexeez](https://osu.ppy.sh/users/1987591 "Rexeez"), [Reyuza](https://osu.ppy.sh/users/2454767 "Reyuza"), [Vorsatz](https://osu.ppy.sh/users/3654630 "Vorsatz") |
+| ![][flag_IL] | Israel | **[MrPotato](https://osu.ppy.sh/users/2787415 "MrPotato")**, [Kyoko](https://osu.ppy.sh/users/3382084 "Kyoko"), [Keysama](https://osu.ppy.sh/users/3376034 "Keysama"), [ilift](https://osu.ppy.sh/users/4903239 "ilift"), [KiroKusA](https://osu.ppy.sh/users/4355621 "KiroKusA"), [Fookiezi](https://osu.ppy.sh/users/4593732 "Fookiezi"), [Slendy](https://osu.ppy.sh/users/2689577 "Slendy") |
+| ![][flag_IT] | Italy       | **[xiAmME](https://osu.ppy.sh/users/1428960 "xiAmME")**, [Koba](https://osu.ppy.sh/users/4448118 "Koba"), [mrspazzaneve17](https://osu.ppy.sh/users/3516241 "mrspazzaneve17"), [-Kazuki-](https://osu.ppy.sh/users/3614356 "-Kazuki-"), [Kirin](https://osu.ppy.sh/users/1852356 "Kirin"), [DT-sama](https://osu.ppy.sh/users/3525018 "DT-sama"), [umii](https://osu.ppy.sh/users/2538695 "umii"), [LLoyd-chan](https://osu.ppy.sh/users/2849149 "LLoyd-chan")   |
+| ![][flag_LV] | Latvia    | **[Forseen](https://osu.ppy.sh/users/556012 "Forseen")**, [waywern2012](https://osu.ppy.sh/users/5870453 "waywern2012"), [Emula](https://osu.ppy.sh/users/2891792 "Emula"), [Jesus\[Krists\]](https://osu.ppy.sh/users/2842992 "Jesus[Krists]")  |
+| ![][flag_MX] | Mexico    | **[Broodich](https://osu.ppy.sh/users/2484629 "Broodich")**, [Ferelix](https://osu.ppy.sh/users/5580827 "Ferelix"), [-Wolfy-](https://osu.ppy.sh/users/4497582 "-Wolfy-"), [KevstracK](https://osu.ppy.sh/users/5325213 "KevstracK"), [\[ AeonLust \]](https://osu.ppy.sh/users/2353490 "[ AeonLust ]"), [Atsuro](https://osu.ppy.sh/users/2279351 "Atsuro"), [-Hebel-](https://osu.ppy.sh/users/6169483 "-Hebel-"), [Atheneon](https://osu.ppy.sh/users/2164627 "Atheneon") |
+| ![][flag_NL] | Netherlands        | **[jackylam5](https://osu.ppy.sh/users/1540807 "jackylam5")**, [n0ah](https://osu.ppy.sh/users/3086393 "n0ah"), [Ahmnesia](https://osu.ppy.sh/users/2715937 "Ahmnesia"), [Synchrostar](https://osu.ppy.sh/users/419705 "Synchrostar"), [Kyshiro](https://osu.ppy.sh/users/640611 "Kyshiro"), [taku](https://osu.ppy.sh/users/684433 "taku"), [Sj-Sama](https://osu.ppy.sh/users/2977954 "Sj-Sama"), [Pittigbaasje](https://osu.ppy.sh/users/2167433 "Pittigbaasje")                 |
+| ![][flag_NZ] | New Zealand | **[shortpotato](https://osu.ppy.sh/users/1266102 "shortpotato")**, [buny](https://osu.ppy.sh/users/1488796 "buny"), [yellowy246](https://osu.ppy.sh/users/3833980 "yellowy246"), [kiyumi](https://osu.ppy.sh/users/3701898 "kiyumi"), [cabbage](https://osu.ppy.sh/users/2358072 "cabbage"), [ningalu](https://osu.ppy.sh/users/6934358 "ningalu"), [xenoframium](https://osu.ppy.sh/users/4502584 "xenoframium"), [smead](https://osu.ppy.sh/users/4293459 "smead") |
+| ![][flag_NO] | Norway        | **[Tobi](https://osu.ppy.sh/users/2970667 "Tobi")**, [CXu](https://osu.ppy.sh/users/84841 "CXu"), [-GN](https://osu.ppy.sh/users/895581 "-GN"), [Sebu](https://osu.ppy.sh/users/3990173 "Sebu"), [Warrock](https://osu.ppy.sh/users/2841744 "Warrock"), [Afrodafro](https://osu.ppy.sh/users/3551255 "Afrodafro"), [-PC](https://osu.ppy.sh/users/2916414 "-PC"), [Hundur](https://osu.ppy.sh/users/3145033 "Hundur")  |
+| ![][flag_PH] | Philippines | **[revurii](https://osu.ppy.sh/users/4180036 "revurii")**, [awmslayer](https://osu.ppy.sh/users/4133147 "awmslayer"), [ededed028](https://osu.ppy.sh/users/3932796 "ededed028"), [2124](https://osu.ppy.sh/users/5315077 "2124"), [HybRidChrome](https://osu.ppy.sh/users/2606470 "HybRidChrome"), [Shii](https://osu.ppy.sh/users/2911062 "Shii"), [konawiki](https://osu.ppy.sh/users/4003979 "konawiki"), [Mira-san](https://osu.ppy.sh/users/1587999 "Mira-san") |
+| ![][flag_PL] | Poland      | **[My Angel Wilchq](https://osu.ppy.sh/users/844815 "My Angel Wilchq")**, [Wilchq](https://osu.ppy.sh/users/2021758 "Wilchq"), [Rafis](https://osu.ppy.sh/users/2558286 "Rafis"), [WubWoofWolf](https://osu.ppy.sh/users/39828 "WubWoofWolf"), [r0ck](https://osu.ppy.sh/users/1549620 "r0ck"), [fartownik](https://osu.ppy.sh/users/56917 "fartownik"), [SpajdeR](https://osu.ppy.sh/users/3446664 "SpajdeR"), [Piggey](https://osu.ppy.sh/users/4163860 "Piggey")  |
+| ![][flag_RU] | Russian Federation | **[Kert](https://osu.ppy.sh/users/119933 "Kert")**, [_index](https://osu.ppy.sh/users/652457 "_index"), [talala](https://osu.ppy.sh/users/1389663 "talala"), [Red_Pixel](https://osu.ppy.sh/users/4170932 "Red_Pixel"), [follon](https://osu.ppy.sh/users/3973474 "follon"), [Shiawase](https://osu.ppy.sh/users/989489 "Shiawase"), [Shockwave000](https://osu.ppy.sh/users/2295157 "Shockwave000"), [unberlin](https://osu.ppy.sh/users/2408278 "unberlin")                       |
+| ![][flag_SG] | Singapore   | **[Nakano-](https://osu.ppy.sh/users/1893953 "Nakano-")**, [GSBlank](https://osu.ppy.sh/users/2312106 "GSBlank"), [Raen](https://osu.ppy.sh/users/2922482 "Raen"), [Repulse](https://osu.ppy.sh/users/2414526 "Repulse"), [Asterix-](https://osu.ppy.sh/users/5138193 "Asterix-"), [Rtyzen](https://osu.ppy.sh/users/2439822 "Rtyzen"), [oneplusone](https://osu.ppy.sh/users/1843447 "oneplusone"), [Raindrop](https://osu.ppy.sh/users/1155871 "Raindrop")         |
+| ![][flag_KR] | South Korea        | **[Neta](https://osu.ppy.sh/users/832084 "Neta")**, [-T A R U L A S-](https://osu.ppy.sh/users/3179601 "-T A R U L A S-"), [Cinia Pacifica](https://osu.ppy.sh/users/1414625 "Cinia Pacifica"), [Yuria](https://osu.ppy.sh/users/625988 "Yuria"), [Angelsim](https://osu.ppy.sh/users/1777162 "Angelsim"), [Enon](https://osu.ppy.sh/users/2043401 "Enon"), [La Valse](https://osu.ppy.sh/users/70863 "La Valse"), [My Aim Sucks](https://osu.ppy.sh/users/1883865 "My Aim Sucks")  |
+| ![][flag_ES] | Spain     | **[Naxurin](https://osu.ppy.sh/users/3589423 "Naxurin")**, [PdPr0x_](https://osu.ppy.sh/users/4086716 "PdPr0x_"), [Painketsu](https://osu.ppy.sh/users/2127432 "Painketsu"), [\[ xFrozZ \]](https://osu.ppy.sh/users/6462387 "[ xFrozZ ]"), [MortalStriker](https://osu.ppy.sh/users/4759050 "MortalStriker"), [adrilolo9](https://osu.ppy.sh/users/4274726 "adrilolo9"), [Widelux13](https://osu.ppy.sh/users/3938945 "Widelux13") |
+| ![][flag_SE] | Sweden         | **[-Kupo-](https://osu.ppy.sh/users/4343103 "-Kupo-")**, [Rapthorn](https://osu.ppy.sh/users/5109930 "Rapthorn"), [Tomoko Kuroki-](https://osu.ppy.sh/users/4418213 "Tomoko Kuroki-"), [Snase](https://osu.ppy.sh/users/4258410 "Snase"), [Suzuta](https://osu.ppy.sh/users/3028834 "Suzuta"), [HenBurgaaa](https://osu.ppy.sh/users/4663479 "HenBurgaaa")  |
+| ![][flag_TW] | Taiwan    | **[Flask](https://osu.ppy.sh/users/959763 "Flask")**, [hvick225](https://osu.ppy.sh/users/50265 "hvick225"), [Rucker](https://osu.ppy.sh/users/147515 "Rucker"), [Small K](https://osu.ppy.sh/users/952751 "Small K"), [My Angel Haruna](https://osu.ppy.sh/users/606544 "My Angel Haruna"), [Koalazy](https://osu.ppy.sh/users/286740 "Koalazy"), [Rizer](https://osu.ppy.sh/users/5155973 "Rizer"), [SevenTeen-](https://osu.ppy.sh/users/1859195 "SevenTeen-")  |
+| ![][flag_UA] | Ukraine     | **[Granje](https://osu.ppy.sh/users/496387 "Granje")**, [-Ranndom-](https://osu.ppy.sh/users/5022536 "-Ranndom-"), [Sadness](https://osu.ppy.sh/users/6560835 "Sadness"), [BloodM0nk](https://osu.ppy.sh/users/2174403 "BloodM0nk"), [FllareA](https://osu.ppy.sh/users/1163931 "FllareA"), [blednak](https://osu.ppy.sh/users/912627 "blednak"), [Elzbieta](https://osu.ppy.sh/users/3734954 "Elzbieta"), [Cloz1k](https://osu.ppy.sh/users/4548264 "Cloz1k")  |
+| ![][flag_GB] | United Kingdom | **[Bubbleman](https://osu.ppy.sh/users/5182050 "Bubbleman")**, [bahamete](https://osu.ppy.sh/users/960620 "bahamete"), [Spook](https://osu.ppy.sh/users/2232928 "Spook"), [Karthy](https://osu.ppy.sh/users/4196808 "Karthy"), [Doomsday](https://osu.ppy.sh/users/18983 "Doomsday"), [Jameslike](https://osu.ppy.sh/users/2415743 "Jameslike"), [OPJames](https://osu.ppy.sh/users/4117142 "OPJames"), [Helix](https://osu.ppy.sh/users/3322597 "Helix")                                   |
+| ![][flag_US] | United States | **[\[Toy\]](https://osu.ppy.sh/users/2757689 "[Toy]")**, [Axarious](https://osu.ppy.sh/users/2614511 "Axarious"), [Ritzeh](https://osu.ppy.sh/users/1028387 "Ritzeh"), [Mlaw22](https://osu.ppy.sh/users/3126596 "Mlaw22"), [fieryrage](https://osu.ppy.sh/users/3533958 "fieryrage"), [HappyStick](https://osu.ppy.sh/users/256802 "HappyStick"), [idke](https://osu.ppy.sh/users/4650315 "idke"), [mniminwoo](https://osu.ppy.sh/users/3929529 "mniminwoo")        |
+
+
+## Groups
+
+
+| Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H |
+| ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
+| ![][flag_FI] Finland | ![][flag_IT] Italy | ![][flag_AR] Argentina | ![][flag_AU] Australia | ![][flag_CA] Canada| ![][flag_AT] Austria | ![][flag_ID] Indonesia | ![][flag_BR] Brazil|
+| ![][flag_FR] France | ![][flag_PH] Philippines | ![][flag_MX] Mexico | ![][flag_DE] Germany | ![][flag_CL] Chile | ![][flag_DK] Denmark| ![][flag_NL] Netherlands | ![][flag_HK] Hong Kong |
+| ![][flag_NZ] New Zealand | ![][flag_PL] Poland | ![][flag_ES] Spain | ![][flag_GR] Greece| ![][flag_CN] China| ![][flag_NO] Norway | ![][flag_RU] Russian Federation| ![][flag_SE] Sweden|
+| ![][flag_SG] Singapore | ![][flag_UA] Ukraine | ![][flag_TW] Taiwan | ![][flag_LV] Latvia | ![][flag_IL] Israel | ![][flag_US] United States | ![][flag_KR] South Korea | ![][flag_GB] United Kingdom |
 
 -----------
 
-![Podium](podium.jpg)
+![OWC 2016 Podium](podium.jpg)
 
 -----------
 
-![Brackets](brackets.jpg)
+![OWC 2016 Brackets](brackets.jpg)
 
 -----------
-
-## Seedings
-
-| Top Seed                    | High Seed                       | Low Seed                 | Unseeded               |
-|-----------------------------|---------------------------------|--------------------------|------------------------|
-| ![][flag_CN] China          | ![][flag_AU] Australia          | ![][flag_AR] Argentina   | ![][flag_DK] Denmark   |
-| ![][flag_FR] France         | ![][flag_BR] Brazil             | ![][flag_AT] Austria     | ![][flag_GR] Greece    |
-| ![][flag_DE] Germany        | ![][flag_CA] Canada             | ![][flag_CL] Chile       | ![][flag_ID] Indonesia |
-| ![][flag_PL] Poland         | ![][flag_FI] Finland            | ![][flag_HK] Hong Kong   | ![][flag_IL] Israel    |
-| ![][flag_KR] South Korea    | ![][flag_IT] Italy              | ![][flag_LV] Latvia      | ![][flag_SG] Singapore |
-| ![][flag_TW] Taiwan         | ![][flag_MX] Mexico             | ![][flag_NL] Netherlands | ![][flag_ES] Spain     |
-| ![][flag_GB] United Kingdom | ![][flag_NO] Norway             | ![][flag_NZ] New Zealand | ![][flag_SE] Sweden    |
-| ![][flag_US] United States  | ![][flag_RU] Russian Federation | ![][flag_PH] Philippines | ![][flag_UA] Ukraine   |
-
-### Group A
-
-| Country                  | Team                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_FR] France      | **[Musty](https://osu.ppy.sh/users/251683 "Musty")**, [filsdelama](https://osu.ppy.sh/users/2831793 "filsdelama"), [ThePooN](https://osu.ppy.sh/users/718454 "ThePooN"), [Flaven](https://osu.ppy.sh/users/3213239 "Flaven"), [NerO](https://osu.ppy.sh/users/1545031 "NerO"), [mrzomb](https://osu.ppy.sh/users/1694887 "mrzomb"), [FayeurS](https://osu.ppy.sh/users/3105416 "FayeurS"), [Elysion](https://osu.ppy.sh/users/106269 "Elysion")                      |
-| ![][flag_FI] Finland     | **[Sanze](https://osu.ppy.sh/users/3110552 "Sanze")**, [thelewa](https://osu.ppy.sh/users/475021 "thelewa"), [Hyppyri](https://osu.ppy.sh/users/3123423 "Hyppyri"), [Subbie](https://osu.ppy.sh/users/1590138 "Subbie"), [Maffe](https://osu.ppy.sh/users/4773855 "Maffe"), [huono_tuuri](https://osu.ppy.sh/users/1432954 "huono_tuuri"), [Sonoda-Umi](https://osu.ppy.sh/users/2197711 "Sonoda-Umi"), [Multtari](https://osu.ppy.sh/users/1097352 "Multtari")      |
-| ![][flag_NZ] New Zealand | **[shortpotato](https://osu.ppy.sh/users/1266102 "shortpotato")**, [buny](https://osu.ppy.sh/users/1488796 "buny"), [yellowy246](https://osu.ppy.sh/users/3833980 "yellowy246"), [kiyumi](https://osu.ppy.sh/users/3701898 "kiyumi"), [cabbage](https://osu.ppy.sh/users/2358072 "cabbage"), [ningalu](https://osu.ppy.sh/users/6934358 "ningalu"), [xenoframium](https://osu.ppy.sh/users/4502584 "xenoframium"), [smead](https://osu.ppy.sh/users/4293459 "smead") |
-| ![][flag_SG] Singapore   | **[Nakano-](https://osu.ppy.sh/users/1893953 "Nakano-")**, [GSBlank](https://osu.ppy.sh/users/2312106 "GSBlank"), [Raen](https://osu.ppy.sh/users/2922482 "Raen"), [Repulse](https://osu.ppy.sh/users/2414526 "Repulse"), [Asterix-](https://osu.ppy.sh/users/5138193 "Asterix-"), [Rtyzen](https://osu.ppy.sh/users/2439822 "Rtyzen"), [oneplusone](https://osu.ppy.sh/users/1843447 "oneplusone"), [Raindrop](https://osu.ppy.sh/users/1155871 "Raindrop")         |
-
-### Group B
-
-| Country                  | Team                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_PL] Poland      | **[My Angel Wilchq](https://osu.ppy.sh/users/844815 "My Angel Wilchq")**, [Wilchq](https://osu.ppy.sh/users/2021758 "Wilchq"), [Rafis](https://osu.ppy.sh/users/2558286 "Rafis"), [WubWoofWolf](https://osu.ppy.sh/users/39828 "WubWoofWolf"), [r0ck](https://osu.ppy.sh/users/1549620 "r0ck"), [fartownik](https://osu.ppy.sh/users/56917 "fartownik"), [SpajdeR](https://osu.ppy.sh/users/3446664 "SpajdeR"), [Piggey](https://osu.ppy.sh/users/4163860 "Piggey")  |
-| ![][flag_IT] Italy       | **[xiAmME](https://osu.ppy.sh/users/1428960 "xiAmME")**, [Koba](https://osu.ppy.sh/users/4448118 "Koba"), [mrspazzaneve17](https://osu.ppy.sh/users/3516241 "mrspazzaneve17"), [-Kazuki-](https://osu.ppy.sh/users/3614356 "-Kazuki-"), [Kirin](https://osu.ppy.sh/users/1852356 "Kirin"), [DT-sama](https://osu.ppy.sh/users/3525018 "DT-sama"), [umii](https://osu.ppy.sh/users/2538695 "umii"), [LLoyd-chan](https://osu.ppy.sh/users/2849149 "LLoyd-chan")       |
-| ![][flag_PH] Philippines | **[revurii](https://osu.ppy.sh/users/4180036 "revurii")**, [awmslayer](https://osu.ppy.sh/users/4133147 "awmslayer"), [ededed028](https://osu.ppy.sh/users/3932796 "ededed028"), [2124](https://osu.ppy.sh/users/5315077 "2124"), [HybRidChrome](https://osu.ppy.sh/users/2606470 "HybRidChrome"), [Shii](https://osu.ppy.sh/users/2911062 "Shii"), [konawiki](https://osu.ppy.sh/users/4003979 "konawiki"), [Mira-san](https://osu.ppy.sh/users/1587999 "Mira-san") |
-| ![][flag_UA] Ukraine     | **[Granje](https://osu.ppy.sh/users/496387 "Granje")**, [-Ranndom-](https://osu.ppy.sh/users/5022536 "-Ranndom-"), [Sadness](https://osu.ppy.sh/users/6560835 "Sadness"), [BloodM0nk](https://osu.ppy.sh/users/2174403 "BloodM0nk"), [FllareA](https://osu.ppy.sh/users/1163931 "FllareA"), [blednak](https://osu.ppy.sh/users/912627 "blednak"), [Elzbieta](https://osu.ppy.sh/users/3734954 "Elzbieta"), [Cloz1k](https://osu.ppy.sh/users/4548264 "Cloz1k")       |
-
-### Group C
-
-| Country                | Team                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_TW] Taiwan    | **[Flask](https://osu.ppy.sh/users/959763 "Flask")**, [hvick225](https://osu.ppy.sh/users/50265 "hvick225"), [Rucker](https://osu.ppy.sh/users/147515 "Rucker"), [Small K](https://osu.ppy.sh/users/952751 "Small K"), [My Angel Haruna](https://osu.ppy.sh/users/606544 "My Angel Haruna"), [Koalazy](https://osu.ppy.sh/users/286740 "Koalazy"), [Rizer](https://osu.ppy.sh/users/5155973 "Rizer"), [SevenTeen-](https://osu.ppy.sh/users/1859195 "SevenTeen-")          |
-| ![][flag_MX] Mexico    | **[Broodich](https://osu.ppy.sh/users/2484629 "Broodich")**, [Ferelix](https://osu.ppy.sh/users/5580827 "Ferelix"), [-Wolfy-](https://osu.ppy.sh/users/4497582 "-Wolfy-"), [KevstracK](https://osu.ppy.sh/users/5325213 "KevstracK"), [\[ AeonLust \]](https://osu.ppy.sh/users/2353490 "[ AeonLust ]"), [Atsuro](https://osu.ppy.sh/users/2279351 "Atsuro"), [-Hebel-](https://osu.ppy.sh/users/6169483 "-Hebel-"), [Atheneon](https://osu.ppy.sh/users/2164627 "Atheneon") |
-| ![][flag_AR] Argentina | **[Glazbom](https://osu.ppy.sh/users/608277 "Glazbom")**, [GaTu](https://osu.ppy.sh/users/3583351 "GaTu"), [Pein](https://osu.ppy.sh/users/2212941 "Pein"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [nicogame14](https://osu.ppy.sh/users/3812213 "nicogame14"), [Catalysis](https://osu.ppy.sh/users/5958063 "Catalysis"), [Toushi](https://osu.ppy.sh/users/2367825 "Toushi")                        |
-| ![][flag_ES] Spain     | **[Naxurin](https://osu.ppy.sh/users/3589423 "Naxurin")**, [PdPr0x_](https://osu.ppy.sh/users/4086716 "PdPr0x_"), [Painketsu](https://osu.ppy.sh/users/2127432 "Painketsu"), [\[ xFrozZ \]](https://osu.ppy.sh/users/6462387 "[ xFrozZ ]"), [MortalStriker](https://osu.ppy.sh/users/4759050 "MortalStriker"), [adrilolo9](https://osu.ppy.sh/users/4274726 "adrilolo9"), [Widelux13](https://osu.ppy.sh/users/3938945 "Widelux13")                                      |
-
-### Group D
-
-| Country                | Team                                                                                                                                                                                                                                                                                                                                                                                                                       |
-|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_DE] Germany   | **[Dustice](https://osu.ppy.sh/users/754565 "Dustice")**, [DoKito](https://osu.ppy.sh/users/537084 "DoKito"), [Beafowl](https://osu.ppy.sh/users/2438122 "Beafowl"), [Neliel](https://osu.ppy.sh/users/1500305 "Neliel"), [imagaK](https://osu.ppy.sh/users/2022445 "imagaK"), [Firstus](https://osu.ppy.sh/users/1856829 "Firstus"), [BDDav](https://osu.ppy.sh/users/1164526 "BDDav"), [W3SON](https://osu.ppy.sh/users/2070822 "W3SON")                 |
-| ![][flag_AU] Australia | **[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [uyghti](https://osu.ppy.sh/users/3641404 "uyghti"), [ithgyu](https://osu.ppy.sh/users/5113781 "ithgyu"), [Dumii](https://osu.ppy.sh/users/3068044 "Dumii"), [Korilak](https://osu.ppy.sh/users/7260014 "Korilak"), [Weber](https://osu.ppy.sh/users/6410432 "Weber"), [Lunirs](https://osu.ppy.sh/users/2118945 "Lunirs"), [Peekamoo](https://osu.ppy.sh/users/2337263 "Peekamoo")                 |
-| ![][flag_LV] Latvia    | **[Forseen](https://osu.ppy.sh/users/556012 "Forseen")**, [waywern2012](https://osu.ppy.sh/users/5870453 "waywern2012"), [Emula](https://osu.ppy.sh/users/2891792 "Emula"), [Jesus\[Krists\]](https://osu.ppy.sh/users/2842992 "Jesus[Krists]")                                                                                                                                                                                              |
-| ![][flag_GR] Greece    | **[Riven](https://osu.ppy.sh/users/3638005 "Riven")**, [JohnyZ](https://osu.ppy.sh/users/4508048 "JohnyZ"), [ThePainG7](https://osu.ppy.sh/users/3478000 "ThePainG7"), [kYorineN](https://osu.ppy.sh/users/4131515 "kYorineN"), [Grapheon](https://osu.ppy.sh/users/2415008 "Grapheon"), [ThOmAstr](https://osu.ppy.sh/users/2793537 "ThOmAstr"), [Tofas](https://osu.ppy.sh/users/2755584 "Tofas"), [xDarxen](https://osu.ppy.sh/users/4625954 "xDarxen") |
-
-### Group E
-
-| Country             | Team                                                                                                                                                                                                                                                                                                                                                                                                                |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_CN] China  | **[Crystal](https://osu.ppy.sh/users/1646397 "Crystal")**, [Totori](https://osu.ppy.sh/users/227717 "Totori"), [Dsan](https://osu.ppy.sh/users/1266166 "Dsan"), [Totoki](https://osu.ppy.sh/users/557197 "Totoki"), [ArtxE](https://osu.ppy.sh/users/954557 "ArtxE"), [SpringLane](https://osu.ppy.sh/users/1343504 "SpringLane"), [GGBY](https://osu.ppy.sh/users/629717 "GGBY"), [MatsumotoRise](https://osu.ppy.sh/users/672726 "MatsumotoRise") |
-| ![][flag_CA] Canada | **[Azer](https://osu.ppy.sh/users/2155578 "Azer")**, [TrickMirror](https://osu.ppy.sh/users/2138739 "TrickMirror"), [MiruHong](https://osu.ppy.sh/users/2866814 "MiruHong"), [Kaifin](https://osu.ppy.sh/users/2596942 "Kaifin"), [Ignite](https://osu.ppy.sh/users/3122948 "Ignite"), [Kyle](https://osu.ppy.sh/users/2694475 "Kyle"), [karalis](https://osu.ppy.sh/users/3146018 "karalis"), [VINXIS](https://osu.ppy.sh/users/4323406 "VINXIS")  |
-| ![][flag_CL] Chile  | **[kafaN](https://osu.ppy.sh/users/1489743 "kafaN")**, [DanyL](https://osu.ppy.sh/users/3069354 "DanyL"), [Neab](https://osu.ppy.sh/users/916693 "Neab"), [etejuano](https://osu.ppy.sh/users/2243537 "etejuano"), [allives](https://osu.ppy.sh/users/3951781 "allives"), [-Dylson-](https://osu.ppy.sh/users/6315784 "-Dylson-"), [DPL](https://osu.ppy.sh/users/3024454 "DPL"), [Criss](https://osu.ppy.sh/users/3188017 "Criss")                 |
-| ![][flag_IL] Israel | **[MrPotato](https://osu.ppy.sh/users/2787415 "MrPotato")**, [Kyoko](https://osu.ppy.sh/users/3382084 "Kyoko"), [Keysama](https://osu.ppy.sh/users/3376034 "Keysama"), [ilift](https://osu.ppy.sh/users/4903239 "ilift"), [KiroKusA](https://osu.ppy.sh/users/4355621 "KiroKusA"), [Fookiezi](https://osu.ppy.sh/users/4593732 "Fookiezi"), [Slendy](https://osu.ppy.sh/users/2689577 "Slendy")                                                 |
-
-### Group F
-
-| Country                    | Team                                                                                                                                                                                                                                                                                                                                                                                                                               |
-|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_US] United States | **[\[Toy\]](https://osu.ppy.sh/users/2757689 "[Toy]")**, [Axarious](https://osu.ppy.sh/users/2614511 "Axarious"), [Ritzeh](https://osu.ppy.sh/users/1028387 "Ritzeh"), [Mlaw22](https://osu.ppy.sh/users/3126596 "Mlaw22"), [fieryrage](https://osu.ppy.sh/users/3533958 "fieryrage"), [HappyStick](https://osu.ppy.sh/users/256802 "HappyStick"), [idke](https://osu.ppy.sh/users/4650315 "idke"), [mniminwoo](https://osu.ppy.sh/users/3929529 "mniminwoo")        |
-| ![][flag_NO] Norway        | **[Tobi](https://osu.ppy.sh/users/2970667 "Tobi")**, [CXu](https://osu.ppy.sh/users/84841 "CXu"), [-GN](https://osu.ppy.sh/users/895581 "-GN"), [Sebu](https://osu.ppy.sh/users/3990173 "Sebu"), [Warrock](https://osu.ppy.sh/users/2841744 "Warrock"), [Afrodafro](https://osu.ppy.sh/users/3551255 "Afrodafro"), [-PC](https://osu.ppy.sh/users/2916414 "-PC"), [Hundur](https://osu.ppy.sh/users/3145033 "Hundur")                                              |
-| ![][flag_AT] Austria       | **[Akane-Yuki](https://osu.ppy.sh/users/3656589 "Akane-Yuki")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [LWMF](https://osu.ppy.sh/users/3632402 "LWMF"), [Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose"), [Myst1k](https://osu.ppy.sh/users/5302223 "Myst1k")                                                                                                                                                           |
-| ![][flag_DK] Denmark       | **[Spork Lover](https://osu.ppy.sh/users/3417469 "Spork Lover")**, [waefwerf](https://osu.ppy.sh/users/3868653 "waefwerf"), [iamVill](https://osu.ppy.sh/users/6295380 "iamVill"), [Zog](https://osu.ppy.sh/users/3722715 "Zog"), [Hudda](https://osu.ppy.sh/users/4103629 "Hudda"), [Crylizhy](https://osu.ppy.sh/users/3023138 "Crylizhy"), [Lemmen](https://osu.ppy.sh/users/6090254 "Lemmen"), [teamplayer51](https://osu.ppy.sh/users/3084508 "teamplayer51") |
-
-### Group G
-
-| Country                         | Team                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_KR] South Korea        | **[Neta](https://osu.ppy.sh/users/832084 "Neta")**, [-T A R U L A S-](https://osu.ppy.sh/users/3179601 "-T A R U L A S-"), [Cinia Pacifica](https://osu.ppy.sh/users/1414625 "Cinia Pacifica"), [Yuria](https://osu.ppy.sh/users/625988 "Yuria"), [Angelsim](https://osu.ppy.sh/users/1777162 "Angelsim"), [Enon](https://osu.ppy.sh/users/2043401 "Enon"), [La Valse](https://osu.ppy.sh/users/70863 "La Valse"), [My Aim Sucks](https://osu.ppy.sh/users/1883865 "My Aim Sucks")  |
-| ![][flag_RU] Russian Federation | **[Kert](https://osu.ppy.sh/users/119933 "Kert")**, [_index](https://osu.ppy.sh/users/652457 "_index"), [talala](https://osu.ppy.sh/users/1389663 "talala"), [Red_Pixel](https://osu.ppy.sh/users/4170932 "Red_Pixel"), [follon](https://osu.ppy.sh/users/3973474 "follon"), [Shiawase](https://osu.ppy.sh/users/989489 "Shiawase"), [Shockwave000](https://osu.ppy.sh/users/2295157 "Shockwave000"), [unberlin](https://osu.ppy.sh/users/2408278 "unberlin")                       |
-| ![][flag_NL] Netherlands        | **[jackylam5](https://osu.ppy.sh/users/1540807 "jackylam5")**, [n0ah](https://osu.ppy.sh/users/3086393 "n0ah"), [Ahmnesia](https://osu.ppy.sh/users/2715937 "Ahmnesia"), [Synchrostar](https://osu.ppy.sh/users/419705 "Synchrostar"), [Kyshiro](https://osu.ppy.sh/users/640611 "Kyshiro"), [taku](https://osu.ppy.sh/users/684433 "taku"), [Sj-Sama](https://osu.ppy.sh/users/2977954 "Sj-Sama"), [Pittigbaasje](https://osu.ppy.sh/users/2167433 "Pittigbaasje")                 |
-| ![][flag_ID] Indonesia          | **[Mood Breaker](https://osu.ppy.sh/users/692065 "Mood Breaker")**, [LongExistence](https://osu.ppy.sh/users/2380426 "LongExistence"), [Rinzler](https://osu.ppy.sh/users/2133381 "Rinzler"), [Genjitsu](https://osu.ppy.sh/users/3531490 "Genjitsu"), [lolimastah](https://osu.ppy.sh/users/3207112 "lolimastah"), [Rexeez](https://osu.ppy.sh/users/1987591 "Rexeez"), [Reyuza](https://osu.ppy.sh/users/2454767 "Reyuza"), [Vorsatz](https://osu.ppy.sh/users/3654630 "Vorsatz") |
-
-### Group H
-
-| Country                     | Team                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ![][flag_GB] United Kingdom | **[Bubbleman](https://osu.ppy.sh/users/5182050 "Bubbleman")**, [bahamete](https://osu.ppy.sh/users/960620 "bahamete"), [Spook](https://osu.ppy.sh/users/2232928 "Spook"), [Karthy](https://osu.ppy.sh/users/4196808 "Karthy"), [Doomsday](https://osu.ppy.sh/users/18983 "Doomsday"), [Jameslike](https://osu.ppy.sh/users/2415743 "Jameslike"), [OPJames](https://osu.ppy.sh/users/4117142 "OPJames"), [Helix](https://osu.ppy.sh/users/3322597 "Helix")                                   |
-| ![][flag_BR] Brazil         | **[Fenrir](https://osu.ppy.sh/users/2644700 "Fenrir")**, [Idealism](https://osu.ppy.sh/users/3869519 "Idealism"), [Texats](https://osu.ppy.sh/users/1638293 "Texats"), [Mirtrax](https://osu.ppy.sh/users/2290888 "Mirtrax"), [Zekker](https://osu.ppy.sh/users/4663554 "Zekker"), [MouseEasy](https://osu.ppy.sh/users/1558603 "MouseEasy"), [fabriciorby](https://osu.ppy.sh/users/209664 "fabriciorby"), [Miyazono](https://osu.ppy.sh/users/529036 "Miyazono")                          |
-| ![][flag_HK] Hong Kong      | **[- G I D Z -](https://osu.ppy.sh/users/2286528 "- G I D Z -")**, [-N a n a k o-](https://osu.ppy.sh/users/1407516 "-N a n a k o-"), [Chaoslitz](https://osu.ppy.sh/users/3621552 "Chaoslitz"), [Rizia](https://osu.ppy.sh/users/1367570 "Rizia"), [DenierNezzar](https://osu.ppy.sh/users/126144 "DenierNezzar"), [MinG3012](https://osu.ppy.sh/users/1583218 "MinG3012"), [StarrStyx](https://osu.ppy.sh/users/4600383 "StarrStyx"), [YoonA-](https://osu.ppy.sh/users/1639250 "YoonA-") |
-| ![][flag_SE] Sweden         | **[-Kupo-](https://osu.ppy.sh/users/4343103 "-Kupo-")**, [Rapthorn](https://osu.ppy.sh/users/5109930 "Rapthorn"), [Tomoko Kuroki-](https://osu.ppy.sh/users/4418213 "Tomoko Kuroki-"), [Snase](https://osu.ppy.sh/users/4258410 "Snase"), [Suzuta](https://osu.ppy.sh/users/3028834 "Suzuta"), [HenBurgaaa](https://osu.ppy.sh/users/4663479 "HenBurgaaa")                                                                                                                          |
 
 ## Mappools
 
-### Group Stage
+### Finals
 
-[Download the mappack here!](https://www.mediafire.com/file/13glkdv1zbyxfpp/OWC_2016_Group_Stage.rar)
+**This mappool will be used in Finals - Week 1 and Finals - Week 2**
 
-- NoMod
-  - [sakuzyo - Altale (toybot) \[Bonzi's Extra\]](https://osu.ppy.sh/beatmaps/1012279)
-  - [Lon - Yuru Fuwa Jukai Girl (Garven) \[Insane\]](https://osu.ppy.sh/beatmaps/153103)
-  - [Itou Kanako - Skyclad no Kansokusha -Remix- (Takos) \[taka\]](https://osu.ppy.sh/beatmaps/110628)
-  - [Rita - Dream Walker (Vert) \[Zweib's Insane\]](https://osu.ppy.sh/beatmaps/778244)
-  - [ONE OK ROCK - Mikansei Koukyoukyoku (Saut) \[Extreme\]](https://osu.ppy.sh/beatmaps/768986)
-  - [Ray - Hajimete Girls! (Meyrink) \[Skystar's Pin Pon~\]](https://osu.ppy.sh/beatmaps/776752)
-- Hidden
-  - [Cyua - Blumenkranz (Shinxyn) \[Insane\]](https://osu.ppy.sh/beatmaps/380475)
-  - [sana - Kotonoha Clinic (Kite) \[Moroi\]](https://osu.ppy.sh/beatmaps/907200)
-- HardRock
-  - [Cascada - How Do You Do (Nightcore Mix) (Asphyxia) \[Insane\]](https://osu.ppy.sh/beatmaps/481450)
-  - [Rameses B - Utopia (ft. Holly Drummond) (Milan-) \[deetz' Paradise\]](https://osu.ppy.sh/beatmaps/662046)
-- DoubleTime
-  - [Satori-san - Hari no Sora (Sure) \[Insane\]](https://osu.ppy.sh/beatmaps/653966)
-  - [07th Expansion - goldenslaughterer (La Cataline) \[Hard\]](https://osu.ppy.sh/beatmaps/121197)
-- FreeMod
-  - [ONE OK ROCK - Re:make (Rucker) \[Remake\]](https://osu.ppy.sh/beatmaps/123152)
-  - [44teru-k - F.I (Jacob) \[Extra445\]](https://osu.ppy.sh/beatmaps/155235)
-  - [Megpoid GUMI - For my soul (val0108) \[Insane\]](https://osu.ppy.sh/beatmaps/80102)
-- Tiebreaker
-  - [kors k - Playing With Fire (Sota Fujimori Remix) (xlni) \[Pyrotechnics\]](https://osu.ppy.sh/beatmaps/478605)
-
-### Round of 16
-
-[Download the mappack here!](https://www.mediafire.com/file/1qbqnc5hxa10xk9/OWC_2016_Round_of_16.rar)
+[Download the mappack here! (148.8MB)](https://www.mediafire.com/file/1rf6jgjsgfilhkx/OWC_2016_Finals.rar)
 
 - NoMod
-  - [Cilvery - Kamisama Nejimaki (sukiNathan) \[Catastrophe\]](https://osu.ppy.sh/beatmaps/821238)
-  - [senya - Renbei no Searchlight (Dailycare) \[Satellite's Catharsis\]](https://osu.ppy.sh/beatmaps/1046536)
-  - [LeaF - Wizdomiot (Asahina Momoko) \[Lunatic\]](https://osu.ppy.sh/beatmaps/743896)
-  - [Katakiri Rekka - Answer (deetz) \[RLC's Darkness\]](https://osu.ppy.sh/beatmaps/947334)
-  - [Hana - Sakura no Uta (Ultimate Madoka) \[VI.Artist of the Sakura\]](https://osu.ppy.sh/beatmaps/994933)
-  - [Memme - Extreme Fantasy (AngelHoney) \[ExtrA\]](https://osu.ppy.sh/beatmaps/152480)
+  - [U1 overground - Dopamine (fanzhen0019) \[C6H3\(OH\)2-CH2-CH2-NH2\]](https://osu.ppy.sh/beatmaps/494818)
+  - [Yousei Teikoku - The Creator (meiikyuu) \[Nyaten\]](https://osu.ppy.sh/beatmaps/202756)
+  - [BABYMETAL - Gimme chocolate!! (alacat) \[BLACK CHOCOLATE!!\]](https://osu.ppy.sh/beatmaps/970048)
+  - [Nanahira - Bassdrop Freaks (Long Ver.) (yf_bmp) \[BASSDROP!!\]](https://osu.ppy.sh/beatmaps/992437)
+  - [ayaponzu* - Yakubyougami (cRyo[iceeicee]) \[B(\]](https://osu.ppy.sh/beatmaps/976190)
+  - [ESTi - HELIX (Edit ver.) (Hollow Wings) \[EX EX\]](https://osu.ppy.sh/beatmaps/462700)
 - Hidden
-  - [IOSYS - Poinsettia (Aakiha) \[Lunatic\]](https://osu.ppy.sh/beatmaps/65233)
-  - [Team:SASAKURATION - AVALON (Leader) \[gowww's Extra\]](https://osu.ppy.sh/beatmaps/430110)
+  - [Demetori - Silent Voyage to Eternity (brikel) \[BMix\]](https://osu.ppy.sh/beatmaps/115384)
+  - [An - Catanoph (Lavender) \[Extra\]](https://osu.ppy.sh/beatmaps/1118285)
 - HardRock
-  - [MYTHOLOGIA by MLREC. - Ymir (Kitami Erika) \[Another\]](https://osu.ppy.sh/beatmaps/716972)
-  - [supercell - Hoshi ga Matataku Konna Yoru ni ([Teichan]) \[Starlight\]](https://osu.ppy.sh/beatmaps/661243))
+  - [Studio EIM - Crescent Moon Island Boss Theme (Rakuen) \[\[ -Scarlet- \]'s Extra\]](https://osu.ppy.sh/beatmaps/434438)
+  - [Camellia feat. Nanahira - Tsukitoro (jonathanlfj) \[Countless\]](https://osu.ppy.sh/beatmaps/837694)
 - DoubleTime
-  - [Kraster - Remember History (Short Ver.) (Serval) \[Lunatic\]](https://osu.ppy.sh/beatmaps/76419)
-  - [SYNC.ART'S - Sins -Kokoro no Tsumi- (Snowy Dream) \[Nightmare\]](https://osu.ppy.sh/beatmaps/158107)
+  - [ClariS - Colorful (Laurier) \[Insane\]](https://osu.ppy.sh/beatmaps/336295)
+  - [LeaF - MEPHISTO (Alumetorz) \[Another\]](https://osu.ppy.sh/beatmaps/282166)
 - FreeMod
-  - [M2U - Nightmare (ignorethis) \[Lesjuh\]](https://osu.ppy.sh/beatmaps/60238)
-  - [yuikonnu & ayaponzu* - Kunoichi demo Koi ga Shitai (alacat) \[Skystar's Extra\]](https://osu.ppy.sh/beatmaps/319694)
-  - [nmk - sola (sjoy) \[Imouto's Extra\]](https://osu.ppy.sh/beatmaps/439824)
+  - [EZFG - Hurting for a Very Hurtful Pain (tutuhaha) \[Dance\]](https://osu.ppy.sh/beatmaps/145669)
+  - [Syrsa - Mad Machine (Louis Cyphre) \[Champion\]](https://osu.ppy.sh/beatmaps/107875)
+  - [USAO - Miracle 5ympho X (Extended Mix) (RLC) \[5ympho XtrA\]](https://osu.ppy.sh/beatmaps/536476)
 - Tiebreaker
-  - [Camellia - d:for the DELTA (ProfessionalBox) \[Delirium\]](https://osu.ppy.sh/beatmaps/862338)
-
-### Quarterfinals
-
-[Download the mappack here!](https://www.mediafire.com/file/7gmr44m72v58p8w/OWC_2016_Quarterfinals.rar)
-
-- NoMod
-  - [Memme - Chinese Restaurant (M o k o r i) \[Spicy\]](https://osu.ppy.sh/beatmaps/587547)
-  - [paraoka - boot (rickyboi) \[Shoe\]](https://osu.ppy.sh/beatmaps/154226)
-  - [Xelia - Illumiscape (Kanna) \[Extra\]](https://osu.ppy.sh/beatmaps/152127)
-  - [Lily - Scarlet Rose (val0108) \[0108 style\]](https://osu.ppy.sh/beatmaps/131564)
-  - [MY FIRST STORY - ALONE (Saut) \[Isolation\]](https://osu.ppy.sh/beatmaps/861381)
-  - [Delain - Go Away (pishifat) \[Extra\]](https://osu.ppy.sh/beatmaps/1016263)
-- Hidden
-  - [Sound Horizon - Raijin no Hidariude (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmaps/60089)
-  - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume wo Miru (Strawberry) \[Lunatic\]](https://osu.ppy.sh/beatmaps/214252)
-- HardRock
-  - [iojjj - Deus Ex Machina (Okoratu) \[GREAT EQUALIZER IS THE DEATH\]](https://osu.ppy.sh/beatmaps/688886)
-  - [mafumafu - Yuugure Semi Nikki (L_P) \[Yuugure\]](https://osu.ppy.sh/beatmaps/180681)
-- DoubleTime
-  - [Mami Kawada - sense (Giralda) \[LC's Insane\]](https://osu.ppy.sh/beatmaps/723285)
-  - [ClariS - Connect (Holoaz) \[Holo\]](https://osu.ppy.sh/beatmaps/87066)
-- FreeMod
-  - [07th Expansion - rog-unlimitation (AngelHoney) \[AngelHoney\]](https://osu.ppy.sh/beatmaps/116128)
-  - [jippusu - Mushikui Saikede Rhythm (Amamiya Yuko) \[Skystar\]](https://osu.ppy.sh/beatmaps/239104)
-  - [beatMARIO - Night of Knights (DJPop) \[SOLO\]](https://osu.ppy.sh/beatmaps/58063)
-- Tiebreaker
-  - [DragonForce - Symphony Of The Night (Evil_Twilight) \[Legend\]](https://osu.ppy.sh/beatmaps/1007546)
+  - [goreshit - burn this moment into the retina of my eye (grumd) \[extra\]](https://osu.ppy.sh/beatmaps/791274)
 
 ### Semifinals
 
-[Download the mappack here!](https://www.mediafire.com/file/byy9j4jan4uhk57/OWC_2016_Semifinals.rar)
+[Download the mappack here! (131MB)](https://www.mediafire.com/file/byy9j4jan4uhk57/OWC_2016_Semifinals.rar)
 
 - NoMod
   - [ZUN remixed by LeaF - Resurrection Spell (Muya) \[VOLCANO\]](https://osu.ppy.sh/beatmaps/658561)
@@ -255,180 +168,208 @@ The osu! World Cup 2016 was run by various community members by distributing the
 - Tiebreaker
   - [Venetian Snares - She Runs (fergas) \[Escape?\]](https://osu.ppy.sh/beatmaps/711923)
 
-### Finals
-
-**This mappool will be used in Finals - Week 1 and Finals - Week 2**
-
-[Download the mappack here!](https://www.mediafire.com/file/1rf6jgjsgfilhkx/OWC_2016_Finals.rar)
-
-- NoMod
-  - [U1 overground - Dopamine (fanzhen0019) \[C6H3(OH)2-CH2-CH2-NH2\]](https://osu.ppy.sh/beatmaps/494818)
-  - [Yousei Teikoku - The Creator (meiikyuu) \[Nyaten\]](https://osu.ppy.sh/beatmaps/202756)
-  - [BABYMETAL - Gimme chocolate!! (alacat) \[BLACK CHOCOLATE!!\]](https://osu.ppy.sh/beatmaps/970048)
-  - [Nanahira - Bassdrop Freaks (Long Ver.) (yf_bmp) \[BASSDROP!!\]](https://osu.ppy.sh/beatmaps/992437)
-  - [ayaponzu* - Yakubyougami (cRyo[iceeicee]) \[B(\]](https://osu.ppy.sh/beatmaps/976190)
-  - [ESTi - HELIX (Edit ver.) (Hollow Wings) \[EX EX\]](https://osu.ppy.sh/beatmaps/462700)
-- Hidden
-  - [Demetori - Silent Voyage to Eternity (brikel) \[BMix\]](https://osu.ppy.sh/beatmaps/115384)
-  - [An - Catanoph (Lavender) \[Extra\]](https://osu.ppy.sh/beatmaps/1118285)
-- HardRock
-  - [Studio EIM - Crescent Moon Island Boss Theme (Rakuen) \[[ -Scarlet- ]'s Extra\]](https://osu.ppy.sh/beatmaps/434438)
-  - [Camellia feat. Nanahira - Tsukitoro (jonathanlfj) \[Countless\]](https://osu.ppy.sh/beatmaps/837694)
-- DoubleTime
-  - [ClariS - Colorful (Laurier) \[Insane\]](https://osu.ppy.sh/beatmaps/336295)
-  - [LeaF - MEPHISTO (Alumetorz) \[Another\]](https://osu.ppy.sh/beatmaps/282166)
-- FreeMod
-  - [EZFG - Hurting for a Very Hurtful Pain (tutuhaha) \[Dance\]](https://osu.ppy.sh/beatmaps/145669)
-  - [Syrsa - Mad Machine (Louis Cyphre) \[Champion\]](https://osu.ppy.sh/beatmaps/107875)
-  - [USAO - Miracle 5ympho X (Extended Mix) (RLC) \[5ympho XtrA\]](https://osu.ppy.sh/beatmaps/536476)
-- Tiebreaker
-  - [goreshit - burn this moment into the retina of my eye (grumd) \[extra\]](https://osu.ppy.sh/beatmaps/791274)
-
-## Match Results
-
-[Detailed match statistics here!](https://docs.google.com/spreadsheets/d/1rvVSjmdHIb-h8pekmVfIIPDPivrD5fACjNRYGo1U9to/pubhtml)
-
-### Grand Finals
-
-Sunday, 18. December 2016
-
-| Team A                     | Score     | Team B                         | History                                   |
-|----------------------------|:---------:|--------------------------------|-------------------------------------------|
-| ![][flag_US] United States | 2 - **7** | ![][flag_CN] **China**         | [#1](https://osu.ppy.sh/community/matches/29702438) |
-| ![][flag_CN] China         | 4 - **7** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/29704086) |
-
-### Finals: Week 1
-
-Saturday, 10. December 2016
-
-| Team A                          | Score     | Team B                      | History                                   |
-|---------------------------------|:---------:|-----------------------------|-------------------------------------------|
-| ![][flag_US] **United States**  | **6** - 4 | ![][flag_KR] South Korea    | [#1](https://osu.ppy.sh/community/matches/29524076) |
-| ![][flag_GB] **United Kingdom** | **6** - 4 | ![][flag_TW] Taiwan         | [#1](https://osu.ppy.sh/community/matches/29530355) |
-| ![][flag_DE] Germany            | 2 - **6** | ![][flag_CN] China          | [#1](https://osu.ppy.sh/community/matches/29531576) |
-| ![][flag_CN] **China**          | **4** - 2 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/29533696) |
-
----
-
-Sunday, 11. December 2016
-
-| Team A                 | Score     | Team B                   | History                                   |
-|------------------------|:---------:|--------------------------|-------------------------------------------|
-| ![][flag_CN] **China** | **6** - 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/29560336) |
-
-### Semifinals
-
-Saturday, 3. December 2016
-
-| Team A                          | Score     | Team B                   | History                                   |
-|---------------------------------|:---------:|--------------------------|-------------------------------------------|
-| ![][flag_KR] **South Korea**    | **6** - 2 | ![][flag_TW] Taiwan      | [#1](https://osu.ppy.sh/community/matches/29379804) |
-| ![][flag_RU] Russian Federation | 5 - **6** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/29381511) |
-| ![][flag_FI] Finland            | 0 - **6** | ![][flag_FR] **France**  | [#1](https://osu.ppy.sh/community/matches/29383842) |
-| ![][flag_US] **United States**  | **6** - 4 | ![][flag_CN] China       | [#1](https://osu.ppy.sh/community/matches/29385744) |
-| ![][flag_GB] **United Kingdom** | **6** - 0 | ![][flag_BR] Brazil      | [#1](https://osu.ppy.sh/community/matches/29388879) |
-| ![][flag_CA] Canada             | 0 - **6** | ![][flag_BR] **Poland**  | [#1](https://osu.ppy.sh/community/matches/29391121) |
-
----
-
-Sunday, 4. December 2016
-
-| Team A              | Score     | Team B                          | History                                   |
-|---------------------|:---------:|---------------------------------|-------------------------------------------|
-| ![][flag_FR] France | 2 - **6** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/29413616) |
-| ![][flag_PL] Poland | 4 - **6** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/29415472) |
-
 ### Quarterfinals
 
-Saturday, 26. November 2016
+[Download the mappack here! (125.1MB)](https://www.mediafire.com/file/7gmr44m72v58p8w/OWC_2016_Quarterfinals.rar)
 
-| Team A                       | Score     | Team B                              | History                                   |
-|------------------------------|:---------:|-------------------------------------|-------------------------------------------|
-| ![][flag_AU] Australia       | 1 - **5** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/29236130) |
-| ![][flag_KR] **South Korea** | **5** - 2 | ![][flag_DE] Germany                | [#1](https://osu.ppy.sh/community/matches/29237189) |
-| ![][flag_CN] **China**       | **5** - 2 | ![][flag_PL] Poland                 | [#1](https://osu.ppy.sh/community/matches/29238760) |
-| ![][flag_TW] **Taiwan**      | **5** - 4 | ![][flag_FR] France                 | [#1](https://osu.ppy.sh/community/matches/29240657) |
-| ![][flag_NO] Norway          | 4 - **5** | ![][flag_GB] **United Kingdom**     | [#1](https://osu.ppy.sh/community/matches/29244637) |
-| ![][flag_FI] **Finland**     | **5** - 2 | ![][flag_AR] Argentina              | [#1](https://osu.ppy.sh/community/matches/29247238) |
-| ![][flag_IT] Italy           | 0 - **5** | ![][flag_CA] **Canada**             | [#1](https://osu.ppy.sh/community/matches/29249433) |
-| ![][flag_BR] Brazil          | 4 - **5** | ![][flag_US] **United States**      | [#1](https://osu.ppy.sh/community/matches/29252039) |
+- NoMod
+  - [Memme - Chinese Restaurant (M o k o r i) \[Spicy\]](https://osu.ppy.sh/beatmaps/587547)
+  - [paraoka - boot (rickyboi) \[Shoe\]](https://osu.ppy.sh/beatmaps/154226)
+  - [Xelia - Illumiscape (Kanna) \[Extra\]](https://osu.ppy.sh/beatmaps/152127)
+  - [Lily - Scarlet Rose (val0108) \[0108 style\]](https://osu.ppy.sh/beatmaps/131564)
+  - [MY FIRST STORY - ALONE (Saut) \[Isolation\]](https://osu.ppy.sh/beatmaps/861381)
+  - [Delain - Go Away (pishifat) \[Extra\]](https://osu.ppy.sh/beatmaps/1016263)
+- Hidden
+  - [Sound Horizon - Raijin no Hidariude (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmaps/60089)
+  - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume wo Miru (Strawberry) \[Lunatic\]](https://osu.ppy.sh/beatmaps/214252)
+- HardRock
+  - [iojjj - Deus Ex Machina (Okoratu) \[GREAT EQUALIZER IS THE DEATH\]](https://osu.ppy.sh/beatmaps/688886)
+  - [mafumafu - Yuugure Semi Nikki (L_P) \[Yuugure\]](https://osu.ppy.sh/beatmaps/180681)
+- DoubleTime
+  - [Mami Kawada - sense (Giralda) \[LC's Insane\]](https://osu.ppy.sh/beatmaps/723285)
+  - [ClariS - Connect (Holoaz) \[Holo\]](https://osu.ppy.sh/beatmaps/87066)
+- FreeMod
+  - [07th Expansion - rog-unlimitation (AngelHoney) \[AngelHoney\]](https://osu.ppy.sh/beatmaps/116128)
+  - [jippusu - Mushikui Saikede Rhythm (Amamiya Yuko) \[Skystar\]](https://osu.ppy.sh/beatmaps/239104)
+  - [beatMARIO - Night of Knights (DJPop) \[SOLO\]](https://osu.ppy.sh/beatmaps/58063)
+- Tiebreaker
+  - [DragonForce - Symphony Of The Night (Evil_Twilight) \[Legend\]](https://osu.ppy.sh/beatmaps/1007546)
 
 ### Round of 16
 
-Saturday, 19. November 2016
+[Download the mappack here! (171.7MB)](https://www.mediafire.com/file/1qbqnc5hxa10xk9/OWC_2016_Round_of_16.rar)
 
-| Team A                         | Score     | Team B                          | History                                   |
-|--------------------------------|:---------:|---------------------------------|-------------------------------------------|
-| ![][flag_CN] **China**         | **5** - 2 | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/29093549) |
-| ![][flag_IT] Italy             | 1 - **5** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/29094300) |
-| ![][flag_NO] Norway            | 4 - **5** | ![][flag_TW] **Taiwan**         | [#1](https://osu.ppy.sh/community/matches/29095270) |
-| ![][flag_PL] **Poland**        | **5** - 3 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/29096444) |
-| ![][flag_FR] **France**        | **5** - 1 | ![][flag_GB] United Kingdom     | [#1](https://osu.ppy.sh/community/matches/29102287) |
-| ![][flag_FI] Finland           | 1 - **5** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/29103875) |
-| ![][flag_CA] Canada            | 1 - **5** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/29105450) |
-| ![][flag_US] **United States** | **5** - 1 | ![][flag_AR] Argentina          | [#1](https://osu.ppy.sh/community/matches/29106903) |
+- NoMod
+  - [Cilvery - Kamisama Nejimaki (sukiNathan) \[Catastrophe\]](https://osu.ppy.sh/beatmaps/821238)
+  - [senya - Renbei no Searchlight (Dailycare) \[Satellite's Catharsis\]](https://osu.ppy.sh/beatmaps/1046536)
+  - [LeaF - Wizdomiot (Asahina Momoko) \[Lunatic\]](https://osu.ppy.sh/beatmaps/743896)
+  - [Katakiri Rekka - Answer (deetz) \[RLC's Darkness\]](https://osu.ppy.sh/beatmaps/947334)
+  - [Hana - Sakura no Uta (Ultimate Madoka) \[VI.Artist of the Sakura\]](https://osu.ppy.sh/beatmaps/994933)
+  - [Memme - Extreme Fantasy (AngelHoney) \[ExtrA\]](https://osu.ppy.sh/beatmaps/152480)
+- Hidden
+  - [IOSYS - Poinsettia (Aakiha) \[Lunatic\]](https://osu.ppy.sh/beatmaps/65233)
+  - [Team:SASAKURATION - AVALON (Leader) \[gowww's Extra\]](https://osu.ppy.sh/beatmaps/430110)
+- HardRock
+  - [MYTHOLOGIA by MLREC. - Ymir (Kitami Erika) \[Another\]](https://osu.ppy.sh/beatmaps/716972)
+  - [supercell - Hoshi ga Matataku Konna Yoru ni ([Teichan]) \[Starlight\]](https://osu.ppy.sh/beatmaps/661243))
+- DoubleTime
+  - [Kraster - Remember History (Short Ver.) (Serval) \[Lunatic\]](https://osu.ppy.sh/beatmaps/76419)
+  - [SYNC.ART'S - Sins -Kokoro no Tsumi- (Snowy Dream) \[Nightmare\]](https://osu.ppy.sh/beatmaps/158107)
+- FreeMod
+  - [M2U - Nightmare (ignorethis) \[Lesjuh\]](https://osu.ppy.sh/beatmaps/60238)
+  - [yuikonnu & ayaponzu* - Kunoichi demo Koi ga Shitai (alacat) \[Skystar's Extra\]](https://osu.ppy.sh/beatmaps/319694)
+  - [nmk - sola (sjoy) \[Imouto's Extra\]](https://osu.ppy.sh/beatmaps/439824)
+- Tiebreaker
+  - [Camellia - d:for the DELTA (ProfessionalBox) \[Delirium\]](https://osu.ppy.sh/beatmaps/862338)
 
 ### Group Stage
 
-Saturday, 12. November 2016
+[Download the mappack here! (153.5MB)](https://www.mediafire.com/file/13glkdv1zbyxfpp/OWC_2016_Group_Stage.rar)
 
-| Team A                              | Score     | Team B                       | History                                   |
-|-------------------------------------|:---------:|------------------------------|-------------------------------------------|
-| ![][flag_NZ] **New Zealand**        | **4** - 1 | ![][flag_SG] Singapore       | [#1](https://osu.ppy.sh/community/matches/28949962) |
-| ![][flag_KR] **South Korea**        | **4** - 0 | ![][flag_ID] Indonesia       | [#1](https://osu.ppy.sh/community/matches/28949969) |
-| ![][flag_FR] France                 | 2 - **4** | ![][flag_NZ] **New Zealand** | [#1](https://osu.ppy.sh/community/matches/28950619) |
-| ![][flag_RU] **Russian Federation** | **4** - 2 | ![][flag_ID] Indonesia       | [#1](https://osu.ppy.sh/community/matches/28950736) |
-| ![][flag_HK] **Hong Kong**          | **4** - 3 | ![][flag_SE] Sweden          | [#1](https://osu.ppy.sh/community/matches/28950642) |
-| ![][flag_DE] **Germany**            | **4** - 1 | ![][flag_AU] Australia       | [#1](https://osu.ppy.sh/community/matches/28951696) |
-| ![][flag_KR] **South Korea**        | **4** - 1 | ![][flag_NL] Netherlands     | [#1](https://osu.ppy.sh/community/matches/28951701) |
-| ![][flag_FR] **France**             | **4** - 0 | ![][flag_SG] Singapore       | [#1](https://osu.ppy.sh/community/matches/28952502) |
-| ![][flag_PH] Philippines            | 1 - **4** | ![][flag_UA] **Ukraine**     | [#1](https://osu.ppy.sh/community/matches/28952508) |
-| ![][flag_TW] **Taiwan**             | **4** - 0 | ![][flag_ES] Spain           | [#1](https://osu.ppy.sh/community/matches/28952517) |
-| ![][flag_RU] **Russian Federation** | **4** - 0 | ![][flag_NL] Netherlands     | [#1](https://osu.ppy.sh/community/matches/28953530) |
-| ![][flag_DE] **Germany**            | **4** - 0 | ![][flag_GR] Greece          | [#1](https://osu.ppy.sh/community/matches/28953535) |
-| ![][flag_CN] **China**              | **4** - 0 | ![][flag_CL] Chile           | [#1](https://osu.ppy.sh/community/matches/28953539) |
-| ![][flag_PL] **Poland**             | **4** - 0 | ![][flag_PH] Philippines     | [#1](https://osu.ppy.sh/community/matches/28955012) |
-| ![][flag_TW] **Taiwan**             | **4** - 1 | ![][flag_AR] Argentina       | [#1](https://osu.ppy.sh/community/matches/28955025) |
-| ![][flag_AT] Austria                | 2 - **4** | ![][flag_DK] **Denmark**     | [#1](https://osu.ppy.sh/community/matches/28955030) |
-| ![][flag_AT] **Brazil**             | **4** - 1 | ![][flag_HK] Hong Kong       | [#1](https://osu.ppy.sh/community/matches/28955037) |
-| ![][flag_DE] **Germany**            | **4** - 1 | ![][flag_LV] Latvia          | [#1](https://osu.ppy.sh/community/matches/28961703) |
-| ![][flag_CA] **Canada**             | **4** - 1 | ![][flag_CL] Chile           | [#1](https://osu.ppy.sh/community/matches/28961705) |
-| ![][flag_GB] **United Kingdom**     | **4** - 1 | ![][flag_SE] Sweden          | [#1](https://osu.ppy.sh/community/matches/28961706) |
-| ![][flag_PL] **Poland**             | **4** - 0 | ![][flag_IT] Italy           | [#1](https://osu.ppy.sh/community/matches/28962677) |
-| ![][flag_US] **United States**      | **4** - 3 | ![][flag_DK] Denmark         | [#1](https://osu.ppy.sh/community/matches/28962678) |
-| ![][flag_US] **Norway**             | **4** - 1 | ![][flag_AT] Austria         | [#1](https://osu.ppy.sh/community/matches/28962679) |
-| ![][flag_MX] Mexico                 | 2 - **4** | ![][flag_AR] **Argentina**   | [#1](https://osu.ppy.sh/community/matches/28964826) |
-| ![][flag_GB] **United Kingdom**     | **4** - 1 | ![][flag_BR] Brazil          | [#1](https://osu.ppy.sh/community/matches/28964827) |
+- NoMod
+  - [sakuzyo - Altale (toybot) \[Bonzi's Extra\]](https://osu.ppy.sh/beatmaps/1012279)
+  - [Lon - Yuru Fuwa Jukai Girl (Garven) \[Insane\]](https://osu.ppy.sh/beatmaps/153103)
+  - [Itou Kanako - Skyclad no Kansokusha -Remix- (Takos) \[taka\]](https://osu.ppy.sh/beatmaps/110628)
+  - [Rita - Dream Walker (Vert) \[Zweib's Insane\]](https://osu.ppy.sh/beatmaps/778244)
+  - [ONE OK ROCK - Mikansei Koukyoukyoku (Saut) \[Extreme\]](https://osu.ppy.sh/beatmaps/768986)
+  - [Ray - Hajimete Girls! (Meyrink) \[Skystar's Pin Pon~\]](https://osu.ppy.sh/beatmaps/776752)
+- Hidden
+  - [Cyua - Blumenkranz (Shinxyn) \[Insane\]](https://osu.ppy.sh/beatmaps/380475)
+  - [sana - Kotonoha Clinic (Kite) \[Moroi\]](https://osu.ppy.sh/beatmaps/907200)
+- HardRock
+  - [Cascada - How Do You Do (Nightcore Mix) (Asphyxia) \[Insane\]](https://osu.ppy.sh/beatmaps/481450)
+  - [Rameses B - Utopia (ft. Holly Drummond) (Milan-) \[deetz' Paradise\]](https://osu.ppy.sh/beatmaps/662046)
+- DoubleTime
+  - [Satori-san - Hari no Sora (Sure) \[Insane\]](https://osu.ppy.sh/beatmaps/653966)
+  - [07th Expansion - goldenslaughterer (La Cataline) \[Hard\]](https://osu.ppy.sh/beatmaps/121197)
+- FreeMod
+  - [ONE OK ROCK - Re:make (Rucker) \[Remake\]](https://osu.ppy.sh/beatmaps/123152)
+  - [44teru-k - F.I (Jacob) \[Extra445\]](https://osu.ppy.sh/beatmaps/155235)
+  - [Megpoid GUMI - For my soul (val0108) \[Insane\]](https://osu.ppy.sh/beatmaps/80102)
+- Tiebreaker
+  - [kors k - Playing With Fire (Sota Fujimori Remix) (xlni) \[Pyrotechnics\]](https://osu.ppy.sh/beatmaps/478605)
 
----
+------------------
 
-Sunday, 13. November 2016
+## Match Results
 
-| Team A                         | Score     | Team B                           | History                                   |
-|--------------------------------|:---------:|----------------------------------|-------------------------------------------|
-| ![][flag_TW] **Taiwan**        | **4** - 3 | ![][flag_MX] Mexico              | [#1](https://osu.ppy.sh/community/matches/28973717) |
-| ![][flag_CN] **China**         | **4** - 3 | ![][flag_CA] Canada              | [#1](https://osu.ppy.sh/community/matches/28973718) |
-| ![][flag_FI] **Finland**       | **4** - 1 | ![][flag_NZ]  New Zealand        | [#1](https://osu.ppy.sh/community/matches/28979458) |
-| ![][flag_AU] **Australia**     | **4** - 0 | ![][flag_GR] Greece              | [#1](https://osu.ppy.sh/community/matches/28979460) |
-| ![][flag_KR] **South Korea**   | **4** - 3 | ![][flag_RU]  Russian Federation | [#1](https://osu.ppy.sh/community/matches/28979461) |
-| ![][flag_NL] Netherlands       | 3 - **4** | ![][flag_ID] **Indonesia**       | [#1](https://osu.ppy.sh/community/matches/28980166) |
-| ![][flag_AU] **Australia**     | **4** - 0 | ![][flag_LV] Latvia              | [#1](https://osu.ppy.sh/community/matches/28980174) |
-| ![][flag_CN] **China**         | **4** - 0 | ![][flag_IL]  Israel             | --- WIN BY DEFAULT ---                    |
-| ![][flag_IT] **Italy**         | **4** - 0 | ![][flag_PH] Philippines         | --- WIN BY DEFAULT ---                    |
-| ![][flag_FI] **Finland**       | **4** - 2 | ![][flag_SG]  Singapore          | [#1](https://osu.ppy.sh/community/matches/28981224) |
-| ![][flag_NO] **Norway**        | **4** - 2 | ![][flag_DK] Denmark             | [#1](https://osu.ppy.sh/community/matches/28981226) |
-| ![][flag_GB] United Kingdom    | 2 - **4** | ![][flag_HK] **Hong Kong**       | [#1](https://osu.ppy.sh/community/matches/28981228) |
-| ![][flag_FR] **France**        | **4** - 3 | ![][flag_FI] Finland             | [#1](https://osu.ppy.sh/community/matches/28987715) |
-| ![][flag_IT] **Italy**         | **4** - 0 | ![][flag_UA] Ukraine             | [#1](https://osu.ppy.sh/community/matches/28987716) |
-| ![][flag_CL] **Chile**         | **4** - 1 | ![][flag_IL] Israel              | [#1](https://osu.ppy.sh/community/matches/28987717) |
-| ![][flag_LV] **Latvia**        | **4** - 2 | ![][flag_GR] Greece              | [#1](https://osu.ppy.sh/community/matches/28988969) |
-| ![][flag_AR] **Argentina**     | **4** - 1 | ![][flag_ES]  Spain              | [#1](https://osu.ppy.sh/community/matches/28988970) |
-| ![][flag_US] **United States** | **4** - 3 | ![][flag_NO]  Norway             | [#1](https://osu.ppy.sh/community/matches/28988971) |
-| ![][flag_PL] **Poland**        | **4** - 0 | ![][flag_UA] Ukraine             | [#1](https://osu.ppy.sh/community/matches/28990447) |
-| ![][flag_CA] **Canada**        | **4** - 0 | ![][flag_IL] Israel              | [#1](https://osu.ppy.sh/community/matches/28990448) |
-| ![][flag_MX] Mexico            | 3 - **4** | ![][flag_ES] **Spain**           | [#1](https://osu.ppy.sh/community/matches/28991703) |
-| ![][flag_US] **United States** | **4** - 0 | ![][flag_AT]  Austria            | [#1](https://osu.ppy.sh/community/matches/28991705) |
-| ![][flag_BR] **Brazil**        | **4** - 3 | ![][flag_SE] Sweden              | [#1](https://osu.ppy.sh/community/matches/28991706) |
+### Grand Finals
+
+| Sunday, 2016-12-18 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  United States ![][flag_US]| 2 | **7** | ![][flag_CN] **China**         | [#1](https://osu.ppy.sh/community/matches/29702438) |
+|  China  ![][flag_CN]       | 4 | **7** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/29704086) |
+
+### Finals
+
+| Saturday, 2016-12-10 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **United States** ![][flag_US] | **6** | 4 | ![][flag_KR] South Korea    | [#1](https://osu.ppy.sh/community/matches/29524076) |
+| **United Kingdom** ![][flag_GB] | **6** | 4 | ![][flag_TW] Taiwan         | [#1](https://osu.ppy.sh/community/matches/29530355) |
+|  Germany   ![][flag_DE]         | 2 | **6** | ![][flag_CN] China          | [#1](https://osu.ppy.sh/community/matches/29531576) |
+|  **China** ![][flag_CN]         | **4** | 2 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/29533696) |
+
+| Sunday, 2016-12-11 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **China** ![][flag_CN]| **6** | 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/29560336) |
+
+### Semifinals
+
+| Saturday, 2016-12-03 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **South Korea**  ![][flag_KR]  | **6** | 2 | ![][flag_TW] Taiwan      | [#1](https://osu.ppy.sh/community/matches/29379804) |
+|  Russian Federation ![][flag_RU]| 5 | **6** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/29381511) |
+|  Finland   ![][flag_FI]         | 0 | **6** | ![][flag_FR] **France**  | [#1](https://osu.ppy.sh/community/matches/29383842) |
+| **United States** ![][flag_US]  | **6** | 4 | ![][flag_CN] China       | [#1](https://osu.ppy.sh/community/matches/29385744) |
+| **United Kingdom** ![][flag_GB] | **6** | 0 | ![][flag_BR] Brazil      | [#1](https://osu.ppy.sh/community/matches/29388879) |
+|  Canada  ![][flag_CA]           | 0 | **6** | ![][flag_BR] **Poland**  | [#1](https://osu.ppy.sh/community/matches/29391121) |
+
+| Sunday, 2016-12-04 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  France ![][flag_FR]| 2 | **6** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/29413616) |
+|  Poland ![][flag_PL]| 4 | **6** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/29415472) |
+
+### Quarterfinals
+
+| Saturday, 2016-11-26 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  Australia  ![][flag_AU]     | 1 | **5** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/29236130) |
+| **South Korea** ![][flag_KR] | **5** | 2 | ![][flag_DE] Germany                | [#1](https://osu.ppy.sh/community/matches/29237189) |
+|  **China**   ![][flag_CN]    | **5** | 2 | ![][flag_PL] Poland                 | [#1](https://osu.ppy.sh/community/matches/29238760) |
+|  **Taiwan** ![][flag_TW]     | **5** | 4 | ![][flag_FR] France                 | [#1](https://osu.ppy.sh/community/matches/29240657) |
+|  Norway  ![][flag_NO]        | 4 | **5** | ![][flag_GB] **United Kingdom**     | [#1](https://osu.ppy.sh/community/matches/29244637) |
+|  **Finland**  ![][flag_FI]   | **5** | 2 | ![][flag_AR] Argentina              | [#1](https://osu.ppy.sh/community/matches/29247238) |
+|  Italy  ![][flag_IT]         | 0 | **5** | ![][flag_CA] **Canada**             | [#1](https://osu.ppy.sh/community/matches/29249433) |
+| Brazil ![][flag_BR]          | 4 | **5** | ![][flag_US] **United States**      | [#1](https://osu.ppy.sh/community/matches/29252039) |
+
+### Round of 16
+
+| Saturday, 2016-11-19 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **China**  ![][flag_CN]       | **5** | 2 | ![][flag_AU] Australia          | [#1](https://osu.ppy.sh/community/matches/29093549) |
+|  Italy  ![][flag_IT]           | 1 | **5** | ![][flag_KR] **South Korea**    | [#1](https://osu.ppy.sh/community/matches/29094300) |
+|  Norway  ![][flag_NO]          | 4 | **5** | ![][flag_TW] **Taiwan**         | [#1](https://osu.ppy.sh/community/matches/29095270) |
+|  **Poland** ![][flag_PL]       | **5** | 3 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/29096444) |
+| **France**  ![][flag_FR]       | **5** | 1 | ![][flag_GB] United Kingdom     | [#1](https://osu.ppy.sh/community/matches/29102287) |
+|  Finland ![][flag_FI]          | 1 | **5** | ![][flag_BR] **Brazil**         | [#1](https://osu.ppy.sh/community/matches/29103875) |
+|  Canada  ![][flag_CA]          | 1 | **5** | ![][flag_DE] **Germany**        | [#1](https://osu.ppy.sh/community/matches/29105450) |
+| **United States** ![][flag_US] | **5** | 1 | ![][flag_AR] Argentina          | [#1](https://osu.ppy.sh/community/matches/29106903) |
+
+### Group Stage
+
+| Saturday, 2016-11-12 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **New Zealand**  ![][flag_NZ]      | **4** | 1 | ![][flag_SG] Singapore       | [#1](https://osu.ppy.sh/community/matches/28949962) |
+|  **South Korea**  ![][flag_KR]      | **4** | 0 | ![][flag_ID] Indonesia       | [#1](https://osu.ppy.sh/community/matches/28949969) |
+| France    ![][flag_FR]              | 2 | **4** | ![][flag_NZ] **New Zealand** | [#1](https://osu.ppy.sh/community/matches/28950619) |
+|  **Russian Federation** ![][flag_RU]| **4** | 2 | ![][flag_ID] Indonesia       | [#1](https://osu.ppy.sh/community/matches/28950736) |
+| **Hong Kong**  ![][flag_HK]         | **4** | 3 | ![][flag_SE] Sweden          | [#1](https://osu.ppy.sh/community/matches/28950642) |
+|  **Germany**  ![][flag_DE]          | **4** | 1 | ![][flag_AU] Australia       | [#1](https://osu.ppy.sh/community/matches/28951696) |
+|  **South Korea**  ![][flag_KR]      | **4** | 1 | ![][flag_NL] Netherlands     | [#1](https://osu.ppy.sh/community/matches/28951701) |
+|  **France** ![][flag_FR]            | **4** | 0 | ![][flag_SG] Singapore       | [#1](https://osu.ppy.sh/community/matches/28952502) |
+|  Philippines  ![][flag_PH]          | 1 | **4** | ![][flag_UA] **Ukraine**     | [#1](https://osu.ppy.sh/community/matches/28952508) |
+|  **Taiwan**  ![][flag_TW]           | **4** | 0 | ![][flag_ES] Spain           | [#1](https://osu.ppy.sh/community/matches/28952517) |
+|  **Russian Federation** ![][flag_RU]| **4** | 0 | ![][flag_NL] Netherlands     | [#1](https://osu.ppy.sh/community/matches/28953530) |
+|  **Germany**  ![][flag_DE]          | **4** | 0 | ![][flag_GR] Greece          | [#1](https://osu.ppy.sh/community/matches/28953535) |
+|  **China**  ![][flag_CN]            | **4** | 0 | ![][flag_CL] Chile           | [#1](https://osu.ppy.sh/community/matches/28953539) |
+|  **Poland**  ![][flag_PL]           | **4** | 0 | ![][flag_PH] Philippines     | [#1](https://osu.ppy.sh/community/matches/28955012) |
+|  **Taiwan**  ![][flag_TW]           | **4** | 1 | ![][flag_AR] Argentina       | [#1](https://osu.ppy.sh/community/matches/28955025) |
+|  Austria ![][flag_AT]               | 2 | **4** | ![][flag_DK] **Denmark**     | [#1](https://osu.ppy.sh/community/matches/28955030) |
+|  **Brazil**  ![][flag_AT]           | **4** | 1 | ![][flag_HK] Hong Kong       | [#1](https://osu.ppy.sh/community/matches/28955037) |
+|  **Germany** ![][flag_DE]           | **4** | 1 | ![][flag_LV] Latvia          | [#1](https://osu.ppy.sh/community/matches/28961703) |
+|  **Canada**  ![][flag_CA]           | **4** | 1 | ![][flag_CL] Chile           | [#1](https://osu.ppy.sh/community/matches/28961705) |
+|  **United Kingdom** ![][flag_GB]    | **4** | 1 | ![][flag_SE] Sweden          | [#1](https://osu.ppy.sh/community/matches/28961706) |
+|  **Poland**  ![][flag_PL]           | **4** | 0 | ![][flag_IT] Italy           | [#1](https://osu.ppy.sh/community/matches/28962677) |
+|  **United States**  ![][flag_US]    | **4** | 3 | ![][flag_DK] Denmark         | [#1](https://osu.ppy.sh/community/matches/28962678) |
+|  **Norway**  ![][flag_US]           | **4** | 1 | ![][flag_AT] Austria         | [#1](https://osu.ppy.sh/community/matches/28962679) |
+|  Mexico ![][flag_MX]                | 2 | **4** | ![][flag_AR] **Argentina**   | [#1](https://osu.ppy.sh/community/matches/28964826) |
+|  **United Kingdom** ![][flag_GB]    | **4** | 1 | ![][flag_BR] Brazil          | [#1](https://osu.ppy.sh/community/matches/28964827) |
+
+| Sunday, 2016-11-13 | | | | |
+| ---: | :---: | :---: | :--- | :---: |
+|  **Taiwan**  ![][flag_TW]      | **4** | 3 | ![][flag_MX] Mexico              | [#1](https://osu.ppy.sh/community/matches/28973717) |
+|  **China**  ![][flag_CN]       | **4** | 3 | ![][flag_CA] Canada              | [#1](https://osu.ppy.sh/community/matches/28973718) |
+| **Finland** ![][flag_FI]       | **4** | 1 | ![][flag_NZ]  New Zealand        | [#1](https://osu.ppy.sh/community/matches/28979458) |
+|  **Australia** ![][flag_AU]    | **4** | 0 | ![][flag_GR] Greece              | [#1](https://osu.ppy.sh/community/matches/28979460) |
+| **South Korea** ![][flag_KR]   | **4** | 3 | ![][flag_RU]  Russian Federation | [#1](https://osu.ppy.sh/community/matches/28979461) |
+| Netherlands  ![][flag_NL]      | 3 | **4** | ![][flag_ID] **Indonesia**       | [#1](https://osu.ppy.sh/community/matches/28980166) |
+|  **Australia** ![][flag_AU]    | **4** | 0 | ![][flag_LV] Latvia              | [#1](https://osu.ppy.sh/community/matches/28980174) |
+|  **China** ![][flag_CN]        | **4** | 0 | ![][flag_IL]  Israel             | -win by default-       |
+| **Italy**  ![][flag_IT]        | **4** | 0 | ![][flag_PH] Philippines         | -win by default-       |
+| **Finland**  ![][flag_FI]      | **4** | 2 | ![][flag_SG]  Singapore          | [#1](https://osu.ppy.sh/community/matches/28981224) |
+|  **Norway**  ![][flag_NO]      | **4** | 2 | ![][flag_DK] Denmark             | [#1](https://osu.ppy.sh/community/matches/28981226) |
+| United Kingdom ![][flag_GB]    | 2 | **4** | ![][flag_HK] **Hong Kong**       | [#1](https://osu.ppy.sh/community/matches/28981228) |
+| **France**  ![][flag_FR]       | **4** | 3 | ![][flag_FI] Finland             | [#1](https://osu.ppy.sh/community/matches/28987715) |
+| **Italy**  ![][flag_IT]        | **4** | 0 | ![][flag_UA] Ukraine             | [#1](https://osu.ppy.sh/community/matches/28987716) |
+|  **Chile**  ![][flag_CL]       | **4** | 1 | ![][flag_IL] Israel              | [#1](https://osu.ppy.sh/community/matches/28987717) |
+|  **Latvia**  ![][flag_LV]      | **4** | 2 | ![][flag_GR] Greece              | [#1](https://osu.ppy.sh/community/matches/28988969) |
+|  **Argentina** ![][flag_AR]    | **4** | 1 | ![][flag_ES]  Spain              | [#1](https://osu.ppy.sh/community/matches/28988970) |
+|  **United States** ![][flag_US]| **4** | 3 | ![][flag_NO]  Norway             | [#1](https://osu.ppy.sh/community/matches/28988971) |
+|  **Poland**  ![][flag_PL]      | **4** | 0 | ![][flag_UA] Ukraine             | [#1](https://osu.ppy.sh/community/matches/28990447) |
+|  **Canada**  ![][flag_CA]      | **4** | 0 | ![][flag_IL] Israel              | [#1](https://osu.ppy.sh/community/matches/28990448) |
+|  Mexico ![][flag_MX]           | 3 | **4** | ![][flag_ES] **Spain**           | [#1](https://osu.ppy.sh/community/matches/28991703) |
+|  **United States** ![][flag_US]| **4** | 0 | ![][flag_AT]  Austria            | [#1](https://osu.ppy.sh/community/matches/28991705) |
+|  **Brazil** ![][flag_BR]       | **4** | 3 | ![][flag_SE] Sweden              | [#1](https://osu.ppy.sh/community/matches/28991706) |
 
 ## Ruleset
 

--- a/wiki/Tournaments/OWC/2016/en.md
+++ b/wiki/Tournaments/OWC/2016/en.md
@@ -27,7 +27,7 @@ The **osu! World Cup 2016** (_**OWC 2016**_) is a country-based osu! tournament 
 In every World Cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
 | Placing    | Prize(s)    |
-|------------|:------------|
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place")   | exclusive and unique merchandise, profile badge, "osu! Champion" user title |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | exclusive and unique merchandise, profile badge                             |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | exclusive and unique merchandise, profile badge                             |
@@ -55,7 +55,7 @@ The osu! World Cup 2016 was run by various community members by distributing the
 ## Participants
 
 | | Country | Members |
-| - | :---: | -------- |
+| :-: | :-: | :-- |
 | ![][flag_AR] | Argentina | **[Glazbom](https://osu.ppy.sh/users/608277 "Glazbom")**, [GaTu](https://osu.ppy.sh/users/3583351 "GaTu"), [Pein](https://osu.ppy.sh/users/2212941 "Pein"), [benjacala](https://osu.ppy.sh/users/1625740 "benjacala"), [Enhu](https://osu.ppy.sh/users/2840499 "Enhu"), [nicogame14](https://osu.ppy.sh/users/3812213 "nicogame14"), [Catalysis](https://osu.ppy.sh/users/5958063 "Catalysis"), [Toushi](https://osu.ppy.sh/users/2367825 "Toushi")  |
 | ![][flag_AU] | Australia | **[Bauxe](https://osu.ppy.sh/users/1881685 "Bauxe")**, [uyghti](https://osu.ppy.sh/users/3641404 "uyghti"), [ithgyu](https://osu.ppy.sh/users/5113781 "ithgyu"), [Dumii](https://osu.ppy.sh/users/3068044 "Dumii"), [Korilak](https://osu.ppy.sh/users/7260014 "Korilak"), [Weber](https://osu.ppy.sh/users/6410432 "Weber"), [Lunirs](https://osu.ppy.sh/users/2118945 "Lunirs"), [Peekamoo](https://osu.ppy.sh/users/2337263 "Peekamoo") |
 | ![][flag_AT] | Austria       | **[Akane-Yuki](https://osu.ppy.sh/users/3656589 "Akane-Yuki")**, [Omgforz](https://osu.ppy.sh/users/578943 "Omgforz"), [LWMF](https://osu.ppy.sh/users/3632402 "LWMF"), [Fedora Goose](https://osu.ppy.sh/users/2323131 "Fedora Goose"), [Myst1k](https://osu.ppy.sh/users/5302223 "Myst1k")  |

--- a/wiki/Tournaments/OWC/2016/en.md
+++ b/wiki/Tournaments/OWC/2016/en.md
@@ -116,7 +116,7 @@ The osu! World Cup 2016 was run by various community members by distributing the
 
 **This mappool will be used in Finals - Week 1 and Finals - Week 2**
 
-[Download the mappack here! (148.8MB)](https://www.mediafire.com/file/1rf6jgjsgfilhkx/OWC_2016_Finals.rar)
+[Download the mappack here! (148 MB)](https://www.mediafire.com/file/1rf6jgjsgfilhkx/OWC_2016_Finals.rar)
 
 - NoMod
   - [U1 overground - Dopamine (fanzhen0019) \[C6H3\(OH\)2-CH2-CH2-NH2\]](https://osu.ppy.sh/beatmaps/494818)
@@ -139,11 +139,11 @@ The osu! World Cup 2016 was run by various community members by distributing the
   - [Syrsa - Mad Machine (Louis Cyphre) \[Champion\]](https://osu.ppy.sh/beatmaps/107875)
   - [USAO - Miracle 5ympho X (Extended Mix) (RLC) \[5ympho XtrA\]](https://osu.ppy.sh/beatmaps/536476)
 - Tiebreaker
-  - [goreshit - burn this moment into the retina of my eye (grumd) \[extra\]](https://osu.ppy.sh/beatmaps/791274)
+  - **[goreshit - burn this moment into the retina of my eye (grumd) \[extra\]](https://osu.ppy.sh/beatmaps/791274)**
 
 ### Semifinals
 
-[Download the mappack here! (131MB)](https://www.mediafire.com/file/byy9j4jan4uhk57/OWC_2016_Semifinals.rar)
+[Download the mappack here! (131 MB)](https://www.mediafire.com/file/byy9j4jan4uhk57/OWC_2016_Semifinals.rar)
 
 - NoMod
   - [ZUN remixed by LeaF - Resurrection Spell (Muya) \[VOLCANO\]](https://osu.ppy.sh/beatmaps/658561)
@@ -166,11 +166,11 @@ The osu! World Cup 2016 was run by various community members by distributing the
   - [Susumu Hirasawa - Big Brother (Gens) \[KIRBY Mix\]](https://osu.ppy.sh/beatmaps/42244)
   - [T & Sugah x Lexurus - No More (Strategas) \[Extra\]](https://osu.ppy.sh/beatmaps/1007896)
 - Tiebreaker
-  - [Venetian Snares - She Runs (fergas) \[Escape?\]](https://osu.ppy.sh/beatmaps/711923)
+  - **[Venetian Snares - She Runs (fergas) \[Escape?\]](https://osu.ppy.sh/beatmaps/711923)**
 
 ### Quarterfinals
 
-[Download the mappack here! (125.1MB)](https://www.mediafire.com/file/7gmr44m72v58p8w/OWC_2016_Quarterfinals.rar)
+[Download the mappack here! (125 MB)](https://www.mediafire.com/file/7gmr44m72v58p8w/OWC_2016_Quarterfinals.rar)
 
 - NoMod
   - [Memme - Chinese Restaurant (M o k o r i) \[Spicy\]](https://osu.ppy.sh/beatmaps/587547)
@@ -193,11 +193,11 @@ The osu! World Cup 2016 was run by various community members by distributing the
   - [jippusu - Mushikui Saikede Rhythm (Amamiya Yuko) \[Skystar\]](https://osu.ppy.sh/beatmaps/239104)
   - [beatMARIO - Night of Knights (DJPop) \[SOLO\]](https://osu.ppy.sh/beatmaps/58063)
 - Tiebreaker
-  - [DragonForce - Symphony Of The Night (Evil_Twilight) \[Legend\]](https://osu.ppy.sh/beatmaps/1007546)
+  - **[DragonForce - Symphony Of The Night (Evil_Twilight) \[Legend\]](https://osu.ppy.sh/beatmaps/1007546)**
 
 ### Round of 16
 
-[Download the mappack here! (171.7MB)](https://www.mediafire.com/file/1qbqnc5hxa10xk9/OWC_2016_Round_of_16.rar)
+[Download the mappack here! (171 MB)](https://www.mediafire.com/file/1qbqnc5hxa10xk9/OWC_2016_Round_of_16.rar)
 
 - NoMod
   - [Cilvery - Kamisama Nejimaki (sukiNathan) \[Catastrophe\]](https://osu.ppy.sh/beatmaps/821238)
@@ -220,11 +220,11 @@ The osu! World Cup 2016 was run by various community members by distributing the
   - [yuikonnu & ayaponzu* - Kunoichi demo Koi ga Shitai (alacat) \[Skystar's Extra\]](https://osu.ppy.sh/beatmaps/319694)
   - [nmk - sola (sjoy) \[Imouto's Extra\]](https://osu.ppy.sh/beatmaps/439824)
 - Tiebreaker
-  - [Camellia - d:for the DELTA (ProfessionalBox) \[Delirium\]](https://osu.ppy.sh/beatmaps/862338)
+  - **[Camellia - d:for the DELTA (ProfessionalBox) \[Delirium\]](https://osu.ppy.sh/beatmaps/862338)**
 
 ### Group Stage
 
-[Download the mappack here! (153.5MB)](https://www.mediafire.com/file/13glkdv1zbyxfpp/OWC_2016_Group_Stage.rar)
+[Download the mappack here! (153 MB)](https://www.mediafire.com/file/13glkdv1zbyxfpp/OWC_2016_Group_Stage.rar)
 
 - NoMod
   - [sakuzyo - Altale (toybot) \[Bonzi's Extra\]](https://osu.ppy.sh/beatmaps/1012279)
@@ -247,7 +247,7 @@ The osu! World Cup 2016 was run by various community members by distributing the
   - [44teru-k - F.I (Jacob) \[Extra445\]](https://osu.ppy.sh/beatmaps/155235)
   - [Megpoid GUMI - For my soul (val0108) \[Insane\]](https://osu.ppy.sh/beatmaps/80102)
 - Tiebreaker
-  - [kors k - Playing With Fire (Sota Fujimori Remix) (xlni) \[Pyrotechnics\]](https://osu.ppy.sh/beatmaps/478605)
+  - **[kors k - Playing With Fire (Sota Fujimori Remix) (xlni) \[Pyrotechnics\]](https://osu.ppy.sh/beatmaps/478605)**
 
 ------------------
 

--- a/wiki/Tournaments/OWC/2017/en.md
+++ b/wiki/Tournaments/OWC/2017/en.md
@@ -124,7 +124,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
   - [Camellia - Fastest Crash (sukiNathan) \[RLC's Paroxysm\]](http://osu.ppy.sh/beatmaps/733432&m=0)
   - [Ayalis - Ai o Chikaishi Hime Kazari (handsome) \[Master\]](http://osu.ppy.sh/beatmaps/1076701&m=0)
 - Tiebreaker
-  - [Wagakki Band - Tengaku (Shiro) \[Uncompressed Fury of a Raging Japanese God\]](http://osu.ppy.sh/beatmaps/816327&m=0)
+  - **[Wagakki Band - Tengaku (Shiro) \[Uncompressed Fury of a Raging Japanese God\]](http://osu.ppy.sh/beatmaps/816327&m=0)**
 
 ### Semifinals
 
@@ -151,7 +151,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
   - [onoken - Viden (-kevincela-) \[Extreme\]](http://osu.ppy.sh/beatmaps/822166&m=0)
   - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume o Miru (Smoothie) \[CRN's Extra\]](http://osu.ppy.sh/beatmaps/178645&m=0)
 - Tiebreaker
-  - [goreshit - fleshbound (Vell) \[martyr\]](http://osu.ppy.sh/beatmaps/1131747&m=0)
+  - **[goreshit - fleshbound (Vell) \[martyr\]](http://osu.ppy.sh/beatmaps/1131747&m=0)**
 
 ### Quarterfinals
 
@@ -178,7 +178,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
   - [Zips - Heisei Cataclysm (Dark Fang) \[Fang\]](http://osu.ppy.sh/beatmaps/206567&m=0)
   - [Hatsune Miku - Mythologia's End (val0108) \[Myth0108ia\]](http://osu.ppy.sh/beatmaps/151229&m=0)
 - Tiebreaker
-  - [Nanahira - Petals (toybot) \[Blossom\]](http://osu.ppy.sh/beatmaps/1193128&m=0)
+  - **[Nanahira - Petals (toybot) \[Blossom\]](http://osu.ppy.sh/beatmaps/1193128&m=0)**
 
 ### Round of 16
 
@@ -205,7 +205,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
   - [sakuzyo - Imprinting (Nozhomi) \[Orchestra\]](http://osu.ppy.sh/beatmaps/655300&m=0)
   - [Agnete Kjolsrud - Get Jinxed (Tarrasky) \[Irrelvis' Diamond\]](http://osu.ppy.sh/beatmaps/806376&m=0)
 - Tiebreaker
-  - [Nana Mizuki - VIRGIN CODE (ShiraKai) \[GENESIS\]](http://osu.ppy.sh/beatmaps/1052795&m=0)
+  - **[Nana Mizuki - VIRGIN CODE (ShiraKai) \[GENESIS\]](http://osu.ppy.sh/beatmaps/1052795&m=0)**
 
 ### Group Stage
 
@@ -232,7 +232,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
   - [Big Giant Circles feat. some1namedjeff - Thunderstruck (Charles445) \[Insane\]](http://osu.ppy.sh/beatmaps/208776&m=0)
   - [Masayoshi Minoshima - Flight of the Bamboo Cutter (a3272509123) \[Lunatic\]](http://osu.ppy.sh/beatmaps/148000&m=0)
 - Tiebreaker
-  - [DJ Noriken - Elektrick U-Phoria(Extended Mix) (sionKotori) \[Illuminate\]](http://osu.ppy.sh/beatmaps/854972&m=0)
+  - **[DJ Noriken - Elektrick U-Phoria(Extended Mix) (sionKotori) \[Illuminate\]](http://osu.ppy.sh/beatmaps/854972&m=0)**
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2017/en.md
+++ b/wiki/Tournaments/OWC/2017/en.md
@@ -11,10 +11,10 @@ The **osu! World Cup 2017** (**_OWC 2017_**) is a country-based osu! tournament 
 
 ## Tournament Schedule
 
-| Event              | Timestamp                       |
-|-------------------:|---------------------------------|
+| Event   | Timestamp  |
+|--------:|:-----------|
 | Registration Phase | 2017-10-13/2017-10-29           |
-| Drawings           | 2017-11-12 (14:00 UTC+0)        |
+| Live Drawings      | 2017-11-12 (14:00 UTC+0)        |
 | Group Stage        | 2017-11-18/2017-11-19           |
 | Round of 16        | 2017-11-25/2017-11-26           |
 | Quarterfinals      | 2017-12-02/2017-12-03           |
@@ -25,17 +25,17 @@ The **osu! World Cup 2017** (**_OWC 2017_**) is a country-based osu! tournament 
 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
-| Place | Prize(s) |
-| --- | --- |
+| Placing | Prize(s) |
+| --- | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | $300 per team member, exclusive osu! tumbler and pins, profile badge, "osu! Champion" user title for one year |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | $160 per team member, exclusive osu! tumbler and pins , profile badge |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | $80 per team member, exclusive osu! tumbler and pins, profile badge |
 
-## Organization
+## Organisation
 
 The osu! World Cup 2017 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
 
-| Position | Members |
+| Position | Member(s) |
 | -------- | ------- |
 | Management | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366), ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_HK] [mangomizer](https://osu.ppy.sh/users/1893718) |
 | Map Selectors | ![][flag_JP] [Delis](https://osu.ppy.sh/users/1603923), ![][flag_DE] [Okorin](https://osu.ppy.sh/users/1623405), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
@@ -44,18 +44,16 @@ The osu! World Cup 2017 was run by various community members by distributing the
 
 ## Links
 
-- [Discussion Thread](https://osu.ppy.sh/community/forums/topics/653192)
+- [Discussion thread](https://osu.ppy.sh/community/forums/topics/653192)
 - [Livestream](https://www.twitch.tv/osulive)
-- **[Statistics Sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRFMsLwUAUFYdDoAhmQLfuXHB7PIIOgUcaRdYI03hpuVDCI8BnmdkMHG5QsO5h889Gwnc-Ani-C_IuV/pubhtml)**
+- **[Statistics sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vRFMsLwUAUFYdDoAhmQLfuXHB7PIIOgUcaRdYI03hpuVDCI8BnmdkMHG5QsO5h889Gwnc-Ani-C_IuV/pubhtml)**
 
 ------------------------------------------------------------------------
 
 ## Participants
 
-### Confirmed Rosters
-
-| | Country | Team Members |
-| ---: | :---: | :--- |
+| | Country | Members |
+| - | :---: | -------- |
 | ![][flag_AR] | **Argentina** | **[Pein](https://osu.ppy.sh/users/2212941)**, [Lexalia](https://osu.ppy.sh/users/1887616), [Serena](https://osu.ppy.sh/users/756068), [benjacala](https://osu.ppy.sh/users/1625740), [Toushi](https://osu.ppy.sh/users/2367825), [-Urushihara-](https://osu.ppy.sh/users/6169195), [Glazbom](https://osu.ppy.sh/users/608277), [zaqlev](https://osu.ppy.sh/users/3188703) |
 | ![][flag_AU] | **Australia** | **[Bauxe](https://osu.ppy.sh/users/1881685)**, [Dumii](https://osu.ppy.sh/users/3068044), [uyghti](https://osu.ppy.sh/users/3641404), [Lunirs](https://osu.ppy.sh/users/2118945), [Blobby3000](https://osu.ppy.sh/users/6916774), [ithgyu](https://osu.ppy.sh/users/5113781), [GranDSenpai](https://osu.ppy.sh/users/3997580), [Weber](https://osu.ppy.sh/users/6410432) |
 | ![][flag_AT] | **Austria** | **[Akane-Yuki](https://osu.ppy.sh/users/3656589)**, [Fedora Goose](https://osu.ppy.sh/users/2323131), [BlueFlame](https://osu.ppy.sh/users/3506191), [Spark-desu](https://osu.ppy.sh/users/4601608), [Kizan](https://osu.ppy.sh/users/3074197), [Teppichreini](https://osu.ppy.sh/users/1371974), [Myst1k](https://osu.ppy.sh/users/5302223), [Tomadoi](https://osu.ppy.sh/users/5712451) |
@@ -106,135 +104,135 @@ The osu! World Cup 2017 was run by various community members by distributing the
 **[Download the mappack here! (138 MB)](http://www.mediafire.com/file/e6vze2hbc13eo8i/OWC_2017_Finals.rar)**
 
 - NoMod
-  - [The Ghost Of 3.13 - Forgotten (Blue Dragon)](http://osu.ppy.sh/beatmaps/169841&m=0) [grumd]
-  - [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm (P o M u T a)](http://osu.ppy.sh/beatmaps/820336&m=0) [ignore's EXTREME]
-  - [TERRASPEX - AMAZING BREAK (Monstrata)](http://osu.ppy.sh/beatmaps/1211828&m=0) [DESPAIR]
-  - [sana - Packet Hero (Fuccho)](http://osu.ppy.sh/beatmaps/880321&m=0) [Ruthless]
-  - [Yousei Teikoku - Kokou no Sousei (Saten-san)](http://osu.ppy.sh/beatmaps/118068&m=0) [Chaos]
-  - [dj TAKA meets DJ YOSHITAKA ft.guit.good-cool - Elemental Creation -GITADO ROCK ver.- (Flower)](http://osu.ppy.sh/beatmaps/306683&m=0) [Extra]
+  - [The Ghost Of 3.13 - Forgotten (Blue Dragon) \[grumd\]](http://osu.ppy.sh/beatmaps/169841&m=0)
+  - [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm (P o M u T a) \[ignore's EXTREME\]](http://osu.ppy.sh/beatmaps/820336&m=0)
+  - [TERRASPEX - AMAZING BREAK (Monstrata) \[DESPAIR\]](http://osu.ppy.sh/beatmaps/1211828&m=0)
+  - [sana - Packet Hero (Fuccho) \[Ruthless\]](http://osu.ppy.sh/beatmaps/880321&m=0)
+  - [Yousei Teikoku - Kokou no Sousei (Saten-san) \[Chaos\]](http://osu.ppy.sh/beatmaps/118068&m=0)
+  - [dj TAKA meets DJ YOSHITAKA ft.guit.good-cool - Elemental Creation -GITADO ROCK ver.- (Flower) \[Extra\]](http://osu.ppy.sh/beatmaps/306683&m=0)
 - Hidden
-  - [Niko - Made of Fire (lesjuh)](http://osu.ppy.sh/beatmaps/40017&m=0) [Oni]
-  - [Sota Fujimori - polygon (Sebu)](http://osu.ppy.sh/beatmaps/1354636&m=0) [heptagon]
+  - [Niko - Made of Fire (lesjuh) \[Oni\]](http://osu.ppy.sh/beatmaps/40017&m=0)
+  - [Sota Fujimori - polygon (Sebu) \[heptagon\]](http://osu.ppy.sh/beatmaps/1354636&m=0)
 - HardRock
-  - [beatMARIO - Night of Knights (alacat)](http://osu.ppy.sh/beatmaps/776951&m=0) [The World]
-  - [Rohi - Kakuzetsu Thanatos (NatsumeRin)](http://osu.ppy.sh/beatmaps/215238&m=0) [Rin]
+  - [beatMARIO - Night of Knights (alacat) \[The World\]](http://osu.ppy.sh/beatmaps/776951&m=0)
+  - [Rohi - Kakuzetsu Thanatos (NatsumeRin) \[Rin\]](http://osu.ppy.sh/beatmaps/215238&m=0)
 - DoubleTime
-  - [Kalafina - Kyrie (Vell)](http://osu.ppy.sh/beatmaps/809513&m=0) [Genesis]
-  - [Zektbach - L'avide (eXseeD)](http://osu.ppy.sh/beatmaps/103403&m=0) [gowww]
+  - [Kalafina - Kyrie (Vell) \[Genesis\]](http://osu.ppy.sh/beatmaps/809513&m=0)
+  - [Zektbach - L'avide (eXseeD) \[gowww\]](http://osu.ppy.sh/beatmaps/103403&m=0)
 - FreeMod
-  - [Mediks - Outbreak (Strategas)](http://osu.ppy.sh/beatmaps/1118311&m=0) [Doomsday]
-  - [Camellia - Fastest Crash (sukiNathan)](http://osu.ppy.sh/beatmaps/733432&m=0) [RLC's Paroxysm]
-  - [Ayalis - Ai o Chikaishi Hime Kazari (handsome)](http://osu.ppy.sh/beatmaps/1076701&m=0) [Master]
+  - [Mediks - Outbreak (Strategas) \[Doomsday\]](http://osu.ppy.sh/beatmaps/1118311&m=0)
+  - [Camellia - Fastest Crash (sukiNathan) \[RLC's Paroxysm\]](http://osu.ppy.sh/beatmaps/733432&m=0)
+  - [Ayalis - Ai o Chikaishi Hime Kazari (handsome) \[Master\]](http://osu.ppy.sh/beatmaps/1076701&m=0)
 - Tiebreaker
-  - [Wagakki Band - Tengaku (Shiro)](http://osu.ppy.sh/beatmaps/816327&m=0) [Uncompressed Fury of a Raging Japanese God]
+  - [Wagakki Band - Tengaku (Shiro) \[Uncompressed Fury of a Raging Japanese God\]](http://osu.ppy.sh/beatmaps/816327&m=0)
 
 ### Semifinals
 
 **[Download the mappack here! (137 MB)](http://www.mediafire.com/file/2rf32niz24xr9xz/OWC_2017_Semifinals.rar)**
 
 - NoMod
-  - [Rita - dorchadas (Delis)](http://osu.ppy.sh/beatmaps/1279490&m=0) [Sharnoth]
-  - [C-Show - PANIC HOLIC (VIP) (Frey)](http://osu.ppy.sh/beatmaps/1023481&m=0) [Regou's Extra]
-  - [xi - Blue Zenith (Asphyxia)](http://osu.ppy.sh/beatmaps/657917&m=0) [ktgster's Extreme]
-  - [Yousei Teikoku - Zetsubou plantation (Saten)](http://osu.ppy.sh/beatmaps/235880&m=0) [Zetsubou!]
-  - [LeaF - I (Maddy)](http://osu.ppy.sh/beatmaps/264090&m=0) [Terror]
-  - [Susumu Hirasawa - SWITCHED-ON LOTUS (Starrodkirby86)](http://osu.ppy.sh/beatmaps/58970&m=0) [KIRBY Mix Deluxe]
+  - [Rita - dorchadas (Delis) \[Sharnoth\]](http://osu.ppy.sh/beatmaps/1279490&m=0)
+  - [C-Show - PANIC HOLIC (VIP) (Frey) \[Regou's Extra\]](http://osu.ppy.sh/beatmaps/1023481&m=0)
+  - [xi - Blue Zenith (Asphyxia) \[ktgster's Extreme\]](http://osu.ppy.sh/beatmaps/657917&m=0)
+  - [Yousei Teikoku - Zetsubou plantation (Saten) \[Zetsubou!\]](http://osu.ppy.sh/beatmaps/235880&m=0)
+  - [LeaF - I (Maddy) \[Terror\]](http://osu.ppy.sh/beatmaps/264090&m=0)
+  - [Susumu Hirasawa - SWITCHED-ON LOTUS (Starrodkirby86) \[KIRBY Mix Deluxe\]](http://osu.ppy.sh/beatmaps/58970&m=0)
 - Hidden
-  - [Eisyo-kobu - Oriental Blossom (Crystal)](http://osu.ppy.sh/beatmaps/1242790&m=0) [Karen's Extra]
-  - [HujuniseikouyuuP - Talent Shredder (val0108)](http://osu.ppy.sh/beatmaps/153857&m=0) [Lesjuh style]
+  - [Eisyo-kobu - Oriental Blossom (Crystal) \[Karen's Extra\]](http://osu.ppy.sh/beatmaps/1242790&m=0)
+  - [HujuniseikouyuuP - Talent Shredder (val0108) \[Lesjuh style\]](http://osu.ppy.sh/beatmaps/153857&m=0)
 - HardRock
-  - [Memme - Acid Burst (Priti)](http://osu.ppy.sh/beatmaps/725026&m=0) [wa's Extra]
-  - [96neko - Buriki no Dance (Lasse)](http://osu.ppy.sh/beatmaps/1253986&m=0) [Expert]
+  - [Memme - Acid Burst (Priti) \[wa's Extra\]](http://osu.ppy.sh/beatmaps/725026&m=0)
+  - [96neko - Buriki no Dance (Lasse) \[Expert\]](http://osu.ppy.sh/beatmaps/1253986&m=0)
 - DoubleTime
-  - [3L - Endless night (sjoy)](http://osu.ppy.sh/beatmaps/430371&m=0) [Eternal]
-  - [Yuuki Aoi - Platinum (Mythol)](http://osu.ppy.sh/beatmaps/229676&m=0) [Collab]
+  - [3L - Endless night (sjoy) \[Eternal\]](http://osu.ppy.sh/beatmaps/430371&m=0)
+  - [Yuuki Aoi - Platinum (Mythol) \[Collab\]](http://osu.ppy.sh/beatmaps/229676&m=0)
 - FreeMod
-  - [Dollscythe - Flashes (Extended) (handsome)](http://osu.ppy.sh/beatmaps/787957&m=0) [Spark]
-  - [onoken - Viden (-kevincela-)](http://osu.ppy.sh/beatmaps/822166&m=0) [Extreme]
-  - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume o Miru (Smoothie)](http://osu.ppy.sh/beatmaps/178645&m=0) [CRN's Extra]
+  - [Dollscythe - Flashes (Extended) (handsome) \[Spark\]](http://osu.ppy.sh/beatmaps/787957&m=0)
+  - [onoken - Viden (-kevincela-) \[Extreme\]](http://osu.ppy.sh/beatmaps/822166&m=0)
+  - [UNDEAD CORPORATION - Yoru Naku Usagi wa Yume o Miru (Smoothie) \[CRN's Extra\]](http://osu.ppy.sh/beatmaps/178645&m=0)
 - Tiebreaker
-  - [goreshit - fleshbound (Vell)](http://osu.ppy.sh/beatmaps/1131747&m=0) [martyr]
+  - [goreshit - fleshbound (Vell) \[martyr\]](http://osu.ppy.sh/beatmaps/1131747&m=0)
 
 ### Quarterfinals
 
 **[Download the mappack here! (107 MB)](http://www.mediafire.com/file/n4le2yxjs478ysf/OWC_2017_Quarterfinals.rar)**
 
 - NoMod
-  - [FujuniseikouyuuP - FREEDMAN (val0108)](http://osu.ppy.sh/beatmaps/293134&m=0) [iyasine]
-  - [LeaF - Calamity Fortune (Frostings)](http://osu.ppy.sh/beatmaps/789752&m=0) [Cataclysm]
-  - [KOAN Sound & Asa - fuego (sakuraburst remix) (Shiirn)](http://osu.ppy.sh/beatmaps/1291369&m=0) [Dreaming of Embers]
-  - [YUC'e - Cinderella Syndrome (Kibbleru)](http://osu.ppy.sh/beatmaps/1187506&m=0) [Affection]
-  - [MY FIRST STORY - Itsuwari NEUROSE (Saut)](http://osu.ppy.sh/beatmaps/803199&m=0) [Madness]
-  - [yak_won - Sewing Machine (ktgster)](http://osu.ppy.sh/beatmaps/772293&m=0) [Extreme]
+  - [FujuniseikouyuuP - FREEDMAN (val0108) \[iyasine\]](http://osu.ppy.sh/beatmaps/293134&m=0)
+  - [LeaF - Calamity Fortune (Frostings) \[Cataclysm\]](http://osu.ppy.sh/beatmaps/789752&m=0)
+  - [KOAN Sound & Asa - fuego (sakuraburst remix) (Shiirn) \[Dreaming of Embers\]](http://osu.ppy.sh/beatmaps/1291369&m=0)
+  - [YUC'e - Cinderella Syndrome (Kibbleru) \[Affection\]](http://osu.ppy.sh/beatmaps/1187506&m=0)
+  - [MY FIRST STORY - Itsuwari NEUROSE (Saut) \[Madness\]](http://osu.ppy.sh/beatmaps/803199&m=0)
+  - [yak_won - Sewing Machine (ktgster) \[Extreme\]](http://osu.ppy.sh/beatmaps/772293&m=0)
 - Hidden
-  - [Jimmy Weckl - Get Happy (buhei)](http://osu.ppy.sh/beatmaps/953945&m=0) [MASTER]
-  - [senya - Zetsubou no Fuchi (-Mo-)](http://osu.ppy.sh/beatmaps/1278874&m=0) [Abyssal]
+  - [Jimmy Weckl - Get Happy (buhei) \[MASTER\]](http://osu.ppy.sh/beatmaps/953945&m=0)
+  - [senya - Zetsubou no Fuchi (-Mo-) \[Abyssal\]](http://osu.ppy.sh/beatmaps/1278874&m=0)
 - HardRock
-  - [USAO - Night sky (sukiNathan)](http://osu.ppy.sh/beatmaps/863532&m=0) [Extra]
-  - [Mitani Nana - Chikyuu Saigo no Kokuhaku o (Star Stream)](http://osu.ppy.sh/beatmaps/191805&m=0) [Collab]
+  - [USAO - Night sky (sukiNathan) \[Extra\]](http://osu.ppy.sh/beatmaps/863532&m=0)
+  - [Mitani Nana - Chikyuu Saigo no Kokuhaku o (Star Stream) \[Collab\]](http://osu.ppy.sh/beatmaps/191805&m=0)
 - DoubleTime
-  - [ChomuP - Gate of Steiner (JauiPlaY)](http://osu.ppy.sh/beatmaps/157886&m=0) [Insane]
-  - [Hana(Usa) & X-Plorez - Summer time music (Frostmourne)](http://osu.ppy.sh/beatmaps/429797&m=0) [Insane]
+  - [ChomuP - Gate of Steiner (JauiPlaY) \[Insane\]](http://osu.ppy.sh/beatmaps/157886&m=0)
+  - [Hana(Usa) & X-Plorez - Summer time music (Frostmourne) \[Insane\]](http://osu.ppy.sh/beatmaps/429797&m=0)
 - FreeMod
-  - [Kuroneko Dungeon - Lilieze to Enryuu Laevateinn (Nyquill)](http://osu.ppy.sh/beatmaps/725139&m=0) [Another†leggendaria]
-  - [Zips - Heisei Cataclysm (Dark Fang)](http://osu.ppy.sh/beatmaps/206567&m=0) [Fang]
-  - [Hatsune Miku - Mythologia's End (val0108)](http://osu.ppy.sh/beatmaps/151229&m=0) [Myth0108ia]
+  - [Kuroneko Dungeon - Lilieze to Enryuu Laevateinn (Nyquill) \[Another†leggendaria\]](http://osu.ppy.sh/beatmaps/725139&m=0)
+  - [Zips - Heisei Cataclysm (Dark Fang) \[Fang\]](http://osu.ppy.sh/beatmaps/206567&m=0)
+  - [Hatsune Miku - Mythologia's End (val0108) \[Myth0108ia\]](http://osu.ppy.sh/beatmaps/151229&m=0)
 - Tiebreaker
-  - [Nanahira - Petals (toybot)](http://osu.ppy.sh/beatmaps/1193128&m=0) [Blossom]
+  - [Nanahira - Petals (toybot) \[Blossom\]](http://osu.ppy.sh/beatmaps/1193128&m=0)
 
 ### Round of 16
 
 **[Download the mappack here! (153 MB)](http://www.mediafire.com/file/klgdrjqmz3l3q36/OWC_2017_Round_of_16.rar)**
 
 - NoMod
-  - [Aimer with chelly (EGOIST) - ninelie (REDSHiFT x Vesuvia remix) (ProfessionalBox)](http://osu.ppy.sh/beatmaps/1018247&m=0) [Daydream]
-  - [Days N' Daze - Misanthropic Drunken Loner (pishifat)](http://osu.ppy.sh/beatmaps/951778&m=0) [Extreme]
-  - [seiya-murai feat.ALT - Sumidagawa Karenka (Sakaue Nachi)](http://osu.ppy.sh/beatmaps/796606&m=0) [Extra]
-  - [MitiS & MaHi - Blu (Speed Up Ver.) (Ashasaki)](http://osu.ppy.sh/beatmaps/644067&m=0) [Asphyxia's Extra]
-  - [THE ORAL CIGARETTES - Kyouran Hey Kids!! (monstrata)](http://osu.ppy.sh/beatmaps/815857&m=0) [God of Speed]
-  - [Comp - Gensou no Satellite (Shinxyn)](http://osu.ppy.sh/beatmaps/63875&m=0) [Extra]
+  - [Aimer with chelly (EGOIST) - ninelie (REDSHiFT x Vesuvia remix) (ProfessionalBox) \[Daydream\]](http://osu.ppy.sh/beatmaps/1018247&m=0)
+  - [Days N' Daze - Misanthropic Drunken Loner (pishifat) \[Extreme\]](http://osu.ppy.sh/beatmaps/951778&m=0)
+  - [seiya-murai feat.ALT - Sumidagawa Karenka (Sakaue Nachi) \[Extra\]](http://osu.ppy.sh/beatmaps/796606&m=0)
+  - [MitiS & MaHi - Blu (Speed Up Ver.) (Ashasaki) \[Asphyxia's Extra\]](http://osu.ppy.sh/beatmaps/644067&m=0)
+  - [THE ORAL CIGARETTES - Kyouran Hey Kids!! (monstrata) \[God of Speed\]  ](http://osu.ppy.sh/beatmaps/815857&m=0)
+  - [Comp - Gensou no Satellite (Shinxyn) \[Extra\]](http://osu.ppy.sh/beatmaps/63875&m=0)
 - Hidden
-  - [Anamanaguchi - Pop It (Bonsai)](http://osu.ppy.sh/beatmaps/1084171&m=0) [Extra]
-  - [sun3 - Higan Retour (saymun)](http://osu.ppy.sh/beatmaps/54373&m=0) [Lunatic]
+  - [Anamanaguchi - Pop It (Bonsai) \[Extra\]](http://osu.ppy.sh/beatmaps/1084171&m=0)
+  - [sun3 - Higan Retour (saymun) \[Lunatic\]](http://osu.ppy.sh/beatmaps/54373&m=0)
 - HardRock
-  - [bj.HaLo - Ende (galvenize)](http://osu.ppy.sh/beatmaps/148716&m=0) [Another]
-  - [baker - Kimi ga Kimi ga -vocanico remix- (jonathanlfj)](http://osu.ppy.sh/beatmaps/1443510&m=0) [Extra]
+  - [bj.HaLo - Ende (galvenize) \[Another\]](http://osu.ppy.sh/beatmaps/148716&m=0)
+  - [baker - Kimi ga Kimi ga -vocanico remix- (jonathanlfj) \[Extra\]](http://osu.ppy.sh/beatmaps/1443510&m=0)
 - DoubleTime
-  - [CYTOKINE - sEE NEW THE WORLD, SHE KNEW THE WORLD - CYTOKINE Remix (Frey)](http://osu.ppy.sh/beatmaps/951393&m=0) [lUNATIC]
-  - [forestpireo - Emotional Blush (S i R i R u)](http://osu.ppy.sh/beatmaps/74959&m=0) [Lunatic]
+  - [CYTOKINE - sEE NEW THE WORLD, SHE KNEW THE WORLD - CYTOKINE Remix (Frey) \[lUNATIC\]](http://osu.ppy.sh/beatmaps/951393&m=0)
+  - [forestpireo - Emotional Blush (S i R i R u) \[Lunatic\]](http://osu.ppy.sh/beatmaps/74959&m=0)
 - FreeMod
-  - [Kano - Sukisuki Zecchoushou (Loreley)](http://osu.ppy.sh/beatmaps/1250198&m=0) [Expert]
-  - [sakuzyo - Imprinting (Nozhomi)](http://osu.ppy.sh/beatmaps/655300&m=0) [Orchestra]
-  - [Agnete Kjolsrud - Get Jinxed (Tarrasky)](http://osu.ppy.sh/beatmaps/806376&m=0) [Irrelvis' Diamond]
+  - [Kano - Sukisuki Zecchoushou (Loreley) \[Expert\]](http://osu.ppy.sh/beatmaps/1250198&m=0)
+  - [sakuzyo - Imprinting (Nozhomi) \[Orchestra\]](http://osu.ppy.sh/beatmaps/655300&m=0)
+  - [Agnete Kjolsrud - Get Jinxed (Tarrasky) \[Irrelvis' Diamond\]](http://osu.ppy.sh/beatmaps/806376&m=0)
 - Tiebreaker
-  - [Nana Mizuki - VIRGIN CODE (ShiraKai)](http://osu.ppy.sh/beatmaps/1052795&m=0) [GENESIS]
+  - [Nana Mizuki - VIRGIN CODE (ShiraKai) \[GENESIS\]](http://osu.ppy.sh/beatmaps/1052795&m=0)
 
 ### Group Stage
 
 **[Download the mappack here! (103 MB)](http://www.mediafire.com/file/8fpkzvgbz3hpoap/OWC_2017_Group_Stage.rar)**
 
 - NoMod
-  - [Amane - TWEEKER (TicClick)](http://osu.ppy.sh/beatmaps/771858&m=0) [Lunatic]
-  - [nano - Bull's Eye (Asphyxia)](http://osu.ppy.sh/beatmaps/904687&m=0) [toybot's Extra]
-  - [Smooth J - Haru yo, Koi (Streliteela)](http://osu.ppy.sh/beatmaps/664611&m=0) [Insane]
-  - [Apocalyptica - 2010 (feat. Dave Lombardo) (pishifat)](http://osu.ppy.sh/beatmaps/724512&m=0) [Extra]
-  - [Nanahoshi Kangengakudan feat.Matsushita - Dance Number o Tomo ni (pkk)](http://osu.ppy.sh/beatmaps/821336&m=0) [deetz' Insane]
-  - [ak+q - Vexaria (Pentori)](http://osu.ppy.sh/beatmaps/1392666&m=0) [Miura's Another]
+  - [Amane - TWEEKER (TicClick) \[Lunatic\]](http://osu.ppy.sh/beatmaps/771858&m=0)
+  - [nano - Bull's Eye (Asphyxia) \[toybot's Extra\]](http://osu.ppy.sh/beatmaps/904687&m=0)
+  - [Smooth J - Haru yo, Koi (Streliteela) \[Insane\]](http://osu.ppy.sh/beatmaps/664611&m=0)
+  - [Apocalyptica - 2010 (feat. Dave Lombardo) (pishifat) \[Extra\]](http://osu.ppy.sh/beatmaps/724512&m=0)
+  - [Nanahoshi Kangengakudan feat.Matsushita - Dance Number o Tomo ni (pkk) \[deetz' Insane\]](http://osu.ppy.sh/beatmaps/821336&m=0)
+  - [ak+q - Vexaria (Pentori) \[Miura's Another\]](http://osu.ppy.sh/beatmaps/1392666&m=0)
 - Hidden
-  - [07th Expansion - Final Answer (gowww)](http://osu.ppy.sh/beatmaps/88633&m=0) [Insane]
-  - [Aiobahn & Yunomi - Ginga Tetsudou no Penguin ft. nicamoq (Stripe.P Remix) (deetz)](http://osu.ppy.sh/beatmaps/951600&m=0) [Collab]
+  - [07th Expansion - Final Answer (gowww) \[Insane\]](http://osu.ppy.sh/beatmaps/88633&m=0)
+  - [Aiobahn & Yunomi - Ginga Tetsudou no Penguin ft. nicamoq (Stripe.P Remix) (deetz) \[Collab\]](http://osu.ppy.sh/beatmaps/951600&m=0)
 - HardRock
-  - [Cororo - Fairy ring (Kite)](http://osu.ppy.sh/beatmaps/705760&m=0) [Serenity]
-  - [IOSYS - Chanteikku Sanyousei no Itazura Daisensou (Kochiya Sanae)](http://osu.ppy.sh/beatmaps/91462&m=0) [Crazy Jay]
+  - [Cororo - Fairy ring (Kite) \[Serenity\]](http://osu.ppy.sh/beatmaps/705760&m=0)
+  - [IOSYS - Chanteikku Sanyousei no Itazura Daisensou (Kochiya Sanae) \[Crazy Jay\]](http://osu.ppy.sh/beatmaps/91462&m=0)
 - DoubleTime
-  - [Pendulum - The Vulture (La Cataline)](http://osu.ppy.sh/beatmaps/82249&m=0) [Insane]
-  - [Ronald Jenkees - Super-Fun (tieff)](http://osu.ppy.sh/beatmaps/257379&m=0) [Fun]
+  - [Pendulum - The Vulture (La Cataline) \[Insane\]](http://osu.ppy.sh/beatmaps/82249&m=0)
+  - [Ronald Jenkees - Super-Fun (tieff) \[Fun\]](http://osu.ppy.sh/beatmaps/257379&m=0)
 - FreeMod
-  - [FELT - a wonderful moon (Naitoshi)](http://osu.ppy.sh/beatmaps/454385&m=0) [Lunatic]
-  - [Big Giant Circles feat. some1namedjeff - Thunderstruck (Charles445)](http://osu.ppy.sh/beatmaps/208776&m=0) [Insane]
-  - [Masayoshi Minoshima - Flight of the Bamboo Cutter (a3272509123)](http://osu.ppy.sh/beatmaps/148000&m=0) [Lunatic]
+  - [FELT - a wonderful moon (Naitoshi) \[Lunatic\]](http://osu.ppy.sh/beatmaps/454385&m=0)
+  - [Big Giant Circles feat. some1namedjeff - Thunderstruck (Charles445) \[Insane\]](http://osu.ppy.sh/beatmaps/208776&m=0)
+  - [Masayoshi Minoshima - Flight of the Bamboo Cutter (a3272509123) \[Lunatic\]](http://osu.ppy.sh/beatmaps/148000&m=0)
 - Tiebreaker
-  - [DJ Noriken - Elektrick U-Phoria(Extended Mix) (sionKotori)](http://osu.ppy.sh/beatmaps/854972&m=0) [Illuminate]
+  - [DJ Noriken - Elektrick U-Phoria(Extended Mix) (sionKotori) \[Illuminate\]](http://osu.ppy.sh/beatmaps/854972&m=0)
 
 ------------------------------------------------------------------------
 
@@ -244,149 +242,146 @@ The osu! World Cup 2017 was run by various community members by distributing the
 
 | Friday, 15. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | 7 | 6 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/38335947) |
-| Germany ![][flag_DE] | 1 | 7 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/38346733) |
-| Poland ![][flag_PL] | 7 | 6 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38350684) |
+| **South Korea** ![][flag_KR] | **7** | 6 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/38335947) |
+| Germany ![][flag_DE] | 1 | **7** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/38346733) |
+| **Poland** ![][flag_PL] | **7** | 6 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38350684) |
 
 | Saturday, 16. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| United Kingdom ![][flag_GB] | 7 | 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/38367964) |
-| United States ![][flag_US] | 7 | 4 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/38384430) |
+| **United Kingdom** ![][flag_GB] | **7** | 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/38367964) |
+| **United States** ![][flag_US] | **7** | 4 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/38384430) |
 
 | Sunday, 17. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| United States ![][flag_US] | 7 | 3 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/38418895) |
-| Poland ![][flag_PL] | 7 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38421285) |
+| **United States** ![][flag_US] | **7** | 3 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/38418895) |
+| **Poland** ![][flag_PL] | **7** | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38421285) |
 
 ### Semifinals
 
 | Saturday, 9. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Norway ![][flag_NO] | 7 | 2 | ![][flag_HK] Hong Kong | [#1](https://osu.ppy.sh/community/matches/38181607) |
-| Netherlands ![][flag_NL] | 4 | 7 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/38186618) |
-| Canada ![][flag_CA] | 1 | 7 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/38190989) |
-| Russian Federation ![][flag_RU] | 5 | 7 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/38196035) |
+| **Norway** ![][flag_NO] | **7** | 2 | ![][flag_HK] Hong Kong | [#1](https://osu.ppy.sh/community/matches/38181607) |
+| Netherlands ![][flag_NL] | 4 | **7** | ![][flag_RU] **Russian Federatio**n | [#1](https://osu.ppy.sh/community/matches/38186618) |
+| Canada ![][flag_CA] | 1 | **7** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/38190989) |
+| Russian Federation ![][flag_RU] | 5 | **7** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/38196035) |
 
 | Sunday, 10. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| South Korea ![][flag_KR] | 7 | 6 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/38206986) |
-| Taiwan ![][flag_TW] | 2 | 7 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38209295) |
-| South Korea ![][flag_KR] | 7 | 2 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/38219678) |
-| United Kingdom ![][flag_GB] | 5 | 7 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/38223284) |
+| **South Korea** ![][flag_KR] | **7** | 6 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/38206986) |
+| Taiwan ![][flag_TW] | 2 | **7** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/38209295) |
+| **South Korea** ![][flag_KR] | **7** | 2 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/38219678) |
+| United Kingdom ![][flag_GB] | 5 | **7** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/38223284) |
 
 
 ### Quarterfinals
 
 | Saturday, 2. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Netherlands ![][flag_NL] | 6 | 4 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/37984347) |
-| Germany ![][flag_DE] | 3 | 6 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/37988813) |
-| Hong Kong ![][flag_HK] | 0 | 6 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/37992145) |
-| Canada ![][flag_CA] | 6 | 4 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37996482) |
+| **Netherland**s ![][flag_NL] | **6** | 4 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/37984347) |
+| Germany ![][flag_DE] | 3 | **6** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/37988813) |
+| Hong Kong ![][flag_HK] | 0 | **6** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/37992145) |
+| **Canada** ![][flag_CA] | **6** | 4 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37996482) |
 
 | Sunday, 3. December 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Denmark ![][flag_DK] | 1 | 6 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/38029594) |
-| Singapore ![][flag_SG] | 0 | 6 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/38031685) |
-| Brazil ![][flag_BR] | 1 | 6 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/38034430) |
-| Russian Federation ![][flag_RU] | 3 | 6 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/38036937) |
+| Denmark ![][flag_DK] | 1 | **6** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/38029594) |
+| Singapore ![][flag_SG] | 0 | **6** | ![][flag_NO] **Norway** | [#1](https://osu.ppy.sh/community/matches/38031685) |
+| Brazil ![][flag_BR] | 1 | **6** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/38034430) |
+| Russian Federation ![][flag_RU] | 3 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/38036937) |
 
 ### Round of 16
 
 | Saturday, 25. November 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Taiwan ![][flag_TW] | 6 | 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/37793064) |
-| United Kingdom ![][flag_GB] | 6 | 2 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/37794394) |
-| Hong Kong ![][flag_HK] | 6 | 4 | ![][flag_NL] Netherlands | [#1](https://osu.ppy.sh/community/matches/37796296) |
-| Singapore ![][flag_SG] | 2 | 6 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/37799185) |
+| **Taiwan** ![][flag_TW] | **6** | 2 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/37793064) |
+| **United Kingdom** ![][flag_GB] | **6** | 2 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/37794394) |
+| **Hong Kong** ![][flag_HK] | **6** | 4 | ![][flag_NL] Netherlands | [#1](https://osu.ppy.sh/community/matches/37796296) |
+| Singapore ![][flag_SG] | 2 | **6** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/37799185) |
 
 | Sunday, 26. November 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Poland ![][flag_PL] | 6 | 1 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37837181) |
-| Denmark ![][flag_DK] | 3 | 6 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/37840289) |
-| Canada ![][flag_CA] | 3 | 6 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/37842093) |
-| Norway ![][flag_NO] | 2 | 6 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/37844547) |
+| **Poland** ![][flag_PL] | **6** | 1 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37837181) |
+| Denmark ![][flag_DK] | 3 | **6** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/37840289) |
+| Canada ![][flag_CA] | 3 | **6** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/37842093) |
+| Norway ![][flag_NO] | 2 | **6** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/37844547) |
 
 ### Group Stage
 
 | Saturday, 18. November 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Indonesia ![][flag_ID] | 2 | 5 | ![][flag_AU] Australia | [#1](https://osu.ppy.sh/community/matches/37609499) |
-| Latvia ![][flag_LV] | 1 | 5 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/37609495) |
-| Israel ![][flag_IL] | 0 | 5 | ![][flag_SG] Singapore | [#1](https://osu.ppy.sh/community/matches/37609502) |
-| Hungary ![][flag_HU] | 2 | 5 | ![][flag_JP] Japan | [#1](https://osu.ppy.sh/community/matches/37610675) |
-| Russian Federation ![][flag_RU] | 5 | 2 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/37610821) |
-| Romania ![][flag_RO] | 0 | 5 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/37610680) |
-| Netherlands ![][flag_NL] | 5 | 3 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/37610687) |
-| Philippines ![][flag_PH] | 0 | 5 | ![][flag_HK] Hong Kong | [#1](https://osu.ppy.sh/community/matches/37612374) |
-| Indonesia ![][flag_ID] | 0 | 5 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/37612236) |
-| Malaysia ![][flag_MY] | 1 | 5 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/37612234) |
-| Argentina ![][flag_AR] | 0 | 5 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/37613921) |
-| Israel ![][flag_IL] | 1 | 5 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/37613946) |
-| Romania ![][flag_RO] | 3 | 5 | ![][flag_SE] Sweden | [#1](https://osu.ppy.sh/community/matches/37614075) |
-| Philippines ![][flag_PH] | 0 | 5 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/37615841) |
-| Hong Kong ![][flag_HK] | 5 | 1 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/37615713) |
-| Hungary ![][flag_HU] | 0 | 5 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/37615928) |
-| Latvia ![][flag_LV] | 0 | 5 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/37623221) |
-| Finland ![][flag_FI] | 5 | 0 | ![][flag_IL] Israel | [#1](https://osu.ppy.sh/community/matches/37623233) |
-| Romania ![][flag_RO] | 2 | 5 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/37623236) |
-| Chile ![][flag_CL] | 2 | 5 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/37625547) |
-| Mexico ![][flag_MX] | 1 | 5 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37625411) |
-| Netherlands ![][flag_NL] | 1 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/37625491) |
-| Denmark ![][flag_DK] | 2 | 5 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/37627968) |
-| Argentina ![][flag_AR] | 1 | 5 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/37628093) |
-| Sweden ![][flag_SE] | 1 | 5 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/37627984) |
-| Mexico ![][flag_MX] | 1 | 5 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/37629909) |
-| Italy ![][flag_IT] | 3 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/37629745) |
-| Hungary ![][flag_HU] | 1 | 5 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/37629750) |
+| Indonesia ![][flag_ID] | 2 | **5** | ![][flag_AU] **Australia** | [#1](https://osu.ppy.sh/community/matches/37609499) |
+| Latvia ![][flag_LV] | 1 | **5** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/37609495) |
+| Israel ![][flag_IL] | 0 | **5** | ![][flag_SG] **Singapore** | [#1](https://osu.ppy.sh/community/matches/37609502) |
+| Hungary ![][flag_HU] | 2 | **5** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/37610675) |
+| **Russian Federation** ![][flag_RU] | **5** | 2 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/37610821) |
+| Romania ![][flag_RO] | 0 | **5** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/37610680) |
+| **Netherlands** ![][flag_NL] | **5** | 3 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/37610687) |
+| Philippines ![][flag_PH] | 0 | **5** | ![][flag_HK] **Hong Kong** | [#1](https://osu.ppy.sh/community/matches/37612374) |
+| Indonesia ![][flag_ID] | 0 | **5** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/37612236) |
+| Malaysia ![][flag_MY] | 1 | **5** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/37612234) |
+| Argentina ![][flag_AR] | 0 | **5** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/37613921) |
+| Israel ![][flag_IL] | 1 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/37613946) |
+| Romania ![][flag_RO] | 3 | **5** | ![][flag_SE] **Sweden** | [#1](https://osu.ppy.sh/community/matches/37614075) |
+| Philippines ![][flag_PH] | 0 | **5** | ![][flag_CL] **Chile** | [#1](https://osu.ppy.sh/community/matches/37615841) |
+| **Hong Kong** ![][flag_HK] | **5** | 1 | ![][flag_NO] Norway | [#1](https://osu.ppy.sh/community/matches/37615713) |
+| Hungary ![][flag_HU] | 0 | **5** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/37615928) |
+| Latvia ![][flag_LV] | 0 | **5** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/37623221) |
+| **Finland** ![][flag_FI] | **5** | 0 | ![][flag_IL] Israel | [#1](https://osu.ppy.sh/community/matches/37623233) |
+| Romania ![][flag_RO] | 2 | **5** | ![][flag_CA] **Canada** | [#1](https://osu.ppy.sh/community/matches/37623236) |
+| Chile ![][flag_CL] | 2 | **5** | ![][flag_NO] **Norway** | [#1](https://osu.ppy.sh/community/matches/37625547) |
+| Mexico ![][flag_MX] | 1 | **5** | ![][flag_AT] **Austria** | [#1](https://osu.ppy.sh/community/matches/37625411) |
+| Netherlands ![][flag_NL] | 1 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/37625491) |
+| Denmark ![][flag_DK] | 2 | **5** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/37627968) |
+| Argentina ![][flag_AR] | 1 | **5** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/37628093) |
+| Sweden ![][flag_SE] | 1 | **5** | ![][flag_CA] **Canada** | [#1](https://osu.ppy.sh/community/matches/37627984) |
+| Mexico ![][flag_MX] | 1 | **5** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/37629909) |
+| Italy ![][flag_IT] | 3 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/37629745) |
+| Hungary ![][flag_HU] | 1 | **5** | ![][flag_FR] **France** | [#1](https://osu.ppy.sh/community/matches/37629750) |
 
 | Sunday, 19. November 2017 | | | | |
 | ---: | :---: | :---: | :--- | :---: |
-| Taiwan ![][flag_TW] | 4 | 5 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/37640223) |
-| Malaysia ![][flag_MY] | 2 | 5 | ![][flag_MX] Mexico | [#1](https://osu.ppy.sh/community/matches/37640683) |
-| China ![][flag_CN] | 1 | 5 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/37640232) |
-| Denmark ![][flag_DK] | 5 | 3 | ![][flag_AU] Australia | [#1](https://osu.ppy.sh/community/matches/37646592) |
-| Finland ![][flag_FI] | 1 | 5 | ![][flag_SG] Singapore | [#1](https://osu.ppy.sh/community/matches/37646594) |
-| Malaysia ![][flag_MY] | 5 | 2 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37646595) |
-| Japan ![][flag_JP] | 5 | 4 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/37647825) |
-| Sweden ![][flag_SE] | 0 | 5 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/37647794) |
-| Italy ![][flag_IT] | 4 | 5 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/37647798) |
-| Philippines ![][flag_PH] | 0 | 5 | ![][flag_NO] Norway | -WIN BY DEFAULT- |
-| Indonesia ![][flag_ID] | 1 | 5 | ![][flag_DK] Denmark | [#1](https://osu.ppy.sh/community/matches/37649009) |
-| Australia ![][flag_AU] | 2 | 5 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/37649125) |
-| Singapore ![][flag_SG] | 2 | 5 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/37649006) |
-| Japan ![][flag_JP] | 0 | 5 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/37650430) |
-| Brazil ![][flag_BR] | 2 | 5 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/37650434) |
-| Italy ![][flag_IT] | 3 | 5 | ![][flag_NL] Netherlands | [#1](https://osu.ppy.sh/community/matches/37650364) |
-| Hong Kong ![][flag_HK] | 5 | 2 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/37652168) |
-| Latvia ![][flag_LV] | 5 | 0 | ![][flag_AR] Argentina | -WIN BY DEFAULT- |
-| Finland ![][flag_FI] | 0 | 5 | ![][flag_GB] United Kingdom | [#1](https://osu.ppy.sh/community/matches/37651999) |
-| Austria ![][flag_AT] | 5 | 3 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/37652008) |
+| Taiwan ![][flag_TW] | 4 | **5** | ![][flag_CA] **Canada** | [#1](https://osu.ppy.sh/community/matches/37640223) |
+| Malaysia ![][flag_MY] | 2 | **5** | ![][flag_MX] **Mexico** | [#1](https://osu.ppy.sh/community/matches/37640683) |
+| China ![][flag_CN] | 1 | **5** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/37640232) |
+| **Denmark** ![][flag_DK] | **5** | 3 | ![][flag_AU] Australia | [#1](https://osu.ppy.sh/community/matches/37646592) |
+| Finland ![][flag_FI] | 1 | **5** | ![][flag_SG] **Singapore** | [#1](https://osu.ppy.sh/community/matches/37646594) |
+| **Malaysia** ![][flag_MY] | **5** | 2 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/37646595) |
+| **Japa**n ![][flag_JP] | **5** | 4 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/37647825) |
+| Sweden ![][flag_SE] | 0 | **5** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/37647794) |
+| Italy ![][flag_IT] | 4 | **5** | ![][flag_CN] **China** | [#1](https://osu.ppy.sh/community/matches/37647798) |
+| Philippines ![][flag_PH] | 0 | **5** | ![][flag_NO] **Norway** | -win by default- |
+| Indonesia ![][flag_ID] | 1 | **5** | ![][flag_DK] **Denmark** | [#1](https://osu.ppy.sh/community/matches/37649009) |
+| Australia ![][flag_AU] | 2 | **5** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/37649125) |
+| Singapore ![][flag_SG] | 2 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/37649006) |
+| Japan ![][flag_JP] | 0 | **5** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/37650430) |
+| Brazil ![][flag_BR] | 2 | **5** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/37650434) |
+| Italy ![][flag_IT] | 3 | **5** | ![][flag_NL] **Netherlands** | [#1](https://osu.ppy.sh/community/matches/37650364) |
+| **Hong Kong** ![][flag_HK] | **5** | 2 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/37652168) |
+| **Latvia** ![][flag_LV] | **5** | 0 | ![][flag_AR] Argentina | -win by default- |
+| Finland ![][flag_FI] | 0 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/37651999) |
+| **Austria** ![][flag_AT] | **5** | 3 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/37652008) |
 
 ------------------------------------------------------------------------
 
 ## Ruleset
+
 ### Tournament Rules
 
 1. The osu! World Cup is a country-based team tournament, played on the osu! game mode.
    - While this competition is planned as a 4 versus 4 setup, this might change depending on the amount of incoming registrations.
-
 2. Beatmap scoring is based on Score V2.
 
 3. The beatmaps for each round will be announced by the mapset selector in advance on the Sunday before the actual matches take place. Only these will be used during the respective matches.
    - The Group Stage mappool will be announced after the drawings.
    - One beatmap will be given as a tiebreaker beatmap. This beatmap will only be played in case of a tie.
-
 4. Match schedule will be settled by the Tournament Management (see below).
 5. If no staff or referee is available, the match will be postponed.
 6. Failed players' scores do not get added to the team score.
    - Reviving and surviving during a beatmap gets considered as passing it.
-
 7. Use of the Visual Settings to alter background dim or disable beatmap elements like storyboards and skins are allowed.
 8. If the beatmap ends in a draw, the game will be nullified.
 9. If a player disconnects, they get treated as if they failed the beatmap.
    - Disconnects within 30 seconds after beatmap begin can be rematched. This is up to the referee's discretion. The played beatmap might be aborted for this.
-
 10. Beatmaps cannot be reused in the same match unless the game was nullified.
 11. If less than the minimum required players attend, the maximum time the match can be postponed is 10 minutes.
 12. Exchanging players during a match is allowed without limitations.
@@ -397,7 +392,6 @@ The osu! World Cup 2017 was run by various community members by distributing the
 17. Disrupting the match by foul play, picking inappropriate warmup beatmaps (see below), insulting and provoking other players or referees, delaying the match or other deliberate inappropriate misbehavior is strictly prohibited.
 18. The multiplayer chatrooms underlie the [osu! community rules](/wiki/Rules). All chat rules apply to the multiplayer chatrooms, too.
     - Breaking the chat rules results in a silence. Silenced players can not participate at multiplayer matches and must be exchanged for the time being.
-
 19. In Group stage, 'Win by default' will be considered as win by 5:0, +1.0 score difference ratio.
 20. Unexpected incidences are handled by the tournament management. Referees may allow higher tolerance depending on the given circumstances. This is up to their discretion.
 21. Penalties for violating the tournament rules can be:
@@ -414,23 +408,19 @@ The osu! World Cup 2017 was run by various community members by distributing the
    - Tournament Management will create a list of potential candidates for a country's team.
    - Tournament Management declares one candidate to the captain of the country's team, albeit temporarily.
    - The declared captain can form their team from the candidate list of their country.
-
 2. To ensure valid and serious registrations, every registered user will be checked by the Tournament Management.
    - Every registered user will be assigned to their respective country's candidate list.
    - To be successfully accepted on the list, you have to ensure that your global osu! performance ranking is above 5000.
    - To be successfully accepted on the list, you have to ensure that you did not violate the [osu! community rules](/wiki/Rules) within the last 12 months.
-
 3. All successfully formed teams will be published after the Registration Phase.
 4. Only the 32 potentially strongest countries will participate. The potential strength of a country is determined by the online statistics of all valid candidates.
    - If the amount of registered countries is below 32, the number might be reduced to 24, 20 or 16. The aim is always to let as many countries participate as possible!
-
 5. Mapset selectors must not participate as a player in this tournament.
 
 ### Stage Instructions
 
 1. In the first stage (Group Stage), the teams will be divided into 8 groups of 4 teams.
    - This may change depending on how many teams are accepted into the competition at the end.
-
 2. All the teams from each group will face each other.
 3. Rankings of each group are determined by sorting the results of each team's performance in the following priority:
    - Most matches won.
@@ -438,10 +428,8 @@ The osu! World Cup 2017 was run by various community members by distributing the
    - Most beatmaps won.
    - Have higher `∑{(total score difference) / (maximum score)}`.
    - Winner of the rematch.
-
 4. The top 2 teams of each group will move on to the Knock-Out Stages.
    -  This may change with the actual Group Stage setup.
-
 5. Following stages are Double Elimination Stages. This means that the winner moves to the next stage and the losing team gets moved to the Loser bracket.
 6. Based on [this image](https://puu.sh/bUq5V/f1066103b0.png), the stages are split up into the following:
 
@@ -462,23 +450,19 @@ The osu! World Cup 2017 was run by various community members by distributing the
 1. A referee will create a multiplayer room 15 minutes in advance. Players must gather during this period.
    - Room settings are osu!, Team-Vs., Win Condition: 'ScoreV2'. Room name must be "OWC 2017: (TeamRed) vs (TeamBlue)".
    - The team mentioned first in the room name must be the red team, the team mentioned second in the room name must be the blue team.
-
 2. Players are free to select up to two warm-up beatmaps. Using beatmaps with questionable content is prohibited. All beatmaps must be osu! specific beatmaps.
 3. Each captain can ban **one beatmap** to be selected from the pool. These beatmaps are not allowed to be picked by any team in the entire match.  
 4. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
 5. Each captain must use "!roll" once in #multiplayer.
    - The winner of the !roll starts picking the first beatmap of the match.
    - The loser of the !roll starts banning one beatmap, followed by the winner of the !roll to ban a beatmap.
-
 6. Captains may pick freely from any bracket.
    - In case of a tie, the tiebreaker beatmap must be played.
-
 7. Results of the Group Stage will be published via a Statistics sheet.
 
 ### Mappool Instructions
 
 1. There will be 1 mappool for the Group Stage, 1 mappool for Round 16, 1 mappool for the Quarterfinals, 1 mappool for the Semifinals and 1 mappool for the Finals.
-
 2. Each mappool consists of 5 brackets: NoMod, [Hidden](/wiki/Game_Modifiers), [HardRock](/wiki/Game_Modifiers), [DoubleTime](/wiki/Game_Modifiers) and FreeMod.
 3. Each mappool consists of 16 maps in total.
 4. Each mappool has one tiebreaker.
@@ -487,10 +471,8 @@ The osu! World Cup 2017 was run by various community members by distributing the
 7. The FreeMod bracket will have FreeMod activated.
    - Possible mod choices are Hidden, HardRock and Hidden+HardRock.
    - When playing a FreeMod map, at least 2 players of each team must have at least one mod activated. For the remaining players, activating mods is optional.
-
 8. The tiebreaker will be played under FreeMod conditions.
    - When playing the tiebreaker, no one needs to have a mod activated.
-
 9. The size of the NoMod bracket will be 6 in all stages.
 10. The size of the Hidden, HardRock and DoubleTime brackets will be 2 in all stages.
 11. The size of the FreeMod bracket will be 3 in all stages.
@@ -501,10 +483,8 @@ The osu! World Cup 2017 was run by various community members by distributing the
 2. Matches in Group Stage may overlap.
 3. All Double Elimination Stages will be held on either Saturday or Sunday, UTC+0.
    - Finals stage may have matches on Friday, depending on the occuring encounters.
-
 4. Scheduling will be handled by the Tournament Management. Schedules will be released on the Sunday before the first matches of the actual stage. Tournament Management will try to create the schedule to respect the participant's time zone.
    - In the stages Quarterfinals and higher: Please inform tournament management before Sunday, if you expect a specific time slot to be unavailable in the following week. Wishes are tried to be followed, alas no promises can be made.
-
 5. Rescheduling after the release of the Schedule on the wiki can not be done in any circumstance.
 6. Captains are responsible for their teams availability. The greater team size exists to ensure every team can provide at least four players for each match. If teams can not provide three players for a match, the match will be considered forfeited.
 

--- a/wiki/Tournaments/OWC/2017/en.md
+++ b/wiki/Tournaments/OWC/2017/en.md
@@ -5,7 +5,7 @@ tags:
 ---
 # osu! World Cup 2017
 
-![osu! World Cup 2017 logo](logo.png)
+![OWC 2017 Logo](logo.png)
 
 The **osu! World Cup 2017** (**_OWC 2017_**) is a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It is the 8th installment of the osu! World Cup.
 
@@ -89,11 +89,11 @@ The osu! World Cup 2017 was run by various community members by distributing the
 
 ------------------------------------------------------------------------
 
-![Winner Podium](podium.jpg)
+![OWC 2017 Podium](podium.jpg)
 
 ------------------------------------------------------------------------
 
-![Double Elimination bracket](bracket.jpg)
+![OWC 2017 Brackets](bracket.jpg)
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2017/en.md
+++ b/wiki/Tournaments/OWC/2017/en.md
@@ -26,7 +26,7 @@ The **osu! World Cup 2017** (**_OWC 2017_**) is a country-based osu! tournament 
 In every world cup, people conquering a place on the podium are eligible to receive unique prizes created specifically for World Cup winners. It is possible that these items change with every installment of the World Cups.
 
 | Placing | Prize(s) |
-| --- | :-- |
+| :-: | :-- |
 | ![Gold Crown](/wiki/shared/GCrown.png "1st place") | $300 per team member, exclusive osu! tumbler and pins, profile badge, "osu! Champion" user title for one year |
 | ![Silver Crown](/wiki/shared/SCrown.png "2nd place") | $160 per team member, exclusive osu! tumbler and pins , profile badge |
 | ![Bronze Crown](/wiki/shared/BCrown.png "3rd place") | $80 per team member, exclusive osu! tumbler and pins, profile badge |
@@ -53,7 +53,7 @@ The osu! World Cup 2017 was run by various community members by distributing the
 ## Participants
 
 | | Country | Members |
-| - | :---: | -------- |
+| :-: | :-: | :-- |
 | ![][flag_AR] | **Argentina** | **[Pein](https://osu.ppy.sh/users/2212941)**, [Lexalia](https://osu.ppy.sh/users/1887616), [Serena](https://osu.ppy.sh/users/756068), [benjacala](https://osu.ppy.sh/users/1625740), [Toushi](https://osu.ppy.sh/users/2367825), [-Urushihara-](https://osu.ppy.sh/users/6169195), [Glazbom](https://osu.ppy.sh/users/608277), [zaqlev](https://osu.ppy.sh/users/3188703) |
 | ![][flag_AU] | **Australia** | **[Bauxe](https://osu.ppy.sh/users/1881685)**, [Dumii](https://osu.ppy.sh/users/3068044), [uyghti](https://osu.ppy.sh/users/3641404), [Lunirs](https://osu.ppy.sh/users/2118945), [Blobby3000](https://osu.ppy.sh/users/6916774), [ithgyu](https://osu.ppy.sh/users/5113781), [GranDSenpai](https://osu.ppy.sh/users/3997580), [Weber](https://osu.ppy.sh/users/6410432) |
 | ![][flag_AT] | **Austria** | **[Akane-Yuki](https://osu.ppy.sh/users/3656589)**, [Fedora Goose](https://osu.ppy.sh/users/2323131), [BlueFlame](https://osu.ppy.sh/users/3506191), [Spark-desu](https://osu.ppy.sh/users/4601608), [Kizan](https://osu.ppy.sh/users/3074197), [Teppichreini](https://osu.ppy.sh/users/1371974), [Myst1k](https://osu.ppy.sh/users/5302223), [Tomadoi](https://osu.ppy.sh/users/5712451) |


### PR DESCRIPTION
Known issues:
- missing Tournament Schedule for `OWC #1` and `OWC #2`
- `OWC #3` article doesn't exist

Related to #350 

---