### PR TITLE
Fix quotes on news page metadata

### DIFF
--- a/news/2016-05-06-osu-circles-remix-contest.md
+++ b/news/2016-05-06-osu-circles-remix-contest.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "osu! "circles!" Remix Contest"
+title: 'osu! "circles!" Remix Contest'
 permalink: http://osunews.tumblr.com/post/143933020033/osu-circles-remix-contest
 date: 2016-05-06 07:40:41 +0000
 tumblr_url: http://osunews.tumblr.com/post/143933020033/osu-circles-remix-contest


### PR DESCRIPTION
String values must be in correct format (double quotes in a double quoted string isn't). Github not rendering the box should provide a good hint something is wrong.