### PR TITLE
Add a link to the Storyboard Scripting Shorthand in the Commands article

### DIFF
--- a/wiki/Storyboard_Scripting/Commands/en.md
+++ b/wiki/Storyboard_Scripting/Commands/en.md
@@ -50,6 +50,8 @@ where:
 -   (starttime) and (endtime) are the starting and ending times of the command, respectively in milliseconds (ms).
 -   (params...) vary between specific values for (event). This is usually what values the variables should take on.
 
+In some special cases, various [shorthands](/wiki/Storyboard_Scripting/Shorthand) can be used.
+
 An object stays active until its last command (time-wise) is done. After that, it disappears. If you simply want an object to stay on-screen, without anything happening to it, staying at its default location, use Fade (F).
 ![Setting a(n) sprite/object with their commands to do (Event).](SBS_Base_C.jpg "Setting a(n) sprite/object with their commands to do (Event).")
 
@@ -86,7 +88,7 @@ Sprite,Pass,Centre,"Sample.png",320,240
 _F,0,1000,3000,1,1
 ```
 
-See the shorthand section for an explanation of how to shorten this last line to just:
+See the [shorthand](/wiki/Storyboard_Scripting/Shorthand) section for an explanation of how to shorten this last line to just:
 
 `_F,0,1000,3000,1`
 

--- a/wiki/Storyboard_Scripting/Commands/ja.md
+++ b/wiki/Storyboard_Scripting/Commands/ja.md
@@ -1,3 +1,6 @@
+---
+outdated: true
+---
 Storyboard Scripting Commands
 =========================================
 


### PR DESCRIPTION
The shorthand page was not linked anywhere (except for the sitemap), there was only a vague reference in the fade command description (which is how I found out about this page in the first place).

---

