### PR TITLE
Update privacy policy to include mention of anti-cheat

### DIFF
--- a/wiki/Legal/Privacy/en.md
+++ b/wiki/Legal/Privacy/en.md
@@ -76,7 +76,7 @@ We respect and value your privacy and do not wish to impose fear on legitimate u
 
 ### Logging
 
-We utilise error log which collects technical and usage information as you use our services. This may include IP address, your username, browser type and version, time zone setting and location, operating system and platform and other details on what devices you use to access our services.
+We utilise error logging which collects technical and usage information as you use our services. This may include IP address, your username, browser type and version, time zone setting and location, operating system and platform and other details on what devices you use to access our services.
 
 This collected data is aggregated and only retained as it is useful. Generally the period of retention for non-aggregated data is less than one month, with automatic purge rules.
 

--- a/wiki/Legal/Privacy/en.md
+++ b/wiki/Legal/Privacy/en.md
@@ -62,7 +62,14 @@ The main purpose of this is to maintain a fair ranking system and help us enforc
 
 When completing a game session (passing or failing a beatmap), details on your performance will be automatically submitted to our server. The scoring portion of this submission includes game replay data and may be displayed publicly in the Global Leaderboards and on your User Profile and can not be deleted or modified.
 
+### Anti-cheat
 
+osu! contains executable code that is used to detect the usage of cheat software. The aim of osu!'s anti-cheat is to maintain a fair and competitive gaming environment for all players, while not affecting gameplay performance or user privacy.
+
+- Cheat detection occurs on your device and no unnecessary data is sent to our server during the detection process.
+- If the anti-cheat determines you are cheating, then this fact in addition to proof in the form of diagnostics and metadata are sent to our servers for verification. If you are not cheating, no anti-cheat data will be transmitted.
+- Even on detection, a best effort attempt is made to never send any information outside of the osu! ecosystem which could be used to personally identify you.
+- Transmitted data is only retained on our server for the duration it is useful. This is generally hours to days while we analyse the reported content.
 
 ### Logging
 

--- a/wiki/Legal/Privacy/en.md
+++ b/wiki/Legal/Privacy/en.md
@@ -69,7 +69,10 @@ osu! contains executable code that is used to detect the usage of cheat software
 - Cheat detection occurs on your device and no unnecessary data is sent to our server during the detection process.
 - If the anti-cheat determines you are cheating, then this fact in addition to proof in the form of diagnostics and metadata are sent to our servers for verification. If you are not cheating, no anti-cheat data will be transmitted.
 - Even on detection, a best effort attempt is made to never send any information outside of the osu! ecosystem which could be used to personally identify you.
-- Transmitted data is only retained on our server for the duration it is useful. This is generally hours to days while we analyse the reported content.
+- Transmitted metadata is only retained on our server for the duration it is useful. This is generally hours to days while we analyse the reported content.
+- Analysis is largely automated. Transmitted metadata is not accessible by support team members, and must be accessed via multi-layered security. Only database server admins are able to view metadata. 
+
+We respect and value your privacy and do not wish to impose fear on legitimate users by having anti-cheat present in the game.
 
 ### Logging
 

--- a/wiki/Legal/Privacy/en.md
+++ b/wiki/Legal/Privacy/en.md
@@ -62,11 +62,13 @@ The main purpose of this is to maintain a fair ranking system and help us enforc
 
 When completing a game session (passing or failing a beatmap), details on your performance will be automatically submitted to our server. The scoring portion of this submission includes game replay data and may be displayed publicly in the Global Leaderboards and on your User Profile and can not be deleted or modified.
 
-### Analytics and Logging
 
-We utilise error log collection and web analytics which collect technical and usage information as you use our services. This may include IP address, your username, browser type and version, time zone setting and location, operating system and platform and other details on what devices you use to access our services.
 
-This collected data is aggregated and only retained as it is useful. Generally the period of retention for non-aggregated data (such as error logs) is less than one month, with automatic purge rules.
+### Logging
+
+We utilise error log which collects technical and usage information as you use our services. This may include IP address, your username, browser type and version, time zone setting and location, operating system and platform and other details on what devices you use to access our services.
+
+This collected data is aggregated and only retained as it is useful. Generally the period of retention for non-aggregated data is less than one month, with automatic purge rules.
 
 ## Disclosures of your personal data
 


### PR DESCRIPTION
Probably not explicitly required, but we are looking to do things correctly (this time around) and want to ensure that users are aware of exactly how we are going about protecting their interests with no compromise.

This also removed mention of analytics since we nuked google analytics from the web. We don't analytics any more.