### PR TITLE
shortcut reference update timing section

### DIFF
--- a/wiki/Shortcut_key_reference/en.md
+++ b/wiki/Shortcut_key_reference/en.md
@@ -287,5 +287,5 @@ These shortcuts work anywhere within the beatmap editor:
 | Shortcut | Action |
 | :-- | :-- |
 | `T` | Set BPM and offset when tapped to the beat of the song. |
-| `Shift` while adjusting the BPM and offset | Increment 5x the normal amount. |
-| `Ctrl` while adjusting the BPM and offset | Increment less than the normal amount: by 0.25 for BPM, by 1 for offset. |
+| `Shift` while adjusting the BPM or offset | Increment 5x the normal amount. |
+| `Ctrl` while adjusting the BPM, offset, or Slider Velocity | Increment less than the normal amount. |

--- a/wiki/Shortcut_key_reference/en.md
+++ b/wiki/Shortcut_key_reference/en.md
@@ -287,5 +287,7 @@ These shortcuts work anywhere within the beatmap editor:
 | Shortcut | Action |
 | :-- | :-- |
 | `T` | Set BPM and offset when tapped to the beat of the song. |
-| `Shift` while adjusting the BPM or offset | Increment 5x the normal amount. |
-| `Ctrl` while adjusting the BPM, offset, or Slider Velocity | Increment less than the normal amount. |
+| `Shift` while adjusting BPM or offset | Increment 5x the normal amount. |
+| `Ctrl` while adjusting BPM | Increment BPM by 0.25 |
+| `Ctrl` while adjusting the offset | Increment offset by 1 |
+| `Ctrl` while adjusting the Slider Velocity | Increment by 0.1 |

--- a/wiki/Shortcut_key_reference/en.md
+++ b/wiki/Shortcut_key_reference/en.md
@@ -288,6 +288,6 @@ These shortcuts work anywhere within the beatmap editor:
 | :-- | :-- |
 | `T` | Set BPM and offset when tapped to the beat of the song. |
 | `Shift` while adjusting BPM or offset | Increment 5x the normal amount. |
-| `Ctrl` while adjusting BPM | Increment BPM by 0.25 |
-| `Ctrl` while adjusting the offset | Increment offset by 1 |
+| `Ctrl` while adjusting BPM | Increment by 0.25 |
+| `Ctrl` while adjusting the offset | Increment by 1 |
 | `Ctrl` while adjusting the Slider Velocity | Increment by 0.1 |

--- a/wiki/Shortcut_key_reference/en.md
+++ b/wiki/Shortcut_key_reference/en.md
@@ -288,6 +288,6 @@ These shortcuts work anywhere within the beatmap editor:
 | :-- | :-- |
 | `T` | Set BPM and offset when tapped to the beat of the song. |
 | `Shift` while adjusting BPM or offset | Increment 5x the normal amount. |
-| `Ctrl` while adjusting BPM | Increment by 0.25 |
-| `Ctrl` while adjusting the offset | Increment by 1 |
-| `Ctrl` while adjusting the Slider Velocity | Increment by 0.1 |
+| `Ctrl` while adjusting BPM | Increment by 0.25. |
+| `Ctrl` while adjusting offset | Increment by 1. |
+| `Ctrl` while adjusting slider velocity | Increment by 0.1. |

--- a/wiki/Shortcut_key_reference/en.md
+++ b/wiki/Shortcut_key_reference/en.md
@@ -287,4 +287,5 @@ These shortcuts work anywhere within the beatmap editor:
 | Shortcut | Action |
 | :-- | :-- |
 | `T` | Set BPM and offset when tapped to the beat of the song. |
-| `Shift` while adjusting the BPM and offset | Increment 4x the normal amount. |
+| `Shift` while adjusting the BPM and offset | Increment 5x the normal amount. |
+| `Ctrl` while adjusting the BPM and offset | Increment less than the normal amount: by 0.25 for BPM, by 1 for offset. |


### PR DESCRIPTION
It's been brought to my attention that I never updated this part back when BPM values were fixed to increment by integer values by default, so this brings it up to date and adds the previously missing CTRL option.