### PR TITLE
Mention that failsound is supposed to be short and small

### DIFF
--- a/wiki/Skinning/Sounds/en.md
+++ b/wiki/Skinning/Sounds/en.md
@@ -515,8 +515,8 @@ Notes:
 Notes:
 
 - Failing a map at any point.
-- Not intended to last for longer than the fail animation (about 5s).
-- Using a long audio track will impact performance as it is loaded each time you play a beatmap, even if you never fail. It's not supposed to be bigger than a few kilobytes.
+- Not intended to last longer than the fail animation (about 5 seconds).
+- Using a long audio track will impact the game client’s performance, as it is loaded each time you play a beatmap, even if you never fail. It isn’t supposed to be bigger than a few kilobytes.
 
 ---
 

--- a/wiki/Skinning/Sounds/en.md
+++ b/wiki/Skinning/Sounds/en.md
@@ -515,6 +515,8 @@ Notes:
 Notes:
 
 - Failing a map at any point.
+- Not intended to last for longer than the fail animation (about 5s).
+- Using a long audio track will impact performance as it is loaded each time you play a beatmap, even if you never fail. It's not supposed to be bigger than a few kilobytes.
 
 ---
 


### PR DESCRIPTION
From peppy (https://twitter.com/ppy/status/1189749758706892800):

> PSA: do not put 3 minute long "failsound" files in your skins. this sound is supposed to be <5s and will be impacting your gameplay performance if you make it a music track.

This seems to be a thing skinners tend to do (https://github.com/ppy/osu-stable-issues/issues/191; I myself did it in [my own skin](https://github.com/kisaragi-hiu/osuskin-retome) and had the same issue), so I think it's better to clarify right in the wiki.

---