### PR TITLE
Run CI workflow on push / merge into master

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,9 @@
 name: osu-wiki continuous integration
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Until now we were only running on PRs themselves. Make it hard to get a sense of where post-merge status is.