### PR TITLE
Wrong linking on /skinning

### DIFF
--- a/wiki/Skinning/en.md
+++ b/wiki/Skinning/en.md
@@ -10,7 +10,7 @@ Skinning is one of the key features of osu! It enables players to derive from th
 
 ## How do I make a skin?
 
-*See also: [Skinning Tutorial](/wiki/Skinning/Tutorial).*
+*See also: [Skinning Tutorial](/wiki/Skinning_Tutorial).*
 
 ## Skin elements lists
 


### PR DESCRIPTION
The skinning tutorial got moved out of /skinning into its own folder, but the link on the main page of /skinning wasnt adjusted.