### PR TITLE
Create "Hover" and "Drag" stubs

### DIFF
--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -11,8 +11,10 @@ tags:
 
 **Drag** is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
 
-Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). 
+*Note: Though players may argue, at the end of the day, it's all down to personal preference; there's no one play style/input method that's objectively better than the other.*
+
+Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). Others also claim that the friction keeps the player grounded.
 
 By the same token, many players that argue against dragging claim that it can damage the surface of the tablet without the use of a tablet cover, requires purchasing replacement nibs (due to nib wear), and that the friction is (technically) "slower".
 
-*Notice: though players may argue, at the end of the day, it's all down to personal preference; there's no one play style/input method that's objectively better than the other.*
+

--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -1,17 +1,14 @@
 ---
+stub: true
 tags:
   - tablet
   - dragging
   - play style
 ---
 
-<!-- This article is a stub -->
-
 # Drag
 
 **Drag** is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
-
-*Note: Though players may argue, at the end of the day, it's all down to personal preference; there's no one play style/input method that's objectively better than the other.*
 
 Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). Others also claim that the friction keeps the player grounded.
 

--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -16,5 +16,3 @@ tags:
 Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). Others also claim that the friction keeps the player grounded.
 
 By the same token, many players that argue against dragging claim that it can damage the surface of the tablet without the use of a tablet cover, requires purchasing replacement nibs (due to nib wear), and that the friction is (technically) "slower".
-
-

--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -1,0 +1,11 @@
+# Drag
+
+*Main Page: [Play Styles](/wiki/Play_Styles)*
+
+Drag is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
+
+Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). 
+
+By the same token, many players that argue against dragging claim that it can damage the surface of the tablet without the use of a tablet cover, requires purchasing replacement nibs (due to nib wear), and that the friction is (techincally) "slower".
+
+*Notice: though players may argue, at the end of the day, it's all down to personal preference; there's no one play style/input method that's objectively better than the other.*

--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -9,12 +9,10 @@ tags:
 
 # Drag
 
-*Main Page: [Play Styles](/wiki/Play_Styles)*
-
 **Drag** is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
 
 Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). 
 
-By the same token, many players that argue against dragging claim that it can damage the surface of the tablet without the use of a tablet cover, requires purchasing replacement nibs (due to nib wear), and that the friction is (techincally) "slower".
+By the same token, many players that argue against dragging claim that it can damage the surface of the tablet without the use of a tablet cover, requires purchasing replacement nibs (due to nib wear), and that the friction is (technically) "slower".
 
 *Notice: though players may argue, at the end of the day, it's all down to personal preference; there's no one play style/input method that's objectively better than the other.*

--- a/wiki/Play_Styles/Drag/en.md
+++ b/wiki/Play_Styles/Drag/en.md
@@ -1,8 +1,17 @@
+---
+tags:
+  - tablet
+  - dragging
+  - play style
+---
+
+<!-- This article is a stub -->
+
 # Drag
 
 *Main Page: [Play Styles](/wiki/Play_Styles)*
 
-Drag is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
+**Drag** is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen by physically touching the pen to the surface of the tablet and "dragging" it to the desired location (as opposed to [hovering](/wiki/Play_Styles/Hover)). This style is used by players of all skill levels and is easy to learn.
 
 Arguments in-favor of dragging often claim that it is more comfortable/natural and is much harder to "overshoot" on [jumps](/wiki/Beatmaps/Pattern/Jump). 
 

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -11,6 +11,6 @@ tags:
 
 Hovering is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen across a tablet by holding the pen above the surface of the tablet while still inside of the active hover zone. Thus you are "hovering" the pen above the tablet. This is a method of pen navigation in opposition to [dragging](/wiki/Play_Styles/Drag). It can be found across players of all skill levels, although it is most often associated with highly skilled players.
 
-Arguments in-favor of hovering often claim that it reduces/removes the need to buy replacement nibs, removes the need for a tablet cover, and is (technically) "faster" due to a lack of friction. Whereas arguments against hovering often claim that it is much more difficult to accurately stop or turn on [jumps](/wiki/Beatmaps/Pattern/Jump) and right angles. 
+*Note: though players may argue, there is no one play style/input method that is objectively better than the other; most everything is down to personal preference at the end of the day.*
 
-*Notice: though players may argue, there is no one play style/input method that is objectively better than the other; most everything is down to personal preference at the end of the day.*
+Arguments in-favor of hovering often claim that it reduces/removes the need to buy replacement nibs, removes the need for a tablet cover, and is (technically) "faster" due to a lack of friction. Whereas arguments against hovering often claim that it is much more difficult to accurately stop or turn on [jumps](/wiki/Beatmaps/Pattern/Jump) and right angles. 

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -6,8 +6,6 @@ tags:
   - play style
 ---
 
-<!-- This article is a stub -->
-
 # Hover
 
 Hovering is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen across a tablet by holding the pen above the surface of the tablet while still inside of the active hover zone. Thus you are "hovering" the pen above the tablet. This is a method of pen navigation in opposition to [dragging](/wiki/Play_Styles/Drag). It can be found across players of all skill levels, although it is most often associated with highly skilled players.

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -9,8 +9,6 @@ tags:
 
 # Hover
 
-*Main Page: [Play Styles](/wiki/Play_Styles)*
-
 Hovering is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen across a tablet by holding the pen above the surface of the tablet while still inside of the active hover zone. Thus you are "hovering" the pen above the tablet. This is a method of pen navigation in opposition to [dragging](/wiki/Play_Styles/Drag). It can be found across players of all skill levels, although it is most often associated with highly skilled players.
 
 Arguments in-favor of hovering often claim that it reduces/removes the need to buy replacement nibs, removes the need for a tablet cover, and is (technically) "faster" due to a lack of friction. Whereas arguments against hovering often claim that it is much more difficult to accurately stop or turn on [jumps](/wiki/Beatmaps/Pattern/Jump) and right angles. 

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -1,3 +1,12 @@
+---
+tags:
+  - tablet
+  - hovering
+  - play style
+---
+
+<!-- This article is a stub -->
+
 # Hover
 
 *Main Page: [Play Styles](/wiki/Play_Styles)*

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -1,0 +1,9 @@
+# Hover
+
+*Main Page: [Play Styles](/wiki/Play_Styles)*
+
+Hovering is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen across a tablet by holding the pen above the surface of the tablet while still inside of the active hover zone. Thus you are "hovering" the pen above the tablet. This is a method of pen navigation in opposition to [dragging](/wiki/Play_Styles/Drag). It can be found across players of all skill levels, although it is most often associated with highly skilled players.
+
+Arguments in-favor of hovering often claim that it reduces/removes the need to buy replacement nibs, removes the need for a tablet cover, and is (technically) "faster" due to a lack of friction. Whereas arguments against hovering often claim that it is much more difficult to accurately stop or turn on [jumps](/wiki/Beatmaps/Pattern/Jump) and right angles. 
+
+*Notice: though players may argue, there is no one play style/input method that is objectively better than the other; most everything is down to personal preference at the end of the day.*

--- a/wiki/Play_Styles/Hover/en.md
+++ b/wiki/Play_Styles/Hover/en.md
@@ -1,4 +1,5 @@
 ---
+stub: true
 tags:
   - tablet
   - hovering
@@ -10,7 +11,5 @@ tags:
 # Hover
 
 Hovering is a term used to describe the act of navigating (or "aiming") a [tablet](/wiki/Glossary#tablet) pen across a tablet by holding the pen above the surface of the tablet while still inside of the active hover zone. Thus you are "hovering" the pen above the tablet. This is a method of pen navigation in opposition to [dragging](/wiki/Play_Styles/Drag). It can be found across players of all skill levels, although it is most often associated with highly skilled players.
-
-*Note: though players may argue, there is no one play style/input method that is objectively better than the other; most everything is down to personal preference at the end of the day.*
 
 Arguments in-favor of hovering often claim that it reduces/removes the need to buy replacement nibs, removes the need for a tablet cover, and is (technically) "faster" due to a lack of friction. Whereas arguments against hovering often claim that it is much more difficult to accurately stop or turn on [jumps](/wiki/Beatmaps/Pattern/Jump) and right angles. 


### PR DESCRIPTION
Resolves part of #3149; part of overall organization effort #3143. Creates stubs for the terms "Hover" and "Drag" under the Play Styles folder.

**Was cleaning out my trash branches, accidentally deleted this branch (Jul. 10)**