### PR TITLE
Remove references to Outer Oni in osu!taiko difficulties

### DIFF
--- a/wiki/Difficulties/id.md
+++ b/wiki/Difficulties/id.md
@@ -35,7 +35,7 @@ Berikut adalah nama tingkat kesulitan yang biasa dimiliki dalam beatmap. Definis
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
 
 ### ![](/wiki/shared/mode/catch.png) osu!catch
 

--- a/wiki/Difficulties/ja.md
+++ b/wiki/Difficulties/ja.md
@@ -36,7 +36,7 @@ tags:
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
 
 ### ![](/wiki/shared/mode/catch.png) osu!catch
 

--- a/wiki/Difficulties/pt-br.md
+++ b/wiki/Difficulties/pt-br.md
@@ -36,7 +36,7 @@ Esses são os típicos níveis de dificuldade que um beatmap pode ser categoriza
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
 
 ### ![](/wiki/shared/mode/catch.png) osu!catch
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/en.md
@@ -23,7 +23,7 @@ These difficulty names are the most commonly used for each game mode.
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii
 - ![](/wiki/shared/diff/insane-t.png) Oni
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni
-- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni
+- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni
 
 ### osu!catch
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/zh.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/zh.md
@@ -23,7 +23,7 @@
 - ![](/wiki/shared/diff/hard-t.png) Muzukashii（难）
 - ![](/wiki/shared/diff/insane-t.png) Oni（鬼）
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni（里鬼）
-- ![](/wiki/shared/diff/expertplus-t.png) Outer/Hell Oni（地狱）
+- ![](/wiki/shared/diff/expertplus-t.png) Hell Oni（地狱）
 
 ### ![osu!catch](/wiki/shared/mode/catch.png "osu!catch") osu!catch
 


### PR DESCRIPTION
(hopefully i didn't break anything it's been a while without using github)

removed Outer from expert+ tier on the Difficulty Naming section of the RC