### PR TITLE
Update the GMT list for all languages

### DIFF
--- a/wiki/People/Global_Moderation_Team/de.md
+++ b/wiki/People/Global_Moderation_Team/de.md
@@ -27,8 +27,9 @@ Das globale Moderationsteam ist für das Wohlergehen der Chats/Foren zuständig 
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanisch | Tournaments |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Technische Unterstützung |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portugisisch, Japanisch | Chat Moderation |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Koreanisch, Japanisch | Chat Moderation, Forum Moderation |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Spieler Hilfe |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarisch | osu!idol hosting, Forum Moderation, Chat Moderation |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarisch | osu!idol hosting, Forum Moderation |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinesisch | Chat Moderation, Forum Moderation |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Französisch | Chat Moderation, Forum Moderation |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polnisch | Chat Moderation |
@@ -59,6 +60,7 @@ Das globale Moderationsteam ist für das Wohlergehen der Chats/Foren zuständig 
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russisch | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Koreanisch, Japanisch | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Französisch | Chat Moderation |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Philippinisch | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanisch | Technische Unterstützung |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polnisch | Chat Moderation |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technische Unterstützung |

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -24,8 +24,9 @@ The Global Moderation Team is responsible for the welfare of the chat/forum and 
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanish | Tournaments |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Technical Support |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Chat Moderation |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Japanese | Chat Moderation, Forum Moderation |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation, Chat Moderation |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Chat Moderation, Forum Moderation |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | French | Chat Moderation, Forum Moderation |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polish | Chat Moderation |
@@ -56,6 +57,7 @@ The Global Moderation Team is responsible for the welfare of the chat/forum and 
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |

--- a/wiki/People/Global_Moderation_Team/es.md
+++ b/wiki/People/Global_Moderation_Team/es.md
@@ -24,8 +24,9 @@ El Equipo de Moderación Global es responsable del bienestar del chat/foro y se 
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Español | Torneos oficiales |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Soporte técnico |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portugués, Japonés | Moderación del chat |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Coreano, Japonés | Moderación del chat, Moderación del foro |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Asistencia al jugador |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Búlgaro | Presentador de osu! idol, Moderación del foro, Moderación del chat |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Búlgaro | Presentador de osu! idol, Moderación del foro |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chino | Moderación del chat, Moderación del foro |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Francés | Moderación del chat, Moderación del foro |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polaco | Moderación del chat |
@@ -56,6 +57,7 @@ El Equipo de Moderación Global es responsable del bienestar del chat/foro y se 
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Ruso | Moderación del chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coreano, Japonés | Moderación del chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francés | Moderación del chat |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Moderación del chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Español | Soporte técnico |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polaco | Moderación del chat |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Soporte técnico |

--- a/wiki/People/Global_Moderation_Team/fr.md
+++ b/wiki/People/Global_Moderation_Team/fr.md
@@ -27,8 +27,9 @@ L'équipe de modération globale est responsable du maintien de la bonne ambianc
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Espanol | Organisation de tournois |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Support technique |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portugais, Japanese | Modération du Chat |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Coréen, Japanese | Modération du Chat, Modération du Forum |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Support du joueur |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgare | osu!idol hosting, Modération du Forum, Modération du Chat |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgare | osu!idol hosting, Modération du Forum |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinois | Modération du Chat, Modération du Forum |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Français | Modération du Chat, Modération du Forum |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polonais | Modération du Chat |
@@ -59,6 +60,7 @@ L'équipe de modération globale est responsable du maintien de la bonne ambianc
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russe | Modération du Chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coréen, Japanese | Modération du Chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Français | Modération du Chat |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Modération du Chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Espanol | Support technique |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polonais | Modération du Chat |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Support technique |

--- a/wiki/People/Global_Moderation_Team/id.md
+++ b/wiki/People/Global_Moderation_Team/id.md
@@ -24,8 +24,9 @@ Tim Moderasi Global bertanggung jawab atas kesejahteraan chatting / forum dan me
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanyol | Turnamen |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Dukungan Teknis |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portugis, Jepang | Moderasi Chat |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Jepang | Moderasi Chat, Moderasi Forum |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Bantuan pemain |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgaria | osu!idol hosting, Moderasi Forum, Moderasi Chat |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgaria | osu!idol hosting, Moderasi Forum |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Cina | Moderasi Chat, Moderasi Forum |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Perancis | Moderasi Chat, Moderasi Forum |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polandia | Moderasi Chat |
@@ -56,6 +57,7 @@ Tim Moderasi Global bertanggung jawab atas kesejahteraan chatting / forum dan me
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Rusia | Moderasi Chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Jepang | Moderasi Chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Perancis | Moderasi Chat |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipina | Moderasi Chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanyol | Dukungan Teknis |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polandia | Moderasi Chat |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Dukungan Teknis |

--- a/wiki/People/Global_Moderation_Team/it.md
+++ b/wiki/People/Global_Moderation_Team/it.md
@@ -27,8 +27,9 @@ I Global Moderation Team sono responsabili del benessere della chat/forum e si p
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spagnolo | Tornei |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Supporto Tecnico |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portoghese, Japanese | Moderazione della chat |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Coreano, Japanese | Moderazione della chat, Moderazione del forum |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Assistenza Giocatori |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgaro | osu!idol hosting, Moderazione del forum, Moderazione della chat |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgaro | osu!idol hosting, Moderazione del forum |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Cinese | Moderazione della chat, Moderazione del forum |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Francese | Moderazione della chat, Moderazione del forum |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polacco | Moderazione della chat |
@@ -59,6 +60,7 @@ I Global Moderation Team sono responsabili del benessere della chat/forum e si p
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russo | Moderazione della chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coreano, Japanese | Moderazione della chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francese | Moderazione della chat |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Moderazione della chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spagnolo | Supporto Tecnico |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polacco | Moderazione della chat |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Supporto Tecnico |

--- a/wiki/People/Global_Moderation_Team/ja.md
+++ b/wiki/People/Global_Moderation_Team/ja.md
@@ -27,8 +27,9 @@ Global Moderation Teamはチャット/フォーラムの快適な運用をサポ
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanish | Tournaments |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Technical Support |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Chat Moderation |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Japanese | Chat Moderation, Forum Moderation |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation, Chat Moderation |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Chat Moderation, Forum Moderation |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | French | Chat Moderation, Forum Moderation |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polish | Chat Moderation |
@@ -59,6 +60,7 @@ Global Moderation Teamはチャット/フォーラムの快適な運用をサポ
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |

--- a/wiki/People/Global_Moderation_Team/ko.md
+++ b/wiki/People/Global_Moderation_Team/ko.md
@@ -24,8 +24,9 @@ Global Moderation Team은 채팅 채널과 포럼의 쾌적한 운용을 책임�
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 스페인어 | 대회 |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | 기술 지원 |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | 포르투갈어, 일본어 | 채팅 관리 |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | 한국어, 일본어  | 채팅 관리, 포럼 관리 |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | 플레이어 지원 |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 불가리아어 | osu! 아이돌 호스팅, 포럼 관리, 채팅 관리 |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 불가리아어 | osu! 아이돌 호스팅, 포럼 관리 |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | 중국어 | 채팅 관리, 포럼 관리 |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | 프랑스어 | 채팅 관리, 포럼 관리 |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | 폴란드어 | 채팅 관리 |
@@ -56,6 +57,7 @@ Global Moderation Team은 채팅 채널과 포럼의 쾌적한 운용을 책임�
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | 러시아어 | 채팅 관리 |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | 한국어, 일본어 | 채팅 관리 |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | 프랑스어 | 채팅 관리 |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | 필리핀어 | 채팅 관리 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 스페인어 | 기술 지원 |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | 폴란드어 | 채팅 관리 |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | 기술 지원 |

--- a/wiki/People/Global_Moderation_Team/pl.md
+++ b/wiki/People/Global_Moderation_Team/pl.md
@@ -24,8 +24,9 @@ Zespół GMT monitoruje i utrzymuje porządek w interakcjach wśród społeczno�
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Hiszpański | Organizacja turniejów |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Pomoc techniczna |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portugalski, Japoński | Moderacja czatu |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Koreański, Japoński | Moderacja czatu oraz Forum |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Pomoc techniczna |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bułgarski | Organizacja osu!idol, Moderacja Forum oraz czatu |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bułgarski | Organizacja osu!idol, Moderacja Forum |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chiński | Moderacja czatu oraz Forum |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Francuski | Moderacja Forum oraz czatu |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polski | Moderacja czatu |
@@ -56,6 +57,7 @@ Zespół GMT monitoruje i utrzymuje porządek w interakcjach wśród społeczno�
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Rosyjski | Moderacja czatu |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Koreański, Japoński | Moderacja czatu |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francuski | Moderacja czatu |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipiński | Moderacja czatu |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Hiszpański | Pomoc techniczna |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polski | Moderacja czatu |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Pomoc techniczna |

--- a/wiki/People/Global_Moderation_Team/pt.md
+++ b/wiki/People/Global_Moderation_Team/pt.md
@@ -27,8 +27,9 @@ O Global Moderation Team é responsável pela moderação do chat/fórum e cuida
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanish | Tournaments |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Technical Support |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Chat Moderation |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Japanese | Chat Moderation, Forum Moderation |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation, Chat Moderation |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Chat Moderation, Forum Moderation |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | French | Chat Moderation, Forum Moderation |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polish | Chat Moderation |
@@ -59,6 +60,7 @@ O Global Moderation Team é responsável pela moderação do chat/fórum e cuida
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |

--- a/wiki/People/Global_Moderation_Team/ru.md
+++ b/wiki/People/Global_Moderation_Team/ru.md
@@ -29,8 +29,9 @@ outdated: true
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | испанский | организация турниров |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | техподдержка |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | португальский, японский | чат |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | корейский, японский | чат, форум |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | игрок поддержки |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | болгарский | организация конкурсов osu!idol, форум, чат |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | болгарский | организация конкурсов osu!idol, форум |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | китайский | чат, форум |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | французский | чат, форум |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | польский | чат |
@@ -61,6 +62,7 @@ outdated: true
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | русский | чат |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | корейский, японский | чат |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | французский | чат |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | тагалог («филиппинский») | чат |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | испанский | техподдержка |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | польский | чат |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | техподдержка |

--- a/wiki/People/Global_Moderation_Team/tl.md
+++ b/wiki/People/Global_Moderation_Team/tl.md
@@ -27,8 +27,9 @@ Ang Global Moderation Team ay responsable sa mga disiplina ng chat/forum at nag-
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanish | Tournaments |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Technical Support |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Chat Moderation |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Japanese | Chat Moderation, Forum Moderation |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation, Chat Moderation |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderation |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Chat Moderation, Forum Moderation |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | French | Chat Moderation, Forum Moderation |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polish | Chat Moderation |
@@ -59,6 +60,7 @@ Ang Global Moderation Team ay responsable sa mga disiplina ng chat/forum at nag-
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |

--- a/wiki/People/Global_Moderation_Team/tr.md
+++ b/wiki/People/Global_Moderation_Team/tr.md
@@ -27,8 +27,9 @@ Global Moderasyon Takımı oyun-içi sohbetin/forumların sağlığından soruml
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanish | Turnuvalar |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | Teknik Destek |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Sohbet Moderasyonu |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | Korean, Japanese | Sohbet Moderasyonu, Forum Moderasyonu |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderasyonu, Sohbet Moderasyonu |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | Bulgarian | osu!idol hosting, Forum Moderasyonu |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Sohbet Moderasyonu, Forum Moderasyonu |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | French | Sohbet Moderasyonu, Forum Moderasyonu |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polish | Sohbet Moderasyonu |
@@ -59,6 +60,7 @@ Global Moderasyon Takımı oyun-içi sohbetin/forumların sağlığından soruml
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Sohbet Moderasyonu |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Sohbet Moderasyonu |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Sohbet Moderasyonu |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Sohbet Moderasyonu |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Teknik Destek |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Sohbet Moderasyonu |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Teknik Destek |

--- a/wiki/People/Global_Moderation_Team/zh.md
+++ b/wiki/People/Global_Moderation_Team/zh.md
@@ -27,8 +27,9 @@ outdated: true
 | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 西班牙语 | 比赛 |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | | 技术支持 |
 | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109) | 葡萄牙语, 日语 | 聊天室管理 |
+| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | 韩语, 日语 | 聊天室管理, 论坛管理 |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | | Player Support |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 保加利亚语 | osu!idol hosting, 论坛管理, 聊天室管理 |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 保加利亚语 | osu!idol hosting, 论坛管理 |
 | ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | 中文 | 聊天室管理, 论坛管理 |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | 法语 | 聊天室管理, 论坛管理 |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | 波兰语 | 聊天室管理 |
@@ -59,6 +60,7 @@ outdated: true
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | 俄语 | 聊天室管理 |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | 韩语, 日语 | 聊天室管理 |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | 法语 | 聊天室管理 |
+| ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | 菲律宾语 | 聊天室管理 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 西班牙语 | 技术支持 |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | 波兰语 | 聊天室管理 |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | 技术支持 |

--- a/wiki/People/Language_Moderators/de.md
+++ b/wiki/People/Language_Moderators/de.md
@@ -14,7 +14,7 @@ Die meisten Channel, die in osu! aufgelistet werden, besitzen ihre eigenen Moder
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Die meisten Channel, die in osu! aufgelistet werden, besitzen ihre eigenen Moder
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/de.md
+++ b/wiki/People/Language_Moderators/de.md
@@ -24,7 +24,7 @@ Die meisten Channel, die in osu! aufgelistet werden, besitzen ihre eigenen Moder
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/en.md
+++ b/wiki/People/Language_Moderators/en.md
@@ -24,7 +24,7 @@ Many of the language channels in osu! have specific moderators who oversee conve
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/en.md
+++ b/wiki/People/Language_Moderators/en.md
@@ -14,7 +14,7 @@ Many of the language channels in osu! have specific moderators who oversee conve
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Many of the language channels in osu! have specific moderators who oversee conve
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/es.md
+++ b/wiki/People/Language_Moderators/es.md
@@ -24,7 +24,7 @@ La mayoría de los canales en osu! tienen sus propios moderadores, que se harán
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/es.md
+++ b/wiki/People/Language_Moderators/es.md
@@ -14,7 +14,7 @@ La mayoría de los canales en osu! tienen sus propios moderadores, que se harán
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ La mayoría de los canales en osu! tienen sus propios moderadores, que se harán
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/fr.md
+++ b/wiki/People/Language_Moderators/fr.md
@@ -14,7 +14,7 @@ Jusqu'au 21 août 2015, il existait des **Chat Moderators**, des modérateurs qu
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Jusqu'au 21 août 2015, il existait des **Chat Moderators**, des modérateurs qu
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/fr.md
+++ b/wiki/People/Language_Moderators/fr.md
@@ -24,7 +24,7 @@ Jusqu'au 21 août 2015, il existait des **Chat Moderators**, des modérateurs qu
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/id.md
+++ b/wiki/People/Language_Moderators/id.md
@@ -24,7 +24,7 @@ Kebanyakan channel-channel yang ditampilkan di osu! memiliki moderatornya masing
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/id.md
+++ b/wiki/People/Language_Moderators/id.md
@@ -14,7 +14,7 @@ Kebanyakan channel-channel yang ditampilkan di osu! memiliki moderatornya masing
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Kebanyakan channel-channel yang ditampilkan di osu! memiliki moderatornya masing
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/it.md
+++ b/wiki/People/Language_Moderators/it.md
@@ -14,7 +14,7 @@ Molti dei canali presenti in osu! hanno i loro moderatori, che si occupano di tu
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Molti dei canali presenti in osu! hanno i loro moderatori, che si occupano di tu
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/it.md
+++ b/wiki/People/Language_Moderators/it.md
@@ -24,7 +24,7 @@ Molti dei canali presenti in osu! hanno i loro moderatori, che si occupano di tu
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/ja.md
+++ b/wiki/People/Language_Moderators/ja.md
@@ -24,7 +24,7 @@ osu!に存在しているほとんどのチャットチャンネルに侵略し�
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/ja.md
+++ b/wiki/People/Language_Moderators/ja.md
@@ -14,7 +14,7 @@ osu!に存在しているほとんどのチャットチャンネルに侵略し�
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ osu!に存在しているほとんどのチャットチャンネルに侵略し�
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/pl.md
+++ b/wiki/People/Language_Moderators/pl.md
@@ -24,7 +24,7 @@ Większość istniejących kanałów osu! ma swoich własnych moderatorów, któ
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/pl.md
+++ b/wiki/People/Language_Moderators/pl.md
@@ -14,7 +14,7 @@ Większość istniejących kanałów osu! ma swoich własnych moderatorów, któ
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Większość istniejących kanałów osu! ma swoich własnych moderatorów, któ
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/pt-br.md
+++ b/wiki/People/Language_Moderators/pt-br.md
@@ -24,7 +24,7 @@ A maioria dos canais presentes no osu! têm seus próprios moderadores, que cuid
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/pt-br.md
+++ b/wiki/People/Language_Moderators/pt-br.md
@@ -14,7 +14,7 @@ A maioria dos canais presentes no osu! têm seus próprios moderadores, que cuid
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ A maioria dos canais presentes no osu! têm seus próprios moderadores, que cuid
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/pt.md
+++ b/wiki/People/Language_Moderators/pt.md
@@ -24,7 +24,7 @@ A maioria dos canais do osu! tem seus próprios moderadores, que cuidam de qualq
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/pt.md
+++ b/wiki/People/Language_Moderators/pt.md
@@ -14,7 +14,7 @@ A maioria dos canais do osu! tem seus próprios moderadores, que cuidam de qualq
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ A maioria dos canais do osu! tem seus próprios moderadores, que cuidam de qualq
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/ru.md
+++ b/wiki/People/Language_Moderators/ru.md
@@ -24,7 +24,7 @@
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/ru.md
+++ b/wiki/People/Language_Moderators/ru.md
@@ -14,7 +14,7 @@
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/tl.md
+++ b/wiki/People/Language_Moderators/tl.md
@@ -24,7 +24,7 @@ Halos lahat ng channels na makikita sa osu! ay may kani-kanilang mga moderators,
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/tl.md
+++ b/wiki/People/Language_Moderators/tl.md
@@ -14,7 +14,7 @@ Halos lahat ng channels na makikita sa osu! ay may kani-kanilang mga moderators,
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ Halos lahat ng channels na makikita sa osu! ay may kani-kanilang mga moderators,
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/tr.md
+++ b/wiki/People/Language_Moderators/tr.md
@@ -14,7 +14,7 @@ osu!'daki pek çok kanalın, o kanaldaki atmosferi bozacak ya da atmosfere ters 
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@ osu!'daki pek çok kanalın, o kanaldaki atmosferi bozacak ya da atmosfere ters 
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/Language_Moderators/tr.md
+++ b/wiki/People/Language_Moderators/tr.md
@@ -24,7 +24,7 @@ osu!'daki pek çok kanalın, o kanaldaki atmosferi bozacak ya da atmosfere ters 
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/zh.md
+++ b/wiki/People/Language_Moderators/zh.md
@@ -24,7 +24,7 @@
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
 | `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
-| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
+| `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |

--- a/wiki/People/Language_Moderators/zh.md
+++ b/wiki/People/Language_Moderators/zh.md
@@ -14,7 +14,7 @@
 | `#czechoslovak` | | |
 | `#dutch` | [Nederlands](https://osu.ppy.sh/forum/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` | | *All Moderators* |
-| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) |
+| `#filipino` | [Tagalog](https://osu.ppy.sh/forum/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
 | `#finnish` | [Suomi](https://osu.ppy.sh/forum/24) | ![][flag_FI] [Lassikko](https://osu.ppy.sh/users/7253731)  |
 | `#french` | [Français](https://osu.ppy.sh/forum/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/forum/37) | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
@@ -23,7 +23,7 @@
 | `#hungarian` | [Magyar](https://osu.ppy.sh/forum/95) | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) |
 | `#indonesian` | [Indonesian](https://osu.ppy.sh/forum/73) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#italian` | [Italiano](https://osu.ppy.sh/forum/36) | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596), ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
+| `#japanese` | [日本語](https://osu.ppy.sh/forum/32) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551), ![][flag_US] [S o h](https://osu.ppy.sh/users/2234772) |
 | `#korean` | [한국어](https://osu.ppy.sh/forum/58) | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069), ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) |
 | `#malaysian` | [Malaysian](https://osu.ppy.sh/forum/94) | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) |
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |

--- a/wiki/People/osu!_Alumni/de.md
+++ b/wiki/People/osu!_Alumni/de.md
@@ -58,7 +58,6 @@ Die **osu! Alumni** sind für ihre bewegenden Beiträge an osu! bekannt. Hätten
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/en.md
+++ b/wiki/People/osu!_Alumni/en.md
@@ -59,7 +59,6 @@ Link to [user group page](https://osu.ppy.sh/groups/16)
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/es.md
+++ b/wiki/People/osu!_Alumni/es.md
@@ -58,7 +58,6 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Moderador del Chat |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/fr.md
+++ b/wiki/People/osu!_Alumni/fr.md
@@ -62,7 +62,6 @@ Les **vétérans**, connus sous le nom de **osu! Alumnis**, ont reçu leur disti
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/id.md
+++ b/wiki/People/osu!_Alumni/id.md
@@ -58,7 +58,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/it.md
+++ b/wiki/People/osu!_Alumni/it.md
@@ -59,7 +59,6 @@ Gli **osu! Alumni** sono coloro che sono conosciuti per i loro contributi che se
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/ja.md
+++ b/wiki/People/osu!_Alumni/ja.md
@@ -58,7 +58,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/ko.md
+++ b/wiki/People/osu!_Alumni/ko.md
@@ -58,7 +58,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/pl.md
+++ b/wiki/People/osu!_Alumni/pl.md
@@ -59,7 +59,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Moderator czatu |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/pt.md
+++ b/wiki/People/osu!_Alumni/pt.md
@@ -58,7 +58,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/ru.md
+++ b/wiki/People/osu!_Alumni/ru.md
@@ -60,7 +60,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | модератор |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/tr.md
+++ b/wiki/People/osu!_Alumni/tr.md
@@ -59,7 +59,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Sohbet Moderatörü |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |

--- a/wiki/People/osu!_Alumni/zh.md
+++ b/wiki/People/osu!_Alumni/zh.md
@@ -58,7 +58,6 @@
 | ![][flag_AU] [Duoprism](https://osu.ppy.sh/users/7186) | BAT |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!dev |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
-| ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
 | ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | Chat Moderator |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |


### PR DESCRIPTION
This PR is intended to update the current Global Moderation Team list, the Language Moderators list and the Alumni list as well, for all available languages, with the following changes:

- Add **[Elfin](https://osu.ppy.sh/users/1399551)** to the Global Moderation Team _(Spoken languages: Korean, Japanese, Area of focus: Chat Moderation, Forum Moderation)_
- Add **[Elfin](https://osu.ppy.sh/users/1399551)** to the Language Moderators of `#korean` and `#japanese`
- Add **[topecnz](https://osu.ppy.sh/users/2103927)** to the Global Moderation Team _(Spoken languages: Filipino, Area of focus: Chat Moderation)_
- Add **[topecnz](https://osu.ppy.sh/users/2103927)** to the Language Moderators of `#filipino`
- Modify **[Flanster](https://osu.ppy.sh/users/447818)**'s Area of focus _(Remove Chat Moderation, as requested)_

- Remove **[Elfin](https://osu.ppy.sh/users/1399551)** from the osu!Alumni _(Moved to the Global Moderation Team)_

---