### PR TITLE
Add integration for Visual Studio Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "mrmlnc.vscode-remark"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "name": "osu-wiki",
     "description": "home of the osu! wiki",
     "repository": "github:ppy/osu-wiki",
+    "scripts": {
+        "lint:wiki" : "npx remark wiki/*.md -qf --no-stdout --report=vfile-reporter-position --color"
+    },
     "dependencies": {
         "remark-cli": "8.0.0",
         "remark": "12.0.0",


### PR DESCRIPTION
This includes [`vscode-remark`](https://github.com/mrmlnc/vscode-remark) and a lint command to run a wiki-wide lint.

![image](https://user-images.githubusercontent.com/14976516/81241233-55320380-903c-11ea-981d-75dd99eee801.png)


However, this does not include integration for other editors, hence the inclusion of the `lint:wiki` command as a way for users with other editors to lint locally on the fly.