### PR TITLE
Add blob size inspection workflow step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    name: remarkjs, changed files
+    name: changed files
     runs-on: ubuntu-latest
     steps:
       - name: sparse checkout
@@ -30,6 +30,35 @@ jobs:
           # fetch the merge commit ref
           git -c protocol.version=2 fetch --no-tags --prune --progress --depth=2 origin +${GITHUB_SHA}:refs/remotes/origin/${BRANCH}
           git checkout --progress --force -B $BRANCH refs/remotes/origin/$BRANCH
+
+      - name: inspect binary file sizes
+        shell: bash
+        run: |
+          WARN_ON_SIZE=500000
+          ERROR_ON_SIZE=1000000
+          EXIT=0
+
+          while read file
+          do
+              echo "Checking ${file}..."
+              # git ls-tree will output:
+              # (file mode) (file type) (blob hash)<TAB>(file name)
+              # we're interested in the hash to pull the file's size using cat-file
+              hash=`git ls-tree ${{ github.sha }} "${file}" | awk -F ' ' '{ print $3 }'`
+              filesize=`git cat-file -s ${hash} 2>/dev/null`
+
+              if [[ ${filesize} -ge ${ERROR_ON_SIZE} ]]; then
+                  echo "::error file=${file}::The size of the file exceeds 1MB. Compress it to optimise performance."
+                  EXIT=1
+              elif [[ ${filesize} -ge ${WARN_ON_SIZE} ]]; then
+                  echo "::warning file=${file}::The size of the file exceeds 500kB. Consider compressing it to optimise performance."
+              else
+                  echo "::debug::File ${file} is ok."
+              fi
+          done < <(git diff --numstat ${{ github.sha }}^ ${{ github.sha }} | grep -Po "\-\t\-\t\K.+$")
+          # git diff --numstat will output -<TAB>-<TAB>$filename for blobs
+
+          exit ${EXIT}
 
       - name: setup node
         uses: actions/setup-node@v1


### PR DESCRIPTION
This PR contains a new additional check step to the wiki CI, which inspects the size of binary files included in each pull request and reports warnings/errors if their sizes exceed a particular threshold.

# Rationale

From what I gather, [attaching an image file over 1MB makes all sorts of alarm bells go off web-side](https://discord.com/channels/188630481301012481/218677502141399041/722089973687517274) (and rightly so, since large files, even static ones, can very easily incur significant load on the servers). As that is something that can be pretty easily checked at CI-time, this PR aims to nip those sorts of issues in the bud by failing checks if a file is deemed too large to be merged.

Right now, the check has two levels, as it will:

* display a check warning if the file size is greater than or equal to 500kB,
* display a check error if the file size is greater than or equal to 1MB.

The thresholds are obviously negotiable, we can go even lower than that if you think that is best.

# Technical details

The interesting part about this PR that it seemingly does not need to make sacrifices in the parts that made CI go fast before (shallow clone & sparse checkout). It turns out that git is literally magic and will accommodate this through some not-very-widely-used commands.

To begin with, the way the workflow performs the shallow clone is very well-suited for our use case. Once the shallow clone is done, the history consists of exactly two commits; the first one is a *grafted* commit (so, basically a commit that pretends not to have parents while actually having parents in a normal clone). That commit is a snapshot of the main branch pre-merge. Meanwhile, the *second* commit is the merge commit applying the open PR to the current state of the main branch.

This basically seems to mean that the shallow clone *does* fetch all of the files in both commits, but just doesn't check them all out (recreate them). However, even though the files aren't recreated, they show up in the diffs, with their sizes being *fully* accurate, and you can even recreate them manually using `git cat-file`. Because there is no magic, that data has to reside *somewhere* - and that somewhere turns out to be a pack file in `.git/objects/pack`.

A pack file is basically [a bundle of loose object files](https://git-scm.com/book/en/v2/Git-Internals-Packfiles), compacted (and indexed) for performance and ease of access. This is exactly what helps this PR do its thing. The snapshots of the blobs are all there in the pack file in the form of packed git objects - moreover, the sizes & offsets of each individual git object are indexed, so I wouldn't be surprised if the size check just accounted to reading the size out of the index file.

Knowing that, the rest of the code is mechanics:

* `git diff --numstat` helps filter out blobs from non-blobs,
* `git ls-tree` maps a filename back to an object hash we want to access from the pack file,
* `git cat-file -s` does the actual read of the size value we need.

The only problem with this approach is that it's not too fast. While I was running the bash script over all existing blobs in the wiki for reliability checks, it could take about 20 minutes to go over them all - but I don't think we should realistically expect to see that many blobs being pushed to a single PR.

# Experimental results

I ran a few basic checks of this on a test PR, and it seems to run as expected.

* Commit bdach/osu-wiki@08685ce adds three images (143kB, 693kB, 1.9MB in size). CI [correctly reports 1 warning and 1 error](https://github.com/bdach/osu-wiki/actions/runs/137693767) (not overly sure why they got duplicated, it was running ok yesterday).
* Commit bdach/osu-wiki@e1255d6 compresses the 693kB image down to 122 kB. CI [correctly reports 1 error](https://github.com/bdach/osu-wiki/actions/runs/137695902), eliminating the warning.
* Commit bdach/osu-wiki@a030ca5 removes the 1.9MB file altogether. CI [correctly reports no errors or warnings](https://github.com/bdach/osu-wiki/actions/runs/137699269) and passes the check.

Now, there are a few caveats with this entire process:

* The blob check step uses [workflow commands](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#about-workflow-commands) for accessing the checks API, but the commands are severely limited - therefore there is no way to show a warning status on the check. All that we can currently work with in this approach is pass/fail.
* Moreover, the nice check views with the annotations I linked above is dreadfully indiscoverable if you don't know where to click. Clicking on the ticks/crosses anywhere on a GitHub Actions run takes you straight to the run log, and if you don't know the "osu-wiki continuous integration" header is clickable, you won't ever see that view. This is why I added the echo statement with the path of each file checked - this way [it can be inferred which file is the problem off the run log alone, too.](https://github.com/bdach/osu-wiki/runs/778220097?check_suite_focus=true)

Since this is a bit of an off-the-wall solution, I'm opening this as draft too - if you think a more structured approach (such as an actual js script or something) is more apt here, then please let me know.