### PR TITLE
Removes the misc link and mark pt/ru as outdated

### DIFF
--- a/wiki/Storyboard_Scripting/de.md
+++ b/wiki/Storyboard_Scripting/de.md
@@ -17,6 +17,4 @@ Es basiert grundsätzlich auf [die offizielen Spezifikationen](http://osu.ppy.sh
 
 [Lies dir bitte erst die Regeln durch, bevor du mit dem SBS anfängst.](/wiki/Storyboard_Scripting/General_Rules) Klicke [hier](/wiki/Storyboard_Scripting/Objects) für Sprite/Objekt spezifische Elemente und [hier](/wiki/Storyboard_Scripting/Commands) für Befehle, um deren Bewegungabläufe festlegen zu können.
 
-[Noch mehr Leckerbissen, falls du interessiert sein solltest.](/wiki/Storyboard_Scripting/Miscellaneous)
-
 Hinweis: **Speichere es zuerst in der Beatmap als .osb-Datei ab**, bevor du es im Textdokument abspeicherst. Der Editor ist dazu auch noch sehr sensibel, daher solltest du **sehr oft** abspeichern, um mögliche Abstürze vorzubeugen.

--- a/wiki/Storyboard_Scripting/en.md
+++ b/wiki/Storyboard_Scripting/en.md
@@ -15,6 +15,6 @@ Full Specification
 
 It is primarily based on [the official specifications](http://osu.ppy.sh/forum/viewtopic.php?p=12468#p12468) and experience in making large SBs. This is **not a step-by-step guide**, although simple examples are provided. It is meant to exhaustively detail how SBS translates into actions on-screen in osu!.
 
-[Please read the rule before doing SBS.](/wiki/Storyboard_Scripting/General_Rules) It will save you the hassle later on. [For sprite/object spec.](/wiki/Storyboard_Scripting/Objects) and [their moveset](/wiki/Storyboard_Scripting/Commands). [Extra tidbits if you are interested](/wiki/Storyboard_Scripting/Miscellaneous).
+[Please read the rule before doing SBS.](/wiki/Storyboard_Scripting/General_Rules) It will save you the hassle later on. [For sprite/object spec.](/wiki/Storyboard_Scripting/Objects) and [their moveset](/wiki/Storyboard_Scripting/Commands).
 
 Note: **Save on beatmap first** before saving in Notepad. Also, the editor can be insensitive at times so **save often**.

--- a/wiki/Storyboard_Scripting/ja.md
+++ b/wiki/Storyboard_Scripting/ja.md
@@ -15,6 +15,6 @@
 
 これは[公式の仕様](http://osu.ppy.sh/forum/viewtopic.php?p=12468#p12468)と大規模なSBの作成に基づいています。 これは**順を追うタイプのガイドではありません。** それはSBSがosu!のスクリーンに影響する詳細についてだけを網羅していることを意味します。
 
-[SBSを弄る前にここを読んでください。それをすることで後で起こるかもしれない面倒事を回避することができるかもしれません](/wiki/Storyboard_Scripting/General_Rules)。 [スプライトとオブジェクトの仕様についてと](/wiki/Storyboard_Scripting/Objects)[動作させるコマンドについて](/wiki/Storyboard_Scripting/Commands). [興味がある場合のその他の項目](/wiki/Storyboard_Scripting/Miscellaneous).
+[SBSを弄る前にここを読んでください。それをすることで後で起こるかもしれない面倒事を回避することができるかもしれません](/wiki/Storyboard_Scripting/General_Rules)。 [スプライトとオブジェクトの仕様についてと](/wiki/Storyboard_Scripting/Objects)[動作させるコマンドについて](/wiki/Storyboard_Scripting/Commands).
 
 注意: ノートパッドを保存する前に **まず最初に譜面を保存してください**。時々Editorの動作が重くなることがあるので頻繁に保存をすることが推奨されています。

--- a/wiki/Storyboard_Scripting/ja.md
+++ b/wiki/Storyboard_Scripting/ja.md
@@ -15,6 +15,6 @@
 
 これは[公式の仕様](http://osu.ppy.sh/forum/viewtopic.php?p=12468#p12468)と大規模なSBの作成に基づいています。 これは**順を追うタイプのガイドではありません。** それはSBSがosu!のスクリーンに影響する詳細についてだけを網羅していることを意味します。
 
-[SBSを弄る前にここを読んでください。それをすることで後で起こるかもしれない面倒事を回避することができるかもしれません](/wiki/Storyboard_Scripting/General_Rules)。 [スプライトとオブジェクトの仕様についてと](/wiki/Storyboard_Scripting/Objects)[動作させるコマンドについて](/wiki/Storyboard_Scripting/Commands).
+[SBSを弄る前にここを読んでください。それをすることで後で起こるかもしれない面倒事を回避することができるかもしれません](/wiki/Storyboard_Scripting/General_Rules)。 [スプライトとオブジェクトの仕様についてと](/wiki/Storyboard_Scripting/Objects)[動作させるコマンドについて](/wiki/Storyboard_Scripting/Commands). [興味がある場合のその他の項目](/wiki/Storyboard_Scripting/Miscellaneous).
 
 注意: ノートパッドを保存する前に **まず最初に譜面を保存してください**。時々Editorの動作が重くなることがあるので頻繁に保存をすることが推奨されています。

--- a/wiki/Storyboard_Scripting/pl.md
+++ b/wiki/Storyboard_Scripting/pl.md
@@ -15,6 +15,6 @@ Pełna specyfikacja
 
 It is primarily based on [the official specifications](http://osu.ppy.sh/forum/viewtopic.php?p=12468#p12468) and experience in making large SBs. This is **not a step-by-step guide**, although simple examples are provided. It is meant to exhaustively detail how SBS translates into actions on-screen in osu!.
 
-[Przeczytaj główne zasady przed zaczęciem skryptowania tła](/wiki/Storyboard_Scripting/General_Rules). Zaoszczędzi ci to późniejszych problemów. Tutaj możesz sprawdzić [specyfikację obiektów w sprite'ów](/wiki/Storyboard_Scripting/Objects) oraz [ich ruch](/wiki/Storyboard_Scripting/Commands). Tutaj mamy [dodatkowe ciekawoski](/wiki/Storyboard_Scripting/Miscellaneous).
+[Przeczytaj główne zasady przed zaczęciem skryptowania tła](/wiki/Storyboard_Scripting/General_Rules). Zaoszczędzi ci to późniejszych problemów. Tutaj możesz sprawdzić [specyfikację obiektów w sprite'ów](/wiki/Storyboard_Scripting/Objects) oraz [ich ruch](/wiki/Storyboard_Scripting/Commands).
 
 Ważne: Przed zapisaniem pracy w Notatniku, **zapisz wpierw beatmapę**. Edytor może czasami nie odpowiadać, więc **często dokonuj zapisów**.

--- a/wiki/Storyboard_Scripting/pt.md
+++ b/wiki/Storyboard_Scripting/pt.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 Storyboard Scripting
 ====================================
 

--- a/wiki/Storyboard_Scripting/ru.md
+++ b/wiki/Storyboard_Scripting/ru.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 Storyboard Scripting
 ======================
 


### PR DESCRIPTION
the link to /wiki/Storyboard_Scripting/Miscellaneous is taken out in this

pt/ru are 2 liners and thus marked as outdated
the link to misc is ded in other languages or contains duplicate info according to #810 so linking to it is just confusing

---