### PR TITLE
[PT-BR] Add Bot account

### DIFF
--- a/wiki/Bot_account/pt-br.md
+++ b/wiki/Bot_account/pt-br.md
@@ -24,11 +24,11 @@ Estes limites se aplicam apenas para mensagens privadas, `#multiplayer`, e `#spe
 
 ## Criando uma conta de bot
 
-Se você está pensando em começar um chat bot, por favor inicie utilizando ele na sua conta do osu!, e certifique-se de respeitar os limites de conta pessoal listados acima. Assim que seu serviço crescer, pode ser uma oportunidade para solicitar uma conta de bot para o time de suporte de conta.
+Se você está pensando em começar um chat bot, por favor inicie utilizando ele na sua conta do osu!, e certifique-se de respeitar os limites de conta pessoal listados acima. Assim que seu serviço crescer, pode ser uma oportunidade para solicitar uma conta de bot para a equipe de suporte de conta.
 
 ### Critérios mínimos
 
-Antes de considerar uma solicitação, o time de suporte requere que o bot cumpra estes critérios:
+Antes de considerar uma solicitação, a equipe de suporte requere que o bot cumpra estes critérios:
 
 - O bot está sendo executado na sua conta por pelo menos 6 meses
 - O bot é totalmente de código aberto e tem documentação pública completa
@@ -58,5 +58,5 @@ O time de suporte de conta irá revisar sua solicitação. Se sua solicitação 
 - A insígnia do grupo `BOT` é mostrada em contas com um grupo primário de `Chat Bots` (grupo #29). A listagem deste grupo não é pública.
 - Algumas contas pessoais estão no grupo de chat bots pois seus donos não quiseram ou pediram para ter uma conta de bot separada para seus serviços, por exemplo ![][flag_DE] [Tillerino](https://osu.ppy.sh/users/2070907) e ![][flag_FR] [ThePooN](https://osu.ppy.sh/users/718454). Este tipo de instalação não é mais oferecido, e novos bots que entrarem no grupo sempre terão uma conta exclusiva.
 
-[flag_DE]: /wiki/shared/flag/DE.gif "Germany"
-[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_DE]: /wiki/shared/flag/DE.gif "Alemanha"
+[flag_FR]: /wiki/shared/flag/FR.gif "França"

--- a/wiki/Bot_account/pt-br.md
+++ b/wiki/Bot_account/pt-br.md
@@ -11,7 +11,7 @@ tags:
 
 Uma **conta de bot** é um tipo especial de conta no osu! gerenciada por um serviço automatizado ao invés de uma pessoa real. No website, elas têm uma insígnia de grupo branca escrito `BOT`, e apenas a seção `eu!` de seu perfil é visível. Contas de bot são comumente usada para hospedar "chat bots" que oferecem várias funcionalidades para a comunidade pelos canais do lobby [multiplayer](/wiki/Multi) ou mensagens privadas.
 
-Contas de bot só podem ser criadas pelo [processo de aplicação](#creating-a-bot-account). A tentativa de criar uma conta de bot registrando normalmente é considerado "multi-accounting" e é contra as [regras da comunidade](/wiki/Rules#community-rules).
+Contas de bot só podem ser criadas pelo [processo de aplicação](#criando-uma-conta-de-bot). A tentativa de criar uma conta de bot registrando normalmente é considerado "multi-accounting" e é contra as [regras da comunidade](/wiki/Rules#regras-da-comunidade).
 
 ## Benefícios de contas de bot
 

--- a/wiki/Bot_account/pt-br.md
+++ b/wiki/Bot_account/pt-br.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - bot accounts
+  - chat bot
+  - chat bots
+  - IRC bot
+  - IRC bots
+---
+
+# Conta de bot
+
+Uma **conta de bot** é um tipo especial de conta no osu! gerenciada por um serviço automatizado ao invés de uma pessoa real. No website, elas têm uma insígnia de grupo branca escrito `BOT`, e apenas a seção `eu!` de seu perfil é visível. Contas de bot são comumente usada para hospedar "chat bots" que oferecem várias funcionalidades para a comunidade pelos canais do lobby [multiplayer](/wiki/Multi) ou mensagens privadas.
+
+Contas de bot só podem ser criadas pelo [processo de aplicação](#creating-a-bot-account). A tentativa de criar uma conta de bot registrando normalmente é considerado "multi-accounting" e é contra as [regras da comunidade](/wiki/Rules#community-rules).
+
+## Benefícios de contas de bot
+
+A principal diferença entre uma conta pessoal e contas de bot estão nos limites que se aplicam ao enviar mensagens no [chat](/wiki/Chat_Console). Contas de bot têm limites mais altos para permitir que seus serviços interajam com mais usuários sem risco de ter a conta [silenciada](/wiki/Glossary#silence):
+
+- Contas pessoais podem enviar 10 mensagens a cada 5 segundos
+- Contas de bot podem enviar 300 mensagens a cada 60 segundos.
+
+Estes limites se aplicam apenas para mensagens privadas, `#multiplayer`, e `#spectator`. Contas de bot não são permitidas de enviar mensagens em outros canais.
+
+## Criando uma conta de bot
+
+Se você está pensando em começar um chat bot, por favor inicie utilizando ele na sua conta do osu!, e certifique-se de respeitar os limites de conta pessoal listados acima. Assim que seu serviço crescer, pode ser uma oportunidade para solicitar uma conta de bot para o time de suporte de conta.
+
+### Critérios mínimos
+
+Antes de considerar uma solicitação, o time de suporte requere que o bot cumpra estes critérios:
+
+- O bot está sendo executado na sua conta por pelo menos 6 meses
+- O bot é totalmente de código aberto e tem documentação pública completa
+- O bot é usado por pelo menos 50 usuários únicos todo mês
+- O bot respeita os limites de conta pessoal.
+- O bot não envia nenhuma mensagem em canais públicos.
+- O bot é útil para uma ampla audiência da comunidade do osu!
+
+### Preenchendo uma solicitação
+
+Se o seu bot cumpre os critérios acima, você pode solicitar a criação de uma conta de bot para ele.
+
+Envie um email para [accounts@ppy.sh](mailto:accounts@ppy.sh) com o assunto `Bot Account Request`. Isto deve ser enviado do endereço de email atrelado a sua conta do osu!.
+
+O corpo do email deve conter o seguinte:
+
+- Seu nome de usuário do osu! (onde você tem executado o bot)
+- O nome de usuário você quer dar à conta de bot
+- A data na qual você começou a executar o bot
+- Um link para o código fonte e dumentação
+- Um pequeno sumário do que seu bot faz
+
+O time de suporte de conta irá revisar sua solicitação. Se sua solicitação for negada, eles te dirão o porquê. Se sua solicitação for aprovada, eles criarão a conta de bot para você e te darão instruções sobre como usá-la.
+
+## Curiosidades
+
+- A insígnia do grupo `BOT` é mostrada em contas com um grupo primário de `Chat Bots` (grupo #29). A listagem deste grupo não é pública.
+- Algumas contas pessoais estão no grupo de chat bots pois seus donos não quiseram ou pediram para ter uma conta de bot separada para seus serviços, por exemplo ![][flag_DE] [Tillerino](https://osu.ppy.sh/users/2070907) e ![][flag_FR] [ThePooN](https://osu.ppy.sh/users/718454). Este tipo de instalação não é mais oferecido, e novos bots que entrarem no grupo sempre terão uma conta exclusiva.
+
+[flag_DE]: /wiki/shared/flag/DE.gif "Germany"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"


### PR DESCRIPTION
- Add full pt-br translation of `Bot account` article

Note for future reviewers: I think `Conta de bot` is a better wording than `Conta de robô` or similar, since these days bot is a well know word in portuguese, also, on line 14, I don't know a good translation to `Multi-accounting` so I left it like this.