### PR TITLE
Fix inaccurate description in the osu!mania Ranking Criteria

### DIFF
--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -20,7 +20,7 @@ Rule proposals as well as suggestions are discussed in the [Ranking Criteria Sub
 - **Column**: Vertical lines on the playfield where notes are placed. The editor uses `0|1|2|3|4|5|6|7|8|9` for timestamp labels. 
 - **Key mode**: The number of columns present in a difficulty.
 - **Key sounding**: Hit sounding using samples extremely similar or directly from the song in their respective places. This method of hit sounding usually provides low feedback to the player.
-- **Slider velocity**: The speed at which the notes/bar lines move on the playfield. Base slider velocity is based user settings and additional changes can be made through inherited (green) timing points.
+- **Slider velocity**: The speed at which the notes/bar lines move on the playfield. Base slider velocity is based on user settings and additional changes can be made through inherited (green) timing points.
 - **Long-term slider velocity**: A slider velocity change lasting more than 4 measures.
 - **Musical phrase**: A standalone unit of musical meter that is usually 4 measures long. 
 - **Short-term slider velocity**: A slider velocity change lasting less than 1/2 of a beat.

--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -20,7 +20,7 @@ Rule proposals as well as suggestions are discussed in the [Ranking Criteria Sub
 - **Column**: Vertical lines on the playfield where notes are placed. The editor uses `0|1|2|3|4|5|6|7|8|9` for timestamp labels. 
 - **Key mode**: The number of columns present in a difficulty.
 - **Key sounding**: Hit sounding using samples extremely similar or directly from the song in their respective places. This method of hit sounding usually provides low feedback to the player.
-- **Slider velocity**: The speed at which the notes/bar lines move on the playfield. Base slider velocity can be controlled in the timing panel and additional changes can be made through inherited (green) timing points.
+- **Slider velocity**: The speed at which the notes/bar lines move on the playfield. Base slider velocity is based user settings and additional changes can be made through inherited (green) timing points.
 - **Long-term slider velocity**: A slider velocity change lasting more than 4 measures.
 - **Musical phrase**: A standalone unit of musical meter that is usually 4 measures long. 
 - **Short-term slider velocity**: A slider velocity change lasting less than 1/2 of a beat.

--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -143,7 +143,7 @@ Bracket patterns should be used sparingly.
 #### Guidelines
 
 - **HP and OD values should not be higher than 8.**
-- **Note snappings of consecutive 1/8 and higher should not be used.** These can be too physically demanding for players of this level. An exception to this rule would be the usage of 3 grace notes that are at higher-end snaps (1/8, 1/12 and 1/16) as they are only used to accentuate gracing sounds.
+- **Note snappings of consecutive 1/8 and higher should not be used.** These can be too physically demanding for players of this level. An exception to this guideline would be the usage of 3 grace notes that are at higher-end snaps (1/8, 1/12 and 1/16) as they are only used to accentuate gracing sounds.
 - **Long streams of 1/4 notes should include, at minimum, a 1/2 pause where natural to implement after every musical phrase.** These can be too physically demanding for players of this level.
 - **Chords within 1/4 streams should be used sparingly.** The density of these patterns is often too difficult for players of this skill level.
 - **Avoid using chords in the middle of 1/6 streams.** However, Using a chord at the beginning or end of a stream is fine.


### PR DESCRIPTION
on osu!mania, its special that Base slider no longer controlled by timing panel, by user setting instead (can press F3/F4 in game to adjusted.)
