### PR TITLE
Add redirects and tags for The Team and Developers

### DIFF
--- a/wiki/People/The_Team/Developers/en.md
+++ b/wiki/People/The_Team/Developers/en.md
@@ -1,6 +1,10 @@
 ---
 tags:
+  - devs
   - osu!dev
+  - osu!devs
+  - osu! dev
+  - osu! devs
 ---
 
 # Developers

--- a/wiki/People/The_Team/Developers/fr.md
+++ b/wiki/People/The_Team/Developers/fr.md
@@ -1,5 +1,12 @@
 ---
 no_native_review: true
+tags:
+  - dev
+  - devs
+  - osu!dev
+  - osu!devs
+  - osu! dev
+  - osu! devs
 ---
 
 # Développeurs

--- a/wiki/People/The_Team/en.md
+++ b/wiki/People/The_Team/en.md
@@ -1,8 +1,10 @@
 ---
 tags:
+  - osu! staff
   - osu!team
   - osu! team
   - staff
+  - team osu!
 ---
 
 # The Team

--- a/wiki/People/The_Team/en.md
+++ b/wiki/People/The_Team/en.md
@@ -1,6 +1,7 @@
 ---
 tags:
   - osu!team
+  - osu! team
   - staff
 ---
 

--- a/wiki/People/The_Team/id.md
+++ b/wiki/People/The_Team/id.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - osu!team
+  - osu! team
+  - staff
+---
+
 # Tim
 
 *Untuk daftar pengguna yang dipromosikan atau telah pensiun, lihat: [Staff Log](/wiki/Staff_Log)*

--- a/wiki/People/The_Team/id.md
+++ b/wiki/People/The_Team/id.md
@@ -1,8 +1,10 @@
 ---
 tags:
+  - osu! staff
   - osu!team
   - osu! team
   - staff
+  - team osu!
 ---
 
 # Tim

--- a/wiki/People/The_Team/pt-br.md
+++ b/wiki/People/The_Team/pt-br.md
@@ -1,8 +1,9 @@
 ---
+no_native_review: true
 tags:
   - osu!team
+  - osu! team
   - staff
-no_native_review: true
 ---
 
 # A Equipe

--- a/wiki/People/The_Team/pt-br.md
+++ b/wiki/People/The_Team/pt-br.md
@@ -1,9 +1,11 @@
 ---
 no_native_review: true
 tags:
+  - osu! staff
   - osu!team
   - osu! team
   - staff
+  - team osu!
 ---
 
 # A Equipe

--- a/wiki/People/The_Team/sv.md
+++ b/wiki/People/The_Team/sv.md
@@ -1,9 +1,11 @@
 ---
 no_native_review: true
 tags:
+  - osu! staff
   - osu!team
   - osu! team
   - staff
+  - team osu!
 ---
 # Teamet
 

--- a/wiki/People/The_Team/sv.md
+++ b/wiki/People/The_Team/sv.md
@@ -1,5 +1,9 @@
 ---
 no_native_review: true
+tags:
+  - osu!team
+  - osu! team
+  - staff
 ---
 # Teamet
 

--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -927,10 +927,13 @@
 "st":                              "People/The_Team/Support_Team"
 "str":                             "People/The_Team/Support_Team"
 
-"osu!team":  "People/The_Team"
-"osu!_team": "People/The_Team"
-"team":      "People/The_Team"
-"the_team":  "People/The_Team"
+"osu!_staff": "People/The_Team"
+"osu!team":   "People/The_Team"
+"osu!_team":  "People/The_Team"
+"staff"       "People/The_Team"
+"team":       "People/The_Team"
+"team_osu!"   "People/The_Team"
+"the_team":   "People/The_Team"
 
 "dev":       "People/The_Team/Developers"
 "devs":      "People/The_Team/Developers"

--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -930,9 +930,9 @@
 "osu!_staff": "People/The_Team"
 "osu!team":   "People/The_Team"
 "osu!_team":  "People/The_Team"
-"staff"       "People/The_Team"
+"staff":      "People/The_Team"
 "team":       "People/The_Team"
-"team_osu!"   "People/The_Team"
+"team_osu!":  "People/The_Team"
 "the_team":   "People/The_Team"
 
 "dev":       "People/The_Team/Developers"

--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -927,12 +927,17 @@
 "st":                              "People/The_Team/Support_Team"
 "str":                             "People/The_Team/Support_Team"
 
-"the_team":                        "People/The_Team"
-"team":                            "People/The_Team"
-"dev":                             "People/The_Team"
-"devs":                            "People/The_Team"
-"osu!dev":                         "People/The_Team"
-"osu!devs":                        "People/The_Team"
+"osu!team":  "People/The_Team"
+"osu!_team": "People/The_Team"
+"team":      "People/The_Team"
+"the_team":  "People/The_Team"
+
+"dev":       "People/The_Team/Developers"
+"devs":      "People/The_Team/Developers"
+"osu!dev":   "People/The_Team/Developers"
+"osu!devs":  "People/The_Team/Developers"
+"osu!_dev":  "People/The_Team/Developers"
+"osu!_devs": "People/The_Team/Developers"
 
 "pp":                          "Performance_Points"
 "ppv2":                        "Performance_Points"


### PR DESCRIPTION
checks off "osu!team" for #3150 and "osu!dev" if it were there. these are already articles but it's hard to get there using these terms