### PR TITLE
Add Pickems link to the MWC 2020 4K article

### DIFF
--- a/wiki/Tournaments/MWC/2020_4K/en.md
+++ b/wiki/Tournaments/MWC/2020_4K/en.md
@@ -49,6 +49,7 @@ The osu!mania 4K World Cup 2020 is run by the [osu! team](/wiki/People/The_Team)
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/1106843)
 - [Livestream](https://www.twitch.tv/osulive)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/41) hosted by ![][flag_DE] [hallowatcher](https://osu.ppy.sh/users/1874761)
 
 ## Participants
 


### PR DESCRIPTION
this commit adds a link to the MWC 4k pickems page following previously agreed on convention.

[https://pickem.hwc.hr/tournaments/41](https://pickem.hwc.hr/tournaments/41)