### PR TITLE
 Fix no-multiple-toplevel-headings remark warnings

### DIFF
--- a/news/2013-09-06-osu-monthly-beatmapping-contest-1.md
+++ b/news/2013-09-06-osu-monthly-beatmapping-contest-1.md
@@ -39,18 +39,18 @@ Calling all mappers! Come show off your mapping skills to the community with the
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
-# Translations
+## Translations
 
 Jump to: [Italian](#it), [French](#fr), [Chinese](#cn), [Indonesian](#id), [Japanese](#jp), [German](#de), [Russian](#ru), [Spanish](#es)  
   
 
 ---
 
-# <a id="it"></a>Italian
+## <a id="it"></a>Italian
 
 Un richiamo per tutti i mapper! Venite e mostrate la vostra bravura nel mapping a tutta la comunità con l'occasione di avere **la vostra beatmap inclusa nel download del gioco**!
 
-## Canzone
+### Canzone
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [Scarica ed entra qui!](https://osu.ppy.sh/p/contest?c=7)  
@@ -59,17 +59,17 @@ Un richiamo per tutti i mapper! Venite e mostrate la vostra bravura nel mapping 
 
 [Ascolta l'anteprima della canzone qui! (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Giudici
+### Giudici
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Premi
+### Premi
 
 - **Il mapset sarà incluso nel download del client di osu!**
 - 6 mesi di supporter
 - Il titolo di "Elite Mapper"
 
-## Regole
+### Regole
 
 - Tutti i mapset e le loro rispettive difficoltà devono seguire [tutti i criteri di ranking del giorno d'oggi.](/wiki/Ranking_Criteria)
 - Tutti i mapsets devono contenere **4 difficoltà (E'_necessario_ uno spread Easy/Normal/Hard/Insane).**
@@ -78,17 +78,17 @@ Un richiamo per tutti i mapper! Venite e mostrate la vostra bravura nel mapping 
 - Non postare, submittare, o mostrare la tua beatmap prima che il contest sia finito per mantenere l'anonimità della tua mappa.
 - Non usare dei nomi nelle difficoltà che potrebbero far riconoscere chi sei. Usa gli standard "Easy/Normal/Hard/Insane" per mantenere la tua mappa anonima.
 
-## Tempo Limite
+### Tempo Limite
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="fr"></a>French
+## <a id="fr"></a>French
 
 Appel à tous les mappeurs ! Venez montrer à la communauté vos talents de mapping, avec à la clé une chance d'avoir votre beatmap **incluse dans le téléchargement du jeu !**
 
-## Chanson
+### Chanson
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [Télécharger et entrer ici !](https://osu.ppy.sh/p/contest?c=7)  
@@ -97,17 +97,17 @@ Appel à tous les mappeurs ! Venez montrer à la communauté vos talents de mapp
 
 [Pré-écouter la chanson ici ! (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Juges
+### Juges
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Prix
+### Prix
 
 - **Le mapset sera inclus dans osu! à son téléchargement.**
 - 6 Mois de supporter
 - Le titre "Elite Mapper" (Mappeur d'élite)
 
-## Règles
+### Règles
 
 - Tous les mapsets et leur difficultés respectives doivent être en accord avec les [règles de ranking.](/wiki/Ranking_Criteria)
 - Tous les mapsets doivent avoir **4 difficultés (ENHI _nécessaire_).**
@@ -116,17 +116,17 @@ Appel à tous les mappeurs ! Venez montrer à la communauté vos talents de mapp
 - Ne pas poster, uploader via BSS, ou encore partager publiquement votre map avant que le tournoi soit terminé, afin de garder l'anonymat des entrées.
 - Ne pas mettre de signes distinctifs dans les noms de difficulté de vos maps. Utilisez les noms standards "Easy/Normal/Hard/Insane" pour garder l'anonymat des entrées.
 
-## Date limite de participation
+### Date limite de participation
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="cn"></a>Chinese
+## <a id="cn"></a>Chinese
 
 至所有的作图者！来展示你的作图能力给大家，可以让你做的谱面被整合到**游戏安装包**里哦！
 
-## 歌曲
+### 歌曲
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [点击这里下载以及进入比赛！](https://osu.ppy.sh/p/contest?c=7)  
@@ -135,17 +135,17 @@ Appel à tous les mappeurs ! Venez montrer à la communauté vos talents de mapp
 
 [点击这里预览歌曲！(Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## 裁判
+### 裁判
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## 奖品
+### 奖品
 
 - **谱面将会被整合到游戏安装包里**
 - 六个月的会员（别名撒泼特）
 - 获得 "Elite Mapper"（杰出作图者）头衔
 
-## 规则
+### 规则
 
 - 所有的谱面以及其中的难度必需符合 [现在的审核标准](/wiki/Ranking_Criteria)
 - 所有的铺面应拥有**四个难度（ENHI是_必须的_）.**
@@ -154,17 +154,17 @@ Appel à tous les mappeurs ! Venez montrer à la communauté vos talents de mapp
 - 为了保持参赛谱面以及制作者的匿名性，在比赛结束之前不可以上传或以任何渠道散播所制作的谱面！
 - 不要在难度名上加入或使用任何多余的字符，请用标准的 "Easy/Normal/Hard/Insane" 以保持参赛作品的匿名性。
 
-## 截止日期
+### 截止日期
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="id"></a>Indonesian
+## <a id="id"></a>Indonesian
 
 Panggilan kepada seluruh mapper! Tunjukkan kepiawaian Anda kepada komunitas serta raih kesempatan dibundelnya karya kreasi Anda **pada setiap unduhan klien permainan**!
 
-## Lagu
+### Lagu
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [Unduh lagu dan ikut serta dalam kontes di sini!](https://osu.ppy.sh/p/contest?c=7)  
@@ -173,17 +173,17 @@ Panggilan kepada seluruh mapper! Tunjukkan kepiawaian Anda kepada komunitas sert
 
 [Pratinjau lagu di sini! (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Juri
+### Juri
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Hadiah
+### Hadiah
 
 - **Mapset akan dibundel pada setiap unduhan klien osu!**
 - osu!Supporter selama 6 bulan
 - Gelar "Elite Mapper"
 
-## Peraturan
+### Peraturan
 
 - Mapset kreasi Anda dan seluruh tingkat kesulitan yang terkandung di dalamnya haruslah memenuhi [Ranking Criteria saat ini.](/wiki/Ranking_Criteria)
 - Semua mapset harus memiliki **4 tingkat kesulitan (Susunan tingkat kesulitan Easy, Normal, Hard, dan Insane _diperlukan_).**
@@ -192,17 +192,17 @@ Panggilan kepada seluruh mapper! Tunjukkan kepiawaian Anda kepada komunitas sert
 - Jangan menempatkan, mengajukan, atau membagikan map anda kepada publik sebelum kontes berakhir untuk menjaga anonimitas peserta.
 - Jangan menggunakan apapun yang dapat dikenal ke dalam nama tingkat kesulitan map Anda. Gunakan "Easy/Normal/Hard/Insane" sebagai nama tingkat kesulitan untuk menjaga anonimitas map Anda.
 
-## Batas Waktu Penyerahan
+### Batas Waktu Penyerahan
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="jp"></a>Japanese
+## <a id="jp"></a>Japanese
 
 mapperのみなさんへ！この度マッピングコンテストが開催される運びになりました。**ゲームクライアントにあなたの譜面を同梱する**チャンスがあります。
 
-## 曲
+### 曲
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [ダウンロード及び申込](https://osu.ppy.sh/p/contest?c=7)  
@@ -211,17 +211,17 @@ mapperのみなさんへ！この度マッピングコンテストが開催さ�
 
 [ここで試聴してください！ (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## 審査員
+### 審査員
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## 賞品
+### 賞品
 
 - **譜面がosu!のクライアントに同梱されます**
 - サポーター6ヶ月分
 - 「Elite Mapper」の称号
 
-## ルール
+### ルール
 
 - 譜面及び難易度は現行の[Ranking Criteria](/wiki/Ranking_Criteria)に適している必要があります。
 - 難易度を4つ以上作る必要があり、Easy、Normal、Hard、Insaneの構成は必須です。
@@ -230,17 +230,17 @@ mapperのみなさんへ！この度マッピングコンテストが開催さ�
 - 参加者の匿名性を保つために、コンテストが終わる前で、譜面をどこかにポストしたり、公式にアップロードしないでください。
 - 上記と同様の理由で、難易度名は"Easy/Normal/Hard/Insane"にして下さい。
 
-## 締め切り
+### 締め切り
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="de"></a>German
+## <a id="de"></a>German
 
 Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine Beatmap zum **Download Bundle von osu!** dazugehört!
 
-## Song
+### Song
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [Lade das Lied hier herunter und nimm teil!](https://osu.ppy.sh/p/contest?c=7)  
@@ -249,17 +249,17 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 
 [Vorschau (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Preisrichter
+### Preisrichter
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Preise
+### Preise
 
 - **Dein Mapset wird dem osu! Game Client Bundle hinzugefügt.**
 - 6 Monate Supporter
 - Usertitel "Elite Mapper"
 
-## Regeln
+### Regeln
 
 - Das Mapset und alle Difficulties müssen [allen aktuell gültigen Ranking Standards](/wiki/Ranking_Criteria) entsprechen
 - Das Mapset muss **4 Difficulties** enthalten. **(ENHI ist _Voraussetzung_)**
@@ -268,17 +268,17 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 - Teile und verbreite deine Beatmap nicht öffentlich, solange der Contest noch nicht beendet ist, um die Anonymität aller Beiträge zu wahren.
 - Hinterlege nichts in den Beatmaps, dass Rückschlüsse auf deine Person zulässt. Benutze die Standardnamen "Easy/Normal/Hard/Insane", um anonym zu bleiben.
 
-## Einsendeschluss
+### Einsendeschluss
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="ru"></a>Russian
+## <a id="ru"></a>Russian
 
 Мапперы! Продемонстрируйте свои навыки маппинга и получите шанс прославиться: вашу карту могут добавить в **новый релиз osu!**
 
-## Песня
+### Песня
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [Скачать и принять участие!](https://osu.ppy.sh/p/contest?c=7)  
@@ -287,17 +287,17 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 
 [Прослушать трек (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Состав жюри
+### Состав жюри
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Призы
+### Призы
 
 - **Карта будет идти в комплекте с новым релизом osu!**
 - 6 месяцев саппорта
 - Титул "Elite Mapper"
 
-## Правила
+### Правила
 
 - Все мапсеты и их сложности должны удовлетворять [критериям ранкинга](/wiki/Ranking_Criteria).
 - Все мапсеты должны содержать **4 сложности (набор ENHI _обязателен_).**
@@ -306,17 +306,17 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 - Не разрешается выгружать, постить на форумах или другим образом распространять свою карту до окончания контеста, чтобы сохранить анонимность публикаций.
 - Не разрешается изменять стандартные названия сложностей (Easy/Normal/Hard/Insane), чтобы сохранить анонимность публикаций.
 
-## Крайнийсрок
+### Крайнийсрок
 
 - **2013-10-01 00:00:00 (UTC+0)**
 
 ---
 
-# <a id="es"></a>Spanish
+## <a id="es"></a>Spanish
 
 ¡Llamando a todos los mappers! ¡Vengan aquí y muestren sus habilidades de mapear a la comunidad con la oportunidad de tener su beatmap incluido en el juego!
 
-## Música
+### Música
 
 - **Rostik - Liquid (Paul Rosenthal Remix)**  
   [¡Descargarlo y haz la entrada haciendo click aquí!](https://osu.ppy.sh/p/contest?c=7)  
@@ -325,17 +325,17 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 
 [¡Escucha la música aquí! (Soundcloud)](https://soundcloud.com/rostik/liquid-paul-rosenthal-1st)
 
-## Jueces
+### Jueces
 
 [**dkun**](https://osu.ppy.sh/users/dkun), [**Nyquill**](https://osu.ppy.sh/users/Nyquill), [**Andrea**](https://osu.ppy.sh/users/Andrea), [**those**](https://osu.ppy.sh/users/those), [**MMzz**](https://osu.ppy.sh/users/MMzz), [**Sync**](https://osu.ppy.sh/users/Sync)
 
-## Premios
+### Premios
 
 - **Su mapset se incluirá en el osu!**
 - 6 meses de supporter
 - El título "Elite Mapper"
 
-## Reglas
+### Reglas
 
 - Todos los directorios de mapas y sus respectivas dificultades deben encajar con [todas las normas de clasificación actuales.](/wiki/Ranking_Criteria)
 - Todos los directorios de mapa tienen que tener **4 dificultades (ENHI es _requerido_).**
@@ -344,7 +344,7 @@ Aufruf an alle Mapper! Zeig uns dein Können und erhalte die Chance, dass deine 
 - No se debe publicar, enviar, ni compartir públicamente tu mapa antes de que el concurso termine a mantener el anonimato de las entradas.
 - No le pongas ningún nombre identificable a las dificultades de tus mapas. Usa el predeterminado "Easy/Normal/Hard/Insane" para mantener las entradas anónimas.
 
-## Fecha límite de presentación
+### Fecha límite de presentación
 
 - **2013-10-01 00:00:00 (UTC+0)** Thanks to the osu!news crew and DarkisTH10 for the translations!
 

--- a/news/2014-09-24-monthly-beatmapping-contest-7.md
+++ b/news/2014-09-24-monthly-beatmapping-contest-7.md
@@ -13,13 +13,13 @@ The song for this contest is **Soleily - Renatus**. You may listen to a short pr
 
 <iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/95082536&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&visual=true"></iframe>
 
-# What are the prizes?
+## What are the prizes?
 
 - 6 months of supporter for you or a friend!
 - 'Elite Mapper' forum title
 - **Winning mapset will be bundled with the osu! game client download!**
 
-# What are the rules?
+## What are the rules?
 
 - You must map 3 difficulties in an appropriate spread - either ENH (easy, normal and hard) or NHI (normal, hard, insane). This counts for all 4 brackets.
 - In the osu!mania bracket, you may only submit difficulties with the same key amount.
@@ -27,7 +27,7 @@ The song for this contest is **Soleily - Renatus**. You may listen to a short pr
 - Difficulty names must only be the name of the respective difficulty, and nothing else. No ztrot's Hard or anything comparable.
 - Maps submitted to the contest must not be submitted to the BSS until the contest has concluded.
 
-# Where can I enter?
+## Where can I enter?
 
 Submit your creations under the following links:
 

--- a/news/2017-09-22-beatmap-spotlights-july-august-2017.md
+++ b/news/2017-09-22-beatmap-spotlights-july-august-2017.md
@@ -25,9 +25,9 @@ First of all, congratulations to the winners of the June 2017 Spotlights. They r
 - **osu!catch:** [\_Asriel](https://osu.ppy.sh/users/566276)
 - **osu!mania:** [Cryolien](https://osu.ppy.sh/users/1626983)
 
-# July 2017 Spotlight
+## July 2017 Spotlight
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/myoujin-henka.jpg)](https://osu.ppy.sh/beatmapsets/559843)
 
@@ -57,7 +57,7 @@ The rhythms are given enough thought to ensure they both represent the song, as 
 
 While it may not be innovative, **[Delis](https://osu.ppy.sh/users/1603923)** has presented us with yet another well made map this month filled, with his nostalgia-focused design choices. What makes Delis's maps stand out from the masses of modern maps is their old-style object composition and slider design, which resemble maps from an age most current osu! players have never gotten a chance to see.
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/soumatou-labyrinth.jpg)](https://osu.ppy.sh/beatmapsets/625493)
 
@@ -91,7 +91,7 @@ Difficult rhythms, dense patterns, streams and various combined note snaps: My S
 
 **[Akemi_Homura](https://osu.ppy.sh/users/707980)** has put out a great entry into Ranked this month with Sayonara Memories! The simple 1/2 + 1/4 patterns are neatly mapped with appropriate consistency and the song parts were divided very well by patterning within the map itself, making it very interesting to play. It is also good practice for Double Time, since the map has many rest sections dividing the more difficult ones. There's bound to be something for everyone in this one!
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/fingerbang.jpg)](https://osu.ppy.sh/beatmapsets/559525)
 
@@ -107,7 +107,7 @@ When you think of "marathons" in osu!catch, a Platter difficulty at 88.5 BPM doe
 
 Despite the lower difficulty level, the map offers a wide variety of patterns and emphasis to keep the player interested over the course of almost six minutes, from short and sharp dashes on synth and percussion sounds, to long, twisting vocal-mapped sliders. Each section of the map is pitched well to the emotion and intensity of the music, resulting in a relaxing yet enjoyable experience that can provide a test of stamina to less-experienced players.
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/I.jpg)](https://osu.ppy.sh/beatmapsets/426638)
 
@@ -127,9 +127,9 @@ Just when we all thought the days of mapping SDVX songs with the SFX were over, 
 
 Furthermore, it utilizes some simple stutter Slider Velocity changes where appropriate. With a heavy focus on visuals as well as having some minijacks and basic Long Note holds and releases, the map provides a unique and varied gameplay experience.
 
-# August 2017 Spotlights
+## August 2017 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/sonata-no-14-in-cis-moll.jpg)](https://osu.ppy.sh/beatmapsets/518426)
 
@@ -161,7 +161,7 @@ The same style is used for every difficulty, which makes the mapset feel very co
 
 [Cherry Blossom](https://osu.ppy.sh/users/1156742) has yet again managed to create a map which is not only insanely clean but also very fun to play in general, with an absolutely clever use of symmetry and a very fitting use of spacing for the streams, underlining properly the intensity of the various instruments. If you like challenging stream maps, you can't go wrong with this one!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/true-blue.jpg)](https://osu.ppy.sh/beatmapsets/643803)
 
@@ -204,7 +204,7 @@ A quite solid mapset brought up by [komasy](https://osu.ppy.sh/users/1980256) th
 
 Black Lotus shines with its well designed structure and snapping changes, making it fairly easy to read. However, the density of the notes coupled with the high BPM still make it quite challenging and a good training map for those who want to train their 1/6 beat snapping mechanics.
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/hikaru-nara.jpg)](https://osu.ppy.sh/beatmapsets/519023)
 
@@ -226,7 +226,7 @@ Despite the rather repetitive nature of the song, Spectator uses just the right 
 
 Accelerating its way to the Spotlights is this mapset by a huge collective of mappers! From [JBHyperion](https://osu.ppy.sh/users/4879508), [NurseHyperion](https://osu.ppy.sh/users/4880672), [- Magic Girl -](https://osu.ppy.sh/users/3095784), [WildOne94](https://osu.ppy.sh/users/3482692), [Withered Lotus](https://osu.ppy.sh/users/3546931), and [Razor Sharp](https://osu.ppy.sh/users/3414261), this map brings a variety of mapping styles on the plate. It features a lot of hectic patterns (contemplated by the higher-than-usual Approach Rate) that compliments the song's fast-paced nature. Just be careful not to get left behind!
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2017-09-22-beatmap-spotlights-july-august-2017/swampgator.jpg)](https://osu.ppy.sh/beatmapsets/613792)
 

--- a/news/2017-12-20-beatmap-spotlights-november-2017.md
+++ b/news/2017-12-20-beatmap-spotlights-november-2017.md
@@ -30,9 +30,9 @@ In conjunction with the above changes, it is my pleasure to welcome our new map 
 - **osu!catch:** [Crystal](https://osu.ppy.sh/users/1646397)
 - **osu!mania:** [Garalulu](https://osu.ppy.sh/users/757783), [Pope Gadget](https://osu.ppy.sh/users/2288341), [Asherz007](https://osu.ppy.sh/users/9014047), [TheToaphster](https://osu.ppy.sh/users/7616811)
 
-# November 2017 Spotlights
+## November 2017 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2017-12-18-beatmap-spotlights-november-2017/shinkirou.jpg)](https://osu.ppy.sh/beatmapsets/628765)
 
@@ -54,7 +54,7 @@ Being the winner of the 3rd Newspaper Cup - a prestigious mapping contest - [Reg
 
 For fans of the Touhou Project and unconventional mapping alike, [Hollow Wings](https://osu.ppy.sh/users/416662) brings us a wonderful mapset of Ten'imuhou. The highest difficulty of the mapset brings an energetic feel with an overall high spacing, while keeping gameplay engaging with a huge variety in jump patterns. A must play if you're looking for an aim challenge!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2017-12-18-beatmap-spotlights-november-2017/collapse.jpg)](https://osu.ppy.sh/beatmapsets/691352)
 
@@ -74,7 +74,7 @@ Ever wanted to bang some drums to the sound of intense violins? Well then, Memme
 
 The highlight of this set would definitely be the Inner Oni difficulty by [aabc271](https://osu.ppy.sh/users/155707). With clever usage of finishers, 1/6 patterns, streams and rhythm switches throughout the map, it offers both a fun yet challenging experience for veteran players. We mustn't forget about the Muzukashii and Oni difficulties though - mapped by [iloveyou4ever](https://osu.ppy.sh/users/4964596) and [Nardoxyribonucleic](https://osu.ppy.sh/users/876419) respectively, they too are also beautifully crafted for players of lower levels to enjoy.
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2017-12-18-beatmap-spotlights-november-2017/towards-the-horizon.jpg)](https://osu.ppy.sh/beatmapsets/629384)
 
@@ -94,7 +94,7 @@ This beatmap is ultimately great fun to play and one you really shouldn't miss o
 
 Having been featured in the osu!catch World Cup a few months ago, [JBHyperion](https://osu.ppy.sh/users/4879508) takes us all the way to a different meta in the ranked section, with the top difficulty of his Arcadia mapset sporting an unconventional Circle Size and gimmicky patterns. Moreover, players of all skill levels can enjoy the ride through this mapset with a difficulty tailored for them. I'm sure you'll be begging for an encore in your attempt to get the highest score on this cool beatmap!
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2017-12-18-beatmap-spotlights-november-2017/nobore.jpg)](https://osu.ppy.sh/beatmapsets/580273)
 

--- a/news/2018-01-23-beatmap-spotlights-december-2017.md
+++ b/news/2018-01-23-beatmap-spotlights-december-2017.md
@@ -18,9 +18,9 @@ First of all, congratulations to the winners of the November 2017 Spotlights. Th
 - **osu!catch:** [monstratorfull](https://osu.ppy.sh/users/1872276)
 - **osu!mania:** [\_SkyFall](https://osu.ppy.sh/users/4893647)
 
-# December 2017 Spotlights
+## December 2017 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2018-01-23-beatmap-spotlights-december-2017/impulse.jpg)](https://osu.ppy.sh/beatmapsets/705788)
 
@@ -54,7 +54,7 @@ This month, veteran mapper [Zero__wind](https://osu.ppy.sh/users/1822830) brings
 
 Winning the 5th Pending Cup, an annual mapping contest that attracts experienced mappers globally, [Chaoslitz](https://osu.ppy.sh/users/3621552) brings us a marvellous collection of top-quality entries! Additionally, as the mapper of the top difficulty, [yf_bmp](https://osu.ppy.sh/users/1243669) vividly expresses the song with well-organized patterns and incredible hitsounding. Still, don't forget to check out all the difficulties if you are a fan of diversity, as both technical and aim-heavy styles are included in this mapset!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2018-01-23-beatmap-spotlights-december-2017/saifu-kamiasobi.jpg)](https://osu.ppy.sh/beatmapsets/627038)
 
@@ -70,7 +70,7 @@ His map of the song "Saifu 'Kamiasobi no Uta'" features varied yet consistent an
 Following his last appearance in the September osu!taiko Spotlights, [Nifty](https://osu.ppy.sh/users/4956097) is featured once again, this time with a mapset that can be considered a sequel to Time Traveler: sakuraburst's remix of fuego!
 Like Time Traveler, fuego features an unusually high amount of slider velocity changes which are executed very well, creating a very unique experience. The patterns used are exceptionally well-structured, from kantan to embers oni, with the lower difficulties made fair for newer players. Hopefully you, the player, can enjoy embers oni's slider velocity changes!
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2018-01-23-beatmap-spotlights-december-2017/cycle-hit.jpg)](https://osu.ppy.sh/beatmapsets/692367)
 
@@ -90,7 +90,7 @@ Bringing this sweet song with a sweet map to us are [-wwwww](https://osu.ppy.sh/
 
 With nice flow and unique vocal emphasis with slider velocity manipulation, [Hareimu](https://osu.ppy.sh/users/4138746)'s map of Fairytale, by cillia brings what we're looking for in Spotlights. It's slider velocity manipulation before the kiai adds some flair that makes the mapping interesting as well as having overall good flow that is smooth to play. We would hope you feel the same way while playing it!
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2018-01-23-beatmap-spotlights-december-2017/just-hold-on.jpg)](https://osu.ppy.sh/beatmapsets/409440)
 

--- a/news/2018-02-23-beatmap-spotlights-january-2018.md
+++ b/news/2018-02-23-beatmap-spotlights-january-2018.md
@@ -18,9 +18,9 @@ First of all, congratulations to the winners of the December 2017 Spotlights. Th
 - **osu!catch:** [Guillotine](https://osu.ppy.sh/users/4365562)
 - **osu!mania:** [\[MY\]Idiot](https://osu.ppy.sh/users/2059742)
 
-# January 2018 Spotlights
+## January 2018 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2018-02-23-beatmap-spotlights-january-2018/yakumo.jpg)](https://osu.ppy.sh/beatmapsets/688877)
 
@@ -52,7 +52,7 @@ An absolute treat of a map to play, and to watch as well! The storyboard, also d
 
 YUC'e - Sengoku HOP, brought to us by [Nathan](https://osu.ppy.sh/users/4785223), [Gamu](https://osu.ppy.sh/users/611174) and [appleeaterx](https://osu.ppy.sh/users/2407160), clearly shows how cuteness and glitch hop music is done, with their breathtakingly wonderful works! This map features rather gimmicky and technical patterns, including stacks and high-speed sliders. Try it out if you want to challenge your reading skills and all other abilities!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2018-02-23-beatmap-spotlights-january-2018/come-and-get-it.jpg)](https://osu.ppy.sh/beatmapsets/417377)
 
@@ -92,7 +92,7 @@ Being the only nominated taiko mapset with no X-rated difficulty, it stands out 
 
 Despite the short song length, it is a well-made mapset that shows his expertise in taiko mapping, as well as understanding of musical emotion. Definitely worth mentioning in this month's Spotlights!
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2018-02-23-beatmap-spotlights-january-2018/algebra.jpg)](https://osu.ppy.sh/beatmapsets/468281)
 
@@ -118,7 +118,7 @@ You've had to have lived under a rock (underneath another rock) to not heard of 
 
 With twisting and turning patterns of streams combined with engaging patterns on even the calmest of parts, this map just keeps you on your toes for its entirety. It also uses quite the unconventional style, using mostly circles instead of sliders on larger part of the map, and with movement not commonly seen in most osu!catch maps. Excellent job by Kyuare for his rendition of this highly-popular song!
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2018-02-23-beatmap-spotlights-january-2018/fuego.jpg)](https://osu.ppy.sh/beatmapsets/622946)
 

--- a/news/2018-03-22-beatmap-spotlights-february-2018.md
+++ b/news/2018-03-22-beatmap-spotlights-february-2018.md
@@ -18,9 +18,9 @@ First of all, congratulations to the winners of the January 2018 Spotlights. The
 - **osu!catch:** [skvix](https://osu.ppy.sh/users/4447639)
 - **osu!mania:** [ZYuan](https://osu.ppy.sh/users/3337688)
 
-# February 2018 Spotlights
+## February 2018 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2018-03-22-beatmap-spotlights-february-2018/future-candy.jpg)](https://osu.ppy.sh/beatmapsets/546820)
 
@@ -54,7 +54,7 @@ If you're looking for an aim challenge, the Extra difficulty is a lot easier on 
 
 Showcasing highly organized patterns and clear attention to the song's details, this map is an excellent addition to this month's Spotlights!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2018-03-22-beatmap-spotlights-february-2018/lets-jump.jpg)](https://osu.ppy.sh/beatmapsets/688928)
 
@@ -96,7 +96,7 @@ Last but certainly not least, this February we're showcasing this month [Kazu](h
 
 The song provides plenty of musical and rhythmic variety throughout its various sections, and the improvisational nature of their mapping styles lend to difficulties which represent this song to its fullest potential. The lower difficulties also shine on their own, making this set one that players of all levels can enjoy.
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2018-03-22-beatmap-spotlights-february-2018/kanpan.jpg)](https://osu.ppy.sh/beatmapsets/633255)
 
@@ -128,7 +128,7 @@ All you want to see about a modern-styled map can be found in this set, with app
 
 Despite some similarities, "Sennen no Kotowari" is a noticeably more subdued mapset in comparison. Gone are the energetic wubs and harsh hyperdashes and in their place are beautifully clean streams and pattern choices that really shine across all difficulties. With a wonderfully natural flow it should be second nature to any avid catch player.
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2018-03-22-beatmap-spotlights-february-2018/yume.jpg)](https://osu.ppy.sh/beatmapsets/619531)
 

--- a/news/2018-06-06-beatmap-spotlights-march-and-april-2018.md
+++ b/news/2018-06-06-beatmap-spotlights-march-and-april-2018.md
@@ -30,9 +30,9 @@ Thanks to everybody who followed along the project for the past few years, and w
 - [March Spotlighted Maps](#march)
 - [April Spotlighted Maps](#april)
 
-# <a name="march" id="march"></a>March 2018 Spotlights
+## <a name="march" id="march"></a>March 2018 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/squall.jpg)](https://osu.ppy.sh/beatmapsets/127772)
 
@@ -61,7 +61,7 @@ Momoko has done a great job here on capturing this song through his difficulty, 
 
 This month, [dsco](https://osu.ppy.sh/users/4330511) brings us "Dum Surfer" by "King Krule". The mapper managed to take geometrical mapping to a whole nother level by combining it with low approach rate and perfectly overlapping stacks. These give the mapper the freedom to use unorthodox mapping techniques like multiple stacked notes with different distances in time. Combined with a type of song not very common on osu!, this mapset is a unique experience you should not miss out on!
 
-## osu!taiko
+### osu!taiko
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/figue-folle.jpg)](https://osu.ppy.sh/beatmapsets/680739)
 
@@ -85,7 +85,7 @@ This is a very technical map, using many odd snaps and rhythms, finishers and sl
 
 An outstanding 1/6 map by the new face [lazyboy007](https://osu.ppy.sh/users/7882675) this month. Despite not having much experience with taiko, he still produced an excellent map with consistent structure. Furthermore, the excellent 1/6 usage and control of pattern density extracts the essence of the song perfectly, making it a worthy contender for this month's Spotlight!
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/nirvana.jpg)](https://osu.ppy.sh/beatmapsets/694025)
 
@@ -101,13 +101,13 @@ Finally making it's long-overdue arrival in the Ranked section, [Tenshichan](htt
 
 After previously producing one of the most dramatic and exhilarating matches of the osu!catch World Cup 2017, it's great to see such a memorable and high quality beatmap given the spotlight it deserves for all to experience.
 
-## osu!mania
+### osu!mania
 
 **The Spotlights team did not find any maps they felt were worthy of the Spotlights this month.**
 
-# <a name="april" id="april"></a>April 2018 Spotlights
+## <a name="april" id="april"></a>April 2018 Spotlights
 
-## osu!
+### osu!
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/iwashi-ga.jpg)](https://osu.ppy.sh/beatmapsets/602367)
 
@@ -171,7 +171,7 @@ Last but most definitely not least, we have [Fallmorph](https://osu.ppy.sh/users
 
 Maintaining a high combo on this map might be easy for the average player, but be warned that getting a high accuracy will be quite the challenge!
 
-## osu!catch
+### osu!catch
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/turii.jpg)](https://osu.ppy.sh/beatmapsets/685428)
 
@@ -195,7 +195,7 @@ The lower two difficulties are also neatly organized with delicate and friendly 
 
 It's time we could enjoy 1/2 jump party! Surrounded by 1/4-rhythm-based overdoses today, [RoseusJaeger](https://osu.ppy.sh/users/67098409) and [Ascendance](https://osu.ppy.sh/users/2931883) are surprisingly gifting us a newly approved mapset, "Akaito" by Rib, with mostly 1/2 patterns. This map features convenient flow and proper emphasis throughout the whole difficulty. Meanwhile it's' also able to come up with different patterns that make it colourful and catchy. With Rib's smooth voice, you are about to love playing this map.
 
-## osu!mania
+### osu!mania
 
 [![](/wiki/shared/news/2018-06-06-beatmap-spotlights-march-and-april-2018/lesson.jpg)](https://osu.ppy.sh/beatmapsets/704987)
 

--- a/news/2018-11-01-beatmap-spotlights-summer-2018.md
+++ b/news/2018-11-01-beatmap-spotlights-summer-2018.md
@@ -31,7 +31,7 @@ We are also pushing to increase the visibility of the Spotlights on the website 
 
 For now, let's get stuck right into this year's blazing summer beatmap hits!
 
-# Summer 2018 Spotlights
+## Summer 2018 Spotlights
 
 ### Navigation
 
@@ -40,7 +40,7 @@ For now, let's get stuck right into this year's blazing summer beatmap hits!
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-## <a name="osu" id="osu"></a>osu!
+### <a name="osu" id="osu"></a>osu!
 
 [![](/wiki/shared/news/2018-11-01-beatmap-spotlights-summer-2018/osu/last-minute.jpg)](https://osu.ppy.sh/beatmapsets/813036)
 
@@ -100,7 +100,7 @@ With an upbeat tempo and groovy beat, [tutuhaha](https://osu.ppy.sh/users/546991
 
 Last but not least, [bor](https://osu.ppy.sh/users/4116573) provides us with a stunning mapset of Draw The Emotional's "Sad Spring". The highest difficulty puts a huge focus on motion, with every object having just the right impact. The extravagant streamshapes feel very satisfying to play. All that accompanied by an ambitious and consistent spread with the help of [Lasse](https://osu.ppy.sh/users/896613) and [Aeril](https://osu.ppy.sh/users/4334976), this is a mapset everyone should try!
 
-## <a name="taiko" id="taiko"></a>osu!taiko
+### <a name="taiko" id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2018-11-01-beatmap-spotlights-summer-2018/taiko/bison-charge.jpg)](https://osu.ppy.sh/beatmapsets/739116)
 
@@ -205,7 +205,7 @@ Super solid mapset overall and a worthy addition to the Spotlights!
 
 Definitely my personal favourite map of the summer, honestly what a banger. odaxelagnia's "#sawg" remixed by Wan Bushi features relatively fast paced breakcore, which [Ulqui](https://osu.ppy.sh/users/1263669) did a great job representing through this map. With beautifully made tricky 1/6 patterns and carefully placed Slider Velocity progressions, they combine to make this map an amazing piece of artwork that is really fun to play!
 
-## <a name="catch" id="catch"></a>osu!catch
+### <a name="catch" id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2018-11-01-beatmap-spotlights-summer-2018/catch/tokei-no-heya.jpg)](https://osu.ppy.sh/beatmapsets/639409)
 
@@ -239,7 +239,7 @@ Bringing us another fantastic map in the style we all know and love, Camellia's 
 
 And of course, for everyone else, the Cup through Rain difficulties definitely provide a challenge well above the curve of a normal mapset, giving something for everyone to play and enjoy!
 
-## <a name="mania" id="mania"></a>osu!mania
+### <a name="mania" id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2018-11-01-beatmap-spotlights-summer-2018/mania/lost.jpg)](https://osu.ppy.sh/beatmapsets/624059)
 

--- a/news/2019-01-16-beatmap-spotlights-fall-2018.md
+++ b/news/2019-01-16-beatmap-spotlights-fall-2018.md
@@ -19,7 +19,7 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Summer 
 - **osu!catch:** [RAMPAGE88](https://osu.ppy.sh/users/448547), [Crystal](https://osu.ppy.sh/users/1646397) and [Nelly](https://osu.ppy.sh/users/4741164)
 - **osu!mania:** [\[Crz\]Satori](https://osu.ppy.sh/users/7082178), [robby250](https://osu.ppy.sh/users/2653437) and [Cryolien](https://osu.ppy.sh/users/1626983)
 
-# Autumn 2018 Spotlights
+## Autumn 2018 Spotlights
 
 ### Navigation
 
@@ -28,7 +28,7 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Summer 
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-## <a name="osu" id="osu"></a>osu!
+### <a name="osu" id="osu"></a>osu!
 
 [![](/wiki/shared/news/2019-01-16-beatmap-spotlights-autumn-2018/osu/kaoru.jpg)](https://osu.ppy.sh/beatmapsets/397764)
 
@@ -102,7 +102,7 @@ Dormin's "Une mage blanche" shows [Sulfur](https://osu.ppy.sh/users/5297447)'s e
 
 [Chaoslitz](https://osu.ppy.sh/users/3621552) and Moecho’s collab on colate and Nanahira’s "Good Night" is a great example of how collab difficulties are supposed to be mapped: the styles of both mappers blending with each other, resulting in a smooth playing experience without either of the mappers’ parts outshining the other. Coupled with the intuitive rhythm and patterns, the result is a very enjoyable map to play for players of all skillsets and levels.
 
-## <a name="taiko" id="taiko"></a>osu!taiko
+### <a name="taiko" id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2019-01-16-beatmap-spotlights-autumn-2018/taiko/passage.jpg)](https://osu.ppy.sh/beatmapsets/587426)
 
@@ -176,7 +176,7 @@ Kazu's often abstract mapping style really works for this kind of abrasive music
 
 Truly, we won't just be on the "Border of extacy", we'll be thoroughly engulfed in it while playing this map!
 
-## <a name="catch" id="catch"></a>osu!catch
+### <a name="catch" id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2019-01-16-beatmap-spotlights-autumn-2018/catch/misanthrope.jpg)](https://osu.ppy.sh/beatmapsets/797236)
 
@@ -210,7 +210,7 @@ The ultimate duo, consisting of [Ascendance](https://osu.ppy.sh/users/2931883) a
 
 Right before leaving for military service, [Spectator](https://osu.ppy.sh/users/702598) managed to give us another fantastic set, this time on a groovy song BUTAOTOME's "Gensou no Satellite". The highest difficulty manages to keep up fast and energetic patterns to keep up with the song. The rest of the set, including a [Xetopia](https://osu.ppy.sh/users/6689101) guest difficulty, doesn't disappoint in giving something to offer to players of all skill levels.
 
-## <a name="mania" id="mania"></a>osu!mania
+### <a name="mania" id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2019-01-16-beatmap-spotlights-autumn-2018/mania/emotional.jpg)](https://osu.ppy.sh/beatmapsets/800663)
 

--- a/news/2019-02-05-new-changes-to-star-rating-performance-points.md
+++ b/news/2019-02-05-new-changes-to-star-rating-performance-points.md
@@ -18,7 +18,7 @@ Prefer video form? Let Doomsday walk your through the changes in 20 minutes:
 
 <iframe width="100%" height="420" src="https://www.youtube.com/embed/5rSaXWr_VUM" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
-# Release Schedule
+## Release Schedule
 
 - ☑ As of the time this article is posted, a new stable release will begin recalculating star ratings of all beatmaps loaded locally. This may take a few minutes (or more if you have many beatmaps) and will continue to run in the background while your game is at song select. **\[COMPLETE\]**
 - ☑ Over the coming hours, server-side star ratings will be updated to match. **\[COMPLETE\]**
@@ -28,9 +28,9 @@ Prefer video form? Let Doomsday walk your through the changes in 20 minutes:
 
 Note that all *new* scores which are set will already be using the up-to-date performance algorithm.
 
-# Summary of changes
+## Summary of changes
 
-## Wide angle jumps
+### Wide angle jumps
 
 The aim difficulty rating of hit objects now considers the angles formed.
 
@@ -43,7 +43,7 @@ Example beatmaps where this change can be seen:
 
 View on GitHub: [#3839](https://github.com/ppy/osu/pull/3839)
 
-## High BPM streams
+### High BPM streams
 
 The difficulty of patterns consisting of high-paced hit circles (streams) now increases exponentially from 200 BPM to 330 BPM.
 
@@ -54,7 +54,7 @@ Example beatmap where this change can be seen:
 
 View on GitHub: [#3839](https://github.com/ppy/osu/pull/3839)
 
-## Highly spaced streams
+### Highly spaced streams
 
 The difficulty rating of streams with very high spacing between hit circles has been decreased slightly. These plays are still quite impressive and worth a lot, but not as much as before.
 
@@ -66,7 +66,7 @@ Example beatmaps where this change can be seen:
 
 View on GitHub: [#3839](https://github.com/ppy/osu/pull/3839)
 
-## Long sliders
+### Long sliders
 
 The difficulty rating of long sliders has been increased significantly.
 
@@ -79,7 +79,7 @@ Example beatmap where this change can be seen:
 
 View on GitHub: [#3839](https://github.com/ppy/osu/pull/3839)
 
-## Speed accuracy
+### Speed accuracy
 
 The performance points awarded for low accuracy scores has been decreased for beatmaps with a high speed rating.
 
@@ -91,7 +91,7 @@ Example beatmaps where this change can be seen:
 
 View on GitHub: [#74](https://github.com/ppy/osu-performance/pull/74)
 
-## Flashlight mod adjustments
+### Flashlight mod adjustments
 
 The performance points awarded due to the flashlight mod has been reduced for short beatmaps and increased for long beatmaps.
 
@@ -103,7 +103,7 @@ Example beatmaps where this change can be seen:
 
 View on GitHub: [#48](https://github.com/ppy/osu-performance/pull/48), [#71](https://github.com/ppy/osu-performance/pull/71)
 
-## Hidden mod adjustments
+### Hidden mod adjustments
 
 The performance points awarded due to the hidden mod has been increased for beatmaps with high aim and accuracy ratings, and decreased for high approach rate beatmaps with high speed ratings.
 
@@ -116,7 +116,7 @@ Example beatmaps where this change can be seen:
 
 View on GitHub: [#72](https://github.com/ppy/osu-performance/pull/72)
 
-## Miscellaneous changes
+### Miscellaneous changes
 
 These are the more minor technical changes that we introduced to fix previous issues and keep things balanced.
 

--- a/news/2019-04-11-beatmap-spotlights-winter-2019.md
+++ b/news/2019-04-11-beatmap-spotlights-winter-2019.md
@@ -19,7 +19,7 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Autumn 
 - **osu!catch:** [Crystal](https://osu.ppy.sh/users/1646397), [Guillotine](https://osu.ppy.sh/users/4365562) and [RAMPAGE88](https://osu.ppy.sh/users/448547)
 - **osu!mania:** [\[Crz\]Satori](https://osu.ppy.sh/users/7082178), [Stink God](https://osu.ppy.sh/users/7381289) and [Cryolien](https://osu.ppy.sh/users/1626983)
 
-# Winter 2019 Spotlights
+## Winter 2019 Spotlights
 
 ### Navigation
 
@@ -28,7 +28,7 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Autumn 
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-## <a name="osu" id="osu"></a>osu!
+### <a name="osu" id="osu"></a>osu!
 
 [![](/wiki/shared/news/2019-04-11-beatmap-spotlights-winter-2019/osu/nice-for-what.jpg)](https://osu.ppy.sh/beatmapsets/873829)
 
@@ -124,7 +124,7 @@ Don't be fooled into thinking that [Mir](https://osu.ppy.sh/users/8688812)'s dif
 
 [Len](https://osu.ppy.sh/users/1686145) strikes back in the ranked section, with his large mapset of the extended version of "Chirality" by none other than Camellia. Boasting ten difficulties in total, this set succeeds in catering to all skill levels. The expert difficulties are not to be underestimated however, since the mappers go all out in expressing the song to the extent of their abilities, and succeed in keeping the player on their toes the whole time because of the song's variety.
 
-## <a name="taiko" id="taiko"></a>osu!taiko
+### <a name="taiko" id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2019-04-11-beatmap-spotlights-winter-2019/taiko/preserved.jpg)](https://osu.ppy.sh/beatmapsets/861177)
 
@@ -211,7 +211,7 @@ After a long break, you can see a very impressive part making use of tremendous 
 
 まさしく，一つの物語として成す譜面です．まず，物語は静寂たる音色とそれに合った静けさに始まります．束の間，まるで大音符とスピナーの嵐かのように劇的に物語は変化します．大音符の視認性は拍車をかかけます．そして嵐は1/6の矢へと移り変わり，逆手の極みを篤と見せつけてくるのです．長い静寂を挟み，強烈な密度変化を取り入れた，凄まじく印象的な場面が広がると，最後はこれまでのすべてのコンセプトを合わせた場面によって物語は終焉を迎えます．同じ配置を繰り返しているようで，つまらぬどころか面白い，それはもちろん，譜面制作の極致に至るこの譜面の持つ趣のまさに一つと言えましょう．
 
-## <a name="catch" id="catch"></a>osu!catch
+### <a name="catch" id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2019-04-11-beatmap-spotlights-winter-2019/catch/good-time.jpg)](https://osu.ppy.sh/beatmapsets/815390)
 
@@ -233,7 +233,7 @@ Besides the patterns, Rocma also showcases his outstanding hitsounding skills by
 
 Egoism 440 showcases a variety of patterns different mappers use hosted by [Ascendance](https://osu.ppy.sh/users/2931883). Specifically, the usage of the patterns in the difficulties Challenge and Double Challenge show how a "Challenge" map in osu!catch can be similar yet so different. If you aren't experienced enough to try those two difficulties, don't worry; all difficulties provide a challenge through unique patterns often unseen in other ranked maps.
 
-## <a name="mania" id="mania"></a>osu!mania
+### <a name="mania" id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2019-04-11-beatmap-spotlights-winter-2019/mania/citrus.jpg)](https://osu.ppy.sh/beatmapsets/854717)
 

--- a/news/2019-07-08-beatmap-spotlights-spring-2019.md
+++ b/news/2019-07-08-beatmap-spotlights-spring-2019.md
@@ -20,16 +20,16 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Winter 
 - **osu!mania:** [\[Crz\]Satori](https://osu.ppy.sh/users/7082178), [Stink God](https://osu.ppy.sh/users/7381289) and [Cryolien](https://osu.ppy.sh/users/1626983)
 
 
-# Navigation
+## Navigation
 
 - <a href="#osu">osu!</a>
 - <a href="#taiko">osu!taiko</a>
 - <a href="#catch">osu!catch</a>
 - <a href="#mania">osu!mania</a>
 
-# Spring 2019 Spotlights
+## Spring 2019 Spotlights
 
-## <a name="osu" id="osu"></a>osu!
+### <a name="osu" id="osu"></a>osu!
 
 [![](/wiki/shared/news/2019-07-07-beatmap-spotlights-spring-2019/osu/kagefumi.jpg)](https://osu.ppy.sh/beatmapsets/910454)
 
@@ -89,7 +89,7 @@ The highly emotive indie track is accented beautifully through a level of flow a
 
 _written by [Toy](https://osu.ppy.sh/users/2757689)_
 
-## <a name="taiko" id="taiko"></a>osu!taiko
+### <a name="taiko" id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2019-07-07-beatmap-spotlights-spring-2019/taiko/ylil.jpg)](https://osu.ppy.sh/beatmapsets/897948)
 
@@ -206,7 +206,7 @@ This concludes it for this season's Spotlights for osu!taiko, and it sure shows 
 
 _written by [Greenshell](https://osu.ppy.sh/users/8693851)_
 
-## <a name="catch" id="catch"></a>osu!catch
+### <a name="catch" id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2019-07-07-beatmap-spotlights-spring-2019/catch/flash-back.jpg)](https://osu.ppy.sh/beatmapsets/706939)
 
@@ -242,7 +242,7 @@ This is not to discount from the lower difficulties, which mapped accordingly to
 
 _written by [Snowless](https://osu.ppy.sh/users/4316266)_
 
-## <a name="mania" id="mania"></a>osu!mania
+### <a name="mania" id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2019-07-07-beatmap-spotlights-spring-2019/mania/suiren.jpg)](https://osu.ppy.sh/beatmapsets/545484)
 

--- a/news/2019-09-29-mca-ayim-2018.md
+++ b/news/2019-09-29-mca-ayim-2018.md
@@ -8,7 +8,7 @@ While a bit late, the annual Mapper's Choice Awards and A Year In Mapping for 20
 
 ![](/wiki/shared/news/2019-09-29-mca-ayim-2018/banner.png)
 
-# Mapper's Choice Awards
+## Mapper's Choice Awards
 
 Mapper's Choice Awards 2018 forum threads: [English](https://osu.ppy.sh/community/forums/topics/966003), [Français](https://osu.ppy.sh/community/forums/topics/966117), [Deutsch](https://osu.ppy.sh/community/forums/topics/966006), [한국어](https://osu.ppy.sh/community/forums/topics/966279), [中文](https://osu.ppy.sh/community/forums/topics/966016), [日本語](https://osu.ppy.sh/community/forums/topics/965995), [Русский язык](https://osu.ppy.sh/community/forums/topics/966093), [Bahasa Indonesia](https://osu.ppy.sh/community/forums/topics/965990), [Nederlands](https://osu.ppy.sh/community/forums/topics/965967), [Tiếng Việt](https://osu.ppy.sh/community/forums/topics/966009)
 
@@ -18,7 +18,7 @@ Each mode will have two **Grand MCA Awards**, one for the best beatmap, and one 
 
 Even if you are not able to vote, feel free to follow along with the events! The results will be released later on via livestreams where commentators will discuss the results.
 
-## Schedule
+### Schedule
 
 Right now, Mapper's Choice Awards is in the nomination stage, and the rest of the schedule can be seen below. If you're eligible to vote or nominate, be sure to do so while you still can!
 
@@ -32,7 +32,7 @@ Right now, Mapper's Choice Awards is in the nomination stage, and the rest of th
 | Storyboard results stream | 2019-10-20 16:00 |
 | osu!standard results stream | 2019-10-20 19:00 |
 
-# A Year In Mapping
+## A Year In Mapping
 
 [A Year In Mapping 2018 forum thread](https://osu.ppy.sh/community/forums/topics/966004)
 

--- a/news/2019-10-05-beatmap-spotlights-summer-2019.md
+++ b/news/2019-10-05-beatmap-spotlights-summer-2019.md
@@ -26,9 +26,9 @@ First of all, congratulations to the winners of the Spring 2019 Seasonal Spotlig
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-# Summer Spotlights
+## Summer Spotlights
 
-## <a name="osu" id="osu"></a>osu!
+### <a name="osu" id="osu"></a>osu!
 
 [![](/wiki/shared/news/2019-10-05-beatmap-spotlights-summer-2019/osu/hide.jpg)](https://osu.ppy.sh/beatmapsets/972932)
 
@@ -184,7 +184,7 @@ And as if the map wasn't already enough of a masterpiece on its own, [Peter](htt
 
 *written by [Deca](https://osu.ppy.sh/users/9088487)*
 
-## <a name="taiko" id="taiko"></a>osu!taiko
+### <a name="taiko" id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2019-10-05-beatmap-spotlights-summer-2019/taiko/field.jpg)](https://osu.ppy.sh/beatmapsets/897127)
 
@@ -245,7 +245,7 @@ If you love some speedy maps with complex patterns, this map will certainly fulf
 
 *written by [Nepuri](https://osu.ppy.sh/users/6637817)*
 
-## <a name="catch" id="catch"></a>osu!catch
+### <a name="catch" id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2019-10-05-beatmap-spotlights-summer-2019/catch/oriental.jpg)](https://osu.ppy.sh/beatmapsets/910194)
 
@@ -283,7 +283,7 @@ Majeure has fun and technical streams with tap dashes and wiggles, which are esp
 
 *written by [F D Flourite](https://osu.ppy.sh/users/2459589)*
 
-## <a name="mania" id="mania"></a>osu!mania
+### <a name="mania" id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2019-10-05-beatmap-spotlights-summer-2019/mania/ari.jpg)](https://osu.ppy.sh/beatmapsets/933455)
 

--- a/news/2020-01-17-beatmap-spotlights-autumn-2019.md
+++ b/news/2020-01-17-beatmap-spotlights-autumn-2019.md
@@ -26,9 +26,9 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Summer 
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-# Autumn Spotlights
+## Autumn Spotlights
 
-## <a id="osu"></a>osu!
+### <a id="osu"></a>osu!
 
 [![](/wiki/shared/news/2020-01-17-beatmap-spotlights-autumn-2019/osu/alex.jpg)](https://osu.ppy.sh/beatmapsets/1054045)
 
@@ -148,7 +148,7 @@ Try this set out! No difficulty on it will disappoint you and all of them are su
 
 *written by [\_Epreus](https://osu.ppy.sh/users/7342798)*
 
-## <a id="taiko"></a>osu!taiko
+### <a id="taiko"></a>osu!taiko
 
 [![](/wiki/shared/news/2020-01-17-beatmap-spotlights-autumn-2019/taiko/fire.jpg)](https://osu.ppy.sh/beatmapsets/978134)
 
@@ -210,7 +210,7 @@ Slider velocity is seamlessly integrated into the map, especially in the variabl
 
 *written by [Kazu](https://osu.ppy.sh/users/920861)*
 
-## <a id="catch"></a>osu!catch
+### <a id="catch"></a>osu!catch
 
 [![](/wiki/shared/news/2020-01-17-beatmap-spotlights-autumn-2019/catch/cold.jpg)](https://osu.ppy.sh/beatmapsets/946446)
 
@@ -282,7 +282,7 @@ After two long years, calling has finally been ranked! [alienflybot](https://osu
 
 *written by [Yumeno Himiko](https://osu.ppy.sh/users/1806962)*
 
-## <a id="mania"></a>osu!mania
+### <a id="mania"></a>osu!mania
 
 [![](/wiki/shared/news/2020-01-17-beatmap-spotlights-autumn-2019/mania/xyz.jpg)](https://osu.ppy.sh/beatmapsets/682615)
 

--- a/news/2020-04-09-aspire-v-a-new-format.md
+++ b/news/2020-04-09-aspire-v-a-new-format.md
@@ -36,7 +36,7 @@ Breaking the bounds in a completely different way, [Shiny Smily Story](https://o
 
 With song restrictions relaxed and even more ways to win, there is little reason not to give it a shot and see how far your creativity can take you.
 
-# Rules
+## Rules
 
 The rules for this Aspire contest are as follows:
 
@@ -59,7 +59,7 @@ The rules for this Aspire contest are as follows:
 
 Any entries that break these rules may be disqualified from the contest.
 
-# Judging and Voting
+## Judging and Voting
 
 The contest will rely on a panel of judges to first categorize the entries before allowing the community to vote for the winner of each one.
 
@@ -71,7 +71,7 @@ Once the results of the categorised voting concludes, phase two of voting will b
 
 If you are interested in being a judge and categorising the entries, please contact [-Mo-](https://osu.ppy.sh/users/2202163). Please note however that judges cannot participate in entering the contest. 
 
-# Prizes
+## Prizes
 
 The prizes for this contest are as follows:
 

--- a/news/2020-04-09-beatmap-spotlights-winter-2020.md
+++ b/news/2020-04-09-beatmap-spotlights-winter-2020.md
@@ -26,9 +26,9 @@ First of all, congratulations to the winners of the Seasonal Spotlights: Autumn 
 - [osu!catch](#catch)
 - [osu!mania](#mania)
 
-# Winter Spotlights
+## Winter Spotlights
 
-## <a id="osu"></a> osu!
+### <a id="osu"></a> osu!
 
 [![](/wiki/shared/news/2020-04-09-beatmap-spotlights-winter-2020/osu/24.jpg)](https://osu.ppy.sh/beatmapsets/1086289)
 
@@ -106,7 +106,7 @@ Try this map and spice up your collection!
 
 *written by [KnightC0re](https://osu.ppy.sh/users/7894340)*
 
-## <a id="taiko"></a> osu!taiko
+### <a id="taiko"></a> osu!taiko
 
 [![](/wiki/shared/news/2020-04-09-beatmap-spotlights-winter-2020/taiko/leviathan.jpg)](https://osu.ppy.sh/beatmapsets/1013884)
 
@@ -142,7 +142,7 @@ The map starts off with the first half being deceivingly calm, until the drop hi
 
 *written by [\_DUSK\_](https://osu.ppy.sh/users/6092181)*
 
-## <a id="catch"></a> osu!catch
+### <a id="catch"></a> osu!catch
 
 [![](/wiki/shared/news/2020-04-09-beatmap-spotlights-winter-2020/catch/chocolate.jpg)](https://osu.ppy.sh/beatmapsets/1061800)
 
@@ -178,7 +178,7 @@ And for last we have a Sweet Overdose which has short slider Hyperdashes to foll
 
 *written by [Kurokami](https://osu.ppy.sh/users/260933)*
 
-## <a id="mania"></a> osu!mania
+### <a id="mania"></a> osu!mania
 
 [![](/wiki/shared/news/2020-04-09-beatmap-spotlights-winter-2020/mania/transhuman.jpg)](https://osu.ppy.sh/beatmapsets/1069426)
 

--- a/news/2020-06-22-aspire-v-category-stage-voting.md
+++ b/news/2020-06-22-aspire-v-category-stage-voting.md
@@ -12,7 +12,7 @@ The first voting stage of Aspire V begins! Help us choose your favourites from s
 
 We have also put together short compilations of each category, consisting of 45 second clips of each beatmap. These are designed to give you a short preview of each beatmap without revealing all they have to offer - we strongly recommend downloading the maps yourself to enjoy in game (it’s definitely worth it).
 
-# Categories
+## Categories
 
 **[You can watch snippets of all entries in all major categories via this link.](https://www.youtube.com/playlist?list=PLmWVQsxi34bPOwMZSzySyrnIzsHGy2xKW)**
 
@@ -34,7 +34,7 @@ We also have an **Innovative Storyboarding** category for the maps that aren’t
 
 Our final category is the **Manipulation of Time** category. A first in Aspire history, each of these osu!mania beatmaps use extreme timing point manipulation to create very impressive visual effects, as well as offering a challenge to all key smashers.
 
-# Voting
+## Voting
 
 The voting page for each of the categories can be found below, as well as download links to their respective zip files:
 

--- a/news/2020-07-21-aspire-v-finals-stage-voting.md
+++ b/news/2020-07-21-aspire-v-finals-stage-voting.md
@@ -14,7 +14,7 @@ The results are in, but it's not over yet - the winners have moved onto the fina
 
 In this final stage, the top two beatmaps of each category have been compiled into one final category, and the winning beatmap's creator will be forever immortalised as an Elite Mapper.
 
-# Category Winners
+## Category Winners
 
 The winning beatmaps of each category are listed below. Remember, the contest isn't over just yet!
 
@@ -65,7 +65,7 @@ The winning beatmaps of each category are listed below. Remember, the contest is
 
 All of these entries will be guaranteed a prize at the end of the contest - congratulations!
 
-# Voting
+## Voting
 
 The above beatmaps have been compiled into one final voting category, the Grand Aspire category. This time, you can vote for up to three beatmaps. Voting will be open for just **10 days** from this post.
 

--- a/wiki/osu!_Program_Files/fr.md
+++ b/wiki/osu!_Program_Files/fr.md
@@ -97,13 +97,13 @@ Les fichiers de configurations ou fichiers CFG configurent les paramètres initi
 - `osu!.cfg`: Stocke des informations de sécurité des fichiers d'application et flux de la version actuelle d'osu!. Cela ne devrait jamais être modifié manuellement.
 - `osu!.<your PC account name>.cfg`: Stocke les données d'[Options](/wiki/Options) et d’autres paramètres de jeu. Voir [Fichier de configuration utilisateur](/wiki/osu!_Program_Files/User_Configuration_File).
 
-## .exe (Application)
+### .exe (Application)
 
 Le composant principal. Cliquez sur eux pour démarrer. Les fichiers .exe sont sûrs à ouvrir en assumant vous avez utilisé le osu!installer pour installer osu!.
 
 - osu!.exe (Démarre osu!)
 
-# Fichiers cachés 
+## Fichiers cachés 
 
 ### .dll (Extension de l'application)
 


### PR DESCRIPTION
also removes first-level headers from news posts