### PR TITLE
Override multiple top-level headers lint rule for news posts

### DIFF
--- a/news/.markdownlint.json
+++ b/news/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../.markdownlint.json",
+    "MD025": false
+}


### PR DESCRIPTION
we allow them here because there's effectively an even-more-top-level header displayed in the header image above the post