### PR TITLE
Update pickem links to new domain

### DIFF
--- a/news/2019-10-16-OWC-2019-registrations-open.md
+++ b/news/2019-10-16-OWC-2019-registrations-open.md
@@ -41,7 +41,7 @@ You can discuss this event and follow the most important changes in the **[offic
 
 ## Pick'Ems
 
-Pick'ems will level up to the next stage! [hallowatcher](https://osu.ppy.sh/users/1874761) is **[hosting the Pick'ems this year again](https://pickem.hwchr.com/tournaments/19)**, but will feature supporter prizes and a badge for the best fortune teller! Check the **[forum page](https://osu.ppy.sh/community/forums/topics/971059)** for details.
+Pick'ems will level up to the next stage! [hallowatcher](https://osu.ppy.sh/users/1874761) is **[hosting the Pick'ems this year again](https://pickem.hwc.hr/tournaments/19)**, but will feature supporter prizes and a badge for the best fortune teller! Check the **[forum page](https://osu.ppy.sh/community/forums/topics/971059)** for details.
 
 ## How do I register?
 

--- a/wiki/Contests/oBWC/2/en.md
+++ b/wiki/Contests/oBWC/2/en.md
@@ -59,7 +59,7 @@ The osu! Beatmapping World Championship is run by various community members.
 - [Discord server](https://discord.gg/CZp4bNx)
 - [Official website](https://obwc.net/)
 - [Twitter](https://twitter.com/osubwc)
-- [Pick'em page](https://pickem.hwchr.com/tournaments/30)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/30) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 
 ## Participants
 

--- a/wiki/Tournaments/CWC/2019/en.md
+++ b/wiki/Tournaments/CWC/2019/en.md
@@ -49,6 +49,7 @@ The osu!catch World Cup 2019 was run by various community members by distributin
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/913952)
 - [Livestream](https://www.twitch.tv/osulive)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/9) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - [Statistics sheet](https://bit.ly/2Jd3RXc)
 
 ---

--- a/wiki/Tournaments/GST/2/en.md
+++ b/wiki/Tournaments/GST/2/en.md
@@ -57,7 +57,7 @@ The Great Singapore Tournament 2 was run by various community members.
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/983074)
 - [GST Discord server](https://discord.gg/kCfW4Jw)
 - [Livestream](https://twitch.tv/osusg)
-- [Pick'em predictions website](https://pickem.hwchr.com/tournaments/20)
+- [Pick'em predictions website](https://pickem.hwc.hr/tournaments/20) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - **[Statistics sheet](https://docs.google.com/spreadsheets/d/1rPNEsq4I_vuVHSccLjgZ5HucIgnAWTuUfgiYFRAkBOI/edit?usp=sharing)**
 
 ## Participants

--- a/wiki/Tournaments/GTS/IGTS_2019/en.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/en.md
@@ -60,7 +60,7 @@ The Intermediate Global Taiko Showdown 2019 was run by various community members
 - [GTS website](https://gtsosu.com/)
 - [Livestream](https://www.twitch.tv/igtsosu)
 - [Challonge brackets](https://challonge.com/dqq46siu)
-- [Pick'em predictions website](https://pickem.hwchr.com/tournaments/8)
+- [Pick'em predictions website](https://pickem.hwc.hr/tournaments/8) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - **[Statistics sheet](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 
 ## Participants

--- a/wiki/Tournaments/GTS/IGTS_2019/es.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/es.md
@@ -59,7 +59,7 @@ Intermediate Global Taiko Showdown 2019 fue realizado por varios miembros de la 
 - [IGTS Servidor de Discord](https://discord.gg/a6PzzFz)
 - [Livestream](https://www.twitch.tv/igtsosu)
 - [Challonge brackets](https://challonge.com/dqq46siu)
-- [Página de Pick'em](https://pickem.hwchr.com/tournaments/8)
+- [Página de Pick'em](https://pickem.hwc.hr/tournaments/8)
 - **[Hoja de Estadísticas](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 
 ---

--- a/wiki/Tournaments/GTS/IGTS_2019/fr.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/fr.md
@@ -59,7 +59,7 @@ L'Intermediate Global Taiko Showdown 2019 était organisé par différents membr
 - [Serveur Discord de l'IGTS](https://discord.gg/a6PzzFz)
 - [Livestream](https://www.twitch.tv/igtsosu)
 - [Tableaux Challonge](https://challonge.com/dqq46siu)
-- [Site de Pick'em](https://pickem.hwchr.com/tournaments/8)
+- [Site de Pick'em](https://pickem.hwc.hr/tournaments/8)
 - **[Sheet de statistiques](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 
 ---

--- a/wiki/Tournaments/GTS/IGTS_2019/ko.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/ko.md
@@ -59,7 +59,7 @@ Intermediate Global Taiko Showdown 2019는 여러 커뮤니티 사람들이 토�
 - [IGTS 디스코드 서버](https://discord.gg/a6PzzFz)
 - [라이브 방송](https://www.twitch.tv/igtsosu)
 - [Challonge 대진표](https://challonge.com/dqq46siu)
-- [Pick'em 사이트](https://pickem.hwchr.com/tournaments/8)
+- [Pick'em 사이트](https://pickem.hwc.hr/tournaments/8)
 - **[메인 스프레드시트](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 
 ---

--- a/wiki/Tournaments/GTS/IGTS_2019/pt-br.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/pt-br.md
@@ -58,7 +58,7 @@ O Intermediate Global Taiko Showdown 2019 foi realizado por vários membros da c
 - [Página de discussão](https://osu.ppy.sh/community/forums/topics/906298)
 - [Server do Discord do IGTS](https://discord.gg/a6PzzFz)
 - [Canal de transmissão](https://www.twitch.tv/igtsosu)
-- [Website do Pick'em](https://pickem.hwchr.com/tournaments/8)
+- [Website do Pick'em](https://pickem.hwc.hr/tournaments/8)
 - [Suportes do Challonge](https://challonge.com/dqq46siu)
 - **[Página de estatísticas](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 

--- a/wiki/Tournaments/GTS/IGTS_2019/ru.md
+++ b/wiki/Tournaments/GTS/IGTS_2019/ru.md
@@ -59,7 +59,7 @@ Intermediate Global Taiko Showdown 2019 был проведён группой �
 - [IGTS Дискорд сервер](https://discord.gg/a6PzzFz)
 - [Стрим](https://www.twitch.tv/igtsosu)
 - [Сетка Challonge](https://challonge.com/dqq46siu)
-- [Сайт Pick'em](https://pickem.hwchr.com/tournaments/8)
+- [Сайт Pick'ems](https://pickem.hwc.hr/tournaments/8)
 - **[Таблица со статистикой](https://docs.google.com/spreadsheets/d/1B_upGgX4mSHpWkvWLrfFRAakPKP77Wm_fDsoU1y3kyY/edit?usp=sharing)**
 
 ---

--- a/wiki/Tournaments/GTS/IGTS_2020/en.md
+++ b/wiki/Tournaments/GTS/IGTS_2020/en.md
@@ -62,7 +62,7 @@ The Intermediate Global Taiko Showdown 2020 is run by various community members.
   - [GTSosu](https://www.twitch.tv/gtsosu)
   - [GTSosu\_b](https://www.twitch.tv/gtsosu_b)
 - [Challonge brackets](https://challonge.com/IGTS2020)
-- [Pick'em predictions website](https://pickem.hwchr.com/tournaments/34)
+- [Pick'em predictions website](https://pickem.hwc.hr/tournaments/34) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 
 ## Participants
 

--- a/wiki/Tournaments/OWC/2018/en.md
+++ b/wiki/Tournaments/OWC/2018/en.md
@@ -49,6 +49,7 @@ The osu! World Cup 2018 is run by various community members by distributing the 
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/815745)
 - [Livestream](https://www.twitch.tv/osulive)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/3) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - [Statistics sheet](https://goo.gl/sKzcd7)
 
 ------------------------------------------------------------------------

--- a/wiki/Tournaments/OWC/2019/en.md
+++ b/wiki/Tournaments/OWC/2019/en.md
@@ -50,7 +50,7 @@ The osu! World Cup 2019 was run by various community members.
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/973724)
 - [Livestream](https://www.twitch.tv/osulive)
-- [Pick'ems page](https://pickem.hwchr.com/tournaments/19)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/19) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - [Challonge bracket](https://challonge.com/OWC2019)
 - [Statistics sheet](https://docs.google.com/spreadsheets/d/e/2PACX-1vREamImW3yN-q3rio2XIFX497uoIoPprEuSqykuPPP9D9WcMfMJQj0bXcBl1ZGxIcm_tPIuoZPk_GFk/pubhtml)
 

--- a/wiki/Tournaments/OWC/2019/tr.md
+++ b/wiki/Tournaments/OWC/2019/tr.md
@@ -50,7 +50,7 @@ osu! 2019 Dünya Kupası, muhtelif topluluk üyeleri tarafından yürütülen bi
 
 - [Tartışma başlığı](https://osu.ppy.sh/community/forums/topics/973724)
 - [Canlı yayın](https://www.twitch.tv/osulive)
-- [Pick'em sayfası](https://pickem.hwchr.com/tournaments/19)
+- [Pick'em sayfası](https://pickem.hwc.hr/tournaments/19)
 - [Challonge kulvarı](https://challonge.com/OWC2019)
 - [İstatistik çizelgesi](https://docs.google.com/spreadsheets/d/e/2PACX-1vREamImW3yN-q3rio2XIFX497uoIoPprEuSqykuPPP9D9WcMfMJQj0bXcBl1ZGxIcm_tPIuoZPk_GFk/pubhtml)
 

--- a/wiki/Tournaments/TSC/2020/en.md
+++ b/wiki/Tournaments/TSC/2020/en.md
@@ -54,7 +54,7 @@ The Taiko Suiji Cup 2020 was run by various community members.
 - [TSC Discord server](https://discord.gg/yV3bDTC)
 - [Livestream](https://twitch.tv/osutaikolive)
 - [Challonge brackets](https://challonge.com/TSCosu2020)
-- [Pick'em predictions website](https://pickem.hwchr.com/tournaments/24)
+- [Pick'em predictions website](https://pickem.hwc.hr/tournaments/24) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - **[Statistics sheet](https://docs.google.com/spreadsheets/d/1wRgZE_xq50KLqYQA7t027CW3nIRrIn7hiY3iTapK4V8/edit?usp=sharing)**
 
 ## Participants

--- a/wiki/Tournaments/TWC/2020/en.md
+++ b/wiki/Tournaments/TWC/2020/en.md
@@ -49,7 +49,7 @@ The osu!taiko World Cup 2020 was run by various community members.
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/1018778)
 - [Livestream](https://www.twitch.tv/osulive)
-- [Pick'ems page](https://pickem.hwchr.com/tournaments/26) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/26) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 - **[Statistics sheet](https://bit.ly/2x46Mix)**
 
 ## Participants


### PR DESCRIPTION
Hello!

The pickem domain is changing from [https://pickem.hwchr.com](https://pickem.hwchr.com) to [https://pickem.hwc.hr](https://pickem.hwc.hr) so I thought I would update all references to point to the new URL.

I also added a "hosted by" next to the pickem link, as this was done for TWC so I thought I would do it for all references.