### PR TITLE
Update remark-lint-osu-links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,7 +1282,7 @@
             }
         },
         "remark-lint-osu-links": {
-            "version": "github:cl8n/remark-lint-osu-links#83d3266662c8b894f82b76b1d95559e2533da0d1",
+            "version": "github:cl8n/remark-lint-osu-links#0d681945e3e377e518b7704190ef41a9ae64f395",
             "from": "github:cl8n/remark-lint-osu-links",
             "requires": {
                 "unified-lint-rule": "^1.0.5",


### PR DESCRIPTION
fixes warning on `/beatmaps/artists`