### PR TITLE
Update BN listing and Staff log

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -143,6 +143,7 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_US] [Kamuy](https://osu.ppy.sh/users/7439226) | Some Korean |
 | ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754) | Korean |
 | ![][flag_AU] [Keiga](https://osu.ppy.sh/users/6866022) | Chinese |
+| ![][flag_NL] [Muse Dash](https://osu.ppy.sh/users/13695676) | Chinese |
 | ![][flag_HK] [PokeSky](https://osu.ppy.sh/users/3617111) | Chinese, Cantonese |
 | ![][flag_ID] [Rivals_7](https://osu.ppy.sh/users/4610379) | Indonesian |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arabic, French |
@@ -190,7 +191,6 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783) | Korean |
 | ![][flag_MY] [Kyousukee](https://osu.ppy.sh/users/8842107) | Indonesian, Malay |
 | ![][flag_PH] [lenpai](https://osu.ppy.sh/users/5314573) | Filipino |
-| ![][flag_NL] [Muse Dash](https://osu.ppy.sh/users/13695676) | Chinese |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentina"
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"

--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -61,7 +61,6 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958) |  |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | Indonesian |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Bengali, some Arabic |
-| ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645) | German |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | Chinese, some French |
 | ![][flag_CA] [Lafayla](https://osu.ppy.sh/users/5312547) |  |
 | ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909) | Chinese |

--- a/wiki/Staff_Log/2020/en.md
+++ b/wiki/Staff_Log/2020/en.md
@@ -314,8 +314,12 @@ Abbreviations for user groups are used throughout this log:
 
 ### Beatmap Nominators
 
+#### Moves
+
+- 2020-08-02: Moved [Muse Dash](https://osu.ppy.sh/users/13695676) from **Probationary BN** to **BN**
+
 #### Removals
 
 - 2020-08-02: Removed [Icekalt](https://osu.ppy.sh/users/5410645) from **BN**
 
-<!-- last update: 2020-08-02 15 UTC removed icekalt from bn -->
+<!-- last update: 2020-08-02 17 UTC moved muse dash to bn -->

--- a/wiki/Staff_Log/2020/en.md
+++ b/wiki/Staff_Log/2020/en.md
@@ -310,4 +310,12 @@ Abbreviations for user groups are used throughout this log:
 - 2020-07-26: Removed [Volta](https://osu.ppy.sh/users/4154071) from **BN**
 - 2020-07-29: Removed [Kaitjuh](https://osu.ppy.sh/users/2225327) from **BN**
 
-<!-- last update: 2020-07-31 23 UTC added c00l to probationary bn -->
+## August
+
+### Beatmap Nominators
+
+#### Removals
+
+- 2020-08-02: Removed [Icekalt](https://osu.ppy.sh/users/5410645) from **BN**
+
+<!-- last update: 2020-08-02 15 UTC removed icekalt from bn -->


### PR DESCRIPTION
- Removed [Icekalt](https://osu.ppy.sh/users/5410645) from the listing due to resignation (osu!standard)
- Moved [Muse Dash](https://osu.ppy.sh/users/13695676) to the full BN members listing (osu!mania)