### PR TITLE
Fix hatnotes usage and formatting

### DIFF
--- a/wiki/Beatmap_Editor/Menu/en.md
+++ b/wiki/Beatmap_Editor/Menu/en.md
@@ -153,9 +153,9 @@ Places of interest.
 Compose
 --------
 
-![Compose menu](img/M_Compose.jpg "Compose menu")
+*Main page: [Compose](/wiki/Beatmap_Editor/Compose)*
 
-***Main page: [Compose](/wiki/Beatmap_Editor/Compose)***
+![Compose menu](img/M_Compose.jpg "Compose menu")
 
 ### Rulers commands
 
@@ -177,9 +177,9 @@ Compose
 Design
 -------
 
-![Design menu](img/M_Design.jpg "Design menu")
+*Main page: [Design](/wiki/Beatmap_Editor/Design)*
 
-***Main page: [Design](/wiki/Beatmap_Editor/Design)***
+![Design menu](img/M_Design.jpg "Design menu")
 
 | Name | Description |
 | ---- | ----------- |
@@ -188,9 +188,9 @@ Design
 Timing
 -------
 
-![Timing menu](img/M_Timing.jpg "Timing menu")
+*Main page: [Timing](/wiki/Beatmap_Editor/Timing)*
 
-***Main page: [Timing](/wiki/Beatmap_Editor/Timing)***
+![Timing menu](img/M_Timing.jpg "Timing menu")
 
 ### Metronome commands
 

--- a/wiki/Beatmap_Editor/Timelines/en.md
+++ b/wiki/Beatmap_Editor/Timelines/en.md
@@ -5,7 +5,7 @@ This article will explain how each of them function.
 
 ## Shortcuts
 
-_For a list of keyboard shortcuts for the timeline, see [shortcut key reference](/wiki/shortcut_key_reference/#general)._
+*For a list of keyboard shortcuts for the timeline, see: [shortcut key reference](/wiki/shortcut_key_reference/#general)*
 
 ## Song Player
 

--- a/wiki/Beatmap_Editor/Timing/en.md
+++ b/wiki/Beatmap_Editor/Timing/en.md
@@ -1,6 +1,6 @@
 # Timing
 
-_See also: [How to time songs](/wiki/How_to_time_songs)_
+*See also: [How to time songs](/wiki/How_to_time_songs)*
 
 ![Timing menu](img/Timing_base.jpg "Timing menu")
 

--- a/wiki/Beatmapping/en.md
+++ b/wiki/Beatmapping/en.md
@@ -19,7 +19,7 @@ Click on the song, this will open the [beatmap editor](/wiki/beatmap_editor) and
 
 ### Song Setup
 
-_See also: [Song Setup](/wiki/Song_Setup)_
+*Main page: [Song Setup](/wiki/Song_Setup)*
 
 When making a new [mapset](/wiki/mapset), you will always see this dialog before any other parts of the beatmap editor.
 
@@ -32,7 +32,7 @@ The next step is to add timing to your beatmap.
 
 ### Timing
 
-_See also: [Timing](/wiki/Timing)_
+*Main page: [Timing](/wiki/Timing)*
 
 **Timing is vital!**
 Incorrectly timed maps will not be considered for ranking.
@@ -43,14 +43,14 @@ This will save you (and the modding community) a lot of hassle later on.
 
 ### Compose
 
-_See also: [Compose](/wiki/Compose)_
+*Main page: [Compose](/wiki/Compose)*
 
 The compose tab of the beatmap editor is where you will probably spend a majority of your time beatmapping.
 It is where you can visually place hit objects and toggle their [hit sounds](/wiki/hit_sounds)
 
 ### Design
 
-_See also: [Design](/wiki/Design) and [Storyboarding](/wiki/Storyboarding)_
+*Main page: [Design](/wiki/Design) and [Storyboarding](/wiki/Storyboarding)*
 
 The design tab of the beatmap editor is where you can set the beatmap's background image, add a video, and/or make a basic storyboard.
 Depending on what you do, you may use the design tab a lot or none at all, if you happen to be doing [SBS](/wiki/SBS) (storyboard scripting).

--- a/wiki/Beatmaps/Packs/en.md
+++ b/wiki/Beatmaps/Packs/en.md
@@ -1,7 +1,5 @@
 # Packs
 
-_Main page: [Beatmaps](/wiki/Beatmaps)_
-
 A beatmaps pack is a `.zip` file containing beatmaps. The name of the pack is based on what they contain (e.g. `Approved Beatmap Pack #7` would only contain [approved](/wiki/approved) beatmaps).
 
 It is worth noting that the most packs are:

--- a/wiki/Beatmaps/en.md
+++ b/wiki/Beatmaps/en.md
@@ -53,7 +53,7 @@ To get a beatmap in the loved status, see the forum post: [Get your beatmap Love
 
 ### Pending
 
-_See also: [Beatmap Ranking Procedure](/wiki/Beatmap_Ranking_Procedure)_
+*Main page: [Beatmap Ranking Procedure](/wiki/Beatmap_Ranking_Procedure)*
 
 Pending beatmaps use the question mark icon (![Question mark icon](/wiki/shared/status/pending.png)) in the song select screen.
 

--- a/wiki/Best_Of/2009/en.md
+++ b/wiki/Best_Of/2009/en.md
@@ -1,7 +1,5 @@
 # 2009
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 ![Best of 2009 results announced by peppy](2009results.png "Best of 2009 results announced by peppy")
 
 - [Results](https://osu.ppy.sh/forum/t/22162)

--- a/wiki/Best_Of/2010/en.md
+++ b/wiki/Best_Of/2010/en.md
@@ -1,7 +1,5 @@
 # 2010
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 - [Results (table text file)](https://puu.sh/Fju)
   - [Forum](https://osu.ppy.sh/forum/t/43834)
 - [Ranking Chart](https://osu.ppy.sh/p/chart?ch=best2010)

--- a/wiki/Best_Of/2011/en.md
+++ b/wiki/Best_Of/2011/en.md
@@ -1,7 +1,5 @@
 # 2011
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 - [Official Google Doc of the results](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdFpEcjlfWklxem8xVVJ2ZW1sY2JfcWc&amp;hl=en_US#gid=0)
 - [Ranking Chart](https://osu.ppy.sh/p/chart?ch=best2011)
 - Download (Mediafire):

--- a/wiki/Best_Of/2012/en.md
+++ b/wiki/Best_Of/2012/en.md
@@ -1,7 +1,5 @@
 # 2012
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 - [Full list of 2012 beatmaps (vote screen)](http://osu.ppy.sh/p/bestof2012) [Legacy link. Content has been removed]
 - [Official Google Doc of the results](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdDRDSjNMN3o3Y1Z6UzA0QUpFNzdlNUE#gid=0)
 - [Ranking Chart](https://osu.ppy.sh/p/chart?ch=BEST2012) (First 31 songs. 21 ranked, 10 approved)

--- a/wiki/Best_Of/2013/en.md
+++ b/wiki/Best_Of/2013/en.md
@@ -1,7 +1,5 @@
 # 2013
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 ## General
 
 - First time in the series expand to cover osu!taiko, osu!catch, and osu!mania (Top 10 only).

--- a/wiki/Best_Of/2014/en.md
+++ b/wiki/Best_Of/2014/en.md
@@ -1,7 +1,5 @@
 # 2014
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 ## General
 
 - [Official Google Doc of the results](https://docs.google.com/spreadsheets/d/1l_8ur1YkaboLx_7bQb70Tgkjg8c7ObyAjmJyWDBM1C0/pubhtml#)

--- a/wiki/Best_Of/2015/en.md
+++ b/wiki/Best_Of/2015/en.md
@@ -1,7 +1,5 @@
 # 2015
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 ## General
 
 - First time in the series to enforce that at least one beatmap in the beatmapset must be played and passed to be votable.

--- a/wiki/Best_Of/2016/en.md
+++ b/wiki/Best_Of/2016/en.md
@@ -1,7 +1,5 @@
 # 2016
 
-_Main page: [Best Of](/wiki/Best_Of "Best Of")_
-
 ## General
 
 - [News Results](https://osu.ppy.sh/news/157306073998)

--- a/wiki/Difficulties/en.md
+++ b/wiki/Difficulties/en.md
@@ -1,8 +1,8 @@
 # Difficulties
 
-*Not to be confused with: [Beatmaps](/wiki/Beatmaps).*
+*Not to be confused with: [Beatmaps](/wiki/Beatmaps)*
 
-*See also: [Ranking Criteria § Mapset](/wiki/Ranking_Criteria/#mapset).*
+*See also: [Ranking Criteria § Mapset](/wiki/Ranking_Criteria/#mapset)*
 
 The difficulty of a beatmap *describes* the level of skill needed to complete it.
 
@@ -25,7 +25,7 @@ The star rating ranges determines which web icon is going to be used on any give
 
 ## Difficulty levels
 
-*See also: [Difficulty Naming](/wiki/Ranking_Criteria/Difficulty_Naming).*
+*Main page: [Difficulty Naming](/wiki/Ranking_Criteria/Difficulty_Naming)*
 
 ### osu!
 

--- a/wiki/Game_Modifiers/Summary/en.md
+++ b/wiki/Game_Modifiers/Summary/en.md
@@ -5,8 +5,6 @@
 
 # Summary
 
-_Main page: [Game Modifiers](/wiki/Game_Modifiers)_
-
 Note: All mods used in osu!mania will never increase the score multiplier.
 
 | Mod | Name (Abbr.) | Multiplier | Effect |

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -763,7 +763,7 @@ Stacking hit circles (a clear violation of beat spacing) is, nevertheless, permi
 
 ### Standard
 
-_See also: [osu!](/wiki/Game_Modes/osu!) (game mode)._
+*Main page: [osu!standard](/wiki/Game_Modes/osu!)*
 
 Standard refers to the game mode in osu! and has been used since it is the first game mode. This is sometimes stylized as _osu!standard_ or osu! (without italics).
 

--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -1,6 +1,6 @@
 # Audio Editing
 
-_See also [Basic MP3 Modifications](/wiki/Beatmap_Editor_Guides/Basic_MP3_Modifications)_
+*See also: [Basic MP3 Modifications](/wiki/Beatmap_Editor_Guides/Basic_MP3_Modifications)*
 
 [osu!academy](/wiki/Announcements/osu!academy) covered this in [Episode 15: Audio Encoding (4:02)](http://www.youtube.com/watch?v=muu3HkG38kk).
 That episode also contains how to install and use Audacity with LAME's `.mp3` export ability.

--- a/wiki/Guides/BSS_Issues/en.md
+++ b/wiki/Guides/BSS_Issues/en.md
@@ -5,8 +5,6 @@ tags:
 ---
 # BSS Issues
 
-*Main page: [Guides](/wiki/Guides).*
-
 *Note: Do not use this guide to steal other creator's beatmaps!*
 
 If the [BSS](/wiki/BSS) (Beatmap Submission System) won't let you submit your own beatmap because it says that you do not own the map then do the following:

--- a/wiki/Guides/Beginner's_Tutorial/en.md
+++ b/wiki/Guides/Beginner's_Tutorial/en.md
@@ -6,7 +6,7 @@ Welcome to the osu! beginner tutorial. The world of osu! can sometimes be a very
 Types of Input
 --------------
 
-*See also [Play Styles](/wiki/Play_Styles).*
+*Main page: [Play Styles](/wiki/Play_Styles)*
 
 By default, a lot of players will start out with the mouse, since it's often the quickest available aiming tool by far. But there are actually multiple means of input to control the cursor and pop the circles:
 
@@ -88,7 +88,7 @@ Getting more out of Gameplay
 
 ### Global Offset
 
-*See also [How to use the Offset Wizard](/wiki/List_of_Guides/How_to_use_the_Offset_Wizard).*
+*Main page: [How to use the Offset Wizard](/wiki/List_of_Guides/How_to_use_the_Offset_Wizard)*
 
 Depending on the devices you use to play osu! with, you may find that the hit circles aren't quite on beat with the music. To correct this, you can change the global offset value in the [Settings](/wiki/Options/) menu. Global offset will change when the first note appears on beatmaps (either earlier or later than default), which in turn delays the rest of the notes by the same amount. A negative offset value will make notes appear slightly later, and a positive value will make them appear earlier.
 
@@ -100,13 +100,13 @@ Adjust your global offset until you are happy with it. Getting the right value w
 
 ### Raw Input
 
-*See also [Options](/wiki/Options/#mouse).*
+*See also: [Options](/wiki/Options/#mouse)*
 
 A commonly overlooked feature of the game is the Raw Input function. This allows for direct reading of your input device into osu! itself. You may use this too if you don't like how Windows handles your mouse cursor, or especially recommended if you use a tablet. Give it a try and play a few maps with it, you might find yourself a lot more comfortable with it!
 
 ### Skins
 
-*See also [Skinning](/wiki/Skinning/).*
+*See also: [Skinning](/wiki/Skinning)*
 
 There are many, many skins to pick from; you can find them on the forums, linked in chat, or even by asking the other users! While these will not improve your gameplay, they can help motivate you, or make playing osu! easier on the eyes. Or, if you prefer to not have a lot of the osu! HUD blocking the screen, you could find a skin with a minimal approach. You can even find skins formed by [the pros](https://osu.ppy.sh/forum/t/87675) and see what makes those skins more successful. Some skins have been built for ease of sight, while some are quirky and just for fun. Alas, it's another way you can get more enjoyment out of osu! and make your experience while climbing up the ranks a little nicer. ;)
 

--- a/wiki/Guides/How_To_Get_Your_Map_Ranked/en.md
+++ b/wiki/Guides/How_To_Get_Your_Map_Ranked/en.md
@@ -1,6 +1,8 @@
 How to Get Your Map Ranked
 ===========================
 
+*See also: [Ranking Criteria](/wiki/Ranking_Criteria)*
+
 Having trouble getting your [map](/wiki/Glossary) ranked? You've come to the right place.
 
 Step 1: Modding
@@ -21,8 +23,3 @@ Step 3: Bubbles
 ---------------
 
 Just because your map is bubbled doesn't mean your work is over! Don't ignore any mods by normal users on your bubbled map — although only a BN or QAT can rank your map, anyone can still help improve it, and a better, more thoroughly modded map means an easier job for the BNG who eventually looks at it. Once you have applied a mod on your bubble the BN who originally gave the bubble will almost always be happy to come back and reinstate it. Keep in mind that you'll also have an easier time getting your bubble noticed by BNG members if it is high priority and on the first page of pending - giving your map some kudos stars to push it up in the list should make the wait a little shorter.
-
-See Also
---------
-
--   [Ranking Criteria](/wiki/Ranking_Criteria)

--- a/wiki/Guides/en.md
+++ b/wiki/Guides/en.md
@@ -4,7 +4,7 @@ Below is a sorted list of guides created by members of the osu!community; most o
 
 ## Beatmapping
 
-_See also: [Beatmapping](/wiki/Beatmapping)_
+*Main page: [Beatmapping](/wiki/Beatmapping)*
 
 - [Adding Custom Hit Sounds](/wiki/Adding_Custom_Hit_Sounds)
 - [Audio Editing](/wiki/Audio_Editing)
@@ -24,7 +24,7 @@ _See also: [Beatmapping](/wiki/Beatmapping)_
 
 ## Modding
 
-_See also: [Modding](/wiki/Modding)_
+*Main page: [Modding](/wiki/Modding)*
 
 - [Getting Your Map Modded](/wiki/Getting_Your_Map_Modded)
 - [How To Get Your Map Ranked](/wiki/How_To_Get_Your_Map_Ranked)
@@ -42,7 +42,9 @@ _See also: [Modding](/wiki/Modding)_
 
 ## Skinning
 
-_See also: [Skinning](/wiki/Skinning) and [Skinning Tutorial](/wiki/Skinning_Tutorial)_
+*Main page: [Skinning](/wiki/Skinning)*
+
+*See also: [Skinning Tutorial](/wiki/Skinning_Tutorial)*
 
 - [Cropping with Complex Backgrounds](/wiki/Cropping_with_Complex_Backgrounds)
 - [Cropping with Simple Backgrounds](/wiki/Cropping_with_Simple_Backgrounds)

--- a/wiki/Guides/osu!mania_Mapping_Guide/en.md
+++ b/wiki/Guides/osu!mania_Mapping_Guide/en.md
@@ -6,7 +6,7 @@ Prologue
 
 ### What is osu!mania?
 
-*See also: [osu!mania](/wiki/Game_Modes/osu!mania)*
+*Main page: [osu!mania](/wiki/Game_Modes/osu!mania)*
 
 So what exactly is osu!mania? Many of you osu! veterans out there might already know what osu!mania is. osu!mania is one of the four game modes. Many people that stumble upon osu!mania for the first time will probably think to themselves "Oh cool! Guitar Hero!". And indeed, osu!mania is very similar to Guitar Hero. Both of these games are so-called "VSRGs", or **Vertical Scrolling Rhythm Games**. This means, as the name already suggests, that the musical notes are falling down or rising up in a vertical manner. There are many rather similar games to osu!mania such as "Stepmania", "O2Jam" or "Beatmania IIDX". But for now, we will be concentrating on osu!mania only!
 

--- a/wiki/History_of_osu!/2007/en.md
+++ b/wiki/History_of_osu!/2007/en.md
@@ -1,7 +1,5 @@
 # 2007
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 The following is some of the history of osu! since its beginning. Special thanks to [Sinistro](/users/5530) for helping in compiling the 2007/2008 content.
 
 ![](img/2007.jpg)

--- a/wiki/History_of_osu!/2008/en.md
+++ b/wiki/History_of_osu!/2008/en.md
@@ -1,7 +1,5 @@
 # 2008
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ![](img/2008.jpg)
 
 ## January

--- a/wiki/History_of_osu!/2009/en.md
+++ b/wiki/History_of_osu!/2009/en.md
@@ -1,7 +1,5 @@
 # 2009
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## January
 
 osu! makes its way to the iPhone from a port to the iPhone by nuudles. The project was given its own [subforum](https://osu.ppy.sh/forum/47).

--- a/wiki/History_of_osu!/2010/en.md
+++ b/wiki/History_of_osu!/2010/en.md
@@ -1,3 +1,1 @@
 # 2010
-
-*Main page: [History of osu!](/wiki/HOO).*

--- a/wiki/History_of_osu!/2011/en.md
+++ b/wiki/History_of_osu!/2011/en.md
@@ -1,7 +1,5 @@
 # 2011
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## December
 
 The osu! wiki was announced, allowing users to add all sorts of information about everything osu! related.

--- a/wiki/History_of_osu!/2012/en.md
+++ b/wiki/History_of_osu!/2012/en.md
@@ -1,7 +1,5 @@
 # 2012
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## September
 
 ![](img/2012-09_01.jpg "osu!'s main menu at the time")

--- a/wiki/History_of_osu!/2013/en.md
+++ b/wiki/History_of_osu!/2013/en.md
@@ -1,7 +1,5 @@
 # 2013
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## January
 
 osu! now supports widescreen in all modes (including the editor too)! Database size was reduced by 10%. The ability to reset key bindings to their defaults was added. Hyperdash issues in [Catch the Beat](/wiki/Catch_the_Beat) was almost fixed. The main menu's copyright graphic was updated for 2013 without the copyright text. [Results for the annual "Best of" is out. (Best of 2012)](https://docs.google.com/a/ppy.sh/spreadsheet/ccc?key=0AlsSAL_F7-xDdDRDSjNMN3o3Y1Z6UzA0QUpFNzdlNUE#gid=0).

--- a/wiki/History_of_osu!/2014/en.md
+++ b/wiki/History_of_osu!/2014/en.md
@@ -1,7 +1,5 @@
 # 2014
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## March
 
 As skinning elements expanded, the element, `playfield.jpg` was removed in it's line of duty and replaced with a new generic one that is unskinnable. `playfield.jpg` was an element that allowed you to use any image as the default background of a beatmap, if one isn't supplied.

--- a/wiki/History_of_osu!/2015/en.md
+++ b/wiki/History_of_osu!/2015/en.md
@@ -1,7 +1,5 @@
 # 2015
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## March
 
 peppy reconsiders that his current business model will not obtain him his "Private osu! G6 Jet" and enables the *[osu!coin](/wiki/osu!coin)* to hopefully increase revenue. Every current player was given 10 osu!coins to play (at the rate of 1 play = 1 osu!coin). These can be replenished after obtaining a combo of multiples of 100. Or simply by purchasing them at these rates:

--- a/wiki/History_of_osu!/2016/en.md
+++ b/wiki/History_of_osu!/2016/en.md
@@ -1,7 +1,5 @@
 # 2016
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## January
 
 A brand new year with additions to the list of [community contributors](/wiki/community_contributors). Best of 2015 voting opened.

--- a/wiki/History_of_osu!/2017/en.md
+++ b/wiki/History_of_osu!/2017/en.md
@@ -1,7 +1,5 @@
 # 2017
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## January
 
 [Ephemeral](/users/102335) posted a news post regarding the new year to reassure that many big things are bound to happen in 2017. [S3RL](/beatmaps/artists/9) and [nanobii](/beatmaps/artists/10) were announced to be osu!'s new featured artists. [cYsmix](/beatmaps/artists/2), [yuki.](/beatmaps/artists/4) and [Helblinde](/beatmaps/artists/5) each released a new album giving osu! 26 new songs to beatmap. Aspire returns for 2017.

--- a/wiki/History_of_osu!/2018/en.md
+++ b/wiki/History_of_osu!/2018/en.md
@@ -1,7 +1,5 @@
 # 2018
 
-*Main page: [History of osu!](/wiki/HOO).*
-
 ## January
 
 After a six-month long hiatus, flyte posted on the [osu!next](http://osunext.tumblr.com) blog with some teaser pictures for the next website design. He explained that the current state of the website had many UX problems, from various functionality specs to user feedback, that wasn't considered at the time of designing. Since then, he had been taking some time to redesign the website's current design from scratch.

--- a/wiki/Installation/en.md
+++ b/wiki/Installation/en.md
@@ -1,6 +1,6 @@
 # Installation
 
-<!-- *See also: [Installation/OS X](/wiki/Installation/OS_X) and [Installation/Linux](/wiki/Installation/Linux).* -->
+<!-- *See also: [Installation/OS X](/wiki/Installation/OS_X) and [Installation/Linux](/wiki/Installation/Linux)* -->
 
 This page will roughly tell you how to get osu! working on your Windows device. The [osu!academy](/wiki/osu!academy) has a [video tutorial](https://www.youtube.com/watch?list=PLmWVQsxi34bMYwAawZtzuptfMmszUa_tl&v=cz522ZAs5aQ) that explains how to install osu! on Windows.
 
@@ -50,7 +50,7 @@ There are two ways to add beatmaps, via the website or osu!direct (requires [osu
 
 ## Adding skins
 
-*See also: [Skins](/wiki/Skins) and [Skinning](/wiki/Skinning).*
+*See also: [Skins](/wiki/Skins) and [Skinning](/wiki/Skinning)*
 
 1.  Go to the [skinning subforums](/community/forums/15) and find a skin you like.
 2.  Once you find a skin, download it.

--- a/wiki/Mapping_Techniques/Making_Good_Sliders/en.md
+++ b/wiki/Mapping_Techniques/Making_Good_Sliders/en.md
@@ -43,7 +43,7 @@ Disable grid snap and move them both in by a tiny bit at a time until the slider
 
 ## Beat Blankets
 
-_See also [../Formations/#blanket-combos]._
+*Main page: [Blanket Combos](/wiki/Mapping_Techniques/Formations#blanket-combos)*
 
 ![Image example of beat blankets (with hit circle)](img/MGS_blankets.png)
 

--- a/wiki/Mapping_Techniques/Sliders/en.md
+++ b/wiki/Mapping_Techniques/Sliders/en.md
@@ -1,6 +1,6 @@
 # Sliders
 
-_If you want to know how to _make good sliders_, please see [Making Good Sliders](../Making-Good-Sliders)._
+*See also: [Making Good Sliders](../Making-Good-Sliders)*
 
 <!-- please place all mapping techniques in alphabetical order -->
 

--- a/wiki/Mapping_Techniques/en.md
+++ b/wiki/Mapping_Techniques/en.md
@@ -17,7 +17,7 @@ If you want to know how to make good sliders, see [Making Good Sliders](./Making
 
 ### Formations
 
-_See also [Mapping Techniques/Formations](./Formations/)._
+*Main page: [Mapping Techniques/Formations](./Formations)*
 
 #### Creative
 
@@ -44,7 +44,7 @@ _See also [Mapping Techniques/Formations](./Formations/)._
 
 ### Jumps
 
-_See also [Mapping Techniques/Jumps](./Jumps/)._
+*Main page: [Mapping Techniques/Jumps](./Jumps)*
 
 #### Hit Circle
 
@@ -62,7 +62,7 @@ _See also [Mapping Techniques/Jumps](./Jumps/)._
 
 ### Rhythm
 
-_See also [Mapping Techniques/Rhythm](./Rhythm/)._
+*Main page: [Mapping Techniques/Rhythm](./Rhythm)*
 
 #### Spacing
 
@@ -93,7 +93,7 @@ _See also [Mapping Techniques/Rhythm](./Rhythm/)._
 
 ### Spinners
 
-_See also [Mapping Techniques/Spinners](./Spinners/)._
+*Main page: [Mapping Techniques/Spinners](./Spinners)*
 
 #### Additional Effects
 
@@ -108,7 +108,7 @@ _See also [Mapping Techniques/Spinners](./Spinners/)._
 
 ### Sliders
 
-_See also [Mapping Techniques/Sliders](./Sliders/)._
+*Main page: [Mapping Techniques/Sliders](./Sliders)*
 
 #### Patterns
 
@@ -142,7 +142,7 @@ _See also [Mapping Techniques/Sliders](./Sliders/)._
 
 ### Unrankable
 
-_See also [Mapping Techniques/Unrankable](./Unrankable/)._
+*Main page: [Mapping Techniques/Unrankable](./Unrankable)*
 
 - [Burai Sliders](./Unrankable/#burai-sliders)
 - [Hold Sliders](./Unrankable/#hold-sliders)

--- a/wiki/Mascots/Gallery/en.md
+++ b/wiki/Mascots/Gallery/en.md
@@ -1,7 +1,5 @@
 # Gallery
 
-*Main page: [Mascots](/wiki/Mascots).*
-
 ## Official
 
 ### pippi

--- a/wiki/Mascots/en.md
+++ b/wiki/Mascots/en.md
@@ -1,6 +1,6 @@
 # Mascots
 
-*See also: [Mascots/Gallery](/wiki/Mascots/Gallery).*
+*See also: [Mascots/Gallery](/wiki/Mascots/Gallery)*
 
 A YouTube video showcasing the osu! mascots can be seen at [Mascot Showcase](https://youtu.be/mJF2cAs_MrI).
 
@@ -14,7 +14,7 @@ pippi, stylized with a lowercase "p", is the osu!standard mascot that joined on 
 
 ### ![osu!catch icon](/wiki/shared/mode/catch.png) Yuzu
 
-<!-- *For the news post, see: [Meet Yuzu](/home/news/89483664163).* -->
+<!-- *For the news post, see: [Meet Yuzu](/home/news/89483664163)* -->
 
 ![Yuzu](img/Yuzu.png "Yuzu")
 
@@ -22,7 +22,7 @@ Yuzu is the osu!catch mascot that joined on 2014-06-22. He was born on 2000-04-1
 
 ### ![osu!mania icon](/wiki/shared/mode/mania.png) Maria
 
-*For the news post, see: [Meet Maria - osu!mania’s new mascot!](/home/news/2016-04-20-meet-maria-osumanias-new-mascot).*
+*For the news post, see: [Meet Maria - osu!mania’s new mascot!](/home/news/2016-04-20-meet-maria-osumanias-new-mascot)*
 
 ![Maria](img/Maria.png "Maria")
 
@@ -30,7 +30,7 @@ Maria is the osu!mania mascot that joined on 2016-03-04. Her art was designed by
 
 ### ![osu!taiko icon](/wiki/shared/mode/taiko.png) Mocha
 
-*For the news post, see: [The new osu!taiko mascot is here!](/home/news/2017-05-25-the-new-osutaiko-mascot-is-here).*
+*For the news post, see: [The new osu!taiko mascot is here!](/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 
 ![Mocha](img/Mocha.png "Mocha")
 

--- a/wiki/Medals/en.md
+++ b/wiki/Medals/en.md
@@ -89,7 +89,7 @@ The Dedication medals can be obtained by playing a lot of osu!standard, collecti
 Mod Introduction
 ----------------
 
-_See also: [Game Modifiers](/wiki/Game_Modifiers)._
+*See also: [Game Modifiers](/wiki/Game_Modifiers)*
 
 The Mod Introduction medals can be obtained by clearing maps with the specified game modifier.
 They are meant to encourage newer players to try out each mod and explore what the game has to offer.

--- a/wiki/Modding/en.md
+++ b/wiki/Modding/en.md
@@ -89,7 +89,7 @@ Do not hesitate to suggest if:
 
 ### New Combos
 
-_See also: [Combo](/wiki/Combo)._
+*See also: [Combo](/wiki/Combo)*
 
 Combos, in the most basic sense, divide the [hit circles](/wiki/Hit_Objects) of a beatmap so that they are easier to read.
 Combos generally do not go over 20 in [Insane](/wiki/Insane), 12 in [Hard](/wiki/Hard), and 8 in [Easy](/wiki/Easy) or [Normal](/wiki/Normal) difficulties.
@@ -109,7 +109,7 @@ If you spot these, it is a noteworthy thing to comment about in a mod post.
 
 ### Awkward Slider Velocity Changes
 
-_See also: [Slider](/wiki/Slider)._
+*See also: [Slider](/wiki/Slider)*
 
 Sometimes maps contain slider velocity changes that may not make much sense or are very hard to follow.
 If a slider velocity change requires more than just intuition to understand, then it is usually not a fitting slider velocity change.
@@ -118,7 +118,7 @@ Here, many mappers would likely slow down the slider velocity to match the calme
 
 ### Hit Sounds
 
-_See also: [Hit Sounds](/wiki/Hit_Sounds)._
+*Main page: [Hit Sounds](/wiki/Hit_Sounds)*
 
 Hit sounds are the noise the game makes when the player successfully taps a [hit object](/wiki/hit_object).
 All maps should have a sufficient amount of hit sounds whether using custom or default hit sounds; otherwise, they cannot be ranked.
@@ -131,7 +131,7 @@ Something like this is noteworthy to pay attention and point out.
 
 ### Kiai Time
 
-_See also: [Kiai Time](/wiki/Kiai_Time)._
+*Main page: [Kiai Time](/wiki/Kiai_Time)*
 
 Kiai time should be used when it makes sense.
 It is generally said to only use it where the music reaches some "epic" climax or during a chorus.
@@ -154,7 +154,7 @@ If the kiai time differently in any way per each difficulty, it is not a bad ide
 
 ### Song Setup
 
-_See also: [Song Setup](/wiki/Song_Setup)._
+*Main page: [Song Setup](/wiki/Song_Setup)*
 
 The actual song setup settings does not impact game play, but it is important to give correct names.
 The artist name, title of the song, source (if applicable), and tags should all be the same in each difficulty.
@@ -172,7 +172,7 @@ Here are some other things to look out for in the song setup:
 
 #### Difficulty
 
-_See also: [osu!standard Ranking Criteria](/wiki/osu!standard_Ranking_Criteria#difficulty-specific) (difficulty-specific section)._
+*See also: [osu!standard Ranking Criteria](/wiki/osu!standard_Ranking_Criteria#difficulty-specific) (difficulty-specific section)*
 
 The difficulty settings can be found in the song setup dialog.
 These are important to game play so that the song is at a fair level of difficulty for the varying difficulties a mapset can have.
@@ -193,7 +193,7 @@ The mapper should not have two almost identical combo colours unless they are se
 
 ### Storyboarding
 
-_See also: [Storyboarding](/wiki/Storyboarding)._
+*Main page: [Storyboarding](/wiki/Storyboarding)*
 
 If you spot anything weird while the storyboard is playing (e.g. bad rendering of pictures, emptiness, etc.), it is a good idea to tell the [storyboarder](/wiki/storyboarder) so that they can fix it.
 You can check out the storyboard by pressing `F2` or clicking the `Design` tab at the top of the screen in editor.
@@ -223,7 +223,7 @@ However, if you see `thumb.db` files, you can ignore them since these are automa
 
 ## Mod Post Mistakes
 
-_See also: [Modding and Mapping](/wiki/Modding_and_Mapping)._
+*See also: [Modding and Mapping](/wiki/Modding_and_Mapping)*
 
 When you make a mod post, it is very important to **not** do any of the following:
 

--- a/wiki/People/Beatmap_Nominators/Beatmap_Veto/en.md
+++ b/wiki/People/Beatmap_Nominators/Beatmap_Veto/en.md
@@ -1,7 +1,5 @@
 # Beatmap Veto
 
-*Main page: [Beatmap Nominators](/wiki/People/Beatmap_Nominators).*
-
 The _beatmap veto_ allows a [Beatmap Nominator](/wiki/People/Beatmap_Nominators) to withhold a beatmap from Qualification if they feel there are significant issues regarding beatmap quality which make it unfit for the Ranked section.
 
 Seeking further discussion or clarification over any kind of quality issues which you feel need to be addressed before the map can proceed with Qualification is one of your main responsibilities. 

--- a/wiki/People/Beatmap_Nominators/Divisions/en.md
+++ b/wiki/People/Beatmap_Nominators/Divisions/en.md
@@ -1,7 +1,5 @@
 # Divisions
 
-*Main page: [Beatmap Nominators](/wiki/People/Beatmap_Nominators).*
-
 Subdivisions are small working groups within the Beatmap Nominators to ensure better teamwork and efficiency.
 
 Leaders are **bolded**.

--- a/wiki/People/Beatmap_Nominators/General_Information/en.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/en.md
@@ -1,7 +1,5 @@
 # General Information
 
-*Main page: [Beatmap Nominators](/wiki/Beatmap_Nominators).*
-
 Are you a Beatmap Nominator, or are interested in becoming one? Then you have come to the right place! This article is all the general information you will need to know as a new Beatmap Nominator. To start, this article will start with a few useful links and then introduce you to the way icons are used, as well as how this transitions into [Beatmap Discussions](/wiki/Beatmap_Discussions) (also known as Modding v2).
 
 ## Useful Information

--- a/wiki/People/Beatmap_Nominators/Rules/en.md
+++ b/wiki/People/Beatmap_Nominators/Rules/en.md
@@ -1,7 +1,5 @@
 # Rules
 
-*Main page: [Beatmap Nominators](/wiki/Beatmap_Nominators).*
-
 The rules listed here affect what Beatmap Nominators can and cannot do when nominating beatmaps as well as set the tone for the general conduct expected from them.
 
 These rules are the result of discussion within the [Quality Assurance Team](/wiki/People/Quality_Assurance_Team) and have taken into account feedback from the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) upon their proposal.

--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -4,7 +4,7 @@
 Beatmap Nominators
 ==================
 
-*See also: [Beatmap Nominator Rules](/wiki/Beatmap_Nominator_Rules) and [General Information for Beatmap Nominator](/wiki/Beatmap_Nominator_General_Information).*
+*See also: [Beatmap Nominator Rules](/wiki/Beatmap_Nominator_Rules) and [General Information for Beatmap Nominator](/wiki/Beatmap_Nominator_General_Information)*
 
 The Beatmap Nominators, commonly abbreviated as *BN*, is a group in charge of [beatmap nomination](/wiki/Submissions/Beatmap_Ranking_Procedure). As of 2014-08-22, they are no longer a part of the staff, revoking their chat moderation in-game, red name in-game, and on the forums. As of 2015-02-01, the team was changed from the *Beatmap Appreciation Team* to the *Beatmap Nominators*. Currently, they have a purple name on the forums.
 

--- a/wiki/People/Staff_Log/en.md
+++ b/wiki/People/Staff_Log/en.md
@@ -5,8 +5,6 @@ tags:
 ---
 # Staff Log
 
-*Main page: [People](/wiki/People).*
-
 As of 2014-01-17, management is going to file all staff promotions and retirements to easily make it trackable for the community. Starting with all changes and additions from 2014.
 
 Using the articles listed below, you can find all Beatmap Nominators and their spoken languages. You can also find a list of QAT members with their specializations. Moreover, you can look up the tasks of the GMT members and the representative language moderators for your respective language's community. Furthermore, you can take a look on the retired staff members and find out about their previous position in this game:

--- a/wiki/Ranking_Criteria/Code_of_Conduct/en.md
+++ b/wiki/Ranking_Criteria/Code_of_Conduct/en.md
@@ -1,8 +1,6 @@
 Code of Conduct: Modding and Mapping
 =====================================
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 The **Code of Conduct: Modding and Mapping** is a set of rules and guidelines that apply to the entirety of the osu! Modding and Mapping ecosystem and an extension to the [osu! community rules](/wiki/Rules) and [General Ranking Criteria](/wiki/Ranking_Criteria). In order to ensure that mapping and modding discussions in threads take place in a constructive, positive and productive environment, a code of conduct is crucial to get everyone on the same page. When participating in the Modding and Mapping ecosystem, it is mandatory to follow this Code of Conduct. Misconduct that violates these rules might lead to penalties issued to your account.
 
 Behaviour and Conduct

--- a/wiki/Ranking_Criteria/Skin_Set_List/en.md
+++ b/wiki/Ranking_Criteria/Skin_Set_List/en.md
@@ -1,8 +1,6 @@
 Skin Set List 
 ============= 
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 The following tables contain skin sets that are used in user-specific and beatmap-specific skins. When skinning gameplay elements in beatmap-specific skins, complete sets of elements need to be skinned in order to avoid conflicts between user-specific and beatmap-specific skins.
 
 Filenames containing `(-n)` can be animated. For example, hitcircleoverlay(-n).png can be skinned as a single image (hitcircleoverlay.png), or multiple images that would be animated in a loop (hitcircleoveray-0.png, hitcircleoverlay-1.png, hitcircleoverlay-2.png, etc.).

--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -1,8 +1,6 @@
 Song Content Rules
 ==================
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 With a wide variety of music available, most tracks will be fine for use in osu!, providing that they are not:
 
 - Intensely explicit, suggestive, or otherwise extremely confrontational in regards to shocking, obscene or highly sexual content

--- a/wiki/Ranking_Criteria/Timing_Songs_With_8-Signatures/en.md
+++ b/wiki/Ranking_Criteria/Timing_Songs_With_8-Signatures/en.md
@@ -1,8 +1,6 @@
 Timing Songs with #/8-Signatures
 ================================
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 Every now and then, songs are being mapped that have a time signature that is not divided into quater-notes (e.g. `3/4`, `4/4`, `7/4`, ...) but into eighth-notes (e.g. `6/8`, `7/8`, ..). Since the current editor does not support those #/8-signatures and we don't know whether this will change in the near future, an addition has been made to the rule concerning this matter on the [corresponding section of the Ranking Criteria](/wiki/Ranking_Criteria#timing.1).
 
 To make that chart more understandable and state more precisely what is meant, this guide will now explain a bit of the relevant music theory behind this, and give examples of how it translates into osu!. For this reason, [three mapsets](https://assets.ppy.sh/media/wiki/TimeSignatures.rar) have been prepared for you to download, which will be used as a reference in this guide.

--- a/wiki/Ranking_Criteria/osu!/Scaling_BPM/en.md
+++ b/wiki/Ranking_Criteria/osu!/Scaling_BPM/en.md
@@ -1,8 +1,6 @@
 Scaling BPM on the Ranking Criteria
 ===================================
 
-_Main page: [osu! Ranking Criteria](/wiki/Ranking_Criteria/osu!)_
-
 The osu! Ranking Criteria's rules and guidelines are based around songs of 180BPM with 4/4 time signatures. This guide clarifies how that scaling works!
 
 We'll be using the following proposed Normal difficulty guideline as an example:

--- a/wiki/Ranking_Criteria/osu!/en.md
+++ b/wiki/Ranking_Criteria/osu!/en.md
@@ -1,8 +1,6 @@
 osu! 
 ======
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 The **osu! Ranking Criteria** is a set of rules and guidelines that apply to the creation of osu!-specific difficulties. In order to get an osu!-specific difficulty ranked, it is mandatory that the creation obeys to the listed criteria. While **all rules must be followed in any circumstance**, guidelines may be violated under exceptional circumstances. These exceptional circumstances must be warranted by an exhaustive explanation as of why the guideline has been violated and why not violating it will interfere with the overall quality of the creation.
 
 Rule proposals as well as suggestions are discussed in the [Ranking Criteria Subforum](https://osu.ppy.sh/forum/87). Any rule that went through a discussion and community approval process is listed here as it has been agreed on in the respective discussion thread.

--- a/wiki/Ranking_Criteria/osu!catch/en.md
+++ b/wiki/Ranking_Criteria/osu!catch/en.md
@@ -1,8 +1,6 @@
 osu!catch
 ===========
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 The **osu!catch Ranking Criteria** is a set of rules and guidelines that apply to the creation of osu!catch-specific difficulties. In order to get a osu!catch-specific difficulty ranked, it is mandatory the creation obeys to the listed criteria. While **all rules must be followed in any circumstance**, guidelines may be violated under exceptional circumstances. These exceptional circumstances must be warranted by an exhaustive explanation as of why the guideline has been violated and why not violating it will interfere with the overall quality of the creation.
 
 Glossary

--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -1,8 +1,6 @@
 osu!mania
 ===========
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 For the record, these include the recent changes made [from the discussion forum](https://osu.ppy.sh/forum/87). Any rule that is being discussed is listed here as it used to be and will be updated once the discussion reaches an agreement.
 
 Terms

--- a/wiki/Ranking_Criteria/osu!taiko/en.md
+++ b/wiki/Ranking_Criteria/osu!taiko/en.md
@@ -1,8 +1,6 @@
 osu!taiko 
 =============
 
-_Main page: [Ranking Criteria](/wiki/Ranking_Criteria)_
-
 These rules and guidelines have been discussed in the [Ranking Criteria subforum](https://osu.ppy.sh/community/forums/87). New ones may be suggested in that forum and this page will be updated once discussions reach an agreement.
 
 Glossary

--- a/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play/en.md
@@ -1,6 +1,4 @@
 # Handling Foul Play
-_Main page: [Reporting Bad Behaviour](/wiki/Reporting_Bad_Behaviour)._
-
 
 ## Why am I restricted?
 A user may get restricted if they do any of the following:

--- a/wiki/Shortcut_Key_Reference/en.md
+++ b/wiki/Shortcut_Key_Reference/en.md
@@ -95,7 +95,7 @@ Note: Not all of these work in the [multi](/wiki/multi) mode's song select scree
 
 ### Game Modifiers
 
-_See also: [Game Modifiers](/wiki/Game_Modifiers)._
+*Main page: [Game Modifiers](/wiki/Game_Modifiers)*
 
 **Notes:**
 
@@ -148,7 +148,7 @@ _See also: [Game Modifiers](/wiki/Game_Modifiers)._
 
 ## Beatmap Editor
 
-_See also: [Beatmap Editor](/wiki/Beatmap_Editor)._
+*Main page: [Beatmap Editor](/wiki/Beatmap_Editor)*
 
 ### General
 

--- a/wiki/Skinning/FAQ/en.md
+++ b/wiki/Skinning/FAQ/en.md
@@ -1,7 +1,5 @@
 # FAQ
 
-*Main page: [Skinning](/wiki/Skinning).*
-
 *This article is about frequently answered skinning questions. For the tutorial, see [Skinning/Tutorial](/wiki/Skinning/Tutorial).*
 
 ## Getting started
@@ -28,7 +26,7 @@ The only exception to this are sounds, as they are typically harder to make. The
 
 ### How do I make a skin?
 
-*See also: [Skinning/Tutorial](/wiki/Skinning/Tutorial).*
+*Main page: [Skinning/Tutorial](/wiki/Skinning/Tutorial)*
 
 ### What should my skin folder contain?
 
@@ -46,7 +44,7 @@ You can also exit and reopen osu! or start the updater to reload the skin, but i
 
 ### What are skinning sets?
 
-*See also: [Ranking Criteria/Skin Set List](/wiki/Ranking_Criteria/Skin_Set_List).*
+*Main page: [Ranking Criteria/Skin Set List](/wiki/Ranking_Criteria/Skin_Set_List)*
 
 In osu!, there are over 200 skinnable elements (not including the individual animated frames). However, you are not required to skin all of them. Instead, you can simply remove them as osu! will use the default images for the ones you don't include.
 
@@ -139,7 +137,7 @@ It is really important to include various screenshots of gameplay and the song s
 
 ### What is skin.ini?
 
-*See also: [skin.ini](/wiki/skin.ini).*
+*Main page: [skin.ini](/wiki/skin.ini)*
 
 ### What is v1.0 and v2.0+?
 
@@ -279,7 +277,7 @@ You must have [osu!supporter](/wiki/osu!supporter) to see the background image i
 
 ### What does the @2x do?
 
-*See also: [HD images](#hd-images).*
+*Main page: [HD images](#hd-images)*
 
 ### My taiko drums are in the wrong position!
 
@@ -287,7 +285,7 @@ Open the [skin.ini](/wiki/skin.ini) file and change the `Version` to `2.1` or hi
 
 ### How do I change the combo colours?
 
-*See also: [skin.ini](/wiki/skin.ini/#[colours]).*
+*Main page: [skin.ini](/wiki/skin.ini/#[colours])*
 
 ### How do I disable one or more hit sounds?
 

--- a/wiki/Skinning/History/en.md
+++ b/wiki/Skinning/History/en.md
@@ -3,8 +3,6 @@
 
 # History
 
-*Main page: [Skinning](/wiki/Skinning)*
-
 The skinning elements listed here are no longer in use.
 
 ## Interface

--- a/wiki/Skinning/Interface/en.md
+++ b/wiki/Skinning/Interface/en.md
@@ -3,8 +3,6 @@
 
 # Interface
 
-*Main page: [Skinning](/wiki/Skinning).*
-
 *See also: [Skinning Interface Tutorial](/wiki/Skinning_Interface_Tutorial) and [Interface](/wiki/Interface)*
 
 Interface skinning elements are used in multiple game modes or parts of the client's user interface.
@@ -177,7 +175,7 @@ Notes:
 
 ## Mod icons
 
-*See also: [Game Modifiers](/wiki/Game_Modifiers).*
+*Main page: [Game Modifiers](/wiki/Game_Modifiers)*
 
 ---
 
@@ -549,7 +547,7 @@ Notes:
 
 ## Offset wizard
 
-*See also: [Offset Wizard](/wiki/Offset_Wizard).*
+*Main page: [Offset Wizard](/wiki/Offset_Wizard)*
 
 ---
 
@@ -780,7 +778,7 @@ Notes:
 
 ### Hit bursts
 
-*See also: [Skinning/FAQ § Ranking screen hierarchy](/wiki/Skinning/FAQ/#ranking-screen-hierarchy).*
+*Main page: [Skinning/FAQ § Ranking screen hierarchy](/wiki/Skinning/FAQ/#ranking-screen-hierarchy)*
 
 ---
 

--- a/wiki/Skinning/en.md
+++ b/wiki/Skinning/en.md
@@ -4,13 +4,13 @@ Skinning is one of the key features of osu! It enables players to derive from th
 
 ## Skinning sets
 
-*See also: [Skin Set List](/wiki/Ranking_Criteria/Skin_Set_List/).*
+*Main page: [Skin Set List](/wiki/Ranking_Criteria/Skin_Set_List)*
 
 **For beatmaps only,** if your beatmap skin contains a single element from the listed sets in the Ranking Criteria, it must contain all of the other elements within said skinning set. This only applies to beatmap skins, but other skinners may want to consider those lists as well.
 
 ## How do I make a skin?
 
-*See also: [Skinning Tutorial](/wiki/Skinning/Tutorial).*
+*Main page: [Skinning Tutorial](/wiki/Skinning/Tutorial)*
 
 ## Skin elements lists
 

--- a/wiki/Skinning/osu!/en.md
+++ b/wiki/Skinning/osu!/en.md
@@ -3,9 +3,7 @@
 
 # osu!
 
-*Main page: [Skinning](/wiki/Skinning).*
-
-*See also: [Skinning osu! Tutorial](/wiki/Skinning_osu!_Tutorial).*
+*See also: [Skinning osu! Tutorial](/wiki/Skinning_osu!_Tutorial)*
 
 ## Comboburst
 

--- a/wiki/Skinning/osu!catch/en.md
+++ b/wiki/Skinning/osu!catch/en.md
@@ -3,9 +3,7 @@
 
 # osu!catch
 
-*Main page: [Skinning](/wiki/Skinning).*
-
-*See also: [Skinning osu!catch Tutorial](/wiki/Skinning_osu!catch_Tutorial).*
+*See also: [Skinning osu!catch Tutorial](/wiki/Skinning_osu!catch_Tutorial)*
 
 ## Catcher
 

--- a/wiki/Skinning/osu!mania/en.md
+++ b/wiki/Skinning/osu!mania/en.md
@@ -3,15 +3,13 @@
 
 # osu!mania
 
-*Main page: [Skinning](/wiki/Skinning).*
-
-*See also: [Skinning osu!mania Tutorial](/wiki/Skinning_osu!mania_Tutorial).*
+*See also: [Skinning osu!mania Tutorial](/wiki/Skinning_osu!mania_Tutorial)*
 
 Since v2.5+, skinners are now able to fully customize the osu!mania notes and stage using the [skin.ini](/wiki/skin.ini) file. The following is what osu! will recognize if one chooses to not use the `skin.ini` for further customization.
 
 ## Hit Bursts
 
-*See also: [Skinning/FAQ § Ranking screen hierarchy](/wiki/Skinning/FAQ/#ranking-screen-hierarchy).*
+*See also: [Skinning/FAQ § Ranking screen hierarchy](/wiki/Skinning/FAQ/#ranking-screen-hierarchy)*
 
 ---
 

--- a/wiki/Skinning/osu!taiko/en.md
+++ b/wiki/Skinning/osu!taiko/en.md
@@ -3,9 +3,7 @@
 
 # osu!taiko
 
-*Main page: [Skinning](/wiki/Skinning).*
-
-*See also: [Skinning osu!taiko Tutorial](/wiki/Skinning_osu!taiko_Tutorial).*
+*See also: [Skinning osu!taiko Tutorial](/wiki/Skinning_osu!taiko_Tutorial)*
 
 You can override the osu!taiko playfield parts by creating a folder called `taiko` inside your skin folder. If this approach is used, the user will need to explicitly enable this in the [options](/wiki/options) (enable the `Use Taiko skin for Taiko mode` button), otherwise the default skin elements will be used.
 

--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -1,6 +1,6 @@
 # skin.ini
 
-*See also: [skin.ini/Blank](/wiki/Skinning/skin.ini/Blank).*
+*See also: [skin.ini/Blank](/wiki/Skinning/skin.ini/Blank)*
 
 The `skin.ini` is an initialization file that is found in almost every skin folder.
 This file will define how osu! will display certain skin elements.

--- a/wiki/Skinning_Tutorial/en.md
+++ b/wiki/Skinning_Tutorial/en.md
@@ -2,7 +2,7 @@
 
 *See also: [Skinning](/wiki/Skinning)*
 
-*For frequently answered skinning questions, see: [Skinning/FAQ](/wiki/Skinning/FAQ).*
+*For frequently answered skinning questions, see: [Skinning/FAQ](/wiki/Skinning/FAQ)*
 
 ## Getting Started
 

--- a/wiki/Skinning_Tutorial/osu!catch/en.md
+++ b/wiki/Skinning_Tutorial/osu!catch/en.md
@@ -1,10 +1,8 @@
 # osu!catch
 
-*Main page: [Skinning Tutorial](/wiki/Skinning_Tutorial).*
-
 ## Skinning elements
 
-*See also: [Skinning/osu!catch](/wiki/Skinning/osu!catch).*
+*See also: [Skinning/osu!catch](/wiki/Skinning/osu!catch)*
 
 ### Fruits
 
@@ -76,7 +74,7 @@ These have a minimum width of 302px and the first 16 horizontal lines from the t
 
 ## Skin configuration
 
-*See also: [skin.ini](/wiki/skin.ini).*
+*See also: [skin.ini](/wiki/skin.ini)*
 
 osu!catch has three unique skin configuration commands:
 

--- a/wiki/Skinning_Tutorial/skin.ini/en.md
+++ b/wiki/Skinning_Tutorial/skin.ini/en.md
@@ -1,6 +1,6 @@
 # skin.ini
 
-*See also: [skin.ini](https://osu.ppy.sh/wiki/Skinning/skin.ini) and [Skinning](https://osu.ppy.sh/help/wiki/Skinning).*
+*See also: [skin.ini](https://osu.ppy.sh/wiki/Skinning/skin.ini) and [Skinning](https://osu.ppy.sh/help/wiki/Skinning)*
 
 ## What does the skin.ini do?
 The skin.ini file can modify the behaviour of certain skinning elements in a skin.

--- a/wiki/Storyboard_Scripting/Objects/en.md
+++ b/wiki/Storyboard_Scripting/Objects/en.md
@@ -3,7 +3,7 @@ Objects
 
 ![SB object/sprite call](SBS_Sprite.jpg "SB object/sprite call")
 
-*For Objects in [osu!](/wiki/Game_Modes/osu!) and [Beatmapping](/wiki/Beatmapping), see [Hit Objects](/wiki/Hit_Objects).*
+*For objects in [osu!standard](/wiki/Game_Modes/osu!) and [Beatmapping](/wiki/Beatmapping), see: [Hit Objects](/wiki/Hit_Objects)*
 
 In [Storyboarding](/wiki/Storyboards), **Objects** are sprites or animations that appear on the screen and make up the storyboard. Instances of SB-specific audio can also be considered to be objects; however, for clarity, they have [their own section of this guide](/wiki/Storyboard_Scripting/Audio).
 

--- a/wiki/Storyboard_Scripting/osu!_File_Toggles/en.md
+++ b/wiki/Storyboard_Scripting/osu!_File_Toggles/en.md
@@ -1,9 +1,9 @@
 Osu File Toggles
 ================
 
-The following are toggles that can be added to .osu (and in some cases, .osb files) to affect [skinning](/wiki/Skinning) / [storyboarding](/wiki/Storyboards). Those that are added/removed by the [Beatmap Editor](/wiki/Beatmap_Editor) can also be included.
+*See also: [skin.ini](/wiki/Skinning/Skin.ini)*
 
-See also [skin.ini](/wiki/Skinning/Skin.ini).
+The following are toggles that can be added to .osu (and in some cases, .osb files) to affect [skinning](/wiki/Skinning) / [storyboarding](/wiki/Storyboards). Those that are added/removed by the [Beatmap Editor](/wiki/Beatmap_Editor) can also be included.
 
 Under [General] Section
 -------------------------

--- a/wiki/Welcome/en.md
+++ b/wiki/Welcome/en.md
@@ -22,21 +22,21 @@ Welcome to osu!, a free-to-win rhythm game developed by peppy with four game mod
 
 ## Beatmapping
 
-*Main page: [Beatmapping](/wiki/Beatmapping/#getting-started).*
+*Main page: [Beatmapping](/wiki/Beatmapping/#getting-started)*
 
 Beatmapping is the process of a creator creating a beatmap. This process includes: selecting music, timing and mapping the beatmap, and testing the beatmap. It might also include: adding a video, adding a [storyboard](/wiki/storyboarding/#getting-started), and/or adding a [custom skin](/wiki/skinning/#getting-started). All of those can be done by the creator alone or with other users, sometimes referred to as *storyboarders*, *skinners*, and/or *guest creators*, depending on what they do.
 
 ## Modding
 
-*Main page: [Modding](/wiki/Modding/#getting-started).*
+*Main page: [Modding](/wiki/Modding/#getting-started)*
 
 Modding is the process of users reviewing (or commonly called "modders") a creator's beatmap in the pending (or work in progress/help) stage. Modding plays a big role in quality control because this allows creators to fix issues with their beatmap.
 
 ## Skinning
 
-*Main page: [Skinning](/wiki/Skinning).*
+*Main page: [Skinning](/wiki/Skinning)*
 
-*See also: [Skinning Tutorial](/wiki/Skinning_Tutorial).*
+*See also: [Skinning Tutorial](/wiki/Skinning_Tutorial)*
 
 Skinning allows anyone to change the way osu! looks and feels. This can be as small as changing the cursor or as big as redoing the appearances of all the game modes and interface.
 

--- a/wiki/osu!_Program_Files/User_Configuration_File/en.md
+++ b/wiki/osu!_Program_Files/User_Configuration_File/en.md
@@ -1,7 +1,5 @@
 # User Configuration File
 
-_Main page: [osu! Program Files](/wiki/osu!_Program_Files)_
-
 This is a list of options in the `osu!{yourpcname}.cfg` file. A lot of these options are available through the in-game options and it is recommended that you change options there. Only edit these values manually if you really must. If the `Description` cell is empty, assume it is the same as the one above it.
 
 | Code                 | Description                                 |

--- a/wiki/osu!_wiki_Contribution_Guide/Common_Issues/en.md
+++ b/wiki/osu!_wiki_Contribution_Guide/Common_Issues/en.md
@@ -1,7 +1,5 @@
 # Common Issues
 
-*Main page: [osu! wiki Contribution Guide](/wiki/owcg).*
-
 ## Someone told me to use meaningful commit messages!
 
 This can also be phrased as, "All of my commits say 'Updated en.md'," or similar.

--- a/wiki/osu!_wiki_Contribution_Guide/GitHub_Desktop/en.md
+++ b/wiki/osu!_wiki_Contribution_Guide/GitHub_Desktop/en.md
@@ -1,7 +1,5 @@
 # GitHub Desktop
 
-*Main page: [osu! wiki Contribution Guide](/wiki/owcg).*
-
 *This article continues from the main page* and assumes that you will be using [GitHub Desktop](https://desktop.github.com). **You may use other git clients on your own terms.** Even if you do work locally, you will still need to access GitHub to create pull requests to make your changes happen.
 
 ## Installing GitHub Desktop

--- a/wiki/osu!_wiki_Contribution_Guide/GitHub_Web_Interface/en.md
+++ b/wiki/osu!_wiki_Contribution_Guide/GitHub_Web_Interface/en.md
@@ -1,7 +1,5 @@
 # GitHub Web Interface
 
-*Main page: [osu! wiki Contribution Guide](/wiki/owcg).*
-
 *This article continues from the main page.* If you are going to make changes to multiple articles (this includes uploading, deleting, and/or moving images or files), please see the other guide, [GitHub Desktop](/wiki/owcg/GitHub_Desktop).
 
 ## Editing

--- a/wiki/osu!supporter/en.md
+++ b/wiki/osu!supporter/en.md
@@ -1,12 +1,12 @@
 # osu!supporter
 
-*For the osu!supporter page from osu!web, see [support the game](/home/support).*
+*For the osu!supporter page from the website, see: [support the game](/home/support)*
 
 ![osu!supporter button](img/signed-out-home.png "osu!supporter button on the home page when signed out")
 
 ## Benefits
 
-*For a list of goodies from having osu!supporter, see [support the game](/home/support).*
+*For a list of goodies from having osu!supporter, see: [support the game](/home/support)*
 
 In general, by buying osu!supporter tag, you will be directly supporting the game's developement while obtaining some extra goodies. It must be noted that the extra features from osu!supporter will never affect gameplay, performance, or score to your advantage in anyway.
 

--- a/wiki/osu!tourney/Multiplayer_Usage/en.md
+++ b/wiki/osu!tourney/Multiplayer_Usage/en.md
@@ -1,7 +1,5 @@
 # Multiplayer Usage
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 ## Match creation
 
 The multiplayer room must be named based on the template listed in the control panel of the osu!tourney client.
@@ -18,7 +16,7 @@ The team names (`Team Name 1` and `Team Name 2`) can be replaced with any team n
 
 ### Tournament Management Commands
 
-_See also: [Tournament Management Commands](/wiki/osu!tourney/Tournament_Management_Commands "Tournament Management Commands")_
+*Main page: [Tournament Management Commands](/wiki/osu!tourney/Tournament_Management_Commands "Tournament Management Commands")*
 
 Make sure to assign the correct slots to the players joining the room using the `!mp move` and `!mp team` commands.
 

--- a/wiki/osu!tourney/Prizes/en.md
+++ b/wiki/osu!tourney/Prizes/en.md
@@ -1,7 +1,5 @@
 # Prizes
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 ## Profile Badges
 
 The osu!team may (at their discretion), provide a community-run tournament with a *profile badge*, a special reward that is visible on a player's profile. 

--- a/wiki/osu!tourney/Setup/en.md
+++ b/wiki/osu!tourney/Setup/en.md
@@ -1,7 +1,5 @@
 # Setup
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 **Note:** An active supporter tag is currently required to use the osu!tourney client.
 
 It is recommended that a **fresh osu! installation** is used. This is because the Songs database may become corrupted. You can have multiple osu! installations, just keep them in separated folders.  

--- a/wiki/osu!tourney/Skinning/en.md
+++ b/wiki/osu!tourney/Skinning/en.md
@@ -1,7 +1,5 @@
 # Skinning
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 ![The client can be customized in various ways](Osutourneycustom.png)
 
 The client supports various modifications so you can customize it for the tournament. To do so, you will need to create the folder structure `/Skins/User/tournament` in the client's installation directory. The skin elements can be placed in this folder and support `.jpg` and `.png` file extensions.

--- a/wiki/osu!tourney/Spectator_Usage/en.md
+++ b/wiki/osu!tourney/Spectator_Usage/en.md
@@ -1,7 +1,5 @@
 # Spectator Usage
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 ![osu!tourney interface](Osutourneymain.png "Basic Interface of the osu!tourney client")
 
 This is the interface of the osu!tourney client. The top of the screen is divided in two halves, representing the two teams of the multiplayer room.

--- a/wiki/osu!tourney/Tournament_Management_Commands/en.md
+++ b/wiki/osu!tourney/Tournament_Management_Commands/en.md
@@ -1,7 +1,5 @@
 # Tournament Management Commands
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 The following chat commands are provided for remote management of multiplayer tournament rooms:
 
 - `!mp make <name>` - Creates a tournament room with the specified name. A maximum of 4 such rooms may be created.

--- a/wiki/osu!tourney/Troubleshooting/en.md
+++ b/wiki/osu!tourney/Troubleshooting/en.md
@@ -1,7 +1,5 @@
 # Troubleshooting
 
-_Main page: [osu!tourney](/wiki/osu!tourney)_
-
 ## How do I create a fresh osu! installation without uninstalling the current game?
 
 Copy `osu!.exe` into an empty folder and run it.


### PR DESCRIPTION
Reworded and moved some hatnotes. Removed leading `Main page:` usages, since it's wrong and some feature is going to be made to click on the parent (index) page.

`wiki/Skinning/osu!taiko/en.md`: Idk what happened, probably a line ending thing.

---