### PR TITLE
Remove "File caching" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,6 @@ Home of the [Knowledge Base](https://osu.ppy.sh/help/wiki/Main_Page).
 
 Please see [the "contributing" file](CONTRIBUTING.md) if you are interested in helping out with the project!
 
-## File caching
-
-### Wiki articles
-
-Articles are cached for up to five hours.
-
-### Images
-
-Images are cached for up to two hours.
-
-### News posts
-
-News posts are cached for up to sixty days. If there are any issues after merging a news post, merge a pull request to fix it then tell Ephemeral (`ephemeralis#0001`) or Shiro (`Shiro#1584`) on the [osu!dev Discord](https://discord.gg/ppy) (`#osu-wiki` channel) to force a refresh for the fixed news post.
-
 ## Licence
 
 The majority of content in this repository is licensed under [CC-BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/legalcode). Please see [the licence file](LICENCE.md) for more information. [tl;dr](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-4.0-international-(cc-by-nc-4.0)) you can use it in a non-commercial manner.


### PR DESCRIPTION
for the most part caching is no longer relevant to wiki contributors. super-specifics like camo'd images and news post editing can be mentioned by #2780