### PR TITLE
Fix corner cases in blob size inspection

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K[^\x0]+\x0$")
+          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K[^\x0]+")
           # git diff --numstat -z will output:
           # -<TAB>-<TAB>$filename<NUL> - for files that weren't moved
           # -<TAB>-<TAB><NUL>$old_filename<NUL>$new_filename<NUL> - for files that were moved

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K([^\x0]+)\x0$")
+          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K[^\x0]+\x0$")
           # git diff --numstat -z will output:
           # -<TAB>-<TAB>$filename<NUL> - for files that weren't moved
           # -<TAB>-<TAB><NUL>$old_filename<NUL>$new_filename<NUL> - for files that were moved

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,8 +55,10 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --numstat ${{ github.sha }}^ ${{ github.sha }} | grep -Po "\-\t\-\t\K.+$")
-          # git diff --numstat will output -<TAB>-<TAB>$filename for blobs
+          done < <(git diff --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K([^\x0]+)\x0$")
+          # git diff --numstat -z will output:
+          # -<TAB>-<TAB>$filename<NUL> - for files that weren't moved
+          # -<TAB>-<TAB><NUL>$old_filename<NUL>$new_filename<NUL> - for files that were moved
 
           exit ${EXIT}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,10 +55,8 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K[^\x0]+")
-          # git diff --numstat -z will output:
-          # -<TAB>-<TAB>$filename<NUL> - for files that weren't moved
-          # -<TAB>-<TAB><NUL>$old_filename<NUL>$new_filename<NUL> - for files that were moved
+          done < <(git diff --numstat --no-renames --diff-filter=d ${{ github.sha }}^ ${{ github.sha }} | grep -Poe "-\t-\t\K.+")
+          # git diff --numstat will output -<TAB>-<TAB>$filename for blobs
 
           exit ${EXIT}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K([^\x0]+)\x0$")
+          done < <(git diff --diff-filter=d --numstat -z ${{ github.sha }}^ ${{ github.sha }} | grep -Po --text "\-\t\-\t(\x0[^\x0]+\x0)?\K([^\x0]+)\x0$")
           # git diff --numstat -z will output:
           # -<TAB>-<TAB>$filename<NUL> - for files that weren't moved
           # -<TAB>-<TAB><NUL>$old_filename<NUL>$new_filename<NUL> - for files that were moved

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
               else
                   echo "::debug::File ${file} is ok."
               fi
-          done < <(git diff --numstat --no-renames --diff-filter=d ${{ github.sha }}^ ${{ github.sha }} | grep -Poe "-\t-\t\K.+")
+          done < <(git diff --numstat --no-renames --diff-filter=d ${{ github.sha }}^ ${{ github.sha }} | grep -Poe '-\t-\t\K.+')
           # git diff --numstat will output -<TAB>-<TAB>$filename for blobs
 
           exit ${EXIT}


### PR DESCRIPTION
As [seen](https://github.com/ppy/osu-wiki/runs/807554788) in #3760.

# Summary

There are two corner cases I forgot about when writing the blob size inspection, namely: files being moved and deleted. This PR is supposed to address both.

Excluding deleted files is easier and is done by specifying `--diff-filter=d` for `git diff`.

When it comes to moved files, `git diff --numstat` used the `{a -> b}` syntax to indicate moves which caused the inspection to catch fire. Thankfully there's a [documented](https://git-scm.com/docs/git-diff#_other_diff_formats), more machine-friendly format that uses `--numstat -z`. Unfortunately it requires more eldritch regexing.

Here's the explanation:

```
\-              first dash
\t              first tab
\-              second dash
\t              second tab
(               group for the old filename
    \x0         NUL byte
    [^\x0]+     anything but a NUL byte, 1 or more times - this is the old filename, *if* the file was moved
    \x0         NUL byte
)?              the old filename section is optional
\K              disregard everything seen up to now
[^\x0]+         anything but a NUL byte, 1 or more times - this is the current filename
(rest is left unmatched, but it's implied it'll be the final NUL byte and newline)
```

Due to the `NUL`s I also had to specify `--text` as `grep` thought it was looking at a blob itself.

This was tested on the following PRs:

| PR | before | after |
| :- | :-: | :-: |
| [case with moved blob](https://github.com/bdach/osu-wiki/pull/8) | ❌ ([execution log](https://github.com/bdach/osu-wiki/runs/808482633)) | :heavy_check_mark: ([execution log](https://github.com/bdach/osu-wiki/runs/808537875)) |
| [case with deleted blob](https://github.com/bdach/osu-wiki/pull/9) | ❌ ([execution log](https://github.com/bdach/osu-wiki/runs/808532206)) | :heavy_check_mark: ([execution log](https://github.com/bdach/osu-wiki/runs/808538325)) |

Note the proper filename in the first case and the lack of a file in the second.