### PR TITLE
Fix osu!lazer hyperlink in main page

### DIFF
--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -67,7 +67,7 @@ Sections: ([Compose](/wiki/Beatmap_Editor/Compose) • [Design](/wiki/Beatmap_Ed
 If you're interested in shaping the future of osu!, you can help by contributing to any of its projects that interest you.
 </p>
 
-[osu!wiki](https://github.com/ppy/osu-wiki) • [osu!lazer](https://github.com/ppy/osu-wiki) • [osu!web](https://github.com/ppy/osu-web)
+[osu!wiki](https://github.com/ppy/osu-wiki) • [osu!lazer](https://github.com/ppy/osu) • [osu!web](https://github.com/ppy/osu-web)
 
 </div>
 </div>


### PR DESCRIPTION
Fix `osu!lazer` hyperlink which is linking to the wiki repository rather than lazer.