### PR TITLE
Added importaint information missing from score documentation

### DIFF
--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -174,11 +174,12 @@ This database contains the scores achieved locally.
 | Long | Timestamp of replay, in Windows ticks |
 | Int | Should always be 0xffffffff (-1). |
 | Long | Online Score ID |
-| Double | Additional mod information. Currently only present if [Target Practice](/wiki/Game_Modifiers/en.md#target-practice) is enabled. |
+| Double | Additional mod information. Only present if [Target Practice](/wiki/Game_Modifiers#special.1) is enabled. |
 
 #### Additional mod information
+
 | Mod | Stored information |
-| --- | ------------------ |
+| :-- | :-- |
 | Target Practice | Total accuracy of all hits. Divide this by the number of targets in the map to find the accuracy displayed in-game. |
 
 Apart from the online score ID, the individual score format is the same as the replay format. This explains the empty string and -1 int. For more information, see [.osr (file format)](/wiki/osu!_File_Formats/Osr_(file_format)).

--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -174,5 +174,11 @@ This database contains the scores achieved locally.
 | Long | Timestamp of replay, in Windows ticks |
 | Int | Should always be 0xffffffff (-1). |
 | Long | Online Score ID |
+| Double | Additional mod information. Currently only present if [Target Practice](/wiki/Game_Modifiers/en.md#target-practice) is enabled. |
+
+#### Additional mod information
+| Mod | Stored information |
+| --- | ------------------ |
+|Target Practice | Total used for calculating accuracy. (Total / Hits) |
 
 Apart from the online score ID, the individual score format is the same as the replay format. This explains the empty string and -1 int. For more information, see [.osr (file format)](/wiki/osu!_File_Formats/Osr_(file_format)).

--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -179,6 +179,6 @@ This database contains the scores achieved locally.
 #### Additional mod information
 | Mod | Stored information |
 | --- | ------------------ |
-|Target Practice | Total used for calculating accuracy. (Total / Hits) |
+| Target Practice | Total accuracy of all hits. Divide this by the number of targets in the map to find the accuracy displayed in-game. |
 
 Apart from the online score ID, the individual score format is the same as the replay format. This explains the empty string and -1 int. For more information, see [.osr (file format)](/wiki/osu!_File_Formats/Osr_(file_format)).

--- a/wiki/osu!_File_Formats/Osr_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/en.md
@@ -44,7 +44,7 @@ Byte offsets are not included in this table due to variable length values.
 **Additional mod information**:
 | Mod | Stored information |
 | --- | ------------------ |
-|Target Practice | Total used for calculating accuracy. (Total / Hits) |
+| Target Practice | Total accuracy of all hits. Divide this by the number of targets in the map to find the accuracy displayed in-game. |
 
 The remaining data contains information about mouse movement and key presses in an [LZMA](https://en.wikipedia.org/wiki/Lempel–Ziv–Markov_chain_algorithm) stream.
 

--- a/wiki/osu!_File_Formats/Osr_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/en.md
@@ -39,11 +39,12 @@ Byte offsets are not included in this table due to variable length values.
 | Integer | Length in bytes of compressed replay data |
 | Byte Array | Compressed replay data |
 | Long | Online Score ID |
-| Double | Additional mod information. Currently only present when [Target Practice](/wiki/Game_Modifiers/en.md#target-practice) is Enabled. |
+| Double | Additional mod information. Only present if [Target Practice](/wiki/Game_Modifiers#special.1) is enabled. |
 
-**Additional mod information**:
+**Additional mod information:**
+
 | Mod | Stored information |
-| --- | ------------------ |
+| :-- | :-- |
 | Target Practice | Total accuracy of all hits. Divide this by the number of targets in the map to find the accuracy displayed in-game. |
 
 The remaining data contains information about mouse movement and key presses in an [LZMA](https://en.wikipedia.org/wiki/Lempel–Ziv–Markov_chain_algorithm) stream.

--- a/wiki/osu!_File_Formats/Osr_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/en.md
@@ -39,6 +39,12 @@ Byte offsets are not included in this table due to variable length values.
 | Integer | Length in bytes of compressed replay data |
 | Byte Array | Compressed replay data |
 | Long | Online Score ID |
+| Double | Additional mod information. Currently only present when [Target Practice](/wiki/Game_Modifiers/en.md#target-practice) is Enabled. |
+
+**Additional mod information**:
+| Mod | Stored information |
+| --- | ------------------ |
+|Target Practice | Total used for calculating accuracy. (Total / Hits) |
 
 The remaining data contains information about mouse movement and key presses in an [LZMA](https://en.wikipedia.org/wiki/Lempel–Ziv–Markov_chain_algorithm) stream.
 


### PR DESCRIPTION
Missing important information regarding additional mod values in score records. Not having this information could lead to errors when reading or writing to files. osu! gives an error if this information is missing from scores.db.