### PR TITLE
Fix or add default news header in old posts

### DIFF
--- a/news/2013-07-31-easy-mod-how-and-why.md
+++ b/news/2013-07-31-easy-mod-how-and-why.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/56948486143/easy-mod-how-and-why
 
 The Easy mod is notorious for actually making most maps harder, creating massive overlaps and unreadable patterns, all in exchange for nearly halving your final score. But if you take the time to learn it and take advantage of its special features, is it really that useless?
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 **What is Easy Mod?**
 
 The first thing that goes through peoples' minds when seeing the Easy mod is "Oh, wonderful! This'll help me out a lot when I'm having trouble passing! And indeed, it does – the lowered HP drain, increased circle size and 2 additional lives are a great boon to those who are starting out. While players on an \[Easy\] difficulty will most definitely be helped out, and most on \[Normal\] difficulties as well, there comes a time when a player will attempt to use their pal Easy Mod on a higher difficulty. "What's going on?, they cry – the reduced approach rate and increased circle size has started to have a much more distinguished effect! Patterns that were previously readable have now become a mental challenge to try and figure out the order of the notes, and the decreased overall difficulty means that missing one note is quite likely to cause the rest of the pattern to be missed as well. Even if the player pushes on and tries to use the Easy mod on an \[Insane\] difficulty, the overlaps and massive circle density are almost sure to alienate the player further, to the point where they realize that maps are much easier without the poorly-named Easy mod. Besides, even getting past all of that, the Easy mod still gives your score a 50% reduction, leaving no chance of beating someone who got a full combo without any mods.

--- a/news/2013-07-31-highlights-of-july.md
+++ b/news/2013-07-31-highlights-of-july.md
@@ -5,6 +5,8 @@ date: 2013-07-31 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/56990275116/highlights-of-july
 ---
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 **osu! hit 3 million users!**
 
 Since osu!'s creation, the amount of registered users has just been going up faster and faster! Let's take a look at the amount of users osu! has gotten over time:

--- a/news/2013-07-31-maras-gaming-corner-july.md
+++ b/news/2013-07-31-maras-gaming-corner-july.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/56948588121/maras-gaming-corner-july
 
 People have been waiting for Cube World's release for two years now. An endless journey on unknown land with action-based combat makes people wait for a reason. However, nobody expected Cube World to suddenly come out on the start of July as alpha version. Does Cube World live with promises or will the alpha version kill all hope for this game?
 
+![](/wiki/shared/news/2013-07-31-maras-gaming-corner-july/CubeWorld1.jpg)
+
 Cube World (PC) Developed by Picroma
 
 Minimum System Requirements
@@ -31,8 +33,7 @@ The game also supports infinite levels. However, this doesn't mean that you can 
 
 Cube World has a combat that focuses on player skill and free movement. Of course, you are not able to defeat insanely high level bosses at level 3, but in most cases you are able to dodge enemy attacks and strike at the right moment. This is one of the reasons why I like this game; the game rewards you for being a skillful player. It feels great to take down an incredibly difficult boss who throws high damage boomerangs at you all by yourself. I wish enemies wouldn't be so simple though. Bosses would be much better if there would be more special attacks that are deadly if not avoided. I also noticed that only a few enemies actually try to dodge your attacks. Enemies that dodge add more intensity to the battle, and I wish it would be a norm for more difficult enemies.
 
-**  
-![image](/wiki/shared/news/2013-07-31-maras-gaming-corner-july/CubeWorld1.jpg)**
+![](/wiki/shared/news/2013-07-31-maras-gaming-corner-july/CubeWorld1.jpg)
 
 _You are able to defeat most monsters in the world if you are skilled enough._
 
@@ -42,8 +43,7 @@ For now, there are four different classes; Warrior, Mage, Ranger and Rogue. Warr
 
 Speaking of riding, one of the features I like are the pets. There are all kinds of animals you can obtain, that do many different things. Some do melee damage, some do ranged damage, some are ridden and there is even one that can heal you! To get a pet in Cube World, first you have to find out what food each animal likes. Then you have to obtain the food and then offer it to the animal. This is really simple but also insanely addicting. It's almost like playing Pokémon all over again; especially along with the fact that they are able to level up!
 
-**  
-![image](/wiki/shared/news/2013-07-31-maras-gaming-corner-july/CubeWorld2.jpg)**
+![](/wiki/shared/news/2013-07-31-maras-gaming-corner-july/CubeWorld2.jpg)
 
 _Multiplayer is great fun if you get the right people to play with you._
 

--- a/news/2013-08-08-osutest-build-now-more-usable.md
+++ b/news/2013-08-08-osutest-build-now-more-usable.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/57687830738/osutest-build-now-more-us
 
 From now on, the osu! test build (supporter only) will now connect to the main bancho server, and allow for ranking and playing with normal users!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 I usually wouldn't announce something like this, but I want as many people to see this as possible. I am hoping that any supporters interested in testing bleeding edge features will permanently switch to osu!test and help iron out bugs **before** they hit the public release.
 
 ![](/wiki/shared/news/2013-08-08-osutest-build-now-more-usable/Screen+Shot+2013-08-07+at+22.18.02.png)

--- a/news/2013-09-15-mapping-analysis-1-flow.md
+++ b/news/2013-09-15-mapping-analysis-1-flow.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/61334266941/mapping-analysis-1-flow
 
 Hello everyone, I'm Shiro, and here is the first post of a map analysis series in which I will go over common mistakes I've found through my modding history, explaining why they are mistakes and how to fix them.
 
+![](/wiki/shared/news/2013-09-15-mapping-analysis-1-flow/tumblr_inline_mr7tu7tf6i1qz4rgp.png)
+
 Keep in mind that flow is subjective, and that things defined as "broken" here might work under certain circumstances. This article assumes that the flow tries to be smooth in a neutral setup.
 
 Flow is a word many mappers and modders use, often without context, and most of the time without a clear definition in mind. Flow is a very difficult thing to define because it's mostly based on personal views when it comes to what flows well and what doesn't. There are however a few things that are globally accepted, and [Charles445](https://osu.ppy.sh/users/85000) wrote [an amazing tutorial](https://osu.ppy.sh/community/forums/topics/86329) explaining these things. I highly recommend you read it before proceeding onto this article. While Charles445 explains what flows well and how to analyze flow in beatmaps, I'm going to go over the main mistakes I've seen while modding. Please note that this is my personal opinion on flow, and it is in no way universal.

--- a/news/2013-09-15-the-adventures-of-clicking-circles-1-never.md
+++ b/news/2013-09-15-the-adventures-of-clicking-circles-1-never.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/61337066445/the-adventures-of-clickin
 
 I'd like to present the first chapter of The Adventures of Clicking Circles, an osu! based comic!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 ![](/wiki/shared/news/2013-09-15-the-adventures-of-clicking-circles-1-never/osu!monthly+comic+resize.png)
 
 —Brian OA

--- a/news/2013-12-08-osu-world-cup-2013-results.md
+++ b/news/2013-12-08-osu-world-cup-2013-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/69421249436/osu-world-cup-2013-result
 
 The osu! World Cup 2013 just ended, and we are proud to announce the winners of the biggest osu! tournament yet.
 
+![](/wiki/shared/news/banners/owc_2013.png)
+
 ![image](/wiki/shared/news/2013-12-08-osu-world-cup-2013-results/podium+(2).jpg)
 
 During the grand final, Korea and Taiwan showed off their amazing playing skills. At the end, Korea won by 6-5 after beating Taiwan on the tiebreaker. You can watch the full record of the final right here:

--- a/news/2013-12-31-happy-new-year.md
+++ b/news/2013-12-31-happy-new-year.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/71746517206/happy-new-year
 
 happy new year everyone!
 
+![](/wiki/shared/news/2013-12-31-happy-new-year/2014.jpg)
+
 [![happy new year!](/wiki/shared/news/2013-12-31-happy-new-year/2014.jpg)](/wiki/shared/news/2013-12-31-happy-new-year/2014.jpg)
 
 —peppy

--- a/news/2014-05-21-first-official-osu-fanart-contest-results.md
+++ b/news/2014-05-21-first-official-osu-fanart-contest-results.md
@@ -5,6 +5,8 @@ date: 2014-05-21 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/86373762103/first-official-osu-fanart-contest-results
 ---
 
+![](/wiki/shared/news/2014-05-21-first-official-osu-fanart-contest-results/thumb-65.jpg)
+
 Hello everyone! The results are in for the first fanart contest, and I have to say, from the number of entries to the number of votes, the response has been truly astonishing. Narrowing down the results for the staff favorites in particular was a daunting task. Please don't feel bad if you didn't win this time. There were far too many amazing entries to feature them all here, but I will gradually post all of them to the facebook page so each can be given the attention they deserve.
 
 The results are broken into two sections, the hard numbers of the public poll results, and the more subjective and personal choices of the staff picks. First place in each section wins a full year supporter tag, along with an [osu!tablet](https://osu.ppy.sh/store/products/1) (or [Pippi plushie](https://osu.ppy.sh/store/products/3), if they prefer). The next four runner-ups in each section will each receive a one-month supporter tag. I've also listed five honorable mentions, who won't be getting prizes but whose art I felt deserved to be featured here as well. We'll be granting the supporter tags and contacting the first prize winners about the physical prizes tonight and tomorrow. If we use any of this art in upcoming merchandise, one of those will be given to the artist as part of the prize as well.

--- a/news/2014-06-03-the-adventures-of-clicking-circles-2-git-gud.md
+++ b/news/2014-06-03-the-adventures-of-clicking-circles-2-git-gud.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/87727265753/the-adventures-of-clickin
 
 Hey guys, here's the long awaited second installment of the osu!comic!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 I think this is something a lot of us can relate to.  
 ![](/wiki/shared/news/2014-06-03-the-adventures-of-clicking-circles-2-git-gud/tumblr_inline_n6m0zpetl21s6rj41.jpg)
 

--- a/news/2014-06-21-meet-yuzu.md
+++ b/news/2014-06-21-meet-yuzu.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/89483664163/meet-yuzu
 
 The osu! community has been growing at a large rate, but now it's the osu! family's turn. Yuzu has joined us as the new official mascot for Catch the Beat.
 
+![](/wiki/shared/news/2014-06-21-meet-yuzu/tumblr_inline_n9kvkg8RuC1s6rj41.png)
+
 Ryuuta was the fruit catcher for Catch the Beat for many years, but now it's Yuzu's turn to step into the spotlight. Yuzu's addition also brings about a change to how the fruit catcher is skinned. fruit-ryuuta. png from now on doesn't work. The 4 new elements are fruit-catcher-idle.png, fruit-catcher-kiai.png and fruit-catcher-fail.png and comboburst-fruits.png.
 
 ztrot and Daru have spent a good few months working on this and the result is amazing. ztrot spent his time working on the fruit catcher while Daru spent his time creating the comboburst and polishing the design.

--- a/news/2014-06-25-osu-catch-the-beat-world-cup-2014-results.md
+++ b/news/2014-06-25-osu-catch-the-beat-world-cup-2014-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/89883225258/osu-catch-the-beat-world-
 
 The osu! Catch the Beat World Cup 2014 ended around two week ago, and we are proud to announce the winners of the biggest Catch the Beat tournament yet.
 
+![](/wiki/shared/news/banners/catch_logo_2014.png)
+
 ![image](/wiki/shared/news/2014-06-25-osu-catch-the-beat-world-cup-2014-results/CWC-podium.jpg)
 
 During the grand final, Germany and South Korea showed off their amazing skills in catching fruits and bananas. At the end, South Korea won by 6-3 after beating Germany on [Ryu* Vs. L.E.D.-G - PARADISE LOST](https://osu.ppy.sh/beatmaps/117383?m=2). You can watch the full record of the grand final right here:

--- a/news/2014-07-04-second-official-osu-fanart-contest-results.md
+++ b/news/2014-07-04-second-official-osu-fanart-contest-results.md
@@ -5,6 +5,8 @@ date: 2014-07-04 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/90764226618/second-official-osu-fanart-contest-results
 ---
 
+![](/wiki/shared/news/2014-07-04-second-official-osu-fanart-contest-results/thumb-7.jpg)
+
 Hello again! The results are finally in for the second official osu! fanart contest! It was very interesting seeing people take this fairly open-ended theme in different directions, and even more interesting to see how those different directions were reflected in the voting results.
 
 The results are broken into two sections, the hard numbers of the public poll results, and the more subjective and personal choices of the staff picks. First place in each section wins a full year supporter tag, along with an [osu!tablet](https://osu.ppy.sh/store/products/1) (or [Pippi plushie](https://osu.ppy.sh/store/products/3), if they prefer). The next four runner-ups in each section will each receive a one-month supporter tag. I've also listed five honorable mentions, who won't be getting prizes but whose art I felt deserved to be featured here as well. We'll be granting the supporter tags and contacting the first prize winners about the physical prizes in the next few days. If we use any of this art in upcoming merchandise, one of those will be given to the artist as part of the prize as well.

--- a/news/2014-08-30-restructuring-ranking-procedure.md
+++ b/news/2014-08-30-restructuring-ranking-procedure.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/96193919888/restructuring-ranking-pro
 
 After announcing the [new division of the team](https://osu.ppy.sh/home/news/2014-08-21-restructuring-of-the-bat), there were quite a few people showing concern over not knowing exactly how the ranking process works. We decided to put together an infographic to clear things up!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 [![ranking procedure](/wiki/shared/news/2014-08-30-restructuring-ranking-procedure/ranking-procedure.png)](/wiki/shared/news/2014-08-30-restructuring-ranking-procedure/ranking-procedure-large.png)
 
 —flyte

--- a/news/2014-10-10-third-official-osu-fanart-contest-results.md
+++ b/news/2014-10-10-third-official-osu-fanart-contest-results.md
@@ -5,6 +5,8 @@ date: 2014-10-10 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/99609478178/third-official-osu-fanart-contest-results
 ---
 
+![](/wiki/shared/news/2014-10-10-third-official-osu-fanart-contest-results/thumb-49.jpg)
+
 Hey there. We received so many awesome entries for the third official osu! fan art contest **"Stickers! So Many Stickers!"** - with the theme of digital stickers (like the ones used on Facebook or Line or other chat programs as large emoticons). Again, the creativity of fans knocked us off our feet; We can definitely see some of these submissions being the perfect way to express osu!-related emotions in chat programs. Well done guys.
 
 Voting has closed, and it's time to announce results. Ready?

--- a/news/2014-11-12-fourth-official-osu-fanart-contest-results.md
+++ b/news/2014-11-12-fourth-official-osu-fanart-contest-results.md
@@ -5,6 +5,8 @@ date: 2014-11-12 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/102429724443/fourth-official-osu-fanart-contest-results
 ---
 
+![](/wiki/shared/news/2014-11-12-fourth-official-osu-fanart-contest-results/thumb-58.jpg)
+
 Woah! So many incredible entries for the 4th official osu! Fanart contest, **"A very osu! Halloween"**. Entries ranged from spooky and cute, to gorey, creepy and downright scary. All in the spirit of Halloween, of course. Thanks for voting everyone - now it's time to announce results.
 
 The results are broken into two sections, the hard numbers of the public poll results, and the more subjective and personal choices of the staff picks. First place in each section wins a full year supporter tag, along with an osu!tablet. The next four runner-ups in each section will each receive a one-month supporter tag. We've also listed five honorable mentions, who won't be getting prizes but whose art deserves a shout-out here too.

--- a/news/2014-11-28-official-osu-fanart-contest-5-begins.md
+++ b/news/2014-11-28-official-osu-fanart-contest-5-begins.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/103785787028/official-osu-fanart-cont
 
 The fifth Official osu! Fanart Contest is here.
 
+![](/wiki/shared/news/2014-11-28-official-osu-fanart-contest-5-begins/osuxmascontestbanner.jpg)
+
 You all did so well with the Halloween osu! fan art, so you can probably guess our theme this time (cue jingling sleigh bells) - but there''s a twist...
 
 Yes, Christmas is just around the corner, and we want spread some festive cheer by giving the osu! title screen a Christmas overhaul...featuring YOUR art! So this time, we're providing templates for the title screen and asking our talented users to come up with original osu! Christmas backgrounds. The best osu! Christmas designs will be rotated on the title screen in the lead up to Christmas (from December 22 ~ 31) for all to see.

--- a/news/2015-01-02-osuidol-2014-results.md
+++ b/news/2015-01-02-osuidol-2014-results.md
@@ -7,7 +7,7 @@ tumblr_url: http://osunews.tumblr.com/post/106902823593/osuidol-2014-results
 
 The osu!idol contest just concluded, so lets wrap this up!
 
-![](http://78.media.tumblr.com/0ee146ce4ea607d6c9a03c25866f0731/tumblr_inline_nhjyauVGuz1s6rj41.png)
+![](/wiki/shared/news/2014-08-24-osuidol-sign-ups-now-open/osuidolannounce.png)
 
 The entries for the final were amazing and a joy to listen to, the efforts the participants put in did not come unnoticed! It was unbelievable how close the point difference was between 1st and 2nd place, just 0.2 points! It would have been even more interesting if there was a tie, but even with such a small difference, the positions are clear.
 

--- a/news/2015-01-04-osu-world-cup-2014-results.md
+++ b/news/2015-01-04-osu-world-cup-2014-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/107084870238/osu-world-cup-2014-resul
 
 The osu! World Cup 2014 ended in the middle of December and we proudly want to remember everyone on the winners our official osu! team tournament again and congratulate them for their outstanding performances.
 
+![](/wiki/shared/news/banners/owc_2014.png)
+
 ![](/wiki/shared/news/2015-01-04-osu-world-cup-2014-results/OWC-podium.jpg)
 
 During the grand final, Japan and Poland showed off their amazing playing skills. In order to be victorious, Japan had to win twice against Poland, because they ascended from the loser brackets into the finals. At the end, Japan achieved the impossible and beat Poland two times in a row, first by 6-1 and then again by 6-2\. You can watch the full record of the finals right here:

--- a/news/2015-01-08-fifth-official-osu-fanart-contest-results.md
+++ b/news/2015-01-08-fifth-official-osu-fanart-contest-results.md
@@ -5,6 +5,8 @@ date: 2015-01-08 00:00:00 +0000
 tumblr_url: http://osunews.tumblr.com/post/107496626248/fifth-official-osu-fanart-contest-results
 ---
 
+![](/wiki/shared/news/2015-01-08-fifth-official-osu-fanart-contest-results/thumb-60.jpg)
+
 You may have noticed the festive Christmas backgrounds, rotated on the title screen in the lead up to Christmas (from December 22 ~ 31) - but now it's finally time to reveal the results of Fanart Contest \#5 voting.
 
 We received a total of 132,988 votes from 22,213 users over two weeks. 8 osu! staff members took part in the staff voting (including peppy, of course!). This time, we're announcing 10 winners who will each win a four month supporter tag: five winners selected by the public poll, five selected by osu! staff. First place wins an osu! tablet too!

--- a/news/2015-03-20-osu-beatmap-blueprints-available-contest.md
+++ b/news/2015-03-20-osu-beatmap-blueprints-available-contest.md
@@ -9,6 +9,8 @@ Introducing the newest product to the [osu!store](https://osu.ppy.sh/store/listi
 
 ![](/wiki/shared/news/2015-03-20-osu-beatmap-blueprints-available-contest/stickers.jpg)
 
+![](/wiki/shared/news/2015-03-20-osu-beatmap-blueprints-available-contest/stickers.jpg)
+
 Now you can beatmap anywhere you want! No admin approval needed - just go ahead and slap them on your books, fridge, laptop and all over the neighbourhood.
 
 Each pack contains two 8.5" x 11" custom sticker sheets featuring elements from the game! Sheet 1 contains 54 hit circles; while Sheet 2 contains 7x sliders (various shapes), 8x blank hit circles, 2x slider direction arrows, 2x approach circles, 3x various phrases (激, 喝 , 999x) and 1x small osu! logo. Each sticker is kiss cut for easy peeling. [More details here!](https://osu.ppy.sh/store/products/9)

--- a/news/2015-04-12-osu-taiko-world-cup-2015-results.md
+++ b/news/2015-04-12-osu-taiko-world-cup-2015-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/116205500393/osu-taiko-world-cup-2015
 
 The osu! Taiko World Cup 2015 has just concluded with a thunderous Grand Final, and a new team has emerged victorious with an absolutely outstanding performance!
 
+![](/wiki/shared/news/banners/TWC_2015.png)
+
 ![](/wiki/shared/news/2015-04-12-osu-taiko-world-cup-2015-results/osu!taiko-ranking.png)
 
 During the grand final, Japan and Taiwan showed off their incredibly impressive Taiko skills. Japan held their ground against the very skilled players from Taiwan, whom clawed themselves up to the Grand Final after being placed in the loser's bracket earlier in the contest, and won with a fantastic score of 6-3.

--- a/news/2015-06-16-osu-catch-the-beat-world-cup-2015-results.md
+++ b/news/2015-06-16-osu-catch-the-beat-world-cup-2015-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/121704697763/osu-catch-the-beat-world
 
 The osu! Catch the Beat World Cup 2015 concluded on Sunday with an amazing Grand Final, and South Korea was able to defend their title after an intense battle against their opponent China!
 
+![](/wiki/shared/news/banners/catch_logo_2015.png)
+
 ![](/wiki/shared/news/2015-06-16-osu-catch-the-beat-world-cup-2015-results/osu!ctb+ranking.png)
 
 During the grand final, South Korea and China showed off their outstanding skills in catching fruits. South Korea gave their best to defend their title against the strong Chinese team, whom they faced the week before already. China was able to win some ground, but was not able to defeat South Korea entirely. After performing a thrilling match, South Korea won with a fantastic score of 6-2.

--- a/news/2015-10-07-osumania-4k-world-cup-2015-results.md
+++ b/news/2015-10-07-osumania-4k-world-cup-2015-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/130679970363/osumania-4k-world-cup-20
 
 The osu!mania 4K World Cup 2015 concluded on Sunday two weeks ago with an amazing Grand Final. We would like to shoutout the results once again and celebrate the winning team with everyone together! The United States were able to achieve their first World Cup Title in all World Cups after battling against Japan with an outstanding performance.
 
+![](/wiki/shared/news/banners/MWC_2015.png)
+
 ![](/wiki/shared/news/2015-10-07-osumania-4k-world-cup-2015-results/osu!mwc4k2015+ranking.png)
 
 During the Grand Final, the United States dominated entirely in the battle against the top-tier team of Japan. With a result of 7-0, the United States won the tournament without giving away a single beatmap against anyone during all stages of this event! Japan fought their way up from the loser's bracket and achieved the second place, after defeating the United Kingdom before, who placed third in this competition.

--- a/news/2015-12-05-osuidol-2015-results.md
+++ b/news/2015-12-05-osuidol-2015-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/134589253878/osuidol-2015-results
 
 Throughout the last 4 months, with over 100 competitors, we went through 4 stages and managed to narrow it down to 3 singers to be our winners.
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 This year it was up to you, the community, to decide who will shine as the osu!idol! Over the course of 2 weeks, we gathered your votes and now that the time is up, the results shall be announced!
 
 ![](/wiki/shared/news/2015-12-05-osuidol-2015-results/finals.png)

--- a/news/2015-12-17-osu-world-cup-2015-results.md
+++ b/news/2015-12-17-osu-world-cup-2015-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/135380700348/osu-world-cup-2015-resul
 
 The osu! World Cup 2015 concluded last Sunday with an amazing Grand Final. In an unexpected turn of events, the United States were able to come back from the loser's bracket and secure their first osu! World Cup Title against their final opponent: China.
 
+![](/wiki/shared/news/banners/owc_2015.jpg)
+
 ![](/wiki/shared/news/2015-12-17-osu-world-cup-2015-results/podium-owc2015.png)
 
 After losing against China in the previous week's semi-finals, the US team made up for their loss by winning the first match 7-2. However as they were returning from the loser's bracket, they needed to win not one but *two* matches! The second battle against China was long, exhausting, thrilling and rewarding. With an amazingly close match ending with the tie breaker "gmtn. (witch's slave) - furioso melodia", the United States secured their win at the very last moment! China put up a great fight and are definitely deserving of their second place.. The third place goes to Poland that already secured their slot a week earlier after facing Germany and South Korea!

--- a/news/2016-02-08-happy-chinese-new-year.md
+++ b/news/2016-02-08-happy-chinese-new-year.md
@@ -9,6 +9,8 @@ tumblr_url: http://osunews.tumblr.com/post/138895980163/happy-chinese-new-year
 
 ![](/wiki/shared/news/2016-02-08-happy-chinese-new-year/cny.png)
 
+![](/wiki/shared/news/2016-02-08-happy-chinese-new-year/cny.png)
+
 鸟语喧花果，猴声啼水帘。玉兔探月观新岁，金猴捧挑笑丰年。
 
 鳥語喧花果，猴聲啼水簾。玉兔探月觀新歲，金猴捧挑笑豐年。

--- a/news/2016-04-20-meet-maria-osumanias-new-mascot.md
+++ b/news/2016-04-20-meet-maria-osumanias-new-mascot.md
@@ -9,6 +9,8 @@ Refined elegance joins the osu! mascot lineup! Meet Maria, osu!mania's new poste
 
 ![](https://puu.sh/o5Hx4/b0a2b5a1f2.jpg)
 
+![](https://puu.sh/o5Hx4/b0a2b5a1f2.jpg)
+
 Joining Pippi and Yuzu in the osu! mascot collection, Maria brings a touch of mature class to the classically older style of rhythm gaming found in osu!mania. An accomplished pianist in her own right, you'll find Maria on any osu!mania map, cheering you on as your combo builds ever higher. She also takes on the mantle of osu!'s official meganekko (or glasses girl, for the more cultured types).
 
 To celebrate Maria's release, we've added a brand new achievement (and swanky medal) to the game. Simply score above 100 combo on any osu!mania map, convert or otherwise, and witness her in all her glory!

--- a/news/2016-07-09-osuweekly-67.md
+++ b/news/2016-07-09-osuweekly-67.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/147133568543/osuweekly-67
 
 With the brief break that our friends in dev get from official tournaments and [existential problems](https://next.ppy.sh/post/145703170363/oh), we shift our focus to more community contributions! Read on to see what your fellow members of the community are up to!
 
+![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 **It looks like we've reached [the end](https://osu.ppy.sh/home/news/2016-05-06-osu-circles-remix-contest) of the first ever osu! remix contest!** It is not an exaggeration to say this this is a historical moment for osu, as it signifies the first of the work from our efforts to bring you original content finally making it's way to everyone. It's still a ways off from properly concluding with a winner, but it's definitely exciting to hit this milestone nevertheless!
 
 **It looks like the [Polish 4K osu!mania tournament](https://osu.ppy.sh/community/forums/topics/449692) we mentioned a few weeks ago is nearing it's conclusion.** The match for the 3rd place was one of the most intense matches of the whole tournament. SitekX won against SutekX[Mientki] 7:5 in a close battle, with less than 1000 points difference on three maps (the score difference on one map was only 36 points!). SitekX is going to play against Hudonom in the grand final, which is taking place on 10th July, 3PM GMT+2.

--- a/news/2016-07-18-osu-mascot-design-contest.md
+++ b/news/2016-07-18-osu-mascot-design-contest.md
@@ -7,6 +7,10 @@ tumblr_url: http://osunews.tumblr.com/post/147587226893/osu-mascot-design-contes
 
 Time to dust off those pens and get that creativity flowing! We're back with another special contest - this time for the intrepid artists among us. We're challenging you to design the new osu!Taiko mascot!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
+<!-- TODO: depending on what this image is (link broken), it might be a good replacement for the default header above -->
+
 ![](https://puu.sh/q3REi/ee84624520.jpg)
 
 Over the years, we've had multiple people assist with mascot designs. Sarumaru for pippi, crystalsuicune for pippidon, ztrot for Yuzu and Daru for Yuzu and Maria. But we'd like to replace our lovable pippidon with something more official, similar to how Ryuuta stepped down for Yuzu a few years back

--- a/news/2016-08-17-new-hush-hush-medals.md
+++ b/news/2016-08-17-new-hush-hush-medals.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/149074719383/new-hush-hush-medals
 
 The first set of new "Hush-Hush" style medals are here at long last. Medal hunters unite!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 Many months ago, we mentioned a number of new medals in development in the meetings posted on [peppy's blog](https://blog.ppy.sh). The Mod Spotlight medals released relatively quietly a few weeks back were just preparation for the big ones coming - and they're finally here!
 
 We'd like to proudly present to you, the first portion of a new set of medals in the "Hush-Hush" style. For those unfamiliar with the concept, "Hush-Hush" medals are a mixture of riddles and gameplay skills. From experimenting with mod combinations, to little similarities in metadata, gaining these coveted medals is more than just simply following a set of instructions towards your goal.

--- a/news/2016-08-29-osuremix-contest-1-results.md
+++ b/news/2016-08-29-osuremix-contest-1-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/149642788073/osuremix-contest-1-resul
 
 The results are in for the first ever osu!remix contest. Get ready to feast your ears on some awesome tracks!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 A little while ago, we held our first official remix contest for one of osu!'s first ever exclusive tracks - *circles!*, by our in-house composer (and developer!) [nekodex](https://osu.ppy.sh/users/nekodex). 21 talented musicians stepped forward and took their own spin on *circles!*, with everything from electronica to dubstep and beyond explored by our intrepid contestants.
 
 To refresh everyone's memory, the contest is split into two prizes - a staff pick and a community vote. The staff pick consists of the members of osu!'s internal team personally voting for their favorite three tracks from the lot. The community vote functioned a bit differently, with everyone being given three votes to distribute across their favorite three tracks from the competition.

--- a/news/2016-09-10-osumania-4k-world-cup-results.md
+++ b/news/2016-09-10-osumania-4k-world-cup-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/150229859723/osumania-4k-world-cup-re
 
 The champions of the osu!mania 4K World Cup have been crowned! Did you catch the excitement on the livestream? If not, we have a recap for you ready complete with VODs and prize information!
 
+![](https://puu.sh/pJ9Ml/8d6f0d1b51.png)
+
 Going into the Grand Finals, the South Korean team came hot off the heels of a rematch between defending champions United States. The confident South Korean team completely annihilated the competition and prepared themselves to meet whoever was coming from the loser's brackets.
 
 The Brazilian team faced a much larger hurdle to reach the Grand Finals. Having been previously defeated by the United States team, it was clear that adjustments needed to be made if they wanted to make it into the Grand Finals. Having swept the Japanese team earlier, the Brazilians carried forth their momentum into the much anticipated rematch and convincingly defeated the American team to earn the right to face Korea in the Grand Finals.

--- a/news/2016-10-25-osuidol-2016-finals-community-voting.md
+++ b/news/2016-10-25-osuidol-2016-finals-community-voting.md
@@ -7,9 +7,9 @@ tumblr_url: http://osunews.tumblr.com/post/152288900053/osuidol-2016-finals-comm
 
 Last year the osu!community voted to determine the winner for 2015's contest and now the time has come again for all of you, to pick who will be the osu!idol for 2016!
 
-We launched the event mid-summer, with more than 150 submissions, went through multiple stages to narrow it down to only a few. We have 3 talented, excited and of course, nervous finalists for you to vote for! Hop onboard and give them a listen!
-
 ![](http://flan.s-ul.eu/Mw0a4Uqy)
+
+We launched the event mid-summer, with more than 150 submissions, went through multiple stages to narrow it down to only a few. We have 3 talented, excited and of course, nervous finalists for you to vote for! Hop onboard and give them a listen!
 
 ## Where can I vote?
 

--- a/news/2016-11-08-osuidol-2016-final-results.md
+++ b/news/2016-11-08-osuidol-2016-final-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/152901340878/osuidol-2016-final-resul
 
 Once again, we have reached the end of another edition of osu!idol. Compared to 2015, we received a lot more contestants this year, giving us an extended amount of singers to listen and evaluate!
 
+![](http://flan.s-ul.eu/IXfP3V7O)
+
 Over the course of a couple of months, throughout 5 stages, our judges worked hard to ensure we have amazing talents lined up on the final podium! Without further ado, here are the results from the finals' voting:
 
 ![](https://i.imgur.com/5yp14zN.png)

--- a/news/2016-12-24-osuworld-cup-2016-results.md
+++ b/news/2016-12-24-osuworld-cup-2016-results.md
@@ -5,11 +5,11 @@ date: 2016-12-24 02:56:30 +0000
 tumblr_url: http://osunews.tumblr.com/post/154875453203/osuworld-cup-2016-results
 ---
 
+![](/wiki/shared/news/banners/twc2017.jpg)
+
 Hello everyone, Evrien here, assigned with the task of informing you the final results of osu! World Cup 2016. Spanning across 6 exciting and hype-filled weekends, the OWC 2016 saw 32 teams representing player communities around the world. Needless to say, the excitement was almost tangible in the air, and this winter was set ablaze by the passion and support from everyone involved.
 
 Without further ado, here are the Top 3 Teams of OWC 2016.
-
-![](/wiki/shared/news/banners/twc2017.jpg)
 
 **Taking 3rd place, the South Korean team showcased great tenacity and well-roundedness.** Team Captain Neta is an experienced veteran from both official and community tournaments, and under his lead the South Korean players strived for the very top. Having climbed to \#1 earlier this year, Angelsim was instrumental alongside My Aim Sucks, carrying the team forward and avoiding several close losses. While they may have lost their star Hidden player Cinia Pacifica early in the tournament, South Korea bonded closely together as – T A R U L A S - , La Valse, Enon, and Yuria did their very best keeping the team afloat all the way to Winner's Finals. Shouldering great responsibility of bringing the champion title back to Asia, the South Koreans faced considerable pressure, but their performance was nothing to be scoffed at, and momentum dictates that they will continue to be a great powerhouse in the osu! competitive scene.
 

--- a/news/2017-01-09-new-featured-artists-s3rl-and-nanobii.md
+++ b/news/2017-01-09-new-featured-artists-s3rl-and-nanobii.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/155616063463/new-featured-artists-s3r
 
 Happy, Hardcore, and Happy Hardcore fans unite! Two new incredibly talented musicians enter the roster of our Featured Artists: namely S3RL and nanobii!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 So much talent all at once. Where do we even start?
 
 ![](https://assets.ppy.sh/artists/9/header.jpg)

--- a/news/2017-01-17-featured-artist-update-cysmix-yuki-and.md
+++ b/news/2017-01-17-featured-artist-update-cysmix-yuki-and.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/155994951623/featured-artist-update-c
 
 In our journey to continue feeding the creative mapping community of osu!, we have added **over twenty new tracks** to the Featured Artist catalog.
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 For those that aren't aware, the [Featured Artist catalog](https://osu.ppy.sh/beatmaps/artists) is a listing of artists who we are working with to bring a larger official library of songs to osu!, for use in tournaments, streaming and other events. Each one of these tracks has been selected by us for their mappability and provided to you - the mappers - in a pretimed template format for your convenience!
 
 ![](https://assets.ppy.sh/artists/2/header.jpg)

--- a/news/2017-01-27-happy-chinese-new-year.md
+++ b/news/2017-01-27-happy-chinese-new-year.md
@@ -9,6 +9,8 @@ Good luck, good health, good cheer. We wish you a happy new year!
 
 ![](https://assets.ppy.sh/events/cny2017/cny2017.jpg)
 
+![](https://assets.ppy.sh/events/cny2017/cny2017.jpg)
+
 With the 2016 Lunar Year coming to a close and the Year of the Rooster dawning in 2017, we'd like to take a moment to wish you and your loved ones a prosperous and successful new year.
 
 神猴辭歲、金鳳迎春；雄雞唱韻、大地回春。萬戶桃符新氣象、群山霞彩富神州；聞雞起舞迎元旦、擊壤而歌頌小康。

--- a/news/2017-02-16-best-of-2016-results.md
+++ b/news/2017-02-16-best-of-2016-results.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/157306073998/best-of-2016-results
 
 Earlier in January, the osu! community at large went to the polls for the first time since last year, coming together from far and wide to deliberate on which maps deserved to be named the "Best of 2016". Now that you have spoken, the results are in!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 **As a part of our mission to always be looking out for your feedback, we've made a couple of changes to weightings from last year's contest.** If you recall, last year we took on the challenge of providing more accurate results for the greater part of the active community.
 
 This year's weighted score was calculated taking into account all the scores the voter has on all the beatmaps within the given set. For each score, we use the following formula to calculate a weighting:

--- a/news/2017-03-18-introducing-to-you-spotlights.md
+++ b/news/2017-03-18-introducing-to-you-spotlights.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/158544426548/introducing-to-you-spotl
 
 The Ranking Charts has been since always a part of the osu! ecosystem, presenting the community the most noteworthy beatmaps each month where players compete for the top and mappers gain recognition for exceptional work on their beatmaps. However, after all the changes the charts have had to undergo in the past years, they will now encounter their biggest one yet!
 
+![](https://osu.ppy.sh/images/headers/news-show-default.jpg)
+
 ## Changes
 
 As previously mentioned in the [official development blog](https://blog.ppy.sh/post/149588555393/2016-08-dev-meeting), the overhaul will kick in by firstly renaming the current Ranking Charts to "Spotlights", bringing additional features in the near future such as a new format of prizes for players (and mappers), as well as more regular releasing of Beatmap Packs.

--- a/news/2017-05-09-osu-at-anime-expo-2017.md
+++ b/news/2017-05-09-osu-at-anime-expo-2017.md
@@ -7,6 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/160469158898/osu-at-anime-expo-2017
 
 Hello everyone! It sure has been a while since I've posted a news post here (thanks to all those involved in keeping the community informed in my place as I focus on development and keeping-things-running!).
 
+![](https://puu.sh/vK85j/3809d9d66d.jpg)
+
 I'm here with some very exciting news: as part of our 10th anniversary celebrations, osu! is going to be present at [Anime Expo 2017](http://www.anime-expo.org)!
 
 ![](https://puu.sh/vK85j/3809d9d66d.jpg)


### PR DESCRIPTION
old news posts didn't have "headers" all the time because they were posted as a tumblr blog. now, headers are created by eating the first image of each post, so those old posts ended up broken in some cases if the first image wasn't supposed to be a header.
[example](https://osu.ppy.sh/home/news/2013-07-31-easy-mod-how-and-why), [example 2](https://osu.ppy.sh/home/news/2013-09-15-the-adventures-of-clicking-circles-1-never)

I've fixed these cases by adding a header to the top, using the first option here that applied:

- an image in the post that looks good as a header
- an image outside of the post that would clearly fit as a header for it (ex. the corresponding OWC header for an OWC results post)
- the default news header

and if the first paragraph made sense as a post preview, I added the headers below that.