### PR TITLE
Update GMT, QAT and osu!Alumni pages

### DIFF
--- a/wiki/People/Global_Moderation_Team/de.md
+++ b/wiki/People/Global_Moderation_Team/de.md
@@ -58,12 +58,12 @@ Das globale Moderationsteam ist für das Wohlergehen der Chats/Foren zuständig 
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Chat Moderation |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Deutsch | Chat Moderation, Forum Moderation |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russisch | Chat Moderation |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russisch | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Koreanisch, Japanisch | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Französisch | Chat Moderation |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Philippinisch | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanisch | Technische Unterstützung |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polnisch | Chat Moderation |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technische Unterstützung |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanisch | Chat Moderation, Tournaments, Forum Moderation |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polnisch | Chat Moderation |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinesisch | Chat Moderation |

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -55,12 +55,12 @@ The Global Moderation Team is responsible for the welfare of the chat/forum and 
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Chat Moderation |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | German | Chat Moderation, Forum Moderation |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanish | Chat Moderation, Tournaments, Forum Moderation |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polish | Chat Moderation |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinese | Chat Moderation |

--- a/wiki/People/Global_Moderation_Team/es.md
+++ b/wiki/People/Global_Moderation_Team/es.md
@@ -55,12 +55,12 @@ El Equipo de Moderación Global es responsable del bienestar del chat/foro y se 
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Húngaro | Moderación del chat |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Alemán | Moderación del chat, Moderación del foro |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Ruso | Moderación del chat |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Ruso | Moderación del chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coreano, Japonés | Moderación del chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francés | Moderación del chat |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Moderación del chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Español | Soporte técnico |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polaco | Moderación del chat |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Soporte técnico |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Español | Moderación del chat, Torneos oficiales, Moderación del foro |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polaco | Moderación del chat |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chino | Moderación del chat |

--- a/wiki/People/Global_Moderation_Team/fr.md
+++ b/wiki/People/Global_Moderation_Team/fr.md
@@ -58,12 +58,12 @@ L'équipe de modération globale est responsable du maintien de la bonne ambianc
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hongrois | Modération du Chat |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Allemand | Modération du Chat, Modération du Forum |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russe | Modération du Chat |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russe | Modération du Chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coréen, Japanese | Modération du Chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Français | Modération du Chat |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Modération du Chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Espanol | Support technique |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polonais | Modération du Chat |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Support technique |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Espanol | Modération du Chat, Organisation de tournois, Modération du Forum |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polonais | Modération du Chat |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinois | Modération du Chat |

--- a/wiki/People/Global_Moderation_Team/id.md
+++ b/wiki/People/Global_Moderation_Team/id.md
@@ -55,12 +55,12 @@ Tim Moderasi Global bertanggung jawab atas kesejahteraan chatting / forum dan me
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Moderasi Chat |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Jerman | Moderasi Chat, Moderasi Forum |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Rusia | Moderasi Chat |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Rusia | Moderasi Chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Jepang | Moderasi Chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Perancis | Moderasi Chat |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipina | Moderasi Chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanyol | Dukungan Teknis |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polandia | Moderasi Chat |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Dukungan Teknis |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanyol | Moderasi Chat, Turnamen, Moderasi Forum |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polandia | Moderasi Chat |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Cina | Moderasi Chat |

--- a/wiki/People/Global_Moderation_Team/it.md
+++ b/wiki/People/Global_Moderation_Team/it.md
@@ -58,12 +58,12 @@ I Global Moderation Team sono responsabili del benessere della chat/forum e si p
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Ungherese | Moderazione della chat |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Tedesco | Moderazione della chat, Moderazione del forum |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russo | Moderazione della chat |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russo | Moderazione della chat |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Coreano, Japanese | Moderazione della chat |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francese | Moderazione della chat |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Moderazione della chat |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spagnolo | Supporto Tecnico |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polacco | Moderazione della chat |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Supporto Tecnico |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spagnolo | Moderazione della chat, Tornei, Moderazione del forum |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polacco | Moderazione della chat |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Cinese | Moderazione della chat |

--- a/wiki/People/Global_Moderation_Team/ja.md
+++ b/wiki/People/Global_Moderation_Team/ja.md
@@ -58,12 +58,12 @@ Global Moderation Teamはチャット/フォーラムの快適な運用をサポ
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Chat Moderation |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | German | Chat Moderation, Forum Moderation |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanish | Chat Moderation, Tournaments, Forum Moderation |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polish | Chat Moderation |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinese | Chat Moderation |

--- a/wiki/People/Global_Moderation_Team/ko.md
+++ b/wiki/People/Global_Moderation_Team/ko.md
@@ -55,12 +55,12 @@ Global Moderation Team은 채팅 채널과 포럼의 쾌적한 운용을 책임�
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | 헝가리어 | 채팅 관리 |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 독일어 | 채팅 관리, 포럼 관리 |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | 러시아어 | 채팅 관리 |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | 러시아어 | 채팅 관리 |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | 한국어, 일본어 | 채팅 관리 |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | 프랑스어 | 채팅 관리 |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | 필리핀어 | 채팅 관리 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 스페인어 | 기술 지원 |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | 폴란드어 | 채팅 관리 |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | 기술 지원 |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | 스페인어 | 채팅 관리, 대회, 포럼 관리 |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | 폴란드어 | 채팅 관리 |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | 중국어 | 채팅 관리 |

--- a/wiki/People/Global_Moderation_Team/pl.md
+++ b/wiki/People/Global_Moderation_Team/pl.md
@@ -55,12 +55,12 @@ Zespół GMT monitoruje i utrzymuje porządek w interakcjach wśród społeczno�
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Węgierski | Moderacja czatu |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Niemiecki | Moderacja Forum oraz czatu |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Rosyjski | Moderacja czatu |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Rosyjski | Moderacja czatu |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Koreański, Japoński | Moderacja czatu |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | Francuski | Moderacja czatu |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipiński | Moderacja czatu |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Hiszpański | Pomoc techniczna |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polski | Moderacja czatu |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Pomoc techniczna |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Hiszpański | Moderacja czatu oraz Forum, Organizacja turniejów |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polski | Moderacja czatu |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chiński | Moderacja czatu |

--- a/wiki/People/Global_Moderation_Team/pt.md
+++ b/wiki/People/Global_Moderation_Team/pt.md
@@ -58,12 +58,12 @@ O Global Moderation Team é responsável pela moderação do chat/fórum e cuida
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Chat Moderation |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | German | Chat Moderation, Forum Moderation |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanish | Chat Moderation, Tournaments, Forum Moderation |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polish | Chat Moderation |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinese | Chat Moderation |

--- a/wiki/People/Global_Moderation_Team/ru.md
+++ b/wiki/People/Global_Moderation_Team/ru.md
@@ -60,12 +60,12 @@ outdated: true
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | венгерский | чат |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | немецкий | чат, форум |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | русский | чат |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | русский | чат |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | корейский, японский | чат |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | французский | чат |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | тагалог («филиппинский») | чат |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | испанский | техподдержка |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | польский | чат |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | техподдержка |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | испанский | чат, организация турниров, форум |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | польский | чат |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | китайский | чат |

--- a/wiki/People/Global_Moderation_Team/tl.md
+++ b/wiki/People/Global_Moderation_Team/tl.md
@@ -58,12 +58,12 @@ Ang Global Moderation Team ay responsable sa mga disiplina ng chat/forum at nag-
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Chat Moderation |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | German | Chat Moderation, Forum Moderation |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Chat Moderation |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russian | Chat Moderation |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Chat Moderation |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Chat Moderation |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat Moderation |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical Support |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Chat Moderation |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Technical Support |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanish | Chat Moderation, Tournaments, Forum Moderation |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polish | Chat Moderation |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinese | Chat Moderation |

--- a/wiki/People/Global_Moderation_Team/tr.md
+++ b/wiki/People/Global_Moderation_Team/tr.md
@@ -58,12 +58,12 @@ Global Moderasyon Takımı oyun-içi sohbetin/forumların sağlığından soruml
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | Hungarian | Sohbet Moderasyonu |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | German | Sohbet Moderasyonu, Forum Moderasyonu |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | Russian | Sohbet Moderasyonu |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | Russian | Sohbet Moderasyonu |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese | Sohbet Moderasyonu |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | French | Sohbet Moderasyonu |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Sohbet Moderasyonu |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Teknik Destek |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | Polish | Sohbet Moderasyonu |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | Teknik Destek |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Spanish | Sohbet Moderasyonu, Turnuvalar, Forum Moderasyonu |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | Polish | Sohbet Moderasyonu |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | Chinese | Sohbet Moderasyonu |

--- a/wiki/People/Global_Moderation_Team/zh.md
+++ b/wiki/People/Global_Moderation_Team/zh.md
@@ -58,12 +58,12 @@ outdated: true
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | 匈牙利语 | 聊天室管理 |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 德语 | 聊天室管理, 论坛管理 |
 | ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) | 俄语 | 聊天室管理 |
+| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | 俄语 | 聊天室管理 |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | 韩语, 日语 | 聊天室管理 |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | 法语 | 聊天室管理 |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | 菲律宾语 | 聊天室管理 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 西班牙语 | 技术支持 |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | 波兰语 | 聊天室管理 |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | | 技术支持 |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | 西班牙语 | 聊天室管理, 比赛, 论坛管理 |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | 波兰语 | 聊天室管理 |
 | ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | 中文 | 聊天室管理 |

--- a/wiki/People/Language_Moderators/de.md
+++ b/wiki/People/Language_Moderators/de.md
@@ -29,7 +29,7 @@ Die meisten Channel, die in osu! aufgelistet werden, besitzen ihre eigenen Moder
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/en.md
+++ b/wiki/People/Language_Moderators/en.md
@@ -29,7 +29,7 @@ Many of the language channels in osu! have specific moderators who oversee conve
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/es.md
+++ b/wiki/People/Language_Moderators/es.md
@@ -29,7 +29,7 @@ La mayoría de los canales en osu! tienen sus propios moderadores, que se harán
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/fr.md
+++ b/wiki/People/Language_Moderators/fr.md
@@ -29,7 +29,7 @@ Jusqu'au 21 août 2015, il existait des **Chat Moderators**, des modérateurs qu
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/id.md
+++ b/wiki/People/Language_Moderators/id.md
@@ -29,7 +29,7 @@ Kebanyakan channel-channel yang ditampilkan di osu! memiliki moderatornya masing
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/it.md
+++ b/wiki/People/Language_Moderators/it.md
@@ -29,7 +29,7 @@ Molti dei canali presenti in osu! hanno i loro moderatori, che si occupano di tu
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/ja.md
+++ b/wiki/People/Language_Moderators/ja.md
@@ -29,7 +29,7 @@ osu!に存在しているほとんどのチャットチャンネルに侵略し�
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/pl.md
+++ b/wiki/People/Language_Moderators/pl.md
@@ -29,7 +29,7 @@ Większość istniejących kanałów osu! ma swoich własnych moderatorów, któ
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/pt-br.md
+++ b/wiki/People/Language_Moderators/pt-br.md
@@ -29,7 +29,7 @@ A maioria dos canais presentes no osu! têm seus próprios moderadores, que cuid
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/pt.md
+++ b/wiki/People/Language_Moderators/pt.md
@@ -29,7 +29,7 @@ A maioria dos canais do osu! tem seus próprios moderadores, que cuidam de qualq
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/ru.md
+++ b/wiki/People/Language_Moderators/ru.md
@@ -29,7 +29,7 @@
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/tl.md
+++ b/wiki/People/Language_Moderators/tl.md
@@ -29,7 +29,7 @@ Halos lahat ng channels na makikita sa osu! ay may kani-kanilang mga moderators,
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/tr.md
+++ b/wiki/People/Language_Moderators/tr.md
@@ -29,7 +29,7 @@ osu!'daki pek çok kanalın, o kanaldaki atmosferi bozacak ya da atmosfere ters 
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Language_Moderators/zh.md
+++ b/wiki/People/Language_Moderators/zh.md
@@ -29,7 +29,7 @@
 | `#polish` | [Polski](https://osu.ppy.sh/forum/26) | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570), ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865), ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) |
 | `#portuguese` | [Português](https://osu.ppy.sh/forum/74) | ![][flag_BR] [Edu](https://osu.ppy.sh/users/5618109), ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) |
 | `#romanian` | | ![][flag_IT] [MrSergio](https://osu.ppy.sh/users/2581696) |
-| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436) |
+| `#russian` | [Русский](https://osu.ppy.sh/forum/35) | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533), ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646), ![][flag_RU] [stymlice](https://osu.ppy.sh/users/5122436), ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) |
 | `#skandinavian` | [Skandinavien](https://osu.ppy.sh/forum/77) | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) |
 | `#spanish` | [Español](https://osu.ppy.sh/forum/33) | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042), ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656), ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568), ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392), ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/forum/54) | |

--- a/wiki/People/Quality_Assurance_Team/en.md
+++ b/wiki/People/Quality_Assurance_Team/en.md
@@ -17,6 +17,7 @@ Link to [user group page](https://osu.ppy.sh/groups/7)
 
 | Name                                              | osu!         | osu!taiko    | osu!catch    | osu!mania    | Additional Languages        |
 |---------------------------------------------------|:------------:|:------------:|:------------:|:------------:|:----------------------------|
+| [-Kazu-](https://osu.ppy.sh/users/920861)             | ![No][false] | ![Yes][true] | ![No][false] | ![No][false] | Spanish                 |
 | [-Mo-](https://osu.ppy.sh/users/2202163)              | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Aloda](https://osu.ppy.sh/users/1190127)             | ![No][false] | ![Yes][true] | ![No][false] | ![No][false] |                         |
 | [Chaoslitz](https://osu.ppy.sh/users/3621552)         | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Cantonese, Chinese      |
@@ -24,13 +25,12 @@ Link to [user group page](https://osu.ppy.sh/groups/7)
 | [Feerum](https://osu.ppy.sh/users/4815717)            | ![No][false] | ![No][false] | ![No][false] | ![Yes][true] | German, Polish          |
 | [Fycho](https://osu.ppy.sh/users/1876867)             | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Chinese                 |
 | [Gabe](https://osu.ppy.sh/users/654108)               | ![Yes][true] | ![Yes][true] | ![No][false] | ![No][false] | French                  |
-| [Hobbes2](https://osu.ppy.sh/users/8157492)           | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Telugu                  |
 | [JBHyperion](https://osu.ppy.sh/users/4879508)        | ![No][false] | ![No][false] | ![Yes][true] | ![No][false] |                         |
+| [Kibbleru](https://osu.ppy.sh/users/3193504)          | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Lanturn](https://osu.ppy.sh/users/1446665)           | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Lasse](https://osu.ppy.sh/users/896613)              | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | German                  |
 | [Mao](https://osu.ppy.sh/users/2204515)               | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | German                  |
 | [Maxus](https://osu.ppy.sh/users/4335785)             | ![No][false] | ![No][false] | ![No][false] | ![Yes][true] | Indonesian              |
-| [Mir](https://osu.ppy.sh/users/8688812)               | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] |                         |
 | [Naxess](https://osu.ppy.sh/users/8129817)            | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | Swedish                 |
 | [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) | ![No][false] | ![Yes][true] | ![No][false] | ![No][false] | Chinese, Cantonese      |
 | [p3n](https://osu.ppy.sh/users/123703)                | ![Yes][true] | ![No][false] | ![No][false] | ![No][false] | German                  |

--- a/wiki/People/osu!_Alumni/de.md
+++ b/wiki/People/osu!_Alumni/de.md
@@ -129,6 +129,7 @@ Die **osu! Alumni** sind für ihre bewegenden Beiträge an osu! bekannt. Hätten
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@ Die **osu! Alumni** sind für ihre bewegenden Beiträge an osu! bekannt. Hätten
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/de.md
+++ b/wiki/People/osu!_Alumni/de.md
@@ -187,7 +187,6 @@ Die **osu! Alumni** sind für ihre bewegenden Beiträge an osu! bekannt. Hätten
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/en.md
+++ b/wiki/People/osu!_Alumni/en.md
@@ -130,6 +130,7 @@ Link to [user group page](https://osu.ppy.sh/groups/16)
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -193,6 +194,7 @@ Link to [user group page](https://osu.ppy.sh/groups/16)
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/en.md
+++ b/wiki/People/osu!_Alumni/en.md
@@ -188,7 +188,6 @@ Link to [user group page](https://osu.ppy.sh/groups/16)
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/es.md
+++ b/wiki/People/osu!_Alumni/es.md
@@ -187,7 +187,6 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/es.md
+++ b/wiki/People/osu!_Alumni/es.md
@@ -129,6 +129,7 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Moderador del Chat |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Equipo de Soporte |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/fr.md
+++ b/wiki/People/osu!_Alumni/fr.md
@@ -133,6 +133,7 @@ Les **vétérans**, connus sous le nom de **osu! Alumnis**, ont reçu leur disti
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -196,6 +197,7 @@ Les **vétérans**, connus sous le nom de **osu! Alumnis**, ont reçu leur disti
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/fr.md
+++ b/wiki/People/osu!_Alumni/fr.md
@@ -191,7 +191,6 @@ Les **vétérans**, connus sous le nom de **osu! Alumnis**, ont reçu leur disti
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/id.md
+++ b/wiki/People/osu!_Alumni/id.md
@@ -187,7 +187,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/id.md
+++ b/wiki/People/osu!_Alumni/id.md
@@ -129,6 +129,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/it.md
+++ b/wiki/People/osu!_Alumni/it.md
@@ -188,7 +188,6 @@ Gli **osu! Alumni** sono coloro che sono conosciuti per i loro contributi che se
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/it.md
+++ b/wiki/People/osu!_Alumni/it.md
@@ -130,6 +130,7 @@ Gli **osu! Alumni** sono coloro che sono conosciuti per i loro contributi che se
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -193,6 +194,7 @@ Gli **osu! Alumni** sono coloro che sono conosciuti per i loro contributi che se
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/ja.md
+++ b/wiki/People/osu!_Alumni/ja.md
@@ -187,7 +187,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/ja.md
+++ b/wiki/People/osu!_Alumni/ja.md
@@ -129,6 +129,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/ko.md
+++ b/wiki/People/osu!_Alumni/ko.md
@@ -187,7 +187,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/ko.md
+++ b/wiki/People/osu!_Alumni/ko.md
@@ -129,6 +129,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/pl.md
+++ b/wiki/People/osu!_Alumni/pl.md
@@ -188,7 +188,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/pl.md
+++ b/wiki/People/osu!_Alumni/pl.md
@@ -130,6 +130,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -193,6 +194,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Moderator czatu |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Członek Pomocy Technicznej |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/pt.md
+++ b/wiki/People/osu!_Alumni/pt.md
@@ -187,7 +187,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/pt.md
+++ b/wiki/People/osu!_Alumni/pt.md
@@ -129,6 +129,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/ru.md
+++ b/wiki/People/osu!_Alumni/ru.md
@@ -131,6 +131,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -194,6 +195,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | модератор |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | техподдержка |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/ru.md
+++ b/wiki/People/osu!_Alumni/ru.md
@@ -189,7 +189,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/tr.md
+++ b/wiki/People/osu!_Alumni/tr.md
@@ -188,7 +188,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/tr.md
+++ b/wiki/People/osu!_Alumni/tr.md
@@ -130,6 +130,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -193,6 +194,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Sohbet Moderatörü |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Destek Ekibi |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |

--- a/wiki/People/osu!_Alumni/zh.md
+++ b/wiki/People/osu!_Alumni/zh.md
@@ -187,7 +187,6 @@
 | ![][flag_ZA] [Teara](https://osu.ppy.sh/users/123491) | BAT |
 | ![][flag_AU] [tensheapz](https://osu.ppy.sh/users/60) | BAT |
 | ![][flag_SE] [theowest](https://osu.ppy.sh/users/60604) | GMT |
-| ![][flag_RU] [TicClick](https://osu.ppy.sh/users/672931) | QAT |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | BAT |
 | ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878) | BAT |
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |

--- a/wiki/People/osu!_Alumni/zh.md
+++ b/wiki/People/osu!_Alumni/zh.md
@@ -129,6 +129,7 @@
 | ![][flag_JP] [Melophobia](https://osu.ppy.sh/users/1077845) | BAT |
 | ![][flag_KR] [Minato Yukina](https://osu.ppy.sh/users/531253) | QAT |
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
+| ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | QAT |
 | ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
@@ -192,6 +193,7 @@
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Chat Moderator |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Support Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |


### PR DESCRIPTION
This PR is intended to update the current Global Moderation Team list, the Language Moderators list and the Alumni list for all available languages, and also the Quality Assurance Team list for English language only, with the following changes _(I might attempt to update the QAT list for the rest of the languages in another PR, but I'll probably have to consult with the others beforehand, because those pages are quite outdated)_:

- Add **[TicClick](https://osu.ppy.sh/users/672931)** to the Global Moderation Team _(Additional language: Russian, Area of focus: Chat Moderation)_
- Add **[TicClick](https://osu.ppy.sh/users/672931)** to the Language Moderators of `#russian`
- Remove **[TicClick](https://osu.ppy.sh/users/672931)** from the osu!Alumni _(Moved to the Global Moderation Team)_
- Remove **[VeilStar](https://osu.ppy.sh/users/4255720)** from the Global Moderation Team _(Moved to the osu!Alumni)_
- Add **[VeilStar](https://osu.ppy.sh/users/4255720)** to the osu!Alumni _(Epitaph: Technical Support)_
- Add **[-Kazu-](https://osu.ppy.sh/users/920861)** to the Quality Assurance Team _(Area: osu!taiko, Additional Language: Spanish)_
- Add **[Kibbleru](https://osu.ppy.sh/users/3193504)** to the Quality Assurance Team _(Area: osu!)_
- Remove **[Hobbes2](https://osu.ppy.sh/users/8157492)** from the Quality Assurance Team
- Remove **[Mir](https://osu.ppy.sh/users/8688812)** from the Quality Assurance Team _(Moved to the osu!Alumni)_
- Add **[Mir](https://osu.ppy.sh/users/8688812)** to the osu!Alumni _(Epitaph: QAT)_
---