### PR TITLE
No longer recommend updating to Cutting Edge

### DIFF
--- a/wiki/osu!tourney/Troubleshooting/en.md
+++ b/wiki/osu!tourney/Troubleshooting/en.md
@@ -51,6 +51,6 @@ Don't forget to adjust the cropping to remove the black control panel from the s
 
 ## My issue/question is not listed here! What to do?
 
-Make sure that osu! is not run as administrator, unless it asked for it on its own, and that it is updated to the newest CuttingEdge build.
+Make sure that osu! is not run as administrator, unless it asked for it on its own, and that it is updated.
 
 Email [tournaments@ppy.sh](mailto:tournaments@ppy.sh) if you have a problem that is not listed here. Make sure to be descriptive and provide screenshots if possible.


### PR DESCRIPTION
CE has been in flux as of the last couple of tournaments, as more and more stuff has been moved to lazer and designs have been adjusted accordingly. Telling people to use CE will result in their tournament displaying a design that doesn't fit with the latest provided [template](https://osu.ppy.sh/help/wiki/osu!tourney/Skinning/).

Stable has been stable for a long period for use in tournaments, thus far.