### PR TITLE
Add an URL fraction to a link pointing to the Layers section in the Storyboard Scripting General Rules article

### DIFF
--- a/wiki/Storyboard_Scripting/Objects/de.md
+++ b/wiki/Storyboard_Scripting/Objects/de.md
@@ -14,7 +14,7 @@ Um eine Instanz von einem Sprite (immernoch ein Bild) oder eine Animation aufzur
 | ----------- | ------------ |
 | Sprite,(layer),(origin),"(filepath)",(x),(y) | Animation,(layer),(origin),"(filepath)",(x),(y),(frameCount),(frameDelay),(looptype) |
 
--   **(layer)** (eng. für Ebene) ist die **[Ebene](/wiki/Storyboard_Scripting/General_Rules) auf denen Objekte erscheinen.** Erlaubte Werte sind:
+-   **(layer)** (eng. für Ebene) ist die **[Ebene](/wiki/Storyboard_Scripting/General_Rules#ebenen) auf denen Objekte erscheinen.** Erlaubte Werte sind:
     -   Background
     -   Fail
     -   Pass

--- a/wiki/Storyboard_Scripting/Objects/en.md
+++ b/wiki/Storyboard_Scripting/Objects/en.md
@@ -18,7 +18,7 @@ To call an instance of a sprite (a still image) or an animation, use a single li
 
 Where:
 
--   **(layer)** is the **[layer](/wiki/Storyboard_Scripting/General_Rules) the object appears on.** Valid values are:
+-   **(layer)** is the **[layer](/wiki/Storyboard_Scripting/General_Rules#layers) the object appears on.** Valid values are:
     -   Background
     -   Fail
     -   Pass

--- a/wiki/Storyboard_Scripting/Objects/ja.md
+++ b/wiki/Storyboard_Scripting/Objects/ja.md
@@ -18,7 +18,7 @@ SB オブジェクト/スプライト
 
 Where:
 
--   **(layer)** は**オブジェクトが表示される[レイヤーを示します](/wiki/Storyboard_Scripting/General_Rules)。** 有効な値は以下のとおりです:
+-   **(layer)** は**オブジェクトが表示される[レイヤーを示します](/wiki/Storyboard_Scripting/General_Rules#%E3%83%AC%E3%82%A4%E3%83%A4%E3%83%BC)。** 有効な値は以下のとおりです:
     -   Background
     -   Fail
     -   Pass


### PR DESCRIPTION
The link was just pointing to the page, which might confuse users. By adding the fragment to the URL, the page will automatically jump to the correct spot.

---

