### PR TITLE
Add "outdated" or "needs_cleanup" tags to articles

### DIFF
--- a/wiki/Accuracy/en.md
+++ b/wiki/Accuracy/en.md
@@ -1,4 +1,10 @@
+---
+needs_cleanup: true
+---
+
 # Accuracy
+
+<!-- TODO: images could be in a more friendly font, wording is sometimes too... wordy -->
 
 Accuracy is a measurement of a player's consistency. There are three types of accuracy that a player can have. One of them being the beatmap's accuracy which is dependent on hit scores gained. Another being the player's overall accuracy that is weighed to allow better scores to stand out more. And lastly, the player's [Performance Points (pp)](/wiki/Performance_Points) accuracy which is dependent on the submitted score's accuracy.
 

--- a/wiki/Accuracy/fr.md
+++ b/wiki/Accuracy/fr.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Accuracy
 
 L'accuracy (précision en français) est une mesure qui sert à établir la constance d'un joueur.

--- a/wiki/Accuracy/pl.md
+++ b/wiki/Accuracy/pl.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Precyzja
 
 Precyzja to wartość określająca umiejętności gracza w śledzeniu rytmu. Termin ten stosuje się w dwóch przypadkach. Pierwszy to precyzja na danej beatmapie liczona poprzez zsumowanie wartości trafień każdego obiektu na beatmapie w stosunku do najwyższej wartości dla wszystkich możliwych obiektów. Drugi to ogólna ważona precyzja gracza, która większy nacisk kładzie na lepsze zagrania.

--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -1,3 +1,8 @@
+---
+needs_cleanup: true
+outdated: true
+---
+
 # BBCode
 
 ![The forum post editor with its buttons](img/editor.jpg "The edit box in the forums")

--- a/wiki/Beatmap_Discussion/en.md
+++ b/wiki/Beatmap_Discussion/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Beatmap Discussion
 
 Beatmap Discussion (introduced as *Modding v2*) is now live!

--- a/wiki/Beatmapping/en.md
+++ b/wiki/Beatmapping/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Beatmapping
 
 **Beatmapping** is the process of creating [beatmaps](/wiki/Beatmaps) in osu! for players to play.

--- a/wiki/Beatmaps/Packs/en.md
+++ b/wiki/Beatmaps/Packs/en.md
@@ -1,4 +1,10 @@
+---
+needs_cleanup: true
+---
+
 # Packs
+
+<!-- TODO: new pack types, new mirrors -->
 
 A beatmaps pack is a `.zip` file containing beatmaps. The name of the pack is based on what they contain (e.g. `Approved Beatmap Pack #7` would only contain [approved](/wiki/approved) beatmaps).
 

--- a/wiki/Beatmaps/Title_Text/fr.md
+++ b/wiki/Beatmaps/Title_Text/fr.md
@@ -6,8 +6,6 @@ tags:
 
 # Texte de titre
 
-<!-- This article was based off of [*Changing the Title Text : The Guide* by: Ekaru](https://osu.ppy.sh/community/forums/topics/14513), but a lot of the content has been changed/updated, so I'm just leaving the link here as a reference. It's not worth linking to from the wiki because it contains incorrect info at some points -->
-
 ![Capture d'écran d'un gameplay osu! avec le titre visible](img/liquid-title-text.jpg "Le titre pour \"Rostik - Liquid (Paul Rosenthal Remix)\" est montré juste après le début de la map.")
 
 **Le titre** apparaît en haut au milieu de l'écran quand vous jouez une beatmap. Le plus souvent, il montre l'artiste et le titre de la chanson au début de la map, mais le créateur de la map peut changer le texte et mettre ce qu'il lui plait. Le créateur peut aussi changer le format du texte et quand il apparaît.

--- a/wiki/Chat_Console/en.md
+++ b/wiki/Chat_Console/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Chat Console
 
 From most screens in osu! you can press `F8` or click the `Show Chat` button on the lower right to overlay the Chat Console on the lower third of the screen.

--- a/wiki/Contests/FBC/en.md
+++ b/wiki/Contests/FBC/en.md
@@ -1,7 +1,7 @@
 ---
 tags:
-- FBC
-- Mapping 
+  - FBC
+  - Mapping
 ---
 
 # French Beatmapping Contest

--- a/wiki/Contests/FBC/fr.md
+++ b/wiki/Contests/FBC/fr.md
@@ -1,7 +1,7 @@
 ---
 tags:
-- FBC
-- Mapping 
+  - FBC
+  - Mapping
 ---
 
 # French Beatmapping Contest

--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 <!-- Please check redirects after adding new sections with year numbers. -->
 [o!s]: /wiki/shared/mode/osu.png
 [o!t]: /wiki/shared/mode/taiko.png

--- a/wiki/Contests/oMWC/1/en.md
+++ b/wiki/Contests/oMWC/1/en.md
@@ -1,8 +1,7 @@
 ---
 tags:
-- 'osu! Mapping World Cup #1'
-- 'o!MWC #1'
-- 'oMWC #1'
+  - o!MWC
+  - oMWC
 ---
 
 # osu! Mapping World Cup #1

--- a/wiki/Do_you_really_want_to_ask_peppy/en.md
+++ b/wiki/Do_you_really_want_to_ask_peppy/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Do you really want to ask peppy?
 
 Hi there. I ([peppy](https://osu.ppy.sh/users/2)) understand your urge to want to contact me personally, but I ask that you first understand that this is **not** the place you want to ask me for help/support. I keep osu! support separate from personal messages, and also find that answering forum PMs is quite hard to keep up with. I therefore ask that you do one of the following options:

--- a/wiki/FAQ/en.md
+++ b/wiki/FAQ/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [osu! wikilink]: /wiki/Game_Modes/osu!/ "osu!"
 [osu!taiko wikilink]: /wiki/Game_Modes/osu!taiko/ "osu!taiko"

--- a/wiki/Game_Modes/en.md
+++ b/wiki/Game_Modes/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Game Modes
 
 ## ![osu! icon](/wiki/shared/mode/osu.png) osu!standard

--- a/wiki/Game_Modes/osu!/en.md
+++ b/wiki/Game_Modes/osu!/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [Play_Styles#osu! wikilink]: /wiki/Play_Styles/ "more info can be found on Play Styles under osu!"
 [Score#osu!SV wikilink]: /wiki/Score/#osu "more info can be found on Score under osu! Scoring Values"

--- a/wiki/Game_Modes/osu!catch/en.md
+++ b/wiki/Game_Modes/osu!catch/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [Play_Styles#osu!catch wikilink]: /wiki/Play_Styles/ "more info can be found on Play Styles under osu!catch"
 [Score#osu!catchSV wikilink]: /wiki/Score/#osu-catch "more info can be found on Score under osu!catch Scoring Values"

--- a/wiki/Game_Modes/osu!mania/en.md
+++ b/wiki/Game_Modes/osu!mania/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [osu! wikilink]: /wiki/Game_Modes/osu! "osu!"
 [osu!taiko wikilink]: /wiki/Game_Modes/osu!taiko/ "osu!taiko"

--- a/wiki/Game_Modes/osu!taiko/en.md
+++ b/wiki/Game_Modes/osu!taiko/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [Play_Styles#osu!taiko wikilink]: /wiki/Play_Styles/ "more info can be found on Play Styles under osu!taiko"
 [Score#osu!taikoSV wikilink]: /wiki/Score/#osu-taiko "more info can be found on Score under osu!taiko Scoring Values"

--- a/wiki/Game_Modifiers/Summary/en.md
+++ b/wiki/Game_Modifiers/Summary/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 [o!s]: /wiki/shared/mode/osu.png "osu!standard"
 [o!t]: /wiki/shared/mode/taiko.png "osu!taiko"
 [o!c]: /wiki/shared/mode/catch.png "osu!catch"

--- a/wiki/Glossary/en.md
+++ b/wiki/Glossary/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Glossary
 
 Throughout the years, the osu! community has adopted its own set of slang that may be confusing for newcomers. This page is a compilation of such terms for reference. Additions and edits are always welcome.

--- a/wiki/Help_Centre/en.md
+++ b/wiki/Help_Centre/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Help Centre
 
 Having trouble with something? We're here to help! Check out some solutions to common issues in the sidebar to the left of your screen.

--- a/wiki/History_of_osu!/2018/en.md
+++ b/wiki/History_of_osu!/2018/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # 2018
 
 ## January

--- a/wiki/History_of_osu!/en.md
+++ b/wiki/History_of_osu!/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # History of osu!
 
 Records of osu!'s history, all in the osu! wiki.

--- a/wiki/History_of_osu!/osu!_wiki/en.md
+++ b/wiki/History_of_osu!/osu!_wiki/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # osu! wiki
 
 ## MediaWiki (2011 - 2017)

--- a/wiki/Hit_Objects/en.md
+++ b/wiki/Hit_Objects/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Hit Objects
 
 A hit object is the core gameplay element in osu!. There are three types of hit objects:

--- a/wiki/How_You_Can_Help!/en.md
+++ b/wiki/How_You_Can_Help!/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # How you can help!
 
 osu!, like any other game, has a very vibrant community, composed of people from all around the world, with differing skill sets and different purposes.

--- a/wiki/Installation/en.md
+++ b/wiki/Installation/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Installation
 
 *See also: [Installation/macOS](/wiki/Installation/macOS)* <!-- and [Installation/Linux](/wiki/Installation/Linux)* -->

--- a/wiki/Interface/en.md
+++ b/wiki/Interface/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!--Logo definitions-->
 [Osu!]: /wiki/shared/mode/osu.png
 [Taiko]: /wiki/shared/mode/taiko.png

--- a/wiki/Internet_Relay_Chat/en.md
+++ b/wiki/Internet_Relay_Chat/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # What is Internet Relay Chat?
 
 The [Internet Relay Chat](http://en.wikipedia.org/wiki/Internet_Relay_Chat), also known as IRC, is a well established standardized protocol for chatting with numerous clients available to connect with.

--- a/wiki/Mascots/Gallery/en.md
+++ b/wiki/Mascots/Gallery/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Gallery
 
 ## Official

--- a/wiki/Medals/Beatmap_Packs_0916/en.md
+++ b/wiki/Medals/Beatmap_Packs_0916/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [media-anime-vol-1]: https://www.mediafire.com/?9n65pm9fp8yp5bn
 [media-anime-vol-2]: https://www.mediafire.com/?722os55j52ikylq
 [media-anime-vol-3]: https://www.mediafire.com/?tky7bjc58hcno6b

--- a/wiki/Medals/en.md
+++ b/wiki/Medals/en.md
@@ -1,3 +1,8 @@
+---
+needs_cleanup: true
+outdated: true
+---
+
 # Medals
 
 Medals, previously known as *achievements*, are badges on a user's profile which indicate that the user has accomplished an exceptional goal. Currently, they are divided into 7 groups: [Beatmap Packs](#beatmap-packs), [Skill](#skill), [Dedication](#dedication), [Mod Introduction](#mod-introduction), [Hush-Hush](#hush-hush), Beatmap Spotlights, and Seasonal Spotlights.

--- a/wiki/Multi/en.md
+++ b/wiki/Multi/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!--Wiki links used-->
 [osu!academy wikilink]: /wiki/osu!academy "osu!academy"
 [Abandoned Wasteland wikilink]: /wiki/Glossary/#abandoned-wasteland "more info can be found on Glossary under Abandoned Wasteland"

--- a/wiki/News_Styling_Criteria/en.md
+++ b/wiki/News_Styling_Criteria/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # News Styling Criteria
 
 *For wiki articles, see: [Article Styling Criteria](/wiki/Article_Styling_Criteria)*

--- a/wiki/Options/Keyboard_Bindings/en.md
+++ b/wiki/Options/Keyboard_Bindings/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Keyboard Bindings
 
 To access this dialog, open the [Options](/wiki/Options/), type in `change` then click on `Change keyboard bindings`.

--- a/wiki/Options/Offset_Wizard/en.md
+++ b/wiki/Options/Offset_Wizard/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Offset Wizard
 
 If, in every single beatmap you play, you hear that the sound effects are out of sync with the song, you may want to adjust your universal offset.

--- a/wiki/Performance_Points/en.md
+++ b/wiki/Performance_Points/en.md
@@ -1,3 +1,9 @@
+---
+needs_cleanup: true
+---
+
+<!-- probably outdated too -->
+
 # Performance Points
 
 The Performance Points system is a ranking metric that aims to be more contextually relevant to a player's progression in a continuous game like osu!.

--- a/wiki/Performance_Points/ppv1/en.md
+++ b/wiki/Performance_Points/ppv1/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # ppv1
 
 The **first performance score** (abbreviated as **ppv1**) is an ancient ranking system for players globally and nationally of all modes from osu!. It replaced the old system of *ranking by total score* and was abandoned for the benefit of [ppv2](../ "ppv2").

--- a/wiki/Play_Styles/en.md
+++ b/wiki/Play_Styles/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wikilink -->
 [osu!stream wikilink]: /wiki/Game_Modes/External_Ports/osu!stream "osu!stream by osu! team"
 

--- a/wiki/Projects/en.md
+++ b/wiki/Projects/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Projects
 
 ## Official

--- a/wiki/Registration/en.md
+++ b/wiki/Registration/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Registration
 
 *Warning: Having more than one osu! user account at any time is an infringement against the [osu! rules](/wiki/Rules)!*

--- a/wiki/Registration/en.md
+++ b/wiki/Registration/en.md
@@ -1,7 +1,3 @@
----
-needs_cleanup: true
----
-
 # Registration
 
 *Warning: Having more than one osu! user account at any time is an infringement against the [osu! rules](/wiki/Rules)!*

--- a/wiki/Reporting_Bad_Behaviour/en.md
+++ b/wiki/Reporting_Bad_Behaviour/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Reporting Bad Behaviour
 
 ## What is the report system?

--- a/wiki/Score/ScoreV1/en.md
+++ b/wiki/Score/ScoreV1/en.md
@@ -1,3 +1,9 @@
+---
+needs_cleanup: true
+---
+
+<!-- TODO: might be a useless article -->
+
 <!-- wiki -->
 [Score main wikilink]: ../ "Score"
 [osu! wikilink]: /wiki/Game_Modes/osu!/ "osu!"

--- a/wiki/Score/en.md
+++ b/wiki/Score/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wiki -->
 [osu! wikilink]: /wiki/Game_Modes/osu!/ "osu!"
 <!-- [osu!taiko wikilink]: /wiki/Game_Modes/osu!taiko/ "osu!taiko" -->

--- a/wiki/Skinning/FAQ/en.md
+++ b/wiki/Skinning/FAQ/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # FAQ
 
 *This article is about frequently answered skinning questions. For the tutorial, see [Skinning/Tutorial](/wiki/Skinning/Tutorial).*

--- a/wiki/Skinning/Guides_and_Important_Threads/en.md
+++ b/wiki/Skinning/Guides_and_Important_Threads/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Guides and Important Threads
 
 List of guides and important threads, created by the community.

--- a/wiki/Skinning/History/en.md
+++ b/wiki/Skinning/History/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/Interface/en.md
+++ b/wiki/Skinning/Interface/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/Sounds/en.md
+++ b/wiki/Skinning/Sounds/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Sounds
 
 `.wav`, `.mp3`, and/or `.ogg` are valid formats for sounds.

--- a/wiki/Skinning/en.md
+++ b/wiki/Skinning/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning
 
 Skinning is one of the key features of osu!. It enables players to derive from the original skinning elements to create their own! Skins can vary from being for-fun, themed, PRO, or be nigh impossible to play with.

--- a/wiki/Skinning/osu!/en.md
+++ b/wiki/Skinning/osu!/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/osu!catch/en.md
+++ b/wiki/Skinning/osu!catch/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/osu!mania/en.md
+++ b/wiki/Skinning/osu!mania/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/osu!taiko/en.md
+++ b/wiki/Skinning/osu!taiko/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png
 

--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # skin.ini
 
 *See also: [skin.ini/Blank](/wiki/Skinning/skin.ini/Blank)*

--- a/wiki/Skinning_Tutorial/Interface/en.md
+++ b/wiki/Skinning_Tutorial/Interface/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning Tutorial (Interface)
 
 ## Welcome Screen

--- a/wiki/Skinning_Tutorial/en.md
+++ b/wiki/Skinning_Tutorial/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning Tutorial
 
 *See also: [Skinning](/wiki/Skinning)*

--- a/wiki/Skinning_Tutorial/osu!/en.md
+++ b/wiki/Skinning_Tutorial/osu!/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning Tutorial (osu!)
 
 The main point of skinning.

--- a/wiki/Skinning_Tutorial/osu!catch/en.md
+++ b/wiki/Skinning_Tutorial/osu!catch/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # osu!catch
 
 ## Skinning elements

--- a/wiki/Skinning_Tutorial/osu!mania/en.md
+++ b/wiki/Skinning_Tutorial/osu!mania/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # osu!mania
 
 This tutorial uses [skin version](/wiki/skin.ini#versions) `2.5`. Since the skin configuration heavily affects osu!mania skinning, this tutorial will discuss both cases: using the default values (henceforth referred to as "basic") and modifying the skin configuration (henceforth referred to as "advanced").

--- a/wiki/Skinning_Tutorial/osu!taiko/en.md
+++ b/wiki/Skinning_Tutorial/osu!taiko/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning Tutorial (osu!taiko)
 
 ## Pippidon

--- a/wiki/Skinning_Tutorial/skin.ini/en.md
+++ b/wiki/Skinning_Tutorial/skin.ini/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # skin.ini
 
 *See also: [skin.ini](/wiki/Skinning/skin.ini) and [Skinning](/wiki/Skinning)*

--- a/wiki/Storyboarding/en.md
+++ b/wiki/Storyboarding/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Storyboarding
 
 <!-- This is a stub. Please write it like Beatmapping if possible. -->

--- a/wiki/Tournament_Drawings/en.md
+++ b/wiki/Tournament_Drawings/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Tournament Drawings
 
 The tournament drawings screen is used to livestream the sorting of teams into groups that will compete in the group stages for a tournament. It is only available in the [osu!lazer](https://github.com/ppy/osu/releases) client.

--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Tournaments
 
 Section dedicated for osu! tournaments. Tournaments have their dedicated forum which can be found [through this link](https://osu.ppy.sh/community/forums/55).

--- a/wiki/Twitter/en.md
+++ b/wiki/Twitter/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Twitter
 
 ## We tweet, too!

--- a/wiki/osu!academy/en.md
+++ b/wiki/osu!academy/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # osu!academy
 
 ![osu!academy's logo](img/osu!academy-logo.jpg "osu!academy logo")

--- a/wiki/osu!stream/en.md
+++ b/wiki/osu!stream/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 <!-- wikilink -->
 [Song List]: ./Song_List "Song list"
 [NF wikilink]: /wiki/Game_Modifiers/ "more information can be found in Game Modifiers under No Fail"

--- a/wiki/osu!supporter/en.md
+++ b/wiki/osu!supporter/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # osu!supporter
 
 *For the osu!supporter page from the website, see: [support the game](https://osu.ppy.sh/home/support)*

--- a/wiki/osu!talk/en.md
+++ b/wiki/osu!talk/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # osu!talk
 
 ![osu!talk logo](osu!talk.jpg)

--- a/wiki/osu!tourney/Multiplayer_Usage/en.md
+++ b/wiki/osu!tourney/Multiplayer_Usage/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Multiplayer Usage
 
 ## Match creation

--- a/wiki/osu!tourney/Prizes/en.md
+++ b/wiki/osu!tourney/Prizes/en.md
@@ -1,3 +1,9 @@
+---
+needs_cleanup: true
+---
+
+<!-- TODO: this article is in the wrong place -->
+
 # Prizes
 
 ## Profile Badges

--- a/wiki/osu!tourney/Setup/en.md
+++ b/wiki/osu!tourney/Setup/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Setup
 
 **Note:** An active supporter tag is currently required to use the osu!tourney client.

--- a/wiki/osu!tourney/Skinning/en.md
+++ b/wiki/osu!tourney/Skinning/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Skinning
 
 ![The client can be customized in various ways](Osutourneycustom.png)

--- a/wiki/osu!tourney/Troubleshooting/en.md
+++ b/wiki/osu!tourney/Troubleshooting/en.md
@@ -1,3 +1,7 @@
+---
+needs_cleanup: true
+---
+
 # Troubleshooting
 
 ## How do I create a fresh osu! installation without uninstalling the current game?


### PR DESCRIPTION
skipped:
- BanchoBot, added tag in #2909
- some things related to beatmapping because #2615 is tracking
- Ranking Criteria
- Tournaments
- Storyboard / scripting
- File formats
- Mapping Techniques
- Guides

whole categories may need to be reorganized so i didnt bother with tags

closes #2681