### PR TITLE
Update BN listing and Staff log

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -118,7 +118,6 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_FR] [realy0\_](https://osu.ppy.sh/users/8863359) | French |
 | ![][flag_ID] [Roger](https://osu.ppy.sh/users/1538223) | Indonesian, some Japanese |
 | ![][flag_JP] [tasuke912](https://osu.ppy.sh/users/2774767) | Japanese |
-| ![][flag_ID] [Volta](https://osu.ppy.sh/users/4154071) | Indonesian |
 
 #### osu!catch
 

--- a/wiki/Staff_Log/2020/en.md
+++ b/wiki/Staff_Log/2020/en.md
@@ -301,5 +301,6 @@ Abbreviations for user groups are used throughout this log:
 
 - 2020-07-16: Removed [JBHyperion](https://osu.ppy.sh/users/4879508) from **BN**
 - 2020-07-22: Removed [Peter](https://osu.ppy.sh/users/8623835) from **BN**
+- 2020-07-26: Removed [Volta](https://osu.ppy.sh/users/4154071) from **BN**
 
-<!-- last update: 2020-07-23 20 UTC moved shimarin to full bn -->
+<!-- last update: 2020-07-26 19 UTC removed volta from bn -->


### PR DESCRIPTION
- Removed [Volta](https://osu.ppy.sh/users/4154071) from the BN members listing (osu!taiko)