### PR TITLE
Replace dead links with new links

### DIFF
--- a/wiki/Help_Centre/en.md
+++ b/wiki/Help_Centre/en.md
@@ -931,7 +931,7 @@ To fix this, ensure you have the osu!go device selected, and right click on the 
 
 **You will need to partition the device from scratch.**
 
-Please follow [this guide](https://tails.boum.org/doc/first_steps/reset/windows/index.en.html) for details on how to do that.
+Please follow [this guide](https://staging.tails.boum.org/doc/first_steps/reset/windows.en.html) for details on how to do that.
 
 #### I've reformatted the osu!go device and it now shows up in Disk Management.
 

--- a/wiki/Help_Centre/fr.md
+++ b/wiki/Help_Centre/fr.md
@@ -930,7 +930,7 @@ Pour corriger cela, assurez-vous d'avoir sélectionné votre clé USB osu!go, cl
 
 **Vous devrez partitionner de zéro.**
 
-Veuillez suivre [ce guide](https://tails.boum.org/doc/first_steps/reset/windows/index.en.html) pour savoir comment faire.
+Veuillez suivre [ce guide](https://tails.boum.org/doc/first_steps/reset/windows/index.fr.html) pour savoir comment faire.
 
 
 #### J'ai reformaté ma clé osu!go et elle n'est plus dans la liste.

--- a/wiki/Help_Centre/id.md
+++ b/wiki/Help_Centre/id.md
@@ -941,7 +941,7 @@ Untuk memperbaikinya, pastikan Anda perangkat osu!go telah terpilih, dan klik ka
 
 **Anda perlu mempartisi perangkat dari awal.**
 
-Silakan ikuti ​[panduan ini](https://tails.boum.org/doc/first_steps/reset/windows/index.en.html) untuk rincian tentang cara melakukannya.
+Silakan ikuti ​[panduan ini](https://staging.tails.boum.org/doc/first_steps/reset/windows.en.html) untuk rincian tentang cara melakukannya.
 
 #### Saya telah memformat ulang perangkat osu!go dan akhirnya sekarang muncul di Disk Management.
 

--- a/wiki/Help_Centre/zh.md
+++ b/wiki/Help_Centre/zh.md
@@ -942,7 +942,7 @@ osu! 安装程序自带有 .NET 框架，为了以防万一，你可以[在这�
 
 **你可能需要为它重新分区。**
 
-请参考[这个指南](https://tails.boum.org/doc/first_steps/reset/windows/index.en.html)，了解具体应该怎么做。
+请参考[这个指南](https://tails.boum.org/doc/first_steps/reset/windows/index.zh.html)，了解具体应该怎么做。
 
 
 #### 我重新格式化了 osu!go U 盘，现在它在磁盘管理中显示了。


### PR DESCRIPTION
Replace the dead link in #2945 with a new link.

According to InternetArchive's WaybackMachine, they are the same.
Old link: https://web.archive.org/web/20190405074557/https://tails.boum.org/doc/first_steps/reset/windows/index.en.html
New Link: https://staging.tails.boum.org/doc/first_steps/reset/windows.en.html

And I linked those links to the language page.
For example, zh is windows.zh.html
Pages that do not have a language like id are linked to en.