### PR TITLE
Quick edit on the "Becoming a Beatmap Nominator" page

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -1,6 +1,6 @@
 # Becoming a Beatmap Nominator
 
-Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) need to go through an application process overseen by the [NAT](/wiki/People/The_Team/Nomination_Assessment_Team). Applications are conducted via the [NAT website](http://bn.mappersguild.com/).
+Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) need to go through an application process overseen by the [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (NAT). Applications are conducted via the [NAT website](http://bn.mappersguild.com/).
 
 Applicants are required to meet a modding activity requirement, submit at least two maps they have recently modded, and complete a test on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. There is a 90-day cooldown for submitting new applications once an application has been submitted. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -7,7 +7,7 @@ Applicants are required to meet a modding activity requirement, submit at least 
 ### Basic criteria
 
 Modders aiming to apply to the Beatmap Nominators must fulfill the following criteria:
-- They have been modding beatmaps actively for at least 3 months prior to the announcement.
+- They have been modding beatmaps actively for at least 3 months prior to applying.
 - They have accumulated at least 150 or 200 [kudosu](/wiki/Glossary#kudosu!) in total, depending on the mode they will apply to.
 - They provide 2 to 4 of their mods which they think qualify them to be a part of the Beatmap Nominators.
 

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -4,9 +4,10 @@ Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatm
 
 Applicants are required to meet a modding activity requirement, submit at least two maps they have recently modded, and complete a test on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. There is a 90-day cooldown for submitting new applications once an application has been submitted. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 
-### Basic criteria
+## Basic criteria
 
 Modders aiming to apply to the Beatmap Nominators must fulfill the following criteria:
+
 - They have been modding beatmaps actively for at least 3 months prior to applying.
 - They have accumulated at least 150 or 200 [kudosu](/wiki/Glossary#kudosu!) in total, depending on the mode they will apply to.
 - They provide 2 to 4 of their mods which they think qualify them to be a part of the Beatmap Nominators.


### PR DESCRIPTION
Edited line which I assume referred to the announcement posts when BN applications were not always open.