### PR TITLE
Overhaul tournament profile badge criteria and requirements

### DIFF
--- a/wiki/osu!tourney/Prizes/en.md
+++ b/wiki/osu!tourney/Prizes/en.md
@@ -2,29 +2,92 @@
 
 _Main page: [osu!tourney](/wiki/osu!tourney)_
 
-We may award profile badges to first-place winners of tournaments meeting the following criteria:
-- This is the second or further iteration of the tournament.
-- The staff members involved in managing the tournament are **not** participating in the tournament themselves.
+## Profile Badges
+
+The osu!team may (at their discretion), provide a community-run tournament with a *profile badge*, a special reward that is visible on a player's profile. 
+
+These badges typically display a player's skill and prowess in tournament play, and are thus regulated to ensure that they retain their worth and value.
+
+### Criteria for Applicable Tournaments
+
+We may award profile badges to any **first-place winners** of community-run tournaments that meet the following criteria:
+
+- The tournament is organized and run by an *experienced team of accomplished and reputable volunteers***¹** , **OR**, the tournament *has been run at least once before without receiving rewards*.
+- The badge request is made **well before** the tournament commences play. (*We suggest at least two to three weeks.*)
+- Any of the staff members involved in managing the tournament are **not** participating in the tournament themselves.
 - The tournament is run four or fewer times per year (seasonal).
 
-Please email tournaments@ppy.sh if your tournament meets this criteria.
+**¹**: "Experienced" team members are loosely defined as someone who has contributed significantly to the successful running of at least **three** badge-receiving tournaments beforehand, or has been a part of the osu! World Cup team.
 
-If you plan to supply a badge with your request, ensure it is no larger than 86x40 and clearly displays the logo or name of your tournament. It must also be below 50kb in size - the smaller, the better. PNG format is preferable.
+### Badge Design Criteria
 
-## Why does a tournament have to run at least twice or more in order to qualify for profile badges?
+Profile badges are expected to adhere to a few minimum standards before they are accepted. 
+
+Please read these carefully - if your proposed badge violates any of these, it may be refused!
+
+- The badge image file MUST be either PNG or JPG/JPEG in format.
+    + If the badge design contains any transparency, it MUST be in PNG format instead.
+- The dimensions of the badge image file MUST NOT exceed 86x40, or 86x34 at the absolute minimum. (*86x40 is the preferred format for all badges and you will be questioned for using 86x34, and outright refused for anything smaller.*)
+- The badge image file MUST be below 50kb in size. (*We suggest using [FileOptimizer](https://nikkhokkho.sourceforge.io/static.php?page=FileOptimizer) if you're having trouble with this.*)
+- The badge MUST clearly display the logo or name of your tournament. (*You may substitute this for a visual motif or a theme so long as it is obvious enough.*)
+- The badge MUST be cleanly designed and of reasonable visual quality.
+
+**We also require a 2x (or 'retina') version of your badge for display on the new website.** It is highly recommended to design your badge in 2x (aka: 172x80 resolution) and then downscale it to 1x (86x40) as listed above.
+
+Here are a few examples of approved badges that are of a quality well beyond the normal:
+
+![](https://assets.ppy.sh/profile-badges/ohc-2017.png)
+![](https://assets.ppy.sh/profile-badges/okt3.png)
+
+Badges that do not meet these standards will be refused with appropriate reasoning, and you may even be asked to completely redesign your badge if some features are particularly problematic. Please account for this.
+
+### Requesting a Profile Badge For Your Tournament
+
+If your tournament meets the criteria listed above, and you have a design ready to be submitted, **please email tournaments@ppy.sh** and include the following information:
+
+- The name of your tournament
+- A brief description of your tournament, including its scoring type and any other appropriate features
+- A list of the players involved in running the tournament
+- Any applicable dates for your tournament
+- Any links to public off-site chatrooms or servers used for the event (Discord, etc)
+- A link to the forum thread on the osu!forum that announces/details your tournament
+- Any links to previous iterations of the same tournament (only where applicable)
+- Two badge images following the design criteria listed above, **at both 1x (86x40) and 2x/retina (172x80) sizes**.
+
+Please allow at **least** a week for a response. We will try our best to handle all requests within a week, but we occasionally have large spikes in workload that can make this impossible.
+
+If your request is approved, you may then submit a list of applicable recipients at the conclusion of your tournament, along with the finalized badge design.
+
+**We reserve the right to withdraw this service should issues arise during the course of a tournament.**
+
+## Frequently Asked Questions (FAQ)
+
+### Why does a tournament have to run at least twice or more in order to qualify for profile badges without experienced staff present?
 
 The second iteration of a tournament is often free of a lot of the organizational issues of the first tournament, and has established a solid workflow and staff involved in its production. They are far less likely to peter out or be subject to questionable choices. The tournament is also far more identifiable if it runs more than just once.
 
-For all of these reasons (and more), we ask that profile badge prizes are only awarded to tournaments that have successfully run at least once before.
+For all of these reasons (and more), we ask that profile badge prizes are only awarded to tournaments that have successfully run at least once before, unless a sizable majority of the team is experienced and accomplished at running tournaments in the past.
 
-## What is considered 'staff' as far as tournament management goes?
+### What is considered 'staff' as far as tournament management goes?
 
-Referees, mappool selectors, judges, team organizers, or any other form of managerial position directly involved in the maintenance and operation of a tournament is considered as part of its staff.
+We consider referees, mappool selectors, judges, team organizers, or any other form of managerial position directly involved in the maintenance and operation of a tournament to be a part of its staff.
 
-Commentators are not considered by us as staff, and may play or interact in tournaments freely so long as they are not directly involved any managerial aspect of running the tournament.
+Commentators are not considered by us as staff, and may play or interact in tournaments freely so long as they are not directly involved any managerial aspect of running the tournament or violate anything mentioned above.
 
 We have historically had issues where unscrupulous organizers have geared tournaments specifically (ie: picked maps they're familiar with, adjusted seeds/brackets, etc) to farm profile badges for them and their friends. While we understand that most groups will not do this, we must enforce this restriction to keep things fair for everyone.
 
-## Why can't badges be awarded to recurring monthly (or weekly) tournaments?
+### Can a player who has been eliminated from play in my tournament join the staff after the fact and not cause problems?
+
+Generally no, unless the role they are assuming is not one that could conceivably alter the outcome of the tournament.
+
+A player may conclude play in your tournament and join as a commentator, for example, but not as a referee, organizer, or anything further.
+
+### Why can't badges be awarded to recurring monthly (or weekly) tournaments?
 
 Flooding the game with profile badges dilutes the prestige of the prize for everybody else. We do not want profile badges to be something that people 'farm' for from a few sets of regular, recurring tournaments.
+
+### Can I request a badge for a beatmap contest or other type of competition?
+
+For beatmap contests, yes, just follow the same rules as above.
+
+For other contests, email us and ask personally. We'll try to work something out.


### PR DESCRIPTION
Updates the Prizes article with critical information regarding new profile badge policy for tournament organizers.