### PR TITLE
Clarify difficulty naming rule in osu!mania RC

### DIFF
--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -60,7 +60,7 @@ Overall rules and guidelines apply to every kind of osu!mania difficulty. Rhythm
 - **There must not be more than 6 notes pressed at any given moment in Insane or lower difficulties.** Using more than 6 notes must also follow a reasonable spread to the next lower difficulty. This rule does not apply to ends of long notes, as they are released, not pressed.
 - **Beatmaps can only use 4 to 9 keys.** Anything else is not supported for the Ranked section.
 - **Each key mode in a beatmap set requires its own spread.** For example, a 4 key beatmap would require its own Normal/Hard/Insane in order to create a proper spread, independent of any other key modes present in the beatmap set.
-- **If multiple key modes are present in a single beatmap set, the key mode must be denoted in the difficulty name.**
+- **If multiple key modes are present in a single beatmap set, the key mode must be denoted in the difficulty name.** Conversely, they key mode must not be denoted in the difficulty name if only a single key mode is present.
 
 ### Guidelines
 

--- a/wiki/Ranking_Criteria/osu!mania/en.md
+++ b/wiki/Ranking_Criteria/osu!mania/en.md
@@ -60,7 +60,7 @@ Overall rules and guidelines apply to every kind of osu!mania difficulty. Rhythm
 - **There must not be more than 6 notes pressed at any given moment in Insane or lower difficulties.** Using more than 6 notes must also follow a reasonable spread to the next lower difficulty. This rule does not apply to ends of long notes, as they are released, not pressed.
 - **Beatmaps can only use 4 to 9 keys.** Anything else is not supported for the Ranked section.
 - **Each key mode in a beatmap set requires its own spread.** For example, a 4 key beatmap would require its own Normal/Hard/Insane in order to create a proper spread, independent of any other key modes present in the beatmap set.
-- **If multiple key modes are present in a single beatmap set, the key mode must be denoted in the difficulty name.** Conversely, they key mode must not be denoted in the difficulty name if only a single key mode is present.
+- **If multiple key modes are present in a single beatmap set, the key mode must be denoted in all difficulty names. Otherwise, the key mode must not be denoted.**
 
 ### Guidelines
 


### PR DESCRIPTION
A little addition for the rule which require to name they key count if multiple key modes are present in the set. 
This addition says to not use "xK" in the difficulty name if there is only a single key mode present. 

RC Thread: https://osu.ppy.sh/community/forums/topics/1015289

Can stay open for a while, thread is new and maybe someone want's to discuss about this change first.