### PR TITLE
Add missing official tournament discussion threads

### DIFF
--- a/wiki/Tournaments/MWC/2015/en.md
+++ b/wiki/Tournaments/MWC/2015/en.md
@@ -50,8 +50,8 @@ The osu!mania 4K World Cup 2015 is run by various community members by distribut
 
 ## Links
 
+- [Discussion thread](https://osu.ppy.sh/community/forums/topics/345431)
 - [Livestream](https://www.twitch.tv/osulive)
-- **[Group Stage statistics](https://owc.nicarim.pw/results/view/6)**
 
 ------------------------------------------------------------------------
 

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -34,7 +34,7 @@ The osu! World Cup #2 was run by various community members by distributing the m
 
 ## Links
 
-- [Tournament schedule](https://docs.google.com/document/d/1aYgninqJ6OolEvkynUsirJMpt8ZcV4Eksb7p4xuU2Jg/edit)
+- [Discussion thread](https://osu.ppy.sh/community/forums/topics/65535)
 - [Pre-tournament interviews](https://docs.google.com/document/d/1xgR7cfCf1yZD1j90_ObGKccS_9OMA6rDHhYJy8uRxNE/edit)
 
 ------------------------------------------


### PR DESCRIPTION
Also removed the broken and not useful links. Missing [TWC 2016](https://github.com/ppy/osu-wiki/blob/master/wiki/Tournaments/TWC/2016/en.md) ~as I am currently unifying the format of TWC right now and will be referenced in another PR's commit.~ Busy...

---