### PR TITLE
Unify the style of table aligns in news posts

### DIFF
--- a/news/2018-02-22-osu-mania-7k-world-cup-ro16-recap.md
+++ b/news/2018-02-22-osu-mania-7k-world-cup-ro16-recap.md
@@ -96,7 +96,7 @@ That concludes all the matches for this weekend! Good luck to all the remaining 
 ### Saturday, 24. February 2018
 
 | Team A |  |  | Team B | Match Time (UTC) |
-| ---: | ---: | :--- | :--- | :---: |
+| --: | --: | :-- | :-- | :-: |
 | China     | ![][flag_CN] | ![][flag_PH] | Philippines | **10:00 UTC**  |
 | Australia | ![][flag_AU] | ![][flag_DE] | Germany     | **11:00 UTC**  |
 | Indonesia | ![][flag_ID] | ![][flag_JP] | Japan       | **12:00 UTC**  |
@@ -104,7 +104,7 @@ That concludes all the matches for this weekend! Good luck to all the remaining 
 ### Sunday, 25. February 2018
 
 | Team A |  |  | Team B | Match Time (UTC) |
-| ---: | ---: | :--- | :--- | :---: |
+| --: | --: | :-- | :-- | :-: |
 | South Korea   | ![][flag_KR] | ![][flag_BR] | Brazil    | **2:00 UTC**  |
 | Singapore     | ![][flag_SG] | ![][flag_CL] | Chile     | **3:00 UTC**  |
 | United States | ![][flag_US] | ![][flag_MY] | Malaysia  | **4:00 UTC**  |

--- a/news/2018-06-23-osu-mapping-olympiad-1-results.md
+++ b/news/2018-06-23-osu-mapping-olympiad-1-results.md
@@ -13,7 +13,7 @@ For the inaugural Olympiad contest, we tasked mappers with choosing one of three
 ## Kuba Oms - Beautiful Uncertainty (Redux)
 
 | Rank | Username | Entry Name | Musical Relevance (50) | Creativity (50) | Technique (50) | Impression (50) | Hitsounding (25) | Total Score |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | \#1 | pishifat | Tactful Manatee | 43.5 | 41.5 | 45 | 41.5 | 19 | **190.5** |
 | \#2 | Fallmorph | Competitive Bison | 41.5 | 43.5 | 37 | 43.5 | 20 | **185.5** |
 | \#3 | Gaia | Needy Pelican | 36 | 32.5 | 36.2 | 35 | 18 | **157.7** |
@@ -32,7 +32,7 @@ And rounding out the top three, **third place** belongs to [**Gaia**](https://os
 ## cYsmix - Escapism
 
 | Rank | Username | Entry Name | Musical Relevance (50) | Creativity (50) | Technique (50) | Impression (50) | Hitsounding (25) | Total Score |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | \#1| Bonzi | Uptight Dolphin | 46 | 41.5 | 44.5 | 43 | 20.5 | **195.5** |
 | \#2| Rokkea | Composed Chipmunk | 41 | 40 | 43.3 | 42.5 | 18.3 | **185.1** |
 | \#3| fanzhen0019 | Vulnerable Pelican | 43.3 | 37 | 38.3 | 40 | 19.3 | **177.9** |
@@ -57,7 +57,7 @@ In **first place** for *Escapism* is [**Bonzi**](https://osu.ppy.sh/users/131396
 ## OISHII - HONEY SNOWFLAKES
 
 | Rank | Username | Entry Name | Musical Relevance (50) | Creativity (50) | Technique (50) | Impression (50) | Hitsounding (25) | Total Score |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | \#1| Monstrata | Responsive Porcupine | 43.5 | 38.8 | 45 | 42 | 21.5 | **190.8** |
 | \#2| Kibbleru | Tenacious Starling | 38.3 | 34.5 | 40 | 34 | 19.5 | **166.3** |
 | \#3| Nozhomi | Happy Raccoon | 34.5 | 33.5 | 35.5 | 35.5 | 18.5 | **157.5** |

--- a/news/2018-07-25-MWC4K-2018-registrations-open.md
+++ b/news/2018-07-25-MWC4K-2018-registrations-open.md
@@ -14,7 +14,7 @@ You can discuss this event and follow the most important changes in the **[offic
 ## Tournament Schedule
 
 | Event              | Timestamp               |
-| -----------------: | :---------------------- |
+| --: | :-- |
 | Registration Phase | 2018-07-25/2018-08-08   |
 | Live Drawings      | 2018-08-18 (14:00 UTC)  |
 | Group Stage        | 2018-08-25/2018-08-26   |

--- a/news/2019-02-06-osu-mapping-olympiad-4-results.md
+++ b/news/2019-02-06-osu-mapping-olympiad-4-results.md
@@ -11,7 +11,7 @@ date: 2019-02-06 20:00:00 +0000
 Back in September, we challenged our great mapping community to create a thorougly fruity difficulty spread to the entrancing tune of [Thaehan](https://osu.ppy.sh/beatmaps/artists/7) - Yuujou. Ten mappers stepped up to the plate, showcasing their abilities for a chance to join the coveted ranks of osu!'s *Elite Mappers*. The results can be seen below:
 
 | Rank | Username | Entry Name | Musical Relevance (30) | Creativity (30) | Technique (30) | Impression (30) | Hitsounding (15) | Difficulty Spread (15) | Total Score |
-| :-: | --- | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| :-: | :-- | :-- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 | \#1 | Sinnoh | Zealous Beaver | 27.5 | 26.5 | 26 | 29 | 13 | 13 |  **135** |
 | \#2 | Minato Yukina | Esteemed Dragon | 27 | 24 | 24 | 26 | 12 | 13 | **126** |
 | \#3 | Ascendance | Puzzled Crow | 23.5 | 23 | 22 | 23.5 | 14 | 11.5 | **117.5** |

--- a/news/2019-05-22-osu-mapping-olympiad-5-results.md
+++ b/news/2019-05-22-osu-mapping-olympiad-5-results.md
@@ -11,7 +11,7 @@ The results for the second osu!standard Mapping Olympiad contest are in! See who
 This installment of the Mapping Olympiad contest challenged mappers to create a pair of difficulties for *[Virtual Self](https://osu.ppy.sh/beatmaps/artists/28)*'s EON BREAK. As an additional challenge, participants were asked to showcase different mapping styles between the two entries to demonstrate their creativity, in reference to the two personas 'Pathselector' and 'technic-Angel' that make up *Virtual Self*. Below are the results: 
 
 | Rank | Username             | Entry Name             | Musical Relevance (40) | Creativity (60) | Technique (40) | Impression (40) | Hitsounding (20) | Score |
-|------|----------------------|------------------------|------------------------|-----------------|----------------|-----------------|------------------|-------|
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | #1   | Necho & Ryuusei Aika | Casual Vole            | 34.5                   | 48.5            | 35             | 36              | 14               | **168**   |
 | #2   | yaspo                | Resilient Bufflehead   | 31.5                   | 52              | 27.5           | 34              | 16.5             | **161.5** |
 | #3   | J1_ & how2miss       | Contemptible Crocodile | 32.5                   | 45              | 35             | 33              | 11.5             | **157**   |

--- a/news/2019-05-29-CWC-2019-registrations-open.md
+++ b/news/2019-05-29-CWC-2019-registrations-open.md
@@ -14,7 +14,7 @@ You can discuss this event and follow the most important changes in the **[offic
 ## Tournament Schedule
 
 | Event | Timestamp |
-| ---: | :--- |
+| --: | :-- |
 | Registration Phase | May 29th - June 11th |
 | Drawings | June 22nd (14:00 UTC) |
 | Group Stage | June 29th & June 30th |
@@ -27,7 +27,7 @@ You can discuss this event and follow the most important changes in the **[offic
 ## Prizes
 
 | Placing | Prize(s) |
-| --- | :--- |
+| :-- | :-- |
 | ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | $150 per team member, profile badge, "osu!catch Champion" user title for one year |
 | ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | $80 per team member, profile badge |
 | ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | $40 per team member, profile badge |

--- a/news/2019-08-20-MWC4K-2019-registrations-open.md
+++ b/news/2019-08-20-MWC4K-2019-registrations-open.md
@@ -27,7 +27,7 @@ You can discuss this event and follow the most important changes in the **[offic
 ## Prizes
 
 | Placing | Prize(s) |
-| --- | :--- |
+| :-- | :-- |
 | ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | $150 per team member, profile badge, "osu!mania Champion" user title for one year |
 | ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | $80 per team member, profile badge |
 | ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | $40 per team member, profile badge |


### PR DESCRIPTION
(\| *-{3,} *\|)|(\| *:-{3,} * \|) -> | :-- |
\| *:-{1,}: *\| -> | :-: |
\| *-{2,}: * \| -> | --: |

also tried regexes from previous table align PR but they weren't useful here