### PR TITLE
Song Content Rules Update: Explicit and heavily political content

### DIFF
--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -16,7 +16,7 @@ They will need to be identified by a line in the beatmap's description reflectin
 
 This is a mildly complicated issue and what is acceptable for one person is often not for another.
 
-When considering the appropriateness of a given track, think of the **20% guideline** - is more than 20% of your track's lyrical content a direct reference to something explicit, suggestive, or otherwise controversial? If so, it may not be appropriate for osu!.
+When considering the appropriateness of a given track, think of the **20% guideline**—is more than 20% of your track's lyrical content a direct reference to something explicit, suggestive, or otherwise controversial? If so, it may not be appropriate for osu!.
 
 This guideline is not a hard rule, but more of a way to help inform your choices on what might work and what probably won't.
 
@@ -24,11 +24,11 @@ Many musical styles or genres make use of explicit lyrics for artistic or stylis
 
 If you aren't sure on how to proceed with your track given all this, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) _before_ uploading your mapset!
 
-## What classifies as 'heavily political' content?
+## What classifies as "heavily political" content?
 
 In the interests of keeping a game about rhythm strictly about rhythm and in accordance with Community Rule number 3, content which is deemed excessively political by the administration is disallowed.
 
-We adhere to no one particular 'end' of a political spectrum - osu! is strictly apolitical and we want people to enjoy themselves, not start feuds or quabble over politics.
+We adhere to no one particular "end" of a political spectrum—osu! is strictly apolitical and we want people to enjoy themselves, not start feuds or quabble over politics.
 
 ## What happens if my track isn't okay?
 
@@ -38,5 +38,4 @@ Each time your submission is removed, you will be afforded an explanation by the
 
 You may contest this with them via PM if you so wish, or seek the opinions of others to substantiate your claim to the track's suitability. If you still cannot find common ground on this front, your claim may be escalated to a consensus vote among the current NAT members, who will collectively decide if your track is acceptable or not.
 
-Excluding severely inappropriate uploads, all users are given a **one submission leeway** before penalties are handed out due to the uncertain nature of this ruling.
-After this leeway has passed, users who continually choose to upload inappropriate tracks will face a 42-hour infringement along with the removal of their submission.
+Excluding severely inappropriate uploads, all users are given a **one submission leeway** before penalties are handed out due to the uncertain nature of this ruling. After this leeway has passed, users who continually choose to upload inappropriate tracks will face a 42-hour infringement along with the removal of their submission.

--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -22,7 +22,7 @@ This guideline is not a hard rule, but more of a way to help inform your choices
 
 Many musical styles or genres make use of explicit lyrics for artistic or stylistic ends, and while profanity and explicit content isn't outright forbidden, tracks that are vulgar to the extreme or are deliberately designed to shock or inflame others are not allowed.
 
-If you aren't sure on how to proceed with your track given all this, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) _before_ uploading your mapset!
+If you aren't sure about how to proceed with your track given these guidelines, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) *before* uploading your mapset!
 
 ## What classifies as "heavily political" content?
 

--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -15,13 +15,14 @@ They will need to be identified by a line in the beatmap's description reflectin
 
 This is a mildly complicated issue and what is acceptable for one person is often not for another.
 
-To address this, roughly apply a variant of the **20% rule** - is more than 20% of your track's lyrical content a direct reference to something explicit, suggestive, or otherwise controversial?
+When considering the appropriateness of a given track, think of the **20% guideline** - is more than 20% of your track's lyrical content a direct reference to something explicit, suggestive, or otherwise controversial? If so, it may not be appropriate for osu!.
 
-If you aren't sure on how to proceed with your track given this rough variant, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) _before_ uploading your mapset!
+This guideline is not a hard rule, but more of a way to help inform your choices on what might work and what probably won't.
 
-Any track that is highly intense or shocking in any manner as described in the three criteria above is not allowed regardless of what percentage of its content falls under the classification.
+Many musical styles or genres make use of explicit lyrics for artistic or stylistic ends, and while profanity and explicit content isn't outright forbidden, tracks that are vulgar to the extreme or are deliberately designed to shock or inflame others are not allowed.
 
-What determines "highly intense" should be abundantly obvious to a large selection of random people.
+If you aren't sure on how to proceed with your track given all this, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) _before_ uploading your mapset!
+
 
 ## What happens if my track isn't okay?
 

--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -6,6 +6,7 @@ With a wide variety of music available, most tracks will be fine for use in osu!
 - Glorifying, promoting or otherwise encouraging drug abuse, suicide, murder, or self-harm
 - Promoting racial tension or division
 - Extremely and unbearably loud or excessively clipped
+- Heavily political
 
 Tracks with explicit lyrics can still be used so long as they do not overtly violate the criteria above.
 
@@ -23,6 +24,11 @@ Many musical styles or genres make use of explicit lyrics for artistic or stylis
 
 If you aren't sure on how to proceed with your track given all this, ask any member of the [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) or [Global Moderation Team](/wiki/People/Global_Moderation_Team) _before_ uploading your mapset!
 
+## What classifies as 'heavily political' content?
+
+In the interests of keeping a game about rhythm strictly about rhythm and in accordance with Community Rule number 3, content which is deemed excessively political by the administration is disallowed.
+
+We adhere to no one particular 'end' of a political spectrum - osu! is strictly apolitical and we want people to enjoy themselves, not start feuds or quabble over politics.
 
 ## What happens if my track isn't okay?
 

--- a/wiki/Ranking_Criteria/Song_Content_Rules/en.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/en.md
@@ -26,7 +26,7 @@ If you aren't sure on how to proceed with your track given all this, ask any mem
 
 ## What classifies as "heavily political" content?
 
-In the interests of keeping a game about rhythm strictly about rhythm and in accordance with Community Rule number 3, content which is deemed excessively political by the administration is disallowed.
+In the interests of keeping a game about rhythm strictly about rhythm and in accordance with [Community Rule](/wiki/Rules#community-rules) #3, content which is deemed excessively political by the administration is disallowed.
 
 We adhere to no one particular "end" of a political spectrum—osu! is strictly apolitical and we want people to enjoy themselves, not start feuds or quabble over politics.
 

--- a/wiki/Ranking_Criteria/Song_Content_Rules/zh.md
+++ b/wiki/Ranking_Criteria/Song_Content_Rules/zh.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # 歌曲内容规定
 
 _父页面：[Ranking Criteria](/wiki/Ranking_Criteria)_


### PR DESCRIPTION
This PR attempts to address a longstanding weakness with the SCR - the "20%" rule regarding explicit content. Discussion in the BN server and with the GMT has repeatedly demonstrated the inability of this rule to form any meaningful end, and thus it has been replaced instead as a directive "guideline" to help inform people's choices.

An additional clause addressing the allowance of explicit lyrics for artistic and stylistic ends has been added.

A note on disallowing heavily political content has also been added to codify long-standing unspoken opinion as far as song content is concerned.