### PR TITLE
Update group listings and Staff log

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -56,7 +56,7 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_US] [eiri-](https://osu.ppy.sh/users/3388410) | Spanish |
 | ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958) |  |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | Indonesian |
-| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) |  |
+| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Bengali, some Arabic |
 | ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645) | German |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | Chinese, some French |
 | ![][flag_NL] [Kaitjuh](https://osu.ppy.sh/users/2225327) | Dutch |
@@ -134,6 +134,7 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_US] [Kamuy](https://osu.ppy.sh/users/7439226) | Some Korean |
 | ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754) | Korean |
 | ![][flag_AU] [Keiga](https://osu.ppy.sh/users/6866022) | Chinese |
+| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | Chinese, Cantonese |
 | ![][flag_ID] [Rivals_7](https://osu.ppy.sh/users/4610379) | Indonesian |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arabic, French |
 | ![][flag_KR] [Sun](https://osu.ppy.sh/users/4115819) | Korean |
@@ -182,7 +183,6 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783) | Korean |
 | ![][flag_MY] [Kyousukee](https://osu.ppy.sh/users/8842107) | Indonesian, Malay |
 | ![][flag_NL] [Muse Dash](https://osu.ppy.sh/users/13695676) | Chinese |
-| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | Chinese, Cantonese |
 | ![][flag_CN] [Shima Rin](https://osu.ppy.sh/users/6089608) | Chinese |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentina"

--- a/wiki/People/The_Team/Beatmap_Nominators/tr.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/tr.md
@@ -51,11 +51,12 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_US] [Cheri](https://osu.ppy.sh/users/5226970) |  |
 | ![][flag_CL] [Cris-](https://osu.ppy.sh/users/6175280) | İspanyolca |
 | ![][flag_CL] [Crissa](https://osu.ppy.sh/users/5405836) | İspanyolca |
+| ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334) |  |
 | ![][flag_CN] [Dored](https://osu.ppy.sh/users/10284894) | Çince |
 | ![][flag_US] [eiri-](https://osu.ppy.sh/users/3388410) | İspanyolca |
 | ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958) |  |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | Endonezce |
-| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) |  |
+| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Bengalce, biraz Arapça |
 | ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645) | Almanca |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | Çince, biraz Fransızca |
 | ![][flag_NL] [Kaitjuh](https://osu.ppy.sh/users/2225327) | Flemenkçe |
@@ -63,10 +64,12 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909) | Çince |
 | ![][flag_RS] [MaridiuS](https://osu.ppy.sh/users/4496961) | Sırpça |
 | ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994) | İspanyolca |
+| ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | Rusça |
 | ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097) | Almanca |
 | ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645) | Almanca |
 | ![][flag_US] [Nao Tomori](https://osu.ppy.sh/users/5364763) |  |
 | ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995) | Çince |
+| ![][flag_US] [Nevo](https://osu.ppy.sh/users/7451883) |  |
 | ![][flag_GR] [Nikakis](https://osu.ppy.sh/users/4351739) | Yunanca |
 | ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981) | Fransızca |
 | ![][flag_IT] [Nuvolina](https://osu.ppy.sh/users/10974170) | İtalyanca |
@@ -82,6 +85,8 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_CA] [Sparhten](https://osu.ppy.sh/users/7601720) |  |
 | ![][flag_GB] [spoes](https://osu.ppy.sh/users/9505704) |  |
 | ![][flag_BE] [Stack](https://osu.ppy.sh/users/6122935) | Flemenkçe |
+| ![][flag_AT] [Stixy](https://osu.ppy.sh/users/9000308) | Almanca, Sırpça |
+| ![][flag_EG] [Teky](https://osu.ppy.sh/users/10520912) | Arapça |
 | ![][flag_FI] [TheKingHenry](https://osu.ppy.sh/users/5128277) | Fince |
 | ![][flag_TH] [timemon](https://osu.ppy.sh/users/2072005) | Tay dili |
 | ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547) | İspanyolca, Fransızca |
@@ -104,6 +109,7 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995) | Çince |
 | ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  |
 | ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) | İspanyolca, Katalanca |
+| ![][flag_FR] [realy0\_](https://osu.ppy.sh/users/8863359) | Fransızca |
 | ![][flag_ID] [Roger](https://osu.ppy.sh/users/1538223) | Endonezce, biraz Japonca |
 | ![][flag_JP] [tasuke912](https://osu.ppy.sh/users/2774767) | Japonca |
 | ![][flag_ID] [Volta](https://osu.ppy.sh/users/4154071) | Endonezce |
@@ -128,11 +134,11 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_US] [Kamuy](https://osu.ppy.sh/users/7439226) | Biraz Korece |
 | ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754) | Korece |
 | ![][flag_AU] [Keiga](https://osu.ppy.sh/users/6866022) | Çince |
+| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | Çince, Kantonca |
 | ![][flag_ID] [Rivals_7](https://osu.ppy.sh/users/4610379) | Endonezce |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arapça, Fransızca |
 | ![][flag_KR] [Sun](https://osu.ppy.sh/users/4115819) | Korece |
 | ![][flag_NL] [UnluckyCroco](https://osu.ppy.sh/users/9461160) | Flemenkçe |
-| ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  |
 | ![][flag_ID] [Voxa](https://osu.ppy.sh/users/9229539) | Endonezce |
 
 ### Deneme sürecindeki Beatmap Aday Göstericiler
@@ -141,16 +147,11 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 
 | İsim | Ek diller |
 | :-- | :-- |
-| ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334) |  |
 | ![][flag_CA] [Elayue](https://osu.ppy.sh/users/6400861) |  |
 | ![][flag_HR] [Fall](https://osu.ppy.sh/users/4800816) | Hırvatça |
-| ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | Rusça |
-| ![][flag_US] [Nevo](https://osu.ppy.sh/users/7451883) |  |
 | ![][flag_GB] [NexusQI](https://osu.ppy.sh/users/13822800) |  |
 | ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | Almanca |
 | ![][flag_SG] [Smoke](https://osu.ppy.sh/users/10726630) |  |
-| ![][flag_AT] [Stixy](https://osu.ppy.sh/users/9000308) | Almanca, Sırpça |
-| ![][flag_EG] [Teky](https://osu.ppy.sh/users/10520912) | Arapça |
 | ![][flag_BR] [Trynna](https://osu.ppy.sh/users/2652951) | Portekizce |
 
 #### osu!taiko
@@ -162,7 +163,6 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 | ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Almanca |
 | ![][flag_US] [Cychloryn](https://osu.ppy.sh/users/6921736) | Biraz Japonca |
 | ![][flag_VN] [davidminh0111](https://osu.ppy.sh/users/9623142) | Vietnamca |
-| ![][flag_FR] [realy0\_](https://osu.ppy.sh/users/8863359) | Fransızca |
 | ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | Almanca, Sırpça |
 | ![][flag_FR] [Yales](https://osu.ppy.sh/users/2377881) | Fransızca, Japonca |
 
@@ -170,7 +170,6 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 
 | İsim | Ek diller |
 | :-- | :-- |
-| ![][flag_TH] [-Luminate](https://osu.ppy.sh/users/4778689) | Tay dili |
 | ![][flag_GB] [Baron](https://osu.ppy.sh/users/10286499) |  |
 | ![][flag_CL] [Bastian](https://osu.ppy.sh/users/6345176) | İspanyolca |
 | ![][flag_NL] [Dako](https://osu.ppy.sh/users/11081858) | Flemenkçe |
@@ -181,8 +180,9 @@ Aşağıda listelenen tablolar Beatmap Aday Göstericilerin hangi oyun modunda/m
 
 | İsim | Ek diller |
 | :-- | :-- |
+| ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783) | Korece |
 | ![][flag_MY] [Kyousukee](https://osu.ppy.sh/users/8842107) | Endonezce, Malay dili |
-| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | Çince, Kantonca |
+| ![][flag_NL] [Muse Dash](https://osu.ppy.sh/users/13695676) | Çince |
 | ![][flag_CN] [Shima Rin](https://osu.ppy.sh/users/6089608) | Çince |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Arjantin"

--- a/wiki/People/The_Team/Beatmap_Nominators/zh.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/zh.md
@@ -51,26 +51,29 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 | ![][flag_US] [Cheri](https://osu.ppy.sh/users/5226970) |  |
 | ![][flag_CL] [Cris-](https://osu.ppy.sh/users/6175280) | 西班牙语 |
 | ![][flag_CL] [Crissa](https://osu.ppy.sh/users/5405836) | 西班牙语 |
+| ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334) |  |
 | ![][flag_CN] [Dored](https://osu.ppy.sh/users/10284894) | 中文 |
 | ![][flag_US] [eiri-](https://osu.ppy.sh/users/3388410) | 西班牙语 |
 | ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958) |  |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | 印度尼西亚语 |
-| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) |  |
+| ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | 孟加拉语，部分阿拉伯语 |
 | ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645) | 德语 |
-| ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | 中文, 部分法语 |
+| ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | 中文，部分法语 |
 | ![][flag_NL] [Kaitjuh](https://osu.ppy.sh/users/2225327) | 荷兰语 |
 | ![][flag_CA] [Lafayla](https://osu.ppy.sh/users/5312547) |  |
 | ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909) | 中文 |
 | ![][flag_RS] [MaridiuS](https://osu.ppy.sh/users/4496961) | 塞尔维亚语 |
 | ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994) | 西班牙语 |
+| ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | 俄语 |
 | ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097) | 德语 |
 | ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645) | 德语 |
 | ![][flag_US] [Nao Tomori](https://osu.ppy.sh/users/5364763) |  |
 | ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995) | 中文 |
+| ![][flag_US] [Nevo](https://osu.ppy.sh/users/7451883) |  |
 | ![][flag_GR] [Nikakis](https://osu.ppy.sh/users/4351739) | 希腊语 |
 | ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981) | 法语 |
 | ![][flag_IT] [Nuvolina](https://osu.ppy.sh/users/10974170) | 意大利语 |
-| ![][flag_PL] [Peter](https://osu.ppy.sh/users/8623835) | 波兰语, 部分俄语 |
+| ![][flag_PL] [Peter](https://osu.ppy.sh/users/8623835) | 波兰语，部分俄语 |
 | ![][flag_BR] [pimp](https://osu.ppy.sh/users/328615) | 葡萄牙语 |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | 法语 |
 | ![][flag_KR] [Riana](https://osu.ppy.sh/users/1997633) | 韩语 |
@@ -82,12 +85,14 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 | ![][flag_CA] [Sparhten](https://osu.ppy.sh/users/7601720) |  |
 | ![][flag_GB] [spoes](https://osu.ppy.sh/users/9505704) |  |
 | ![][flag_BE] [Stack](https://osu.ppy.sh/users/6122935) | 荷兰语 |
+| ![][flag_AT] [Stixy](https://osu.ppy.sh/users/9000308) | 德语，塞尔维亚语 |
+| ![][flag_EG] [Teky](https://osu.ppy.sh/users/10520912) | 阿拉伯语 |
 | ![][flag_FI] [TheKingHenry](https://osu.ppy.sh/users/5128277) | 芬兰语 |
 | ![][flag_TH] [timemon](https://osu.ppy.sh/users/2072005) | 泰语 |
-| ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547) | 西班牙语, 法语 |
+| ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547) | 西班牙语，法语 |
 | ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631) | 波兰语 |
 | ![][flag_US] [Yahuri](https://osu.ppy.sh/users/4682629) |  |
-| ![][flag_CN] [Yugu](https://osu.ppy.sh/users/3161834) | 中文, 日语 |
+| ![][flag_CN] [Yugu](https://osu.ppy.sh/users/3161834) | 中文，日语 |
 | ![][flag_PL] [Zelq](https://osu.ppy.sh/users/8953955) | 波兰语 |
 
 #### osu!taiko
@@ -97,14 +102,15 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 | ![][flag_US] [eiri-](https://osu.ppy.sh/users/3388410) | 西班牙语 |
 | ![][flag_TR] [frukoyurdakul](https://osu.ppy.sh/users/7612550) | 土耳其语 |
 | ![][flag_DE] [Greenshell](https://osu.ppy.sh/users/8693851) | 德语 |
-| ![][flag_KR] [Hoshikuz](https://osu.ppy.sh/users/9892196) | 韩语, 日语 |
+| ![][flag_KR] [Hoshikuz](https://osu.ppy.sh/users/9892196) | 韩语，日语 |
 | ![][flag_US] [incandescence](https://osu.ppy.sh/users/6256027) | 部分西班牙语 |
-| ![][flag_HK] [kanpakyin](https://osu.ppy.sh/users/394326) | 日语, 粤语, 中文 |
-| ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) | 中文, 粤语 |
+| ![][flag_HK] [kanpakyin](https://osu.ppy.sh/users/394326) | 日语，粤语，中文 |
+| ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) | 中文，粤语 |
 | ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995) | 中文 |
 | ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  |
-| ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) | 西班牙语, 加泰罗尼亚语 |
-| ![][flag_ID] [Roger](https://osu.ppy.sh/users/1538223) | 印度尼西亚语, 部分日语 |
+| ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) | 西班牙语，加泰罗尼亚语 |
+| ![][flag_FR] [realy0\_](https://osu.ppy.sh/users/8863359) | 法语 |
+| ![][flag_ID] [Roger](https://osu.ppy.sh/users/1538223) | 印度尼西亚语，部分日语 |
 | ![][flag_JP] [tasuke912](https://osu.ppy.sh/users/2774767) | 日语 |
 | ![][flag_ID] [Volta](https://osu.ppy.sh/users/4154071) | 印度尼西亚语 |
 
@@ -116,7 +122,7 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 | ![][flag_ID] [Dapuluous](https://osu.ppy.sh/users/8140944) | 印度尼西亚语 |
 | ![][flag_PH] [Jemzuu](https://osu.ppy.sh/users/7890134) | 菲律宾语 |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) |  |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | 印度尼西亚语, 部分中文 |
+| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | 印度尼西亚语，部分中文 |
 
 #### osu!mania
 
@@ -128,11 +134,11 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 | ![][flag_US] [Kamuy](https://osu.ppy.sh/users/7439226) | 部分韩语 |
 | ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754) | 韩语 |
 | ![][flag_AU] [Keiga](https://osu.ppy.sh/users/6866022) | 中文 |
+| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | 中文，粤语 |
 | ![][flag_ID] [Rivals_7](https://osu.ppy.sh/users/4610379) | 印度尼西亚语 |
-| ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | 阿拉伯语, 法语 |
+| ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | 阿拉伯语，法语 |
 | ![][flag_KR] [Sun](https://osu.ppy.sh/users/4115819) | 韩语 |
 | ![][flag_NL] [UnluckyCroco](https://osu.ppy.sh/users/9461160) | 荷兰语 |
-| ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  |
 | ![][flag_ID] [Voxa](https://osu.ppy.sh/users/9229539) | 印度尼西亚语 |
 
 ### 见习成员
@@ -141,36 +147,29 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 
 | 名字 | 语言 |
 | :-- | :-- |
-| ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334) |  |
 | ![][flag_CA] [Elayue](https://osu.ppy.sh/users/6400861) |  |
-| ![][flag_HR] [Fall](https://osu.ppy.sh/users/4800816) | Croatian |
-| ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | 俄语 |
-| ![][flag_US] [Nevo](https://osu.ppy.sh/users/7451883) |  |
+| ![][flag_HR] [Fall](https://osu.ppy.sh/users/4800816) | 克罗地亚语 |
 | ![][flag_GB] [NexusQI](https://osu.ppy.sh/users/13822800) |  |
 | ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | 德语 |
 | ![][flag_SG] [Smoke](https://osu.ppy.sh/users/10726630) |  |
-| ![][flag_AT] [Stixy](https://osu.ppy.sh/users/9000308) | 德语, 塞尔维亚语 |
-| ![][flag_EG] [Teky](https://osu.ppy.sh/users/10520912) | 阿拉伯语 |
 | ![][flag_BR] [Trynna](https://osu.ppy.sh/users/2652951) | 葡萄牙语 |
 
 #### osu!taiko
 
 | 名字 | 语言 |
 | :-- | :-- |
-| ![][flag_GB] [\_DUSK\_](https://osu.ppy.sh/users/6092181) | 乌尔都语, 部分阿拉伯语 |
+| ![][flag_GB] [\_DUSK\_](https://osu.ppy.sh/users/6092181) | 乌尔都语，部分阿拉伯语 |
 | ![][flag_AR] [Axer](https://osu.ppy.sh/users/7299864) | 西班牙语 |
 | ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | 德语 |
 | ![][flag_US] [Cychloryn](https://osu.ppy.sh/users/6921736) | 部分日语 |
 | ![][flag_VN] [davidminh0111](https://osu.ppy.sh/users/9623142) | 越南语 |
-| ![][flag_FR] [realy0\_](https://osu.ppy.sh/users/8863359) | 法语 |
-| ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 德语, 塞尔维亚语 |
-| ![][flag_FR] [Yales](https://osu.ppy.sh/users/2377881) | 法语, 日语 |
+| ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 德语，塞尔维亚语 |
+| ![][flag_FR] [Yales](https://osu.ppy.sh/users/2377881) | 法语，日语 |
 
 #### osu!catch
 
 | 名字 | 语言 |
 | :-- | :-- |
-| ![][flag_TH] [-Luminate](https://osu.ppy.sh/users/4778689) | 泰语 |
 | ![][flag_GB] [Baron](https://osu.ppy.sh/users/10286499) |  |
 | ![][flag_CL] [Bastian](https://osu.ppy.sh/users/6345176) | 西班牙语 |
 | ![][flag_NL] [Dako](https://osu.ppy.sh/users/11081858) | 荷兰语 |
@@ -181,8 +180,9 @@ BN 的新成员将从一个月的见习期开始。如果他们的提名和行�
 
 | 名字 | 语言 |
 | :-- | :-- |
-| ![][flag_MY] [Kyousukee](https://osu.ppy.sh/users/8842107) | 印度尼西亚语, 马来语 |
-| ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | 中文, 粤语 |
+| ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783) | 韩语 |
+| ![][flag_MY] [Kyousukee](https://osu.ppy.sh/users/8842107) | 印度尼西亚语，马来语 |
+| ![][flag_NL] [Muse Dash](https://osu.ppy.sh/users/13695676) | 中文 |
 | ![][flag_CN] [Shima Rin](https://osu.ppy.sh/users/6089608) | 中文 |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "阿根廷"

--- a/wiki/People/The_Team/Global_Moderation_Team/en.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/en.md
@@ -64,6 +64,7 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 | ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | French, Russian | Chat moderation |
 | ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | Portuguese | Chat moderation, beatmap moderation |
 | ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646) | Russian | Chat moderation, beatmap moderation |
+| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | Finnish | Chat moderation |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | German | Beatmap moderation |
 | ![][flag_TW] [Loneight](https://osu.ppy.sh/users/663131) | Chinese | Chat moderation |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu! development |
@@ -111,7 +112,7 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 | `#dutch` | [Nederlands](https://osu.ppy.sh/community/forums/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` |  | *All moderators* |
 | `#filipino` | [Tagalog](https://osu.ppy.sh/community/forums/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
-| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) |  |
+| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) | ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) |
 | `#french` | [Français](https://osu.ppy.sh/community/forums/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/community/forums/37) | ![][flag_DE] [- Felix](https://osu.ppy.sh/users/8503985), ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
 | `#greek` |  |  |
@@ -142,6 +143,7 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"
 [flag_DE]: /wiki/shared/flag/DE.gif "Germany"
 [flag_ES]: /wiki/shared/flag/ES.gif "Spain"
+[flag_FI]: /wiki/shared/flag/FI.gif "Finland"
 [flag_FR]: /wiki/shared/flag/FR.gif "France"
 [flag_GB]: /wiki/shared/flag/GB.gif "United Kingdom"
 [flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"

--- a/wiki/People/The_Team/Global_Moderation_Team/tr.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/tr.md
@@ -64,6 +64,7 @@ Genellikle, ekibe değerli bir katkı olup olamayacaklarına emin olabilmek adı
 | ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | Fransızca, Rusça | Sohbet moderasyonu |
 | ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | Portekizce | Sohbet moderasyonu, beatmap moderasyonu |
 | ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646) | Rusça | Sohbet moderasyonu, beatmap moderasyonu |
+| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | Fince | Sohbet moderasyonu |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Almanca | Beatmap moderasyonu |
 | ![][flag_TW] [Loneight](https://osu.ppy.sh/users/663131) | Çince | Sohbet moderasyonu |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu! geliştirme |
@@ -111,7 +112,7 @@ Genellikle, ekibe değerli bir katkı olup olamayacaklarına emin olabilmek adı
 | `#dutch` | [Nederlands](https://osu.ppy.sh/community/forums/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` |  | *Tüm moderatörler* |
 | `#filipino` | [Tagalog](https://osu.ppy.sh/community/forums/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
-| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) |  |
+| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) | ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) |
 | `#french` | [Français](https://osu.ppy.sh/community/forums/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/community/forums/37) | ![][flag_DE] [- Felix](https://osu.ppy.sh/users/8503985), ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
 | `#greek` |  |  |
@@ -142,6 +143,7 @@ Genellikle, ekibe değerli bir katkı olup olamayacaklarına emin olabilmek adı
 [flag_CL]: /wiki/shared/flag/CL.gif "Şili"
 [flag_DE]: /wiki/shared/flag/DE.gif "Almanya"
 [flag_ES]: /wiki/shared/flag/ES.gif "İspanya"
+[flag_FI]: /wiki/shared/flag/FI.gif "Finlandiya"
 [flag_FR]: /wiki/shared/flag/FR.gif "Fransa"
 [flag_GB]: /wiki/shared/flag/GB.gif "Birleşik Krallık"
 [flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"

--- a/wiki/People/The_Team/Global_Moderation_Team/zh.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/zh.md
@@ -45,56 +45,57 @@ tags:
 
 | 名字 | 语言 | 专注范围 |
 | :-- | :-- | :-- |
-| ![][flag_MY] [- [bibitaru] -](https://osu.ppy.sh/users/4482419) | 中文, 马来语 | 聊天室管理员 |
+| ![][flag_MY] [- [bibitaru] -](https://osu.ppy.sh/users/4482419) | 中文，马来语 | 聊天室管理员 |
 | ![][flag_DE] [- Felix](https://osu.ppy.sh/users/8503985) | 德语 | 聊天室管理员 |
 | ![][flag_US] [abraker](https://osu.ppy.sh/users/4635891) |  | 论坛管理员 |
-| ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870) |  | 聊天室管理员, 谱面管理员 |
+| ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870) |  | 聊天室管理员，谱面管理员 |
 | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343) | 德语 | 聊天室管理员 |
-| ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042) | 西班牙语 | 聊天室管理员, 论坛管理员 |
-| ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  | 聊天室管理员, 技术支持, 谱面管理员 |
-| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 西班牙语 | 锦标赛管理员, 谱面管理员 |
+| ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042) | 西班牙语 | 聊天室管理员，论坛管理员 |
+| ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  | 聊天室管理员，技术支持，谱面管理员 |
+| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 西班牙语 | 锦标赛管理员，谱面管理员 |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  | 技术支持 |
-| ![][flag_BR] [Edward](https://osu.ppy.sh/users/5618109) | 葡萄牙语, 日语 | 聊天室管理员 |
+| ![][flag_BR] [Edward](https://osu.ppy.sh/users/5618109) | 葡萄牙语，日语 | 聊天室管理员 |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) |  | 玩家支持 |
-| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 保加利亚语 | osu!idol 主持者, 论坛管理员, 谱面管理员 |
-| ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | 法语 | 聊天室管理员, 论坛管理员, 谱面管理员 |
+| ![][flag_BG] [Flanster](https://osu.ppy.sh/users/447818) | 保加利亚语 | osu!idol 主持者，论坛管理员，谱面管理员 |
+| ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | 法语 | 聊天室管理员，论坛管理员，谱面管理员 |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | 波兰语 | 聊天室管理员 |
-| ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) |  | 聊天室管理员, 谱面管理员 |
+| ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) |  | 聊天室管理员，谱面管理员 |
 | ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | 西班牙语 | 锦标赛管理员 |
-| ![][flag_HK] [kanpakyin](https://osu.ppy.sh/users/394326) | 粤语, 中文, 日语 | 聊天室管理员 |
-| ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533) | 俄语 | 聊天室管理员, 谱面管理员 |
-| ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | 法语, 俄语 | 聊天室管理员 |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | 葡萄牙语 | 聊天室管理员, 谱面管理员 |
-| ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646) | 俄语 | 聊天室管理员, 谱面管理员 |
+| ![][flag_HK] [kanpakyin](https://osu.ppy.sh/users/394326) | 粤语，中文，日语 | 聊天室管理员 |
+| ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533) | 俄语 | 聊天室管理员，谱面管理员 |
+| ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | 法语，俄语 | 聊天室管理员 |
+| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | 葡萄牙语 | 聊天室管理员，谱面管理员 |
+| ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646) | 俄语 | 聊天室管理员，谱面管理员 |
+| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | 芬兰语 | 聊天室管理员 |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | 德语 | 谱面管理员 |
 | ![][flag_TW] [Loneight](https://osu.ppy.sh/users/663131) | 中文 | 聊天室管理员 |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu! 开发 |
-| ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) | 荷兰语 | 聊天室管理员, 论坛管理员 |
-| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | 菲律宾语 | 聊天室管理员, 论坛管理员, 技术支持, 谱面管理员 |
+| ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) | 荷兰语 | 聊天室管理员，论坛管理员 |
+| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | 菲律宾语 | 聊天室管理员，论坛管理员，技术支持，谱面管理员 |
 | ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059) | 法语 | 聊天室管理员 |
-| ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | 德语 | 论坛管理员, 聊天室管理员, 谱面管理员 |
+| ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | 德语 | 论坛管理员，聊天室管理员，谱面管理员 |
 | ![][flag___] [osu!team](https://osu.ppy.sh/users/4341397) |  | 官方团队 |
-| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | 德语 | 锦标赛管理员, 谱面管理员 |
-| ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983) | 法语 | 聊天室管理员, 论坛管理员 |
+| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | 德语 | 锦标赛管理员，谱面管理员 |
+| ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983) | 法语 | 聊天室管理员，论坛管理员 |
 | ![][flag_PT] [Pereira006](https://osu.ppy.sh/users/537344) | 葡萄牙语 | 聊天室管理员 |
-| ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) | 西班牙语, 加泰罗尼亚语 | 聊天室管理员 |
-| ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | 西班牙语 | 聊天室管理员, wiki 管理 |
+| ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) | 西班牙语，加泰罗尼亚语 | 聊天室管理员 |
+| ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | 西班牙语 | 聊天室管理员，wiki 管理 |
 | ![][flag_DE] [RockRoller](https://osu.ppy.sh/users/8388854) | 德语 | 论坛管理员 |
 | ![][flag_KR] [ruexia](https://osu.ppy.sh/users/385069) | 韩语 | 聊天室管理员 |
 | ![][flag_JP] [S o h](https://osu.ppy.sh/users/2234772) | 日语 | 聊天室管理员 |
-| ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | 瑞典语, 西班牙语 | 聊天室管理员, 谱面管理员 |
+| ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | 瑞典语，西班牙语 | 聊天室管理员，谱面管理员 |
 | ![][flag_IT] [Seijiro](https://osu.ppy.sh/users/2581696) | 意大利语 | 聊天室管理员 |
-| ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | 法语, 西班牙语 | 聊天室管理员 |
+| ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | 法语，西班牙语 | 聊天室管理员 |
 | ![][flag_ID] [Shurelia](https://osu.ppy.sh/users/3807986) | 印度尼西亚语 | 聊天室管理员 |
 | ![][flag_TW] [spboxer3](https://osu.ppy.sh/users/197974) | 中文 | 聊天室管理员 |
-| ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 德语, 塞尔维亚语 | 聊天室管理员, 论坛管理员 |
+| ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907) | 德语，塞尔维亚语 | 聊天室管理员，论坛管理员 |
 | ![][flag_CH] [TicClick](https://osu.ppy.sh/users/672931) | 俄语 | 聊天室管理员 |
 | ![][flag_KR] [ToGlette](https://osu.ppy.sh/users/1076236) | 韩语 | 聊天室管理员 |
 | ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) | 法语 | 聊天室管理员 |
 | ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) | 菲律宾语 | 聊天室管理员 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 西班牙语 | 技术支持 |
 | ![][flag_PL] [Ukami](https://osu.ppy.sh/users/820865) | 波兰语 | 聊天室管理员 |
-| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | 西班牙语 | 聊天室管理员, 锦标赛管理员, wiki 管理, 论坛管理员 |
+| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | 西班牙语 | 聊天室管理员，锦标赛管理员，wiki 管理，论坛管理员 |
 | ![][flag_PL] [Yason](https://osu.ppy.sh/users/2574392) | 波兰语 | 聊天室管理员 |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) |  | 聊天室管理员 |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | 德语 | 聊天室管理员 |
@@ -113,7 +114,7 @@ tags:
 | `#dutch` | [Nederlands](https://osu.ppy.sh/community/forums/69) | ![][flag_NL] [n0ah](https://osu.ppy.sh/users/3086393) |
 | `#english` |  | *全局管理员* |
 | `#filipino` | [Tagalog](https://osu.ppy.sh/community/forums/76) | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078), ![][flag_PH] [topecnz](https://osu.ppy.sh/users/2103927) |
-| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) |  |
+| `#finnish` | [Suomi](https://osu.ppy.sh/community/forums/24) | ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) |
 | `#french` | [Français](https://osu.ppy.sh/community/forums/34) | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108), ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089), ![][flag_FR] [Neil Watts](https://osu.ppy.sh/users/3048059), ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983), ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005), ![][flag_FR] [Tommay](https://osu.ppy.sh/users/3132818) |
 | `#german` | [Deutsch](https://osu.ppy.sh/community/forums/37) | ![][flag_DE] [- Felix](https://osu.ppy.sh/users/8503985), ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343), ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405), ![][flag_AT] [Stefan](https://osu.ppy.sh/users/626907), ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) |
 | `#greek` |  |  |
@@ -144,6 +145,7 @@ tags:
 [flag_CL]: /wiki/shared/flag/CL.gif "智利"
 [flag_DE]: /wiki/shared/flag/DE.gif "德国"
 [flag_ES]: /wiki/shared/flag/ES.gif "西班牙"
+[flag_FI]: /wiki/shared/flag/FI.gif "芬兰"
 [flag_FR]: /wiki/shared/flag/FR.gif "法国"
 [flag_GB]: /wiki/shared/flag/GB.gif "英国"
 [flag_HK]: /wiki/shared/flag/HK.gif "香港"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/zh.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/zh.md
@@ -40,22 +40,22 @@ NAT 会长期关注潜在的 NAT 候选人，并偶尔进行讨论已决定是�
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) |  | 评估, 管理 |
-| ![][flag_HK] [Chaoslitz](https://osu.ppy.sh/users/3621552) | 粤语, 中文 | 评估 |
+| ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) |  | 评估，管理 |
+| ![][flag_HK] [Chaoslitz](https://osu.ppy.sh/users/3621552) | 粤语，中文 | 评估 |
 | ![][flag_CA] [Kibbleru](https://osu.ppy.sh/users/3193504) |  | 评估 |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | 德语 | 评估 |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | 德语 | 评估 |
-| ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) | 瑞典语 | 构造, 沟通 |
-| ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) |  | 评估, 构造, 沟通 |
+| ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) | 瑞典语 | 构造，沟通 |
+| ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) |  | 评估，构造，沟通 |
 | ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) |  | 构造 |
-| ![][flag_BR] [Seto Kousuke](https://osu.ppy.sh/users/2857314) | 葡萄牙语 | 评估, 构造, 沟通 |
+| ![][flag_BR] [Seto Kousuke](https://osu.ppy.sh/users/2857314) | 葡萄牙语 | 评估，构造，沟通 |
 | ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926) | 荷兰语 | 评估 |
 
 ### osu!taiko
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | 粤语, 中文 | 评估 |
+| ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | 粤语，中文 | 评估 |
 | ![][flag_DE] [Nepuri](https://osu.ppy.sh/users/6637817) | 德语 | 评估 |
 | ![][flag_TH] [Tyistiana](https://osu.ppy.sh/users/1421452) | 泰语 | 评估 |
 
@@ -63,15 +63,15 @@ NAT 会长期关注潜在的 NAT 候选人，并偶尔进行讨论已决定是�
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 西班牙语, 德语 | 评估, 管理 |
+| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | 西班牙语，德语 | 评估，管理 |
 | ![][flag_NL] [Greaper](https://osu.ppy.sh/users/2369776) | 荷兰语 | 评估 |
 
 ### osu!mania
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717) | 德语, 波兰语 | 评估 |
-| ![][flag_NL] [Leniane](https://osu.ppy.sh/users/7138602) | 荷兰语 | 评估, 管理 |
+| ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717) | 德语，波兰语 | 评估 |
+| ![][flag_NL] [Leniane](https://osu.ppy.sh/users/7138602) | 荷兰语 | 评估，管理 |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "比利时"
 [flag_BR]: /wiki/shared/flag/BR.gif "巴西"

--- a/wiki/People/The_Team/Support_Team/zh.md
+++ b/wiki/People/The_Team/Support_Team/zh.md
@@ -29,7 +29,7 @@ Support Team 主要负责:
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  |
 | ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | 菲律宾语 |
-| ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | 瑞典语, 西班牙语 |
+| ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | 瑞典语，西班牙语 |
 | ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) |  |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | 德语 |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | 西班牙语 |

--- a/wiki/People/The_Team/osu!_Alumni/en.md
+++ b/wiki/People/The_Team/osu!_Alumni/en.md
@@ -116,7 +116,6 @@ The [osu! Alumni group page](https://osu.ppy.sh/groups/16) lists all of the memb
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Chat Moderator |
 | ![][flag_CA] [Lanturn](https://osu.ppy.sh/users/1446665) | QAT |
-| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | GMT |
 | ![][flag_IT] [Leader](https://osu.ppy.sh/users/631530) | GMT |
 | ![][flag_DO] [Lissette](https://osu.ppy.sh/users/19835) | BAT |
 | ![][flag_DO] [Lizbeth](https://osu.ppy.sh/users/21970) | MAT |

--- a/wiki/People/The_Team/osu!_Alumni/tr.md
+++ b/wiki/People/The_Team/osu!_Alumni/tr.md
@@ -116,7 +116,6 @@
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Sohbet Moderatörü |
 | ![][flag_CA] [Lanturn](https://osu.ppy.sh/users/1446665) | QAT |
-| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | GMT |
 | ![][flag_IT] [Leader](https://osu.ppy.sh/users/631530) | GMT |
 | ![][flag_DO] [Lissette](https://osu.ppy.sh/users/19835) | BAT |
 | ![][flag_DO] [Lizbeth](https://osu.ppy.sh/users/21970) | MAT |

--- a/wiki/People/The_Team/osu!_Alumni/zh.md
+++ b/wiki/People/The_Team/osu!_Alumni/zh.md
@@ -13,9 +13,9 @@ tags:
 
 | 用户名 | 曾任职务 |
 | :-- | :-- |
-| ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596) | BAT, GMT |
+| ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596) | BAT，GMT |
 | ![][flag_ID] [-SiN-](https://osu.ppy.sh/users/10560) | 聊天室管理员 |
-| ![][flag_HU] [[ Another ]](https://osu.ppy.sh/users/3416573) | 聊天室管理员, GMT |
+| ![][flag_HU] [[ Another ]](https://osu.ppy.sh/users/3416573) | 聊天室管理员，GMT |
 | ![][flag_HK] [aabc271](https://osu.ppy.sh/users/155707) | BAT |
 | ![][flag_CN] [abalee](https://osu.ppy.sh/users/13103) | BAT |
 | ![][flag_US] [Agnes](https://osu.ppy.sh/users/136982) | GMT |
@@ -26,8 +26,8 @@ tags:
 | ![][flag_CA] [An64fan](https://osu.ppy.sh/users/38836) | BAT |
 | ![][flag_IT] [Andrea](https://osu.ppy.sh/users/33599) | GMT |
 | ![][flag_IT] [Armin](https://osu.ppy.sh/users/105902) | BAT |
-| ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | QAT, NAT |
-| ![][flag_FI] [Asphyxia](https://osu.ppy.sh/users/1715720) | BAT, GMT, QAT |
+| ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | QAT，NAT |
+| ![][flag_FI] [Asphyxia](https://osu.ppy.sh/users/1715720) | BAT，GMT，QAT |
 | ![][flag_CN] [Atrue](https://osu.ppy.sh/users/1758523) | GMT |
 | ![][flag_CA] [awp](https://osu.ppy.sh/users/2650) | GMT |
 | ![][flag_AU] [Azure_Kite](https://osu.ppy.sh/users/66296) | MAT |
@@ -43,7 +43,7 @@ tags:
 | ![][flag_IT] [Card N'FoRcE](https://osu.ppy.sh/users/3936) | BAT |
 | ![][flag_US] [Cecilthemos](https://osu.ppy.sh/users/2233) | BAT |
 | ![][flag_AU] [chan](https://osu.ppy.sh/users/94) | BAT |
-| ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) | GMT, QAT |
+| ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) | GMT，QAT |
 | ![][flag_CA] [CheeseWarlock](https://osu.ppy.sh/users/9072) | BAT |
 | ![][flag_IT] [Chewin](https://osu.ppy.sh/users/617323) | BAT |
 | ![][flag_CN] [Colin Hou](https://osu.ppy.sh/users/196614) | BAT |
@@ -51,7 +51,7 @@ tags:
 | ![][flag_FR] [Cyclohexane](https://osu.ppy.sh/users/116078) | GMT |
 | ![][flag_US] [Cyclone](https://osu.ppy.sh/users/18589) | GMT |
 | ![][flag_TH] [Cyril Scarlet](https://osu.ppy.sh/users/108066) | MAT |
-| ![][flag_MX] [DakeDekaane](https://osu.ppy.sh/users/1425253) | BAT, QAT |
+| ![][flag_MX] [DakeDekaane](https://osu.ppy.sh/users/1425253) | BAT，QAT |
 | ![][flag_CA] [Dakeyrus](https://osu.ppy.sh/users/10441) | GMT |
 | ![][flag_DE] [Dangaard](https://osu.ppy.sh/users/19488) | BAT |
 | ![][flag_US] [Daru](https://osu.ppy.sh/users/32480) | osu! 开发者 |
@@ -63,7 +63,7 @@ tags:
 | ![][flag_TH] [DJPop](https://osu.ppy.sh/users/2363) | BAT |
 | ![][flag_US] [dkun](https://osu.ppy.sh/users/154400) | BAT |
 | ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983) | BAT |
-| ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893) | GMT, QAT |
+| ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893) | GMT，QAT |
 | ![][flag_FR] [Drafura](https://osu.ppy.sh/users/326099) | BAT |
 | ![][flag_BR] [Dragvon](https://osu.ppy.sh/users/126927) | 聊天室管理员 |
 | ![][flag_US] [drum drum](https://osu.ppy.sh/users/4435526) | GMT |
@@ -71,7 +71,7 @@ tags:
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu! 开发者 |
 | ![][flag_US] [EiJi](https://osu.ppy.sh/users/2024) | BAT |
 | ![][flag_KR] [Elfin](https://osu.ppy.sh/users/1399551) | GMT |
-| ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | 聊天室管理员, GMT |
+| ![][flag_CO] [ErunamoJAZZ](https://osu.ppy.sh/users/1869764) | 聊天室管理员，GMT |
 | ![][flag_FI] [ethox](https://osu.ppy.sh/users/441380) | 聊天室管理员 |
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |
 | ![][flag_AR] [Extor](https://osu.ppy.sh/users/555) | BAT |
@@ -80,15 +80,15 @@ tags:
 | ![][flag_SG] [Faust](https://osu.ppy.sh/users/65152) | BAT |
 | ![][flag_US] [foulcoon](https://osu.ppy.sh/users/19883) | BAT |
 | ![][flag_FI] [Fraeon](https://osu.ppy.sh/users/2271) | BAT |
-| ![][flag_TH] [Frostmourne](https://osu.ppy.sh/users/199669) | GMT, QAT |
-| ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | BAT, 聊天室管理员, GMT, QAT |
+| ![][flag_TH] [Frostmourne](https://osu.ppy.sh/users/199669) | GMT，QAT |
+| ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | BAT，聊天室管理员，GMT，QAT |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | QAT |
 | ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) | QAT |
 | ![][flag_FI] [Gemi](https://osu.ppy.sh/users/7365) | BAT |
 | ![][flag_MX] [Gens](https://osu.ppy.sh/users/23062) | BAT |
 | ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) | GMT |
 | ![][flag_PE] [Gonzvlo](https://osu.ppy.sh/users/237733) | BAT |
-| ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, 聊天室管理员, QAT |
+| ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT，聊天室管理员，QAT |
 | ![][flag_RU] [h3k1ru](https://osu.ppy.sh/users/291211) | GMT |
 | ![][flag_NL] [happy30](https://osu.ppy.sh/users/27767) | BAT |
 | ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | 锦标赛管理员 |
@@ -97,7 +97,7 @@ tags:
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | GMT |
 | ![][flag_US] [Hitoshirenu Shourai](https://osu.ppy.sh/users/602) | BAT |
 | ![][flag_US] [Hobbes2](https://osu.ppy.sh/users/8157492) | QAT |
-| ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) | BAT, 聊天室管理员, GMT, QAT |
+| ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) | BAT，聊天室管理员，GMT，QAT |
 | ![][flag_RU] [IceBeam](https://osu.ppy.sh/users/208440) | BAT |
 | ![][flag_CN] [ignorethis](https://osu.ppy.sh/users/27343) | BAT |
 | ![][flag_IT] [Inamaru](https://osu.ppy.sh/users/76382) | GMT |
@@ -107,23 +107,22 @@ tags:
 | ![][flag_GB] [jericho2442](https://osu.ppy.sh/users/88904) | BAT |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | BAT |
 | ![][flag_MX] [Kai](https://osu.ppy.sh/users/4537) | BAT |
-| ![][flag_CA] [karterfreak](https://osu.ppy.sh/users/1031958) | GMT, osu!media 创立者 |
+| ![][flag_CA] [karterfreak](https://osu.ppy.sh/users/1031958) | GMT，osu!media 创立者 |
 | ![][flag_KR] [Kawayi Rika](https://osu.ppy.sh/users/596298) | BAT |
 | ![][flag_MX] [Kenezz](https://osu.ppy.sh/users/167050) | BAT |
 | ![][flag_TH] [Kharl](https://osu.ppy.sh/users/452) | BAT |
 | ![][flag_US] [kingcobra52](https://osu.ppy.sh/users/9934) | BAT |
 | ![][flag_AU] [kingking9](https://osu.ppy.sh/users/1277097) | GMT |
 | ![][flag_CA] [Kitokofox](https://osu.ppy.sh/users/1815420) | 聊天室管理员 |
-| ![][flag_FR] [Krah](https://osu.ppy.sh/users/1436748) | BAT, GMT, QAT |
+| ![][flag_FR] [Krah](https://osu.ppy.sh/users/1436748) | BAT，GMT，QAT |
 | ![][flag_CL] [Krisom](https://osu.ppy.sh/users/99269) | BAT |
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | 聊天室管理员 |
-| ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
+| ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT，GMT，QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | 聊天室管理员 |
 | ![][flag_CA] [Lanturn](https://osu.ppy.sh/users/1446665) | QAT |
-| ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | GMT |
 | ![][flag_IT] [Leader](https://osu.ppy.sh/users/631530) | GMT |
 | ![][flag_DO] [Lissette](https://osu.ppy.sh/users/19835) | BAT |
 | ![][flag_DO] [Lizbeth](https://osu.ppy.sh/users/21970) | MAT |
@@ -134,7 +133,7 @@ tags:
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | GMT |
 | ![][flag_AU] [Lumino](https://osu.ppy.sh/users/59) | BAT |
 | ![][flag_US] [LunarSakuya](https://osu.ppy.sh/users/1027860) | BAT |
-| ![][flag_US] [Lust](https://osu.ppy.sh/users/2316951) | BAT, QAT |
+| ![][flag_US] [Lust](https://osu.ppy.sh/users/2316951) | BAT，QAT |
 | ![][flag_US] [Lybydose](https://osu.ppy.sh/users/64501) | BAT |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | BAT |
 | ![][flag_US] [machol30](https://osu.ppy.sh/users/5772) | BAT |
@@ -143,7 +142,7 @@ tags:
 | ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909) | QAT |
 | ![][flag_US] [Makar](https://osu.ppy.sh/users/686389) | GMT |
 | ![][flag_UY] [mancuso\_JM\_](https://osu.ppy.sh/users/521568) | GMT |
-| ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) | GMT, osu! 开发者 |
+| ![][flag_PL] [Marcin](https://osu.ppy.sh/users/722665) | GMT，osu! 开发者 |
 | ![][flag_CA] [mattyu007](https://osu.ppy.sh/users/4934) | BAT |
 | ![][flag_ID] [Maxus](https://osu.ppy.sh/users/4335785) | NAT |
 | ![][flag_GB] [MaxwellDemon](https://osu.ppy.sh/users/4254) | BAT |
@@ -151,15 +150,15 @@ tags:
 | ![][flag_KR] [minyeob](https://osu.ppy.sh/users/9207) | BAT |
 | ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812) | NAT |
 | ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | osu! 开发者 |
-| ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | BAT, QAT |
+| ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) | BAT，QAT |
 | ![][flag_US] [Mogsy](https://osu.ppy.sh/users/4018) | BAT |
 | ![][flag_US] [MOOMANiBE](https://osu.ppy.sh/users/8950) | BAT |
 | ![][flag_NL] [mrtn](https://osu.ppy.sh/users/7013) | BAT |
 | ![][flag_US] [mtmcl](https://osu.ppy.sh/users/5960) | BAT |
 | ![][flag_HU] [Mystyk](https://osu.ppy.sh/users/930165) | 聊天室管理员 |
-| ![][flag_DE] [Myxomatosis](https://osu.ppy.sh/users/2202645) | BAT, QAT |
+| ![][flag_DE] [Myxomatosis](https://osu.ppy.sh/users/2202645) | BAT，QAT |
 | ![][flag_UY] [narakucrimson](https://osu.ppy.sh/users/287468) | BAT |
-| ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) | QAT, NAT |
+| ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) | QAT，NAT |
 | ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) | BAT |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | BAT |
 | ![][flag_TR] [Nishiji](https://osu.ppy.sh/users/167629) | GMT |
@@ -167,40 +166,40 @@ tags:
 | ![][flag_PH] [NoHitter](https://osu.ppy.sh/users/124455) | BAT |
 | ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | osu! 开发者 |
 | ![][flag_CN] [Nymph](https://osu.ppy.sh/users/601990) | BAT |
-| ![][flag_CN] [Nyquill](https://osu.ppy.sh/users/682935) | BAT, GMT |
-| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | 聊天室管理员, 支持团队 |
+| ![][flag_CN] [Nyquill](https://osu.ppy.sh/users/682935) | BAT，GMT |
+| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | 聊天室管理员，支持团队 |
 | ![][flag_DE] [OnosakiHito](https://osu.ppy.sh/users/290128) | QAT |
 | ![][flag_TH] [orioncomet](https://osu.ppy.sh/users/104827) | BAT |
 | ![][flag_FI] [Orkel](https://osu.ppy.sh/users/39385) | 聊天室管理员 |
 | ![][flag_PH] [Osu Tatakae Ouendan](https://osu.ppy.sh/users/594210) | GMT |
 | ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345) | BAT |
-| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT, 支持团队 |
+| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT，支持团队 |
 | ![][flag_NL] [Pittigbaasje](https://osu.ppy.sh/users/2167433) | GMT |
 | ![][flag_HK] [Pokie](https://osu.ppy.sh/users/207340) | BAT |
 | ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) | BAT |
 | ![][flag_MY] [PROGUY](https://osu.ppy.sh/users/528181) | QAT |
 | ![][flag_US] [Protastic101](https://osu.ppy.sh/users/6712747) | QAT |
-| ![][flag_MY] [QHideaki13](https://osu.ppy.sh/users/733998) | 聊天室管理员, GMT |
+| ![][flag_MY] [QHideaki13](https://osu.ppy.sh/users/733998) | 聊天室管理员，GMT |
 | ![][flag_GB] [RandomJibberish](https://osu.ppy.sh/users/157879) | BAT |
 | ![][flag_US] [RemmyX25](https://osu.ppy.sh/users/612) | BAT |
-| ![][flag_RU] [riffy](https://osu.ppy.sh/users/597957) | BAT, GMT, QAT |
+| ![][flag_RU] [riffy](https://osu.ppy.sh/users/597957) | BAT，GMT，QAT |
 | ![][flag_US] [Roddie](https://osu.ppy.sh/users/121337) | BAT |
 | ![][flag_US] [Rolled](https://osu.ppy.sh/users/5243) | BAT |
 | ![][flag_IT] [Roxas](https://osu.ppy.sh/users/1041833) | QAT |
-| ![][flag_CO] [Sakura](https://osu.ppy.sh/users/289422) | BAT, GMT |
+| ![][flag_CO] [Sakura](https://osu.ppy.sh/users/289422) | BAT，GMT |
 | ![][flag_US] [SapphireGhost](https://osu.ppy.sh/users/388602) | BAT |
 | ![][flag_US] [Saturos](https://osu.ppy.sh/users/3781) | BAT |
 | ![][flag_US] [Seibei4211](https://osu.ppy.sh/users/31537) | BAT |
 | ![][flag_MD] [senaya](https://osu.ppy.sh/users/304103) | 聊天室管理员 |
-| ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) | 聊天室管理员, GMT |
+| ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) | 聊天室管理员，GMT |
 | ![][flag_US] [Shinde](https://osu.ppy.sh/users/103282) | MAT |
 | ![][flag_CA] [Shinxyn](https://osu.ppy.sh/users/13996) | BAT |
 | ![][flag_AR] [Shockwave](https://osu.ppy.sh/users/251631) | GMT |
 | ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | GMT |
 | ![][flag_US] [Skyripper](https://osu.ppy.sh/users/31803) | GMT |
-| ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | 聊天室管理员, GMT |
+| ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | 聊天室管理员，GMT |
 | ![][flag_HU] [Spkz](https://osu.ppy.sh/users/2964029) | GMT |
-| ![][flag_BE] [Stack](https://osu.ppy.sh/users/6122935) | QAT, NAT |
+| ![][flag_BE] [Stack](https://osu.ppy.sh/users/6122935) | QAT，NAT |
 | ![][flag_US] [Starrodkirby86](https://osu.ppy.sh/users/410) | BAT |
 | ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) | QAT |
 | ![][flag_CN] [Strawberry](https://osu.ppy.sh/users/519978) | BAT |
@@ -220,7 +219,7 @@ tags:
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | 聊天室管理员 |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, 支持团队 |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT，支持团队 |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |
@@ -234,7 +233,7 @@ tags:
 | ![][flag_US] [yeahyeahyeahhh](https://osu.ppy.sh/users/58042) | MAT |
 | ![][flag_AU] [YGOkid8](https://osu.ppy.sh/users/69114) | BAT |
 | ![][flag_CA] [YTYuyu](https://osu.ppy.sh/users/660484) | BAT |
-| ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | BAT, GMT |
+| ![][flag_CN] [Zero__wind](https://osu.ppy.sh/users/1822830) | BAT，GMT |
 | ![][flag_CA] [Zerostarry](https://osu.ppy.sh/users/3480) | BAT |
 | ![][flag_SG] [ZHSteven](https://osu.ppy.sh/users/142413) | BAT |
 | ![][flag_CL] [ZiRoX](https://osu.ppy.sh/users/200768) | NAT |

--- a/wiki/Staff_Log/2020/en.md
+++ b/wiki/Staff_Log/2020/en.md
@@ -226,6 +226,7 @@ Abbreviations for user groups are used throughout this log:
 - 2020-06-01: Removed [Pawsu](https://osu.ppy.sh/users/2371454) from **Support Team**
 - 2020-06-02: Added [abraker](https://osu.ppy.sh/users/4635891) to **GMT**
 - 2020-06-17: Added [RockRoller](https://osu.ppy.sh/users/8388854) to **GMT**
+- 2020-06-24: Moved [Laurakko](https://osu.ppy.sh/users/7253731) from **osu! Alumni** to **GMT**
 
 ### Beatmap Nominators
 
@@ -255,6 +256,7 @@ Abbreviations for user groups are used throughout this log:
 - 2020-06-23: Moved [Mirash](https://osu.ppy.sh/users/2841009) from **Probationary BN** to **BN**
 - 2020-06-23: Moved [Nevo](https://osu.ppy.sh/users/7451883) from **Probationary BN** to **BN**
 - 2020-06-23: Moved [Stixy](https://osu.ppy.sh/users/9000308) from **Probationary BN** to **BN**
+- 2020-06-26: Moved [PokeSky](https://osu.ppy.sh/users/3617111) from **Probationary BN** to **BN**
 
 #### Removals
 
@@ -264,4 +266,4 @@ Abbreviations for user groups are used throughout this log:
 - 2020-06-22: Removed [-Luminate](https://osu.ppy.sh/users/4778689) from **Probationary BN**
 - 2020-06-23: Removed [Unpredictable](https://osu.ppy.sh/users/7560872) from **BN**
 
-<!-- last update: 2020-06-23 23 UTC moved stixy to full bn -->
+<!-- last update: 2020-06-26 6 UTC moved pokesky to full bn -->


### PR DESCRIPTION
- [Laurakko](https://osu.ppy.sh/users/7253731) moved to the Global Moderation Team (Staff log only)
- Moved [PokeSky](https://osu.ppy.sh/users/3617111) to the Full Beatmap Nominator members listing (osu!mania)
- Added additional languages for myself ([hypercyte](https://osu.ppy.sh/users/9155377))