### PR TITLE
[EN/FR] Update db file format for stable 20191107.2

### DIFF
--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -56,7 +56,7 @@ Some data types specific to osu!.db are defined below.
 
 | Data type | Description |
 | --------- | ----------- |
-| Int | Size in bytes of the beatmap entry. Only present if version is less than 20191107. |
+| Int | Size in bytes of the beatmap entry. Only present if version is less than 20191106. |
 | String | Artist name |
 | String | Artist name, in Unicode |
 | String | Song title |

--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -56,7 +56,7 @@ Some data types specific to osu!.db are defined below.
 
 | Data type | Description |
 | --------- | ----------- |
-| Int | Size in bytes of the beatmap entry |
+| Int | Size in bytes of the beatmap entry. Only present if version is less than 20191107. |
 | String | Artist name |
 | String | Artist name, in Unicode |
 | String | Song title |

--- a/wiki/osu!_File_Formats/Db_(file_format)/fr.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/fr.md
@@ -55,7 +55,7 @@ Quelques types de données sont spécifiques à osu!.db, les voici:
 
 | Type de donnée | Description |
 | --------- | ----------- |
-| Int | Taille en octet de la beatmap. Seulement présent depuis la version 20191107. |
+| Int | Taille en octet de la beatmap. Seulement présent depuis la version 20191106. |
 | String | Nom de l'artiste |
 | String | Nom de l'artiste, en Unicode |
 | String | Titre de la musique |

--- a/wiki/osu!_File_Formats/Db_(file_format)/fr.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/fr.md
@@ -55,7 +55,7 @@ Quelques types de données sont spécifiques à osu!.db, les voici:
 
 | Type de donnée | Description |
 | --------- | ----------- |
-| Int | Taille en octet de la beatmap |
+| Int | Taille en octet de la beatmap. Seulement présent depuis la version 20191107. |
 | String | Nom de l'artiste |
 | String | Nom de l'artiste, en Unicode |
 | String | Titre de la musique |


### PR DESCRIPTION
See https://osu.ppy.sh/home/changelog/stable40/20191107.2
and https://twitter.com/smoogipoo/status/1192351592617406464

The first field of all beatmap entries has been removed.