### PR TITLE
Add pick'em link to the wiki page

### DIFF
--- a/wiki/Tournaments/OWC/2019/en.md
+++ b/wiki/Tournaments/OWC/2019/en.md
@@ -48,6 +48,7 @@ The osu! World Cup 2019 is run by various community members by distributing the 
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/973724)
 - [Livestream](https://www.twitch.tv/osulive)
+- [Pick'em](https://pickem.hwchr.com/tournaments/19)
 - **[Registration page](https://osu.ppy.sh/community/tournaments/22)**
 
 ---

--- a/wiki/Tournaments/OWC/2019/en.md
+++ b/wiki/Tournaments/OWC/2019/en.md
@@ -48,7 +48,7 @@ The osu! World Cup 2019 is run by various community members by distributing the 
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/973724)
 - [Livestream](https://www.twitch.tv/osulive)
-- [Pick'em](https://pickem.hwchr.com/tournaments/19)
+- [Pick'ems page](https://pickem.hwchr.com/tournaments/19)
 - **[Registration page](https://osu.ppy.sh/community/tournaments/22)**
 
 ---

--- a/wiki/Tournaments/OWC/2019/en.md
+++ b/wiki/Tournaments/OWC/2019/en.md
@@ -49,7 +49,6 @@ The osu! World Cup 2019 is run by various community members by distributing the 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/973724)
 - [Livestream](https://www.twitch.tv/osulive)
 - [Pick'ems page](https://pickem.hwchr.com/tournaments/19)
-- **[Registration page](https://osu.ppy.sh/community/tournaments/22)**
 
 ---
 


### PR DESCRIPTION
The pick'em page was included in the news article but not in the wiki page.
The perfect place to fit it would be in the links section.
Hope this is okay.