### PR TITLE
Fix author not showing on Yuzu's news header

### DIFF
--- a/news/2019-01-09-introducing-yuzu.md
+++ b/news/2019-01-09-introducing-yuzu.md
@@ -50,7 +50,7 @@ Hmm? Is that someone banging on my door? Oh, welp, guess it's time for me to get
 
 *[Download the full, high quality design documentation here!](https://assets.ppy.sh/media/yuzu/yuzu-hq.pdf)*
 
-—Yuzu
-
-Character Design & Illustrations: [Thievley](https://osu.ppy.sh/users/4717672)\
+Character Design & Illustrations: [Thievley](https://osu.ppy.sh/users/4717672)  
 Key Art & Additional Illustrations: [Crowie](https://osu.ppy.sh/users/6894067)
+
+—Yuzu


### PR DESCRIPTION
Some new feature that the author is shown in the news header *if the ending line is the em-dash + author*.

---