### PR TITLE
Beatmap Veto: Clarify mediation conditions

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Veto/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Veto/en.md
@@ -21,7 +21,7 @@ Assuming the issues are satisfactorily resolved or justified with all parties in
 
 Beatmapping is extremely diverse and creative differences are to be expected. This is to be encouraged for the sake of creating a variety of content all players can enjoy! However, such differences can naturally lead to disagreements.
 
-If discussion is no longer progressing after 48 hours have passed since the veto was initiated, the beatmap creator or vetoing Beatmap Nominator can request for mediation. If no request is received, mediation will not begin and the mapper will be assumed to have given up on the beatmapset.
+If discussion is no longer progressing in the direction of a compromise, or is otherwise unable to be reasonably resolved, the beatmap creator or vetoing Beatmap Nominator can request for mediation. If no request is received, mediation will not begin and the mapper will be assumed to have given up on the beatmapset.
 
 During mediation, the randomly selected jury of Beatmap Nominators and members of the NAT will vote for whether to uphold or dismiss the veto anonymously. Once initiated, this process can take anywhere from a day to a week depending on how quickly members of the jury make their decisions.
 


### PR DESCRIPTION
The 48h part isn't actually used anymore after we trialed it, where both parties ended up going in circles until the time ran out (this was a long time ago and we haven't updated the page since).

Currently, it would be more accurate to say that the NAT decide whether to start the mediation based on the existing discussion upon receiving the request; making sure that the discussion has reached a dead end or loop, where additional arguments don't seem to bring things closer to a compromise.