### PR TITLE
Storyboard Scripting - Move command specification fixes

### DIFF
--- a/wiki/Storyboard_Scripting/Commands/en.md
+++ b/wiki/Storyboard_Scripting/Commands/en.md
@@ -96,7 +96,7 @@ See the shorthand section for an explanation of how to shorten this last line to
 
 | Affects | Value definition | Default value |
 | ------- | ---------------- | ------------- |
-| The location of the object in the play area. | An (x,y) position, as specified above. Decimals are allowed. | An (x,y) position, as specified above. Decimals are not allowed. |
+| The location of the object in the play area. | An (x,y) position, as specified above. Decimals are allowed. | The location defined in the [object declaration](/wiki/Storyboard_Scripting/Objects). |
 
 where:
 

--- a/wiki/Storyboard_Scripting/Commands/en.md
+++ b/wiki/Storyboard_Scripting/Commands/en.md
@@ -96,7 +96,7 @@ See the shorthand section for an explanation of how to shorten this last line to
 
 | Affects | Value definition | Default value |
 | ------- | ---------------- | ------------- |
-| The location of the object in the play area. | An (x,y) position, as specified above. Decimals are not allowed. | An (x,y) position, as specified above. Decimals are not allowed. |
+| The location of the object in the play area. | An (x,y) position, as specified above. Decimals are allowed. | An (x,y) position, as specified above. Decimals are not allowed. |
 
 where:
 


### PR DESCRIPTION
- the value definition stated that decimals are not allowed, but in reality they are
- the default value description seems to be a copy-paste error

---
