### PR TITLE
[TR] Add Nomination Assessment Team

### DIFF
--- a/meta/group-info/tr.yaml
+++ b/meta/group-info/tr.yaml
@@ -15,7 +15,7 @@ gmt:
 nat:
   areas:
     communication: İletişim
-    evaluation: Denetleme
+    evaluation: Değerlendirme
     moderation: Moderasyon
     structural: Yapısal
 languages:

--- a/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
@@ -5,13 +5,13 @@ tags:
 
 # Aday Gösterme Denetleme Takımı
 
-**Aday Gösterme Denetleme Takımı** *(Nomination Assessment Team)* (***NAT***) [Beatmap Aday Göstericiler](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ekibinin moderatörleridir ve osu!'nun *beatmapping* kısmının fonksiyonel kalmasından sorumludurlar.
+**Aday Gösterme Denetleme Takımı** (*Nomination Assessment Team*, ***NAT***) [Beatmap Aday Göstericiler](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ekibinin moderatörleridir ve osu!'nun *beatmapping* kısmının fonksiyonel kalmasından sorumludurlar.
 
 NAT üyeleri kırmızı renk kullanıcı isimlerinden ve ünvanlarından ayırt edilebilirler. [Küresel Moderasyon Takımı](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*) gibi, onların da site çaplı moderasyon yetkileri ve oyun-içi sohbet kanallarında koyu kırmızı kullanıcı ismine sahiptirler.
 
 ## Sorumluluklar
 
-NAT mapping ile ilgili pek çok işten sorumludur, bunlar dört alt kategoride incelenebilir: 
+NAT mapping ile ilgili pek çok işten sorumludur, bunlar dört alt kategoride incelenebilir:
 
 - **Değerlendirme:** Mevcut Beatmap Aday Göstericilerin ve adayların yeterliliklerini ve aktivitelerini değerlendirme. NAT üyelerinin çoğu bu alt kategorinin iştirakından sorumludur.
 - **Yapısal:** Derecelendirme sürecini çerçeveleyen konuları belgeleme, kuralları ve yönergeleri [derecelendirme kriterleri](/wiki/Ranking_Criteria) doğrultusunda değiştirme, ilgili araçları ve web sayfalarını geliştirme ve sürdürme.
@@ -28,7 +28,7 @@ NAT'ye katılmadan önce, bir kullanıcı ya asil Beatmap Aday Göstericiler üy
 
 Yeni NAT üyelerinin büyük çoğunluğu BN değerlendirilmesine yardım edecekleri için, NAT adaylarının diğerlerinin yeterliliklerini ölçmede yetkin olmaları önemlidir. Asil BN'lerin, NAT'nin gerçek değerlendirmelerinin yanı sıra, alıştırma yapmak amacıyla sahte değerlendirmeler yapma gibi bir seçenekleri bulunmaktadır. Bir NAT adayı, eğer yaptığı değerlendirmeler detaylı ve NAT'ninkilere benzer sonuca ulaşıyorsa (veya ayrıca destekleyici bir mantığa sahipse) çok daha yüksek bir terfi etme şansı elde eder.
 
-NAT uzun zaman periyodlarıyla potansiyel NAT üyelerini gözetler, ve genellikle, BN değerlendirmelerinin yapılmasına benzer bir şekilde, adayın terfi edip etmemesi üzerine karar verilmesi için toplanır. BN'ler de eğer geri bildirim almak ve dikkate alınıp alınmadıklarını öğrenmek istiyorlarsa NAT'ye katılmak ile ilgili soru sorma konusunda serbesttirler. Nitekim, mevcut NAT'nin aktivitesine ve beceri setine bağlı olarak, yeni bir üyeye ihtiyaç olmayabilir. Ancak mevcut üyeler giderek inaktif olmaya başladığında, ya da daha çok üye gerektiren yeni bir dizi iş yükü bindiğinde, vs. olası yeni NAT terfi edilir. 
+NAT uzun zaman periyodlarıyla potansiyel NAT üyelerini gözetler, ve genellikle, BN değerlendirmelerinin yapılmasına benzer bir şekilde, adayın terfi edip etmemesi üzerine karar verilmesi için toplanır. BN'ler de eğer geri bildirim almak ve dikkate alınıp alınmadıklarını öğrenmek istiyorlarsa NAT'ye katılmak ile ilgili soru sorma konusunda serbesttirler. Nitekim, mevcut NAT'nin aktivitesine ve beceri setine bağlı olarak, yeni bir üyeye ihtiyaç olmayabilir. Ancak mevcut üyeler giderek inaktif olmaya başladığında, ya da daha çok üye gerektiren yeni bir dizi iş yükü bindiğinde, vs. olası yeni NAT terfi edilir.
 
 ## Takım üyeleri
 

--- a/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - NAT
+---
+
+# Aday Gösterme Denetleme Takımı
+
+**Aday Gösterme Denetleme Takımı** *(Nomination Assessment Team)* (***NAT***) [Beatmap Aday Göstericiler](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ekibinin moderatörleridir ve osu!'nun *beatmapping* kısmının fonksiyonel kalmasından sorumludurlar.
+
+NAT üyeleri kırmızı renk kullanıcı isimlerinden ve ünvanlarından ayırt edilebilirler. [Küresel Moderasyon Takımı](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*) gibi, onların da site çaplı moderasyon yetkileri ve oyun-içi sohbet kanallarında koyu kırmızı kullanıcı ismine sahiptirler.
+
+## Sorumluluklar
+
+NAT mapping ile ilgili pek çok işten sorumludur, bunlar dört alt kategoride incelenebilir: 
+
+- **Değerlendirme:** Mevcut Beatmap Aday Göstericilerin ve adayların yeterliliklerini ve aktivitelerini değerlendirme. NAT üyelerinin çoğu bu alt kategorinin iştirakından sorumludur.
+- **Yapısal:** Derecelendirme sürecini çerçeveleyen konuları belgeleme, kuralları ve yönergeleri [derecelendirme kriterleri](/wiki/Ranking_Criteria) doğrultusunda değiştirme, ilgili araçları ve web sayfalarını geliştirme ve sürdürme.
+- **Moderasyon:** Kullanıcı raporlarını işleme alma ve Beatmap Aday Göstericilerin uygunsuz davranışlarını denetleme. Bu alt kategori NAT ve GMT arası ortak bir çalışmadır.
+- **İletişim:** Toplantıların oluşturulması ve sunulması dahil, NAT ve mapping/modding topluluğu arasında şeffaflığı kurma.
+
+Bir NAT üyesi, birincil sorumlulukları ne olarak listelenmiş olsa da, seçtikleri alt kategori içerisinde her türlü iş üzerinde çalışabilir. Örneğin, eğer bir NAT üyesi Yapısal alt kategorisi üzerinde yoğunlaşmışsa, o alt kategori içerisindeki tüm işlerden sorumlu değildir ve bir başka alt kategori içerisindeki işlerde yardımcı olabilir.
+
+Birincil olarak değerlendirme alt kategorisine katkıda bulunan NAT üyeleri her ay en az 3 beatmap modlamaktan sorumludur. Bu, Beatmap Aday Göstericilerini değerlendirirken NAT'nin modding topluluğu ile güncel kalmalarını sağlar. Modding aktivite gereksinimlerini karşılayamayan üyeler uyarılır. Eğer sonraki ay içerisinde aktiviteleri gelişmezse, NAT üyelikleri sonlandırılır. Mapping ile ilgili diğer projeler üzerinde çalışan NAT üyeleri duruma göre modding gereksinimlerinden muaf tutulabilirler.
+
+## NAT'ye terfi etmek
+
+NAT'ye katılmadan önce, bir kullanıcı ya asil Beatmap Aday Göstericiler üyesi olmalı, ya da halen daha topluluk içerisinde aktif olan eski bir NAT üyesi olmalıdır. Çoğu NAT adayı öncelikle mapping ve modding topluluğuna yardımcı olma çabaları üzerine dikkate alınırlar, ve dahası NAT sorumluluklarının tüm alt kategorilerine katkıda bulunma becerisi gösterme çoğunlukla terfi etmenin temelini oluşturur.
+
+Yeni NAT üyelerinin büyük çoğunluğu BN değerlendirilmesine yardım edecekleri için, NAT adaylarının diğerlerinin yeterliliklerini ölçmede yetkin olmaları önemlidir. Asil BN'lerin, NAT'nin gerçek değerlendirmelerinin yanı sıra, alıştırma yapmak amacıyla sahte değerlendirmeler yapma gibi bir seçenekleri bulunmaktadır. Bir NAT adayı, eğer yaptığı değerlendirmeler detaylı ve NAT'ninkilere benzer sonuca ulaşıyorsa (veya ayrıca destekleyici bir mantığa sahipse) çok daha yüksek bir terfi etme şansı elde eder.
+
+NAT uzun zaman periyodlarıyla potansiyel NAT üyelerini gözetler, ve genellikle, BN değerlendirmelerinin yapılmasına benzer bir şekilde, adayın terfi edip etmemesi üzerine karar verilmesi için toplanır. BN'ler de eğer geri bildirim almak ve dikkate alınıp alınmadıklarını öğrenmek istiyorlarsa NAT'ye katılmak ile ilgili soru sorma konusunda serbesttirler. Nitekim, mevcut NAT'nin aktivitesine ve beceri setine bağlı olarak, yeni bir üyeye ihtiyaç olmayabilir. Ancak mevcut üyeler giderek inaktif olmaya başladığında, ya da daha çok üye gerektiren yeni bir dizi iş yükü bindiğinde, vs. olası yeni NAT terfi edilir. 
+
+## Takım üyeleri
+
+[Aday Gösterme Denetleme Takımı grup sayfası](https://osu.ppy.sh/groups/7) tüm ekip üyelerini listeler.
+
+*Not: Tüm NAT üyeleri, aksi not edilmediği sürece, belirtilen dillerin yanısıra İngilizce de konuşabilirler.*
+
+### osu!
+
+| İsim | Ek diller | Birincil sorumluluklar |
+| :-- | :-- | :-- |
+| ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) |  | Değerlendirme, Moderasyon |
+| ![][flag_HK] [Chaoslitz](https://osu.ppy.sh/users/3621552) | Kantonca, Çince | Değerlendirme |
+| ![][flag_CA] [Kibbleru](https://osu.ppy.sh/users/3193504) |  | Değerlendirme |
+| ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Almanca | Değerlendirme |
+| ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) | İsveççe | Yapısal, İletişim |
+| ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) |  | Değerlendirme, Yapısal, İletişim |
+| ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) |  | Yapısal |
+| ![][flag_BR] [Seto Kousuke](https://osu.ppy.sh/users/2857314) | Portekizce | Değerlendirme, Yapısal, İletişim |
+| ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926) | Flemenkçe | Değerlendirme |
+
+### osu!taiko
+
+| İsim | Ek diller | Birincil sorumluluklar |
+| :-- | :-- | :-- |
+| ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Kantonca, Çince | Değerlendirme |
+| ![][flag_DE] [Nepuri](https://osu.ppy.sh/users/6637817) | Almanca | Değerlendirme |
+| ![][flag_TH] [Tyistiana](https://osu.ppy.sh/users/1421452) | Tay dili | Değerlendirme |
+
+### osu!catch
+
+| İsim | Ek diller | Birincil sorumluluklar |
+| :-- | :-- | :-- |
+| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | İspanyolca, Almanca | Değerlendirme, Moderasyon |
+| ![][flag_NL] [Greaper](https://osu.ppy.sh/users/2369776) | Flemenkçe | Değerlendirme |
+
+### osu!mania
+
+| İsim | Ek diller | Birincil sorumluluklar |
+| :-- | :-- | :-- |
+| ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717) | Almanca, Lehçe | Değerlendirme |
+| ![][flag_NL] [Leniane](https://osu.ppy.sh/users/7138602) | Flemenkçe | Değerlendirme, Moderasyon |
+
+[flag_BE]: /wiki/shared/flag/BE.gif "Belçika"
+[flag_BR]: /wiki/shared/flag/BR.gif "Brezilya"
+[flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
+[flag_DE]: /wiki/shared/flag/DE.gif "Almanya"
+[flag_ES]: /wiki/shared/flag/ES.gif "İspanya"
+[flag_GB]: /wiki/shared/flag/GB.gif "Birleşik Krallık"
+[flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
+[flag_NL]: /wiki/shared/flag/NL.gif "Hollanda"
+[flag_SE]: /wiki/shared/flag/SE.gif "İsveç"
+[flag_TH]: /wiki/shared/flag/TH.gif "Tayland"
+[flag_US]: /wiki/shared/flag/US.gif "Birleşik Devletler"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
@@ -5,9 +5,9 @@ tags:
 
 # Aday Gösterme Denetleme Takımı
 
-**Aday Gösterme Denetleme Takımı** (*Nomination Assessment Team*, ***NAT***) [Beatmap Aday Göstericiler](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ekibinin moderatörleridir ve osu!'nun *beatmapping* kısmının fonksiyonel kalmasından sorumludurlar.
+**Aday Gösterme Denetleme Takımı** (*Nomination Assessment Team*, ***NAT***) [Beatmap Aday Göstericiler](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ekibinin moderatörleridir ve osu!'nun *beatmap yaratma* kısmının fonksiyonel kalmasından sorumludurlar.
 
-NAT üyeleri kırmızı renk kullanıcı isimlerinden ve ünvanlarından ayırt edilebilirler. [Küresel Moderasyon Takımı](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*) gibi, onların da site çaplı moderasyon yetkileri ve oyun-içi sohbet kanallarında koyu kırmızı kullanıcı ismine sahiptirler.
+NAT üyeleri kırmızı renk kullanıcı isimlerinden ve ünvanlarından ayırt edilebilirler. [Küresel Moderasyon Takımı](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*) gibi, onların da site çaplı moderasyon yetkileri vardır ve oyun-içi sohbet kanallarında koyu kırmızı kullanıcı ismine sahiptirler.
 
 ## Sorumluluklar
 


### PR DESCRIPTION
- Add Turkish translations of `Nomination_Assessment_Team` article
- Fix a subcategory translation in `group-info` metafiles 