### PR TITLE
Update Beatmap Nominators article for restructure

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -11,12 +11,12 @@ The Beatmap Nominators, commonly abbreviated as *BN*, is a group in charge of [b
 Roles and Responsibilities
 --------------------------
 
-Members of the Beatmap Nominators are responsible primarily for [modding](/wiki/Modding) the [pending beatmaps](/wiki/Beatmaps) into the ranking cycle. Beatmap Nominators are the people to go to for advice or requests about anything mapping or modding related. They are also responsible for disqualifying beatmaps in the qualified section that are found to have significant issues.
+Members of the Beatmap Nominators are responsible primarily for [modding](/wiki/Modding) the [pending beatmaps](/wiki/Beatmaps) into the ranking cycle. Beatmap Nominators are the people to go to for advice or requests about anything mapping or modding related. Full members of the Beatmap Nominators are also responsible for disqualifying beatmaps in the qualified section that are found to have significant issues, while probationary Beatmap Nominators focus solely on nomination.
 
 Becoming a Beatmap Nominator
 ----------------------------
 
-With the change to the team in May 2019, joining the Beatmap Nominators became a lot easier than it used to be in the past. Applications to join can be submitted on [this website](http://bn.mappersguild.com). 
+With the change to the team in May 2019, joining the Beatmap Nominators became a lot easier than it used to be in the past. Applications to join can be submitted on [this website](http://bn.mappersguild.com/bnapps). 
 
 Applicants are required to meet a modding activity requirement, submit at least two maps they have recently modded, and complete a test on the [ranking criteria](/wiki/Ranking_Criteria) in order to submit their application. There is a 90 day cooldown for submitting new applications once an application has been submitted. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 
@@ -31,7 +31,7 @@ Modders that aim to apply to the Beatmap Nominators must fulfil the following cr
 + A mod post qualifies as one if it has received a Kudosu and has been created within the 3 months.
 + Since November 2017, beatmaps affected under Modding V2 had a reward system implemented based on upvotes/downvotes. The "mod post" equivalent in this case is a beatmap discussion, in which at least one suggestion/problem got awarded with an upvote.
 + The gamemode (osu!, osu!mania, osu!catch, osu!taiko) that you modded beatmaps in does not matter as your activity in the modding community as a whole is being measured and not the activity in a certain game mode.
-+ The point in time at which the Kudosu has been awarded to your mod post **does** matter. 
++ The point in time at which the Kudosu has been awarded to your mod post **does** matter, as the calculator embed in the website will fetch the data from your own Modding History events. 
 
 ### How the Required Minimum Score is Calculated
 + This depends on the total `Mod Score` an applicant achieved over the last months. This value is determined according to the following formula:
@@ -68,7 +68,7 @@ Team Members
 
 The tables listed below indicate the game mode(s) in which each Beatmap Nominator is formally qualified to nominate.
 
-_Please note: All BN speak English unless otherwise noted._ Link to the [user group page](https://osu.ppy.sh/groups/28).
+_Please note: All BN speak English unless otherwise noted._ Link to the [full user group page](https://osu.ppy.sh/groups/28) and [probationary user group page](https://osu.ppy.sh/groups/32).
 
 ### osu!standard
 

--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -6,17 +6,19 @@ Beatmap Nominators
 
 *See also: [Beatmap Nominator Rules](/wiki/Beatmap_Nominator_Rules) and [General Information for Beatmap Nominator](/wiki/Beatmap_Nominator_General_Information)*
 
-The Beatmap Nominators, commonly abbreviated as *BN*, is a group in charge of [beatmap nomination](/wiki/Submission/Beatmap_Ranking_Procedure). As of 2014-08-22, they are no longer a part of the staff, revoking their chat moderation in-game, red name in-game, and on the forums. As of 2015-02-01, the team was changed from the *Beatmap Appreciation Team* to the *Beatmap Nominators*. Currently, they have a purple name on the forums.
+The Beatmap Nominators, commonly abbreviated as *BN*, is a group in charge of [beatmap nomination](/wiki/Submission/Beatmap_Ranking_Procedure). As of 2014-08-22, they are no longer a part of the staff, revoking their chat moderation in-game, red name in-game, and on the forums. As of 2015-02-01, the team was changed from the *Beatmap Appreciation Team* to the *Beatmap Nominators*. Currently, they have a purple name on the forums and in beatmap discussions.
 
 Roles and Responsibilities
 --------------------------
 
-Members of the Beatmap Nominators are responsible primarily for [modding](/wiki/Modding) the [pending beatmaps](/wiki/Beatmaps) into the ranking cycle. Beatmap Nominators are the people to go to for advice or requests about anything mapping or modding related.
+Members of the Beatmap Nominators are responsible primarily for [modding](/wiki/Modding) the [pending beatmaps](/wiki/Beatmaps) into the ranking cycle. Beatmap Nominators are the people to go to for advice or requests about anything mapping or modding related. They are also responsible for disqualifying beatmaps in the qualified section that are found to have significant issues.
 
 Becoming a Beatmap Nominator
 ----------------------------
 
-With the change to the team in August 2014, joining the Beatmap Nominators became a lot easier than it used to be in the past. The [Quality Assurance Team](https://osu.ppy.sh/groups/7) will create a newspost for Beatmap Nominator Sign-ups in irregular intervals of approximately two months.
+With the change to the team in May 2019, joining the Beatmap Nominators became a lot easier than it used to be in the past. Applications to join can be submitted on [this website](http://bn.mappersguild.com). 
+
+Applicants are required to meet a modding activity requirement, submit at least two maps they have recently modded, and complete a test on the [ranking criteria](/wiki/Ranking_Criteria) in order to submit their application. There is a 90 day cooldown for submitting new applications once an application has been submitted. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 
 ### Basic Criteria
 Modders that aim to apply to the Beatmap Nominators must fulfil the following criteria:
@@ -25,11 +27,11 @@ Modders that aim to apply to the Beatmap Nominators must fulfil the following cr
 + They provide 2 to 4 of their mods which they think qualify them to be a part of the Beatmap Nominators.
 
 ### What Qualifies as a Mod Post
-+ Upon signing up you will be asked to provide the total amount of Kudosu as well as the amount of mod posts within the last 3 months, sorted by month upon signing up. So if the announcement is posted in April, the mod posts for January, February, and March will be relevant. The relevant months will also be listed on the submission form.
-+ A mod post qualifies as one if it has received a Kudosu and has been created within the time span listed on the submission form.
++ Upon signing up the website will automatically calculate your kudosu score from the last 3 months.
++ A mod post qualifies as one if it has received a Kudosu and has been created within the 3 months.
 + Since November 2017, beatmaps affected under Modding V2 had a reward system implemented based on upvotes/downvotes. The "mod post" equivalent in this case is a beatmap discussion, in which at least one suggestion/problem got awarded with an upvote.
 + The gamemode (osu!, osu!mania, osu!catch, osu!taiko) that you modded beatmaps in does not matter as your activity in the modding community as a whole is being measured and not the activity in a certain game mode.
-+ The point in time at which the Kudosu has been awarded to you mod post does not matter. The only relevant information about a mod post is its post date and time in UTC+0 as well as the fact that it has been awarded Kudosu.
++ The point in time at which the Kudosu has been awarded to your mod post **does** matter. 
 
 ### How the Required Minimum Score is Calculated
 + This depends on the total `Mod Score` an applicant achieved over the last months. This value is determined according to the following formula:
@@ -49,7 +51,7 @@ Modders that aim to apply to the Beatmap Nominators must fulfil the following cr
 
 ### How new potential Beatmap Nominators are chosen
 + The `Mod Score` of all applications will be doublechecked to confirm if they reached the `Required Minimum Score`.
-+ Modders that acquired enough score will be evaluated by the corresponding QAT members of the game mode they applied for, taking into account the following criteria:
++ Modders that acquired enough score will be evaluated by the corresponding NAT members of the game mode they applied for, taking into account the following criteria:
   + General attitude: Tone of delivery of the mods and other behavioural expectations from the [Code of Conduct](/wiki/Ranking_Criteria/Code_of_Conduct), as well as general behaviour in chat/forums.
   + Modding abilities: Knowledge of the general [Ranking Criteria](/wiki/Ranking_Criteria) and specific criteria of each game mode. Additional abilities like Metadata, Timing, and some others will also be taken into consideration.
 + After evaluating each modder, a discussion will be made on whether the modder will join the Beatmap Nominators.


### PR DESCRIPTION
In preperation for https://github.com/ppy/osu-wiki/pull/2162

QAT -> NAT
New site to apply
BNs can now DQ
Changes to what counts as a mod post for v2

BN listings should be updated at https://github.com/ppy/osu-wiki/pull/2164