### PR TITLE
Fix CI failures on modifying files with quotes in name

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,8 +73,9 @@ jobs:
         run: npm install
 
       - name: run remark on changed files
+        # xargs is ran with -d '\n' to properly handle single and double quotes
         # stdout is discarded (remark prints files being checked there)
-        run: git diff --diff-filter=d --name-only ${{ github.sha }}^ ${{ github.sha }} '*.md' | xargs npx remark -qf --no-stdout --silently-ignore --report=vfile-reporter-position --color
+        run: git diff --diff-filter=d --name-only ${{ github.sha }}^ ${{ github.sha }} '*.md' | xargs -d '\n' npx remark -qf --no-stdout --silently-ignore --report=vfile-reporter-position --color
 
       - name: run yamllint on all yaml files
         uses: ibiqlik/action-yamllint@v1.0.0


### PR DESCRIPTION
As seen in #4103 / #4106.

# Summary

It's been spotted that the CI workflow will fail if any of the files changed in a PR contain single quotes (`'`) in their filenames. This is due to `xargs` treating them specially and not forwarding them in the standard manner to the command being run.

To resolve, explicitly specify `\n` as the delimiter of entries as output by `git diff --name-only`.

For the effects of this change, see the two following check runs from my fork:

- [before](https://github.com/bdach/osu-wiki/runs/1045114898) - note the `xargs` error message:

  ```
  xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
  ```

- [after](https://github.com/bdach/osu-wiki/runs/1045158900) - also a failure, but due to actual errors in the file.

# Remarks

Just using `xargs -0` doesn't work as `remark` [dies on an `ENOENT`/`No such file or directory`](https://github.com/bdach/osu-wiki/runs/1045120508?check_suite_focus=true). Not sure what that's about, as the file name as output by `remark` looks correct. Maybe it's appending a `NUL` byte or something.

If someone has a bright idea of using `\n` in a filename this might break, but hopefully that doesn't happen...