### PR TITLE
Update BN listing

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -77,12 +77,9 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Andrea](https://osu.ppy.sh/users/33599)              | Italian                  |
 | [bossandy](https://osu.ppy.sh/users/360437)           | Chinese                  |
 | [BOUYAAA](https://osu.ppy.sh/users/405449)            | French, some German      |
-| [Cris-](https://osu.ppy.sh/users/6175280)             | Spanish                  |
 | [DeRandom Otaku](https://osu.ppy.sh/users/5156153)    | Urdu                     |
 | [Doormat](https://osu.ppy.sh/users/3230571)           |                          |
 | [Electoz](https://osu.ppy.sh/users/6485263)           | Thai                     |
-| [F D Flourite](https://osu.ppy.sh/users/2459589)      | Chinese                  |
-| [frogyfro](https://osu.ppy.sh/users/7010859)          |                          |
 | [Garden](https://osu.ppy.sh/users/2849992)            | Chinese                  |
 | [Gero](https://osu.ppy.sh/users/1467715)              | Spanish                  |
 | [Gottagof4st](https://osu.ppy.sh/users/6122935)       | Dutch                    |
@@ -90,14 +87,12 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [iYiyo](https://osu.ppy.sh/users/3919785)             | Spanish, some German     |
 | [jonathanlfj](https://osu.ppy.sh/users/270377)        | Chinese, some French     |
 | [Kalibe](https://osu.ppy.sh/users/3376777)            | Polish                   |
-| [Karen](https://osu.ppy.sh/users/3143784)             | Chinese                  |
 | [Kibbleru](https://osu.ppy.sh/users/3193504)          |                          |
 | [Kuron-kun](https://osu.ppy.sh/users/2697284)         | Portuguese               |
 | [Lafayla](https://osu.ppy.sh/users/5312547)           |                          |
 | [MaridiuS](https://osu.ppy.sh/users/4496961)          | Serbian                  |
 | [Mirash](https://osu.ppy.sh/users/2841009)            | Russian                  |
 | [Mordred](https://osu.ppy.sh/users/7265097)           | German                   |
-| [MrSergio](https://osu.ppy.sh/users/2581696)          | Italian, Romanian        |
 | [Namki](https://osu.ppy.sh/users/5248582)             | Estonian, Russian        |
 | [Nao Tomori](https://osu.ppy.sh/users/5364763)        | French                   |
 | [Natsu](https://osu.ppy.sh/users/1953876)             | Spanish                  |
@@ -114,7 +109,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [riffy](https://osu.ppy.sh/users/597957)              | Russian                  |
 | [Rizen](https://osu.ppy.sh/users/3056732)             |                          |
 | [Seto Kousuke](https://osu.ppy.sh/users/2857314)      | Portuguese               |
-| [Sieg](https://osu.ppy.sh/users/1404615)              | Russian                  |
 | [smallboat](https://osu.ppy.sh/users/243049)          | Chinese                  |
 | [Sonnyc](https://osu.ppy.sh/users/11771)              | Korean                   |
 | [TheKingHenry](https://osu.ppy.sh/users/5128277)      | Finnish                  |
@@ -124,7 +118,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [UndeadCapulet](https://osu.ppy.sh/users/2523533)     |                          |
 | [Wishkey](https://osu.ppy.sh/users/1101704)           | Dutch, German            |
 | [Yauxo](https://osu.ppy.sh/users/898306)              | German                   |
-| [Yugu](https://osu.ppy.sh/users/3161834)              | Chinese, some Japanese   |
 
 ### osu!taiko
 
@@ -153,12 +146,10 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Ascendance](https://osu.ppy.sh/users/2931883)        |                          |
 | [Benny-](https://osu.ppy.sh/users/4023183)            | Norwegian                |
 | [Electoz](https://osu.ppy.sh/users/6485263)           | Thai                     |
-| [Fii](https://osu.ppy.sh/users/3922569)               |                          |
 | [JeirYagtama](https://osu.ppy.sh/users/7483452)       | Filipino                 |
 | [Nokashi](https://osu.ppy.sh/users/5431196)           | Greek                    |
 | [Sinnoh](https://osu.ppy.sh/users/4236057)            |                          |
 | [Yumeno Himiko](https://osu.ppy.sh/users/1806962)     | Chinese                  |
-| [ZiRoX](https://osu.ppy.sh/users/200768)              | Spanish                  |
 
 ### osu!mania
 
@@ -168,7 +159,6 @@ _Please note: All BN speak English unless otherwise noted._ Link to the [user gr
 | [Asherz007](https://osu.ppy.sh/users/9014047)         |                          |
 | [Critical_Star](https://osu.ppy.sh/users/3793196)     | Chinese                  |
 | [DoNotMess](https://osu.ppy.sh/users/1596318)         | Indonesian               |
-| [Garalulu](https://osu.ppy.sh/users/757783)           | Korean                   |
 | [Kawawa](https://osu.ppy.sh/users/4647754)            | Korean                   |
 | [Rivals_7](https://osu.ppy.sh/users/4610379)          | Indonesian               |
 | [Sandalphon](https://osu.ppy.sh/users/2633753)        | Chinese                  |


### PR DESCRIPTION
Removed BNs that failed probation/resigned/failed activity
Also removed ZiRox from osu!catch listing as they have been added to the QAT

https://osu.ppy.sh/community/forums/topics/179514?start=6775335

---