### PR TITLE
Update difficulty naming schemes from other games

### DIFF
--- a/wiki/Difficulties/en.md
+++ b/wiki/Difficulties/en.md
@@ -38,7 +38,7 @@ These are the typical levels of difficulty that a beatmap can fall under. Specif
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
 
 ### ![](/wiki/shared/mode/catch.png) osu!catch
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -25,7 +25,7 @@ These difficulty names are the most commonly used for each game mode.
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
 
 ### osu!catch
 
@@ -120,7 +120,20 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
 - ![](/wiki/shared/diff/expertplus-s.png) VIVID / VVD
 
-If more than provided difficulty names are needed for large mapsets, however, using difficulty names from other versions is allowed.
+If more than provided difficulty names are needed for large mapsets, difficulty names from other versions are usually used.
+
+### Arcaea
+
+- ![](/wiki/shared/diff/normal-s.png) Past
+- ![](/wiki/shared/diff/hard-s.png) Present
+- ![](/wiki/shared/diff/insane-s.png) Future
+
+### Lanota
+
+- ![](/wiki/shared/diff/normal-s.png) Whisper
+- ![](/wiki/shared/diff/hard-s.png) Acoustic
+- ![](/wiki/shared/diff/insane-s.png) Ultra
+- ![](/wiki/shared/diff/expert-s.png) Master
 
 ### maimai, CHUNITHM, Ongeki
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -8,6 +8,7 @@ These difficulty names are the most commonly used for each game mode.
 
 *Note: The special difficulty name **Marathon** historically allowed mappers to submit maps of longer songs, and thus became popular for single-difficulty mapsets. Today, the name has no special meaning and is typically only used for very long songs or song compilations.*
 
+<!-- markdownlint-disable MD045 -->
 <!-- markdownlint-disable MD026 -->
 ### osu!
 <!-- markdownlint-enable MD026 -->

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -98,6 +98,8 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 
 ### SOUND VOLTEX
 
+*Note: Large mapsets of SOUND VOLTEX songs often use difficulty names from multiple versions of the game, even if the song does not appear in all of them.*
+
 - ![](/wiki/shared/diff/easy-s.png) BASIC / BSC
 - ![](/wiki/shared/diff/normal-s.png) NOVICE / NOV
 - ![](/wiki/shared/diff/hard-s.png) ADVANCED / ADV
@@ -120,8 +122,6 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 
 - ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
 - ![](/wiki/shared/diff/expertplus-s.png) VIVID / VVD
-
-If more than provided difficulty names are needed for large mapsets, difficulty names from other versions are usually used.
 
 ### Arcaea
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -8,7 +8,9 @@ These difficulty names are the most commonly used for each game mode.
 
 *Note: The special difficulty name **Marathon** historically allowed mappers to submit maps of longer songs, and thus became popular for single-difficulty mapsets. Today, the name has no special meaning and is typically only used for very long songs or song compilations.*
 
-### ![](/wiki/shared/mode/osu.png) osu!
+<!-- markdownlint-disable MD026 -->
+### osu!
+<!-- markdownlint-enable MD026 -->
 
 - ![](/wiki/shared/diff/easy-s.png) Easy
 - ![](/wiki/shared/diff/normal-s.png) Normal
@@ -16,7 +18,7 @@ These difficulty names are the most commonly used for each game mode.
 - ![](/wiki/shared/diff/insane-s.png) Insane
 - ![](/wiki/shared/diff/expert-s.png) Expert
 
-### ![](/wiki/shared/mode/taiko.png) osu!taiko
+### osu!taiko
 
 - ![](/wiki/shared/diff/easy-t.png) Kantan
 - ![](/wiki/shared/diff/normal-t.png) Futsuu
@@ -25,7 +27,7 @@ These difficulty names are the most commonly used for each game mode.
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
 - ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
 
-### ![](/wiki/shared/mode/catch.png) osu!catch
+### osu!catch
 
 - ![](/wiki/shared/diff/easy-c.png) Cup
 - ![](/wiki/shared/diff/normal-c.png) Salad
@@ -33,7 +35,7 @@ These difficulty names are the most commonly used for each game mode.
 - ![](/wiki/shared/diff/insane-c.png) Rain
 - ![](/wiki/shared/diff/expert-c.png) Overdose
 
-### ![](/wiki/shared/mode/mania.png) osu!mania
+### osu!mania
 
 - ![](/wiki/shared/diff/easy-m.png) Easy
 - ![](/wiki/shared/diff/normal-m.png) Normal
@@ -70,7 +72,7 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/insane-s.png) MX
 - ![](/wiki/shared/diff/expert-s.png) SC
 
-### EZ2DJ / EZ2AC
+### EZ2DJ, EZ2AC
 
 - ![](/wiki/shared/diff/easy-s.png) EZ
 - ![](/wiki/shared/diff/normal-s.png) NM
@@ -100,20 +102,20 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/hard-s.png) ADVANCED / ADV
 - ![](/wiki/shared/diff/insane-s.png) EXHAUST / EXH
 
-For **SOUND VOLTEX II -infinite infection-** songs:
+#### SOUND VOLTEX II -infinite infection-
 
 - ![](/wiki/shared/diff/expert-s.png) INFINITE / INF
 
-For **SOUND VOLTEX III GRAVITY WARS** songs:
+#### SOUND VOLTEX III GRAVITY WARS
 
 - ![](/wiki/shared/diff/expert-s.png) GRAVITY / GRV
 
-For **SOUND VOLTEX IV HEAVENLY HAVEN** songs:
+#### SOUND VOLTEX IV HEAVENLY HAVEN
 
 - ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
 - ![](/wiki/shared/diff/expertplus-s.png) HEAVENLY / HVN
 
-For **SOUND VOLTEX VIVID WAVE** songs:
+#### SOUND VOLTEX VIVID WAVE
 
 - ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
 - ![](/wiki/shared/diff/expertplus-s.png) VIVID / VVD
@@ -127,7 +129,18 @@ If more than provided difficulty names are needed for large mapsets, however, us
 - ![](/wiki/shared/diff/hard-s.png) ADVANCED
 - ![](/wiki/shared/diff/insane-s.png) EXPERT
 - ![](/wiki/shared/diff/expert-s.png) MASTER
-- ![](/wiki/shared/diff/expertplus-s.png) Re:MASTER(maimai), WORLD'S END(CHUNITHM), LUNATIC(Ongeki)
+
+#### maimai
+
+- ![](/wiki/shared/diff/expertplus-s.png) Re:MASTER
+
+#### CHUNITHM
+
+- ![](/wiki/shared/diff/expertplus-s.png) WORLD'S END
+
+#### Ongeki
+
+- ![](/wiki/shared/diff/expertplus-s.png) LUNATIC
 
 ### Cytus, Deemo, VOEZ
 
@@ -135,7 +148,18 @@ If more than provided difficulty names are needed for large mapsets, however, us
 - ![](/wiki/shared/diff/normal-s.png) Normal
 - ![](/wiki/shared/diff/hard-s.png) Hard
 - ![](/wiki/shared/diff/insane-s.png) Insane
-- ![](/wiki/shared/diff/expert-s.png) Chaos(Cytus), Extra(Deemo), Special(VOEZ)
+
+#### Cytus
+
+- ![](/wiki/shared/diff/expert-s.png) Chaos
+
+#### Deemo
+
+- ![](/wiki/shared/diff/expert-s.png) Extra
+
+#### VOEZ
+
+- ![](/wiki/shared/diff/expert-s.png) Special
 
 ### Touhou Project
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -45,13 +45,14 @@ These difficulty names are the most commonly used for each game mode.
 
 Mapsets of songs that originated from other rhythm games often borrow that game's difficulty naming scheme. Usage of these difficulty names is acceptable for any song. Some of the common naming schemes that made their way into osu! are listed here:
 
-### Beatmania
+### Beatmania IIDX
 
 - ![](/wiki/shared/diff/easy-s.png) Beginner
 - ![](/wiki/shared/diff/normal-s.png) Normal
 - ![](/wiki/shared/diff/hard-s.png) Hyper
 - ![](/wiki/shared/diff/insane-s.png) Another
 - ![](/wiki/shared/diff/expert-s.png) Black Another
+- ![](/wiki/shared/diff/expertplus-s.png) Leggendaria
 
 ### DanceDanceRevolution
 
@@ -61,8 +62,9 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/insane-s.png) Expert
 - ![](/wiki/shared/diff/expert-s.png) Challenge
 
-### DJMax
+### DJMAX
 
+- ![](/wiki/shared/diff/easy-s.png) EZ
 - ![](/wiki/shared/diff/normal-s.png) NM
 - ![](/wiki/shared/diff/hard-s.png) HD
 - ![](/wiki/shared/diff/insane-s.png) MX
@@ -84,7 +86,7 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/hard-s.png) Hard
 - ![](/wiki/shared/diff/insane-s.png) Expert
 
-### Pop 'n Music
+### Pop'n Music
 
 - ![](/wiki/shared/diff/easy-s.png) Easy
 - ![](/wiki/shared/diff/normal-s.png) Normal
@@ -97,7 +99,51 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/normal-s.png) NOVICE / NOV
 - ![](/wiki/shared/diff/hard-s.png) ADVANCED / ADV
 - ![](/wiki/shared/diff/insane-s.png) EXHAUST / EXH
+
+For **SOUND VOLTEX II -infinite infection-** songs:
+
 - ![](/wiki/shared/diff/expert-s.png) INFINITE / INF
+
+For **SOUND VOLTEX III GRAVITY WARS** songs:
+
+- ![](/wiki/shared/diff/expert-s.png) GRAVITY / GRV
+
+For **SOUND VOLTEX IV HEAVENLY HAVEN** songs:
+
+- ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
+- ![](/wiki/shared/diff/expertplus-s.png) HEAVENLY / HVN
+
+For **SOUND VOLTEX VIVID WAVE** songs:
+
+- ![](/wiki/shared/diff/expert-s.png) MAXIMUM / MXM
+- ![](/wiki/shared/diff/expertplus-s.png) VIVID / VVD
+
+If more than provided difficulty names are needed for large mapsets, however, using difficulty names from other versions is allowed.
+
+### maimai
+
+- ![](/wiki/shared/diff/easy-s.png) EASY
+- ![](/wiki/shared/diff/normal-s.png) BASIC
+- ![](/wiki/shared/diff/hard-s.png) ADVANCED
+- ![](/wiki/shared/diff/insane-s.png) EXPERT
+- ![](/wiki/shared/diff/expert-s.png) MASTER
+- ![](/wiki/shared/diff/expertplus-s.png) Re:MASTER
+
+### CHUNITHM
+
+- ![](/wiki/shared/diff/normal-s.png) BASIC
+- ![](/wiki/shared/diff/hard-s.png) ADVANCED
+- ![](/wiki/shared/diff/insane-s.png) EXPERT
+- ![](/wiki/shared/diff/expert-s.png) MASTER
+- ![](/wiki/shared/diff/expertplus-s.png) WORLD'S END
+
+### Ongeki
+
+- ![](/wiki/shared/diff/normal-s.png) BASIC
+- ![](/wiki/shared/diff/hard-s.png) ADVANCED
+- ![](/wiki/shared/diff/insane-s.png) EXPERT
+- ![](/wiki/shared/diff/expert-s.png) MASTER
+- ![](/wiki/shared/diff/expertplus-s.png) LUNATIC
 
 ### Touhou Project
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -120,30 +120,22 @@ For **SOUND VOLTEX VIVID WAVE** songs:
 
 If more than provided difficulty names are needed for large mapsets, however, using difficulty names from other versions is allowed.
 
-### maimai
+### maimai, CHUNITHM, Ongeki
 
 - ![](/wiki/shared/diff/easy-s.png) EASY
 - ![](/wiki/shared/diff/normal-s.png) BASIC
 - ![](/wiki/shared/diff/hard-s.png) ADVANCED
 - ![](/wiki/shared/diff/insane-s.png) EXPERT
 - ![](/wiki/shared/diff/expert-s.png) MASTER
-- ![](/wiki/shared/diff/expertplus-s.png) Re:MASTER
+- ![](/wiki/shared/diff/expertplus-s.png) Re:MASTER(maimai), WORLD'S END(CHUNITHM), LUNATIC(Ongeki)
 
-### CHUNITHM
+### Cytus, Deemo, VOEZ
 
-- ![](/wiki/shared/diff/normal-s.png) BASIC
-- ![](/wiki/shared/diff/hard-s.png) ADVANCED
-- ![](/wiki/shared/diff/insane-s.png) EXPERT
-- ![](/wiki/shared/diff/expert-s.png) MASTER
-- ![](/wiki/shared/diff/expertplus-s.png) WORLD'S END
-
-### Ongeki
-
-- ![](/wiki/shared/diff/normal-s.png) BASIC
-- ![](/wiki/shared/diff/hard-s.png) ADVANCED
-- ![](/wiki/shared/diff/insane-s.png) EXPERT
-- ![](/wiki/shared/diff/expert-s.png) MASTER
-- ![](/wiki/shared/diff/expertplus-s.png) LUNATIC
+- ![](/wiki/shared/diff/easy-s.png) Easy
+- ![](/wiki/shared/diff/normal-s.png) Normal
+- ![](/wiki/shared/diff/hard-s.png) Hard
+- ![](/wiki/shared/diff/insane-s.png) Insane
+- ![](/wiki/shared/diff/expert-s.png) Chaos(Cytus), Extra(Deemo), Special(VOEZ)
 
 ### Touhou Project
 


### PR DESCRIPTION
- Added "Outer Oni" to osu!taiko difficulty names
- Added "IIDX" after beatmania to prevent confusion
- Added "Leggendaria" difficulty to beatmania IIDX
- Fixed "Pop 'n Music" to "Pop'n Music"
- Fixed "DJMax" to "DJMAX"
- Added various difficulty names differing by SOUND VOLTEX version
- Added Arcaea
- Added Lanota
- Added SEGA's rhythm games (maimai, CHUNITHM, Ongeki)
- Added Rayark's rhythm games (Cytus, Deemo, VOEZ)

As rhythm games are getting more variable, so should the wiki be.