### PR TITLE
Fix Belgian flag not loading in the osu! Alumni pages

### DIFF
--- a/wiki/People/Global_Moderation_Team/de.md
+++ b/wiki/People/Global_Moderation_Team/de.md
@@ -72,7 +72,6 @@ Das globale Moderationsteam ist für das Wohlergehen der Chats/Foren zuständig 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -69,7 +69,6 @@ The Global Moderation Team is responsible for the welfare of the chat/forum and 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/es.md
+++ b/wiki/People/Global_Moderation_Team/es.md
@@ -69,7 +69,6 @@ El Equipo de Moderación Global es responsable del bienestar del chat/foro y se 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/fr.md
+++ b/wiki/People/Global_Moderation_Team/fr.md
@@ -72,7 +72,6 @@ L'équipe de modération globale est responsable du maintien de la bonne ambianc
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/id.md
+++ b/wiki/People/Global_Moderation_Team/id.md
@@ -69,7 +69,6 @@ Tim Moderasi Global bertanggung jawab atas kesejahteraan chatting / forum dan me
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/it.md
+++ b/wiki/People/Global_Moderation_Team/it.md
@@ -72,7 +72,6 @@ I Global Moderation Team sono responsabili del benessere della chat/forum e si p
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/ja.md
+++ b/wiki/People/Global_Moderation_Team/ja.md
@@ -72,7 +72,6 @@ Global Moderation Teamはチャット/フォーラムの快適な運用をサポ
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/ko.md
+++ b/wiki/People/Global_Moderation_Team/ko.md
@@ -69,7 +69,6 @@ Global Moderation Team은 채팅 채널과 포럼의 쾌적한 운용을 책임�
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/pl.md
+++ b/wiki/People/Global_Moderation_Team/pl.md
@@ -69,7 +69,6 @@ Zespół GMT monitoruje i utrzymuje porządek w interakcjach wśród społeczno�
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/pt.md
+++ b/wiki/People/Global_Moderation_Team/pt.md
@@ -72,7 +72,6 @@ O Global Moderation Team é responsável pela moderação do chat/fórum e cuida
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/ru.md
+++ b/wiki/People/Global_Moderation_Team/ru.md
@@ -74,7 +74,6 @@ outdated: true
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/tl.md
+++ b/wiki/People/Global_Moderation_Team/tl.md
@@ -72,7 +72,6 @@ Ang Global Moderation Team ay responsable sa mga disiplina ng chat/forum at nag-
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/tr.md
+++ b/wiki/People/Global_Moderation_Team/tr.md
@@ -72,7 +72,6 @@ Global Moderasyon Takımı oyun-içi sohbetin/forumların sağlığından soruml
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/Global_Moderation_Team/zh.md
+++ b/wiki/People/Global_Moderation_Team/zh.md
@@ -72,7 +72,6 @@ outdated: true
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AT]: /wiki/shared/flag/AT.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BG]: /wiki/shared/flag/BG.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif

--- a/wiki/People/osu!_Alumni/de.md
+++ b/wiki/People/osu!_Alumni/de.md
@@ -213,6 +213,7 @@ Die **osu! Alumni** sind für ihre bewegenden Beiträge an osu! bekannt. Hätten
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/en.md
+++ b/wiki/People/osu!_Alumni/en.md
@@ -214,6 +214,7 @@ Link to [user group page](https://osu.ppy.sh/groups/16)
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/es.md
+++ b/wiki/People/osu!_Alumni/es.md
@@ -213,6 +213,7 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/fr.md
+++ b/wiki/People/osu!_Alumni/fr.md
@@ -217,6 +217,7 @@ Les **vétérans**, connus sous le nom de **osu! Alumnis**, ont reçu leur disti
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/id.md
+++ b/wiki/People/osu!_Alumni/id.md
@@ -213,6 +213,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/it.md
+++ b/wiki/People/osu!_Alumni/it.md
@@ -214,6 +214,7 @@ Gli **osu! Alumni** sono coloro che sono conosciuti per i loro contributi che se
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/ja.md
+++ b/wiki/People/osu!_Alumni/ja.md
@@ -213,6 +213,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/ko.md
+++ b/wiki/People/osu!_Alumni/ko.md
@@ -213,6 +213,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/pl.md
+++ b/wiki/People/osu!_Alumni/pl.md
@@ -214,6 +214,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/pt.md
+++ b/wiki/People/osu!_Alumni/pt.md
@@ -213,6 +213,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/ru.md
+++ b/wiki/People/osu!_Alumni/ru.md
@@ -215,6 +215,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/tr.md
+++ b/wiki/People/osu!_Alumni/tr.md
@@ -214,6 +214,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif

--- a/wiki/People/osu!_Alumni/zh.md
+++ b/wiki/People/osu!_Alumni/zh.md
@@ -213,6 +213,7 @@
 
 [flag_AR]: /wiki/shared/flag/AR.gif
 [flag_AU]: /wiki/shared/flag/AU.gif
+[flag_BE]: /wiki/shared/flag/BE.gif
 [flag_BR]: /wiki/shared/flag/BR.gif
 [flag_CA]: /wiki/shared/flag/CA.gif
 [flag_CH]: /wiki/shared/flag/CH.gif


### PR DESCRIPTION
In my last PR ([#1785](https://github.com/ppy/osu-wiki/pull/1785)) I overlooked a flag issue where by moving [VeilStar](https://osu.ppy.sh/users/4255720) from the GMT to the osu! Alumni, made their flag's icon doesn't load in the Alumni pages, because there weren't any Belgian members yet:
![image](https://spkz.s-ul.eu/3L6aMJe4.png)
So for addressing this issue, this PR is for two changes:
- Remove the Belgian flag from image pre-loads in the GMT pages, since [VeilStar](https://osu.ppy.sh/users/4255720) was the only Belgian member of the GMT and has been moved to the Alumni since.
- Add the Belgian flag to image pre-loads in the osu! Alumni pages, so it will show properly.
---