### PR TITLE
Fix documentation of mania judgement storage

### DIFF
--- a/wiki/osu!_File_Formats/Db_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/en.md
@@ -161,10 +161,10 @@ This database contains the scores achieved locally.
 | String | Player name |
 | String | Replay MD5 hash |
 | Short | Number of 300's |
-| Short | Number of 100's in osu!Standard, 150's in Taiko, 100's in CTB, 200's in Mania |
+| Short | Number of 100's in osu!Standard, 150's in Taiko, 100's in CTB, 100's in Mania |
 | Short | Number of 50's in osu!Standard, small fruit in CTB, 50's in Mania |
 | Short | Number of Gekis in osu!Standard, Max 300's in Mania |
-| Short | Number of Katus in osu!Standard, 100's in Mania |
+| Short | Number of Katus in osu!Standard, 200's in Mania |
 | Short | Number of misses |
 | Int | Replay score |
 | Short | Max Combo |

--- a/wiki/osu!_File_Formats/Db_(file_format)/fr.md
+++ b/wiki/osu!_File_Formats/Db_(file_format)/fr.md
@@ -160,10 +160,10 @@ Cette base de données contient tous les scores réalisés localement.
 | Chaîne de caractère (string) | Nom du joueur |
 | Chaîne de caractère (string) | Replay chiffrée en MD5 |
 | Court (short) | Nombre de 300 |
-| Court (short) | Nombre de 100 en osu!standard, de 150 en osu!taiko, de 100 en osu!catch, et de 200 en osu!mania |
+| Court (short) | Nombre de 100 en osu!standard, de 150 en osu!taiko, de 100 en osu!catch, et de 100 en osu!mania |
 | Court (short) | Nombre de 50 en osu!standard, petit fruits en osu!catch, et de 50 en osu!mania |
 | Court (short) | Nombre de Gekis en osu!standard, et de Max 300 en osu!mania |
-| Court (short) | Nombre de Katus en osu!standard, et de 100 en osu!mania |
+| Court (short) | Nombre de Katus en osu!standard, et de 200 en osu!mania |
 | Court (short) | Nombre de fautes (misses) |
 | Entier (Int) | Score total |
 | Court (short) | Meilleur combo effectué |

--- a/wiki/osu!_File_Formats/Osr_(file_format)/en.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/en.md
@@ -25,10 +25,10 @@ Byte offsets are not included in this table due to variable length values.
 | String | Player name |
 | String | osu! replay MD5 hash (includes certain properties of the replay) |
 | Short | Number of 300s |
-| Short | Number of 100s in standard, 150s in Taiko, 100s in CTB, 200s in mania |
+| Short | Number of 100s in standard, 150s in Taiko, 100s in CTB, 100s in mania |
 | Short | Number of 50s in standard, small fruit in CTB, 50s in mania |
 | Short | Number of Gekis in standard, Max 300s in mania |
-| Short | Number of Katus in standard, 100s in mania |
+| Short | Number of Katus in standard, 200s in mania |
 | Short | Number of misses |
 | Integer | Total score displayed on the score report |
 | Short | Greatest combo displayed on the score report |

--- a/wiki/osu!_File_Formats/Osr_(file_format)/fr.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/fr.md
@@ -25,10 +25,10 @@ Les Byte offsets ne sont pas inclus dans ce tableau à cause des valeurs à tail
 | Chaîne de caractère (string) | Nom du joueur ayant effectué ce replay |
 | Chaîne de caractère (string) | Hash de la beatmap en MD5 incluant des données du replay |
 | Court (short) | Nombre de 300 |
-| Court (short) | Nombre de 100 en osu!standard, de 150 en osu!taiko, de 100 en osu!catch, ou de 200 en osu!mania |
+| Court (short) | Nombre de 100 en osu!standard, de 150 en osu!taiko, de 100 en osu!catch, ou de 100 en osu!mania |
 | Court (short) | Nombre de 50 en osu!standard, petit fruits en osu!catch, ou de 50 en osu!mania |
 | Court (short) | Nombre de Gekis en osu!standard, ou de Max 300 en osu!mania |
-| Court (short) | Nombre de Katus en osu!standard, ou de 100 en osu!mania |
+| Court (short) | Nombre de Katus en osu!standard, ou de 200 en osu!mania |
 | Court (short) | Nombre de fautes (misses) |
 | Entier (int) | Score total |
 | Court (short) | Combo maximum effectué lors du replay |

--- a/wiki/osu!_File_Formats/Osr_(file_format)/zh.md
+++ b/wiki/osu!_File_Formats/Osr_(file_format)/zh.md
@@ -29,10 +29,10 @@ outdated: true
 | String | 玩家名称 |
 | String | 回放文件的 MD5 hash (包含回放的确定属性) |
 | Short | “300”判定的数量 |
-| Short | “100”判定（osu!standard），“150”判定（Taiko），“100”判定（CTB），“200”判定（osu!mania）的数量 |
+| Short | “100”判定（osu!standard），“150”判定（Taiko），“100”判定（CTB），“100”判定（osu!mania）的数量 |
 | Short | “50”判定（osu!standard），小水果（CTB），“50”判定（osu!mania）的数量 |
 | Short | Number of Gekis in standard, Max 300s in mania“激”判定（osu!standard），彩色“300”判定（osu!mania）的数量 |
-| Short | Number of Katus in standard, 100s in mania“喝”判定（osu!standard），“100”判定（osu!mania）的数量 |
+| Short | Number of Katus in standard, 200s in mania“喝”判定（osu!standard），“200”判定（osu!mania）的数量 |
 | Short | Miss的数量 |
 | Integer | 结算界面显示的总分 |
 | Short | 结算界面显示的最大连击数 |


### PR DESCRIPTION
Please double check, but I found that when implementing a database reader that this (see changes) is actually how mania judgements are stored. I checked what I was reading against the scores as displayed in game.