### PR TITLE
Catch RC combo colour rule fix

### DIFF
--- a/wiki/Ranking_Criteria/osu!catch/en.md
+++ b/wiki/Ranking_Criteria/osu!catch/en.md
@@ -57,7 +57,7 @@ Overall rules and guidelines apply to every kind of osu!catch difficulty.
 - **Sliderends of extended sliders should be snapped according to the song's beat structure.** If the song is using a straight beat, 1/4, 1/8, and 1/16 should be used. If the song is using a swing beat, 1/6 or 1/12 should be used. If the song has a sound in a different snap from what was recommended, snapping to an actual beat always takes priority.
 - **Slider tick rate should be set according to the song.** For example if your song only uses 1/3 snapping, using tick rate 2 or 4 would not be fitting.
 - **Avoid using combo colours with ~50 luminosity or lower.** Dark colours impact readability of fruits with low background dim.
-- **Avoid using combo colours with ~220 luminosity or higher.** They create bright pulses during Kiai time which can be unpleasant to the eyes.
+- **Avoid using combo colours with ~220 luminosity or higher if Kiai time is used.** Light colours create bright pulses during Kiai time, which can be unpleasant to the eyes.
 - **Avoid replacing the hit finish in soft/normal samplesets with frequently used custom hit sound samples.** This can sound obnoxious for anyone disabling beatmap hit sounds. Replacing hit whistles/claps is recommended because those samples are used more often.
 
 ### Skinning


### PR DESCRIPTION
When adding rules about combo colours, I assumed kiai would always be used but it doesn't have to be. This fixes my oversight.