### PR TITLE
Add information about [audio] tag on BBCode page

### DIFF
--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -345,7 +345,7 @@ Embeds a YouTube video in your post.
 [youtube]VIDEO_ID[/youtube]
 ```
 
-### audio
+### Audio
 
 **Show an HTML5 audio player from an online audio source**.
 

--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -356,8 +356,6 @@ The audio files can be sourced from anywhere, as long as the audio exists from t
 Please upload the audio file to reputable file sharing sites like [puush](https://puush.me/ "puush"). Once the audio file is uploaded successfully, copy and paste the direct link provided in-between the audio tags. Also note that some websites don't appreciate direct links to their audio files (otherwise known as _hotlinks_).  Please beware that not all file sharing services might be okay with audio files, due to music piracy concerns. File sharing sites listed here should be okay.
 
 - Dedicated button: N/A
-- Notes:
-  - If you have many images or large images, it is recommended to put them inside a [Box](#box).
 - Syntax:
   - Where `URL` is the the direct link to an audio track.
 ```

--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -347,13 +347,13 @@ Embeds a YouTube video in your post.
 
 ### Audio
 
-**Show an HTML5 audio player from an online audio source**.
+**Shows an HTML5 audio player from an online audio source**.
 
 The audio files can be sourced from anywhere, as long as the audio exists from the given url.
 
 **Do not link the audio directly from a local filepath!** Using `C:\Users\Name\Music\audio.mp3` will **not work**.
 
-Please upload the audio file to reputable file sharing sites like [puush](https://puush.me/ "puush"). Once the audio file is uploaded successfully, copy and paste the direct link provided in-between the audio tags. Also note that some websites don't appreciate direct links to their audio files (otherwise known as _hotlinks_).  Please beware that not all file sharing services might be okay with audio files, due to music piracy concerns. File sharing sites listed in here should be okay.
+Please upload the audio file to reputable file sharing sites like [puush](https://puush.me/ "puush"). Once the audio file is uploaded successfully, copy and paste the direct link provided in-between the audio tags. Also note that some websites don't appreciate direct links to their audio files (otherwise known as _hotlinks_).  Please beware that not all file sharing services might be okay with audio files, due to music piracy concerns. File sharing sites listed here should be okay.
 
 - Dedicated button: N/A
 - Notes:

--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -345,6 +345,25 @@ Embeds a YouTube video in your post.
 [youtube]VIDEO_ID[/youtube]
 ```
 
+### audio
+
+**Show an HTML5 audio player from an online audio source**.
+
+The audio files can be sourced from anywhere, as long as the audio exists from the given url.
+
+**Do not link the audio directly from a local filepath!** Using `C:\Users\Name\Music\audio.mp3` will **not work**.
+
+Please upload the audio file to reputable file sharing sites like [puush](https://puush.me/ "puush"). Once the audio file is uploaded successfully, copy and paste the direct link provided in-between the audio tags. Also note that some websites don't appreciate direct links to their audio files (otherwise known as _hotlinks_).  Please beware that not all file sharing services might be okay with audio files, due to music piracy concerns. File sharing sites listed in here should be okay.
+
+- Dedicated button: N/A
+- Notes:
+  - If you have many images or large images, it is recommended to put them inside a [Box](#box).
+- Syntax:
+  - Where `URL` is the the direct link to an audio track.
+```
+[audio]URL[/audio]
+```
+
 ### Heading (v1)
 
 Adds a big fancy pink heading.


### PR DESCRIPTION
Since this was misisng there, I have decided to add it. Though, I think this tag was mainly intended for FA news pages, it still works in forums. 