### PR TITLE
Confirm profile badge in NPC 2 article

### DIFF
--- a/wiki/Tournaments/NPC/2/en.md
+++ b/wiki/Tournaments/NPC/2/en.md
@@ -29,7 +29,7 @@ The **Non-Professional Cup 2** (***NPC2***) is an international team-based doubl
 
 | Placing | Prize |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | Pending profile badge & 2 months of supporter |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | Profile badge & 2 months of supporter |
 | ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of supporter |
 
 ![](img/badge.png "Pending profile badge")

--- a/wiki/Tournaments/NPC/2/en.md
+++ b/wiki/Tournaments/NPC/2/en.md
@@ -29,8 +29,8 @@ The **Non-Professional Cup 2** (***NPC2***) is an international team-based doubl
 
 | Placing | Prize |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | Profile badge & 2 months of supporter |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of supporter |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | Unique profile badge, 2 months of osu!supporter tag |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of osu!supporter tag |
 
 ![](img/badge.png "Pending profile badge")
 


### PR DESCRIPTION
NPC2 is officially badged, so remove the word "pending" in the prize section.