### PR TITLE
Conclude T2T 2019

### DIFF
--- a/wiki/Tournaments/T2T/2019/en.md
+++ b/wiki/Tournaments/T2T/2019/en.md
@@ -63,7 +63,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [sana - Packet Hero (Fuccho) [Broccoly's Extra]](https://osu.ppy.sh/beatmapsets/404910#osu/944864)
   - [DM Ashura - deltaMAX (rustbell) [Challenge]](https://osu.ppy.sh/beatmapsets/18315#osu/106965)
   - [Getty vs. DJ DiA - DropZ-Line- (Realazy) [Sing's Master]](https://osu.ppy.sh/beatmapsets/727049#osu/1674139)
-  - [xi - xi TAG compilation (Riviclia) [FREEDOM DIVE]](https://osu.ppy.sh/b/687084)
+  - [xi - xi TAG compilation (Riviclia) [FREEDOM DIVE]](. "Deleted beatmap (#687084)")
   - [System of a Down - Vicinity of Obscenity (Larto) [Impossible]](https://osu.ppy.sh/beatmapsets/13768#osu/50712)
   - [Two Door Cinema Club - Undercover Martyn (Topoi) [topoi's Last Time]](https://osu.ppy.sh/beatmapsets/734705#osu/1551121)
 - Hidden
@@ -93,7 +93,7 @@ The TAG2 Tournament 2019 was run by various community members.
 
 - NoMod
   - [Carpenter Brut - Anarchy Road (Voyen) [2070]](https://osu.ppy.sh/beatmapsets/345086#osu/762207)
-  - [UNDEAD CORPORATION - Kasha no Sakebu Yori ni (Xexxar) [idke's Combustion]](https://osu.ppy.sh/b/1845407)
+  - [UNDEAD CORPORATION - Kasha no Sakebu Yori ni (Xexxar) [idke's Combustion]](. "Deleted beatmap (#1845407)")
   - [lapix - Labyrinth (Akali) [Who's the fucking gangster?]](https://osu.ppy.sh/beatmapsets/615878#osu/1299008)
   - [Seiryu - Ultramarine (RLC) [fanzhen's Extra]](https://osu.ppy.sh/beatmapsets/107377#osu/281390)
   - [Tanya Degurechaff (CV: Yuki Aoi) - Los! Los! Los! (DJPop) [TAG2]](https://osu.ppy.sh/beatmapsets/875387#osu/1829402)

--- a/wiki/Tournaments/T2T/2019/en.md
+++ b/wiki/Tournaments/T2T/2019/en.md
@@ -1,14 +1,14 @@
 ---
 tags:
-- T2T
-- T2T2019
+  - T2T
+  - T2T2019
 ---
 
 # TAG2 Tournament 2019
 
-![T2T 2019 Logo](img/logo.png)
+![T2T 2019 logo](img/logo.png)
 
-The **TAG2 Tournament 2019** (***T2T 2019***) was an international Tag Team VS. tournament hosted by [Mara](https://osu.ppy.sh/users/194294) and [Malteser](https://osu.ppy.sh/users/5218178). It was the 3rd installment of the TAG Tournament series. The tournament followed on from [Tayo](https://osu.ppy.sh/users/8910355)'s 2 previous TAG Tournaments: [T4T 2017](https://osu.ppy.sh/community/forums/topics/624941) and [T4T 2018](https://osu.ppy.sh/community/forums/topics/789136).
+The **TAG2 Tournament 2019** (***T2T 2019***) was an international Tag Team VS. tournament hosted by ![][flag_FI] [Mara](https://osu.ppy.sh/users/194294) and ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178). It was the 3rd installment of the TAG Tournament series. The tournament followed on from ![][flag_NL] [Tayo](https://osu.ppy.sh/users/8910355)'s two previous TAG Tournaments: [T4T 2017](https://osu.ppy.sh/community/forums/topics/624941) and [T4T 2018](https://osu.ppy.sh/community/forums/topics/789136).
 
 ## Tournament Schedule
 
@@ -27,20 +27,20 @@ The **TAG2 Tournament 2019** (***T2T 2019***) was an international Tag Team VS. 
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag, profile badge |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | 2 months of osu!supporter tag |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag, profile badge |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 2 months of osu!supporter tag |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag |
 
 ## Organisation
 
-The TAG2 Tournament 2019 was run by various community members by distributing the multitude of tasks into various fields of responsibility.
+The TAG2 Tournament 2019 was run by various community members.
 
-| Position | Member(s) |
+| Position | Members |
 | --: | :-- |
 | Host | ![][flag_FI] [Mara](https://osu.ppy.sh/users/194294), ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178) |
-| Co-Host | ![][flag_FI] [Lefafel](https://osu.ppy.sh/users/2295850), ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973) |
-| Map Selector | ![][flag_CA] [Legless](https://osu.ppy.sh/users/3224243), ![][flag_GB] [Doughy](https://osu.ppy.sh/users/5275937), ![][flag_FI] [Mara](https://osu.ppy.sh/users/194294), ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178), ![][flag_US] [Junjou](https://osu.ppy.sh/users/7077648) |
-| Referee | ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973), ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178), ![][flag_FI] [Lefafel](https://osu.ppy.sh/users/2295850), ![][flag_TR] [112servis](https://osu.ppy.sh/users/3953470), ![][flag_BR] [Flow-](https://osu.ppy.sh/users/4222824), ![][flag_PL] [HAEN24](https://osu.ppy.sh/users/4390077), ![][flag_VN] [steve_04_](https://osu.ppy.sh/users/10852911), ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731), ![][flag_MY] [Stupid Idiot](https://osu.ppy.sh/users/8355574), ![][flag_US] [YoshiLover456](https://osu.ppy.sh/users/6843383), ![][flag_GR] [nikolomara](https://osu.ppy.sh/users/10077264), ![][flag_CH] [Icerite](https://osu.ppy.sh/users/7226287) |
+| Co-host | ![][flag_FI] [Lefafel](https://osu.ppy.sh/users/2295850), ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973) |
+| Map selector | ![][flag_CA] [Legless](https://osu.ppy.sh/users/3224243), ![][flag_GB] [Doughy](https://osu.ppy.sh/users/5275937), ![][flag_FI] [Mara](https://osu.ppy.sh/users/194294), ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178), ![][flag_US] [Junjou](https://osu.ppy.sh/users/7077648) |
+| Referee | ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973), ![][flag_GB] [Malteser](https://osu.ppy.sh/users/5218178), ![][flag_FI] [Lefafel](https://osu.ppy.sh/users/2295850), ![][flag_TR] [112servis](https://osu.ppy.sh/users/3953470), ![][flag_BR] [Flow-](https://osu.ppy.sh/users/4222824), ![][flag_PL] [HAEN24](https://osu.ppy.sh/users/4390077), ![][flag_VN] [steve_04\_](https://osu.ppy.sh/users/10852911), ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731), ![][flag_MY] [Stupid Idiot](https://osu.ppy.sh/users/8355574), ![][flag_US] [YoshiLover456](https://osu.ppy.sh/users/6843383), ![][flag_GR] [nikolomara](https://osu.ppy.sh/users/10077264), ![][flag_CH] [Icerite](https://osu.ppy.sh/users/7226287) |
 | Statistician | ![][flag_TR] [oralekin](https://osu.ppy.sh/users/7631823), ![][flag_NO] [YokesPai](https://osu.ppy.sh/users/6399568) |
 | Designer | ![][flag_GB] [Doomsday is Bad](https://osu.ppy.sh/users/3481378), ![][flag_FI] [Mara](https://osu.ppy.sh/users/194294) |
 
@@ -56,6 +56,7 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
 ## Mappools
 
 ### Grand Finals
+
 **[Download the mappack here! (254 MB)](https://drive.google.com/open?id=1H-kqXt2rWPbv7js7jrUSI9riPS2pu7gy)**
 
 - NoMod
@@ -87,6 +88,7 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
   - [DragonForce - Extraction Zone (Woey) [The Zone]](https://osu.ppy.sh/beatmapsets/903585#osu/1886274)
 
 ### Finals
+
 **[Download the mappack here! (220 MB)](https://drive.google.com/file/d/1wIcJdNsReVUXxJ6LEJR5Co1A3k9CGg_o)**
 
 - NoMod
@@ -116,6 +118,7 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
   - [Armin van Buuren vs. Vini Vici feat. Hilight Tribe - Great Spirit (Extended Mix) (IceKalt) [Tribal Echoes]](https://osu.ppy.sh/beatmapsets/765801#osu/1610046)
 
 ### Semifinals
+
 **[Download the mappack here! (135 MB)](https://drive.google.com/open?id=14d7uqSQRP5uBNV_LYp50hDk2tBaT2rUf)**
 
 - NoMod
@@ -145,6 +148,7 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
   - [shoujo byou - Gareki no Shuuon (Kibbleru) [Flore Albo]](https://osu.ppy.sh/beatmapsets/618290#osu/1303380)
 
 ### Quarterfinals
+
 **[Download the mappack here! (118 MB)](https://drive.google.com/open?id=1VDfbJoi26YwyCe28gELupkxGkJnnhuIe)**
 
 - NoMod
@@ -173,6 +177,7 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
   - [t+pazolite feat. Rizna - Distorted Lovesong (RLC) [Love]](https://osu.ppy.sh/beatmapsets/81694#osu/226605)
 
 ### Round of 16
+
 **[Download the mappack here! (134 MB)](https://drive.google.com/open?id=1UoUgV1rhczD19S14dRmlajWKXGo5AwX7)**
 
 - NoMod
@@ -239,58 +244,56 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
 - DoubleTime
   - [Megpoid GUMI - (raririn) Nisemono no Uta [Hard]](https://osu.ppy.sh/beatmapsets/45843#osu/142989)
 
----
-
 ## Participants
 
 | Team | Members |
 | :-: | :-- |
-|**Jelosefied** | ![][flag_GB] [deanio97](https://osu.ppy.sh/users/3284292), ![][flag_IL] [My Waifu Holo](https://osu.ppy.sh/users/10822717) |
-|**tikkayes** | ![][flag_FI] [tikkanen](https://osu.ppy.sh/users/7341081), ![][flag_FI] [Yes](https://osu.ppy.sh/users/6567244) |
-|**osu! schmosu!** | ![][flag_GB] [-Roxas](https://osu.ppy.sh/users/1986262), ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983), ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050) |
-|**KATIUSZA** | ![][flag_RU] [\_NotSoFast\_](https://osu.ppy.sh/users/4663676), ![][flag_PL] [Zabijaka](https://osu.ppy.sh/users/3526708), ![][flag_PL] [ZBUKU](https://osu.ppy.sh/users/3669758) |
-|**https:/<!---->/puu.sh/CML6I/8e0e9c5219.png** | ![][flag_DE] [Veth](https://osu.ppy.sh/users/1715441), ![][flag_DE] [okinamo](https://osu.ppy.sh/users/3765989), ![][flag_DE] [Knalli](https://osu.ppy.sh/users/8147403) |
-|**Pats** | ![][flag_PL] [Hedzio](https://osu.ppy.sh/users/8028264), ![][flag_PL] [Reazen](https://osu.ppy.sh/users/3053670), ![][flag_PL] [Pawlyk here](https://osu.ppy.sh/users/2095976) |
-|**Fat sack of cat crap** | ![][flag_NZ] [HashBrownDoyler](https://osu.ppy.sh/users/5975025), ![][flag_US] [asneakyfatcat](https://osu.ppy.sh/users/5458499) |
-|**big gem slappers** | ![][flag_LT] [shineroo](https://osu.ppy.sh/users/4360718), ![][flag_NL] [Lazer](https://osu.ppy.sh/users/1799925) |
-|**A League of Our Own** | ![][flag_NZ] [Blujae](https://osu.ppy.sh/users/10613885), ![][flag_US] [_windex](https://osu.ppy.sh/users/7107711) |
-|**Order of the Black Knights** | ![][flag_RU] [AD_GOD](https://osu.ppy.sh/users/7121899), ![][flag_RU] [Zelepupka](https://osu.ppy.sh/users/10324595), ![][flag_RU] [Liswiera](https://osu.ppy.sh/users/9356954) |
-|**Flyg slem** | ![][flag_SE] [Reedkatt](https://osu.ppy.sh/users/8335950), ![][flag_SE] [FlySlime](https://osu.ppy.sh/users/3876402) |
-|**NumZyo009** | ![][flag_US] [Num5119](https://osu.ppy.sh/users/5198060), ![][flag_US] [BearZyo](https://osu.ppy.sh/users/6116759), ![][flag_US] [Ninjaadrian009](https://osu.ppy.sh/users/7017724) |
-|**@Zenzi#8087 CS?** | ![][flag_DE] [Bakugo-](https://osu.ppy.sh/users/4990127), ![][flag_DE] [Zenzi](https://osu.ppy.sh/users/7307130), ![][flag_DE] [Sylvarus](https://osu.ppy.sh/users/4505918) |
-|**You’re cute uwu** | ![][flag_DE] [[Lucky]](https://osu.ppy.sh/users/1303685), ![][flag_DE] [DokiPon](https://osu.ppy.sh/users/3283468), ![][flag_IS] [davidercool](https://osu.ppy.sh/users/4043420) |
-|**taiko** | ![][flag_US] [closed](https://osu.ppy.sh/users/5116922), ![][flag_US] [dragonworm](https://osu.ppy.sh/users/11464752) |
-|**:sunflower:** | ![][flag_FR] [TLQ_Yoshii](https://osu.ppy.sh/users/7157133), ![][flag_GB] [DeltaZero](https://osu.ppy.sh/users/6472042), ![][flag_AU] [loveleft](https://osu.ppy.sh/users/9240047) |
-|**JMIH TEAM** | ![][flag_RU] [slivkigames1](https://osu.ppy.sh/users/11240921), ![][flag_RU] [HOMEPON](https://osu.ppy.sh/users/11978105), ![][flag_KZ] [d4rkymode](https://osu.ppy.sh/users/12743301) |
-|**deranker fan club** | ![][flag_CA] [trevrasher](https://osu.ppy.sh/users/3893420), ![][flag_PL] [Bartek22830](https://osu.ppy.sh/users/6404027), ![][flag_GB] [majoreh](https://osu.ppy.sh/users/7959222) |
-|**Thank You** | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445), ![][flag_IL] [Xilver15](https://osu.ppy.sh/users/3099689), ![][flag_US] [Conyoh](https://osu.ppy.sh/users/4844496) |
-|**idk** | ![][flag_PL] [pajwoj](https://osu.ppy.sh/users/4899393), ![][flag_GB] [Nega](https://osu.ppy.sh/users/3181083), ![][flag_LT] [PainSinger](https://osu.ppy.sh/users/697843) |
-|**sleepy squad** | ![][flag_CA] [PayneTrain](https://osu.ppy.sh/users/10275038), ![][flag_CA] [Saltystick](https://osu.ppy.sh/users/2165408) |
-|**HibikiLover** | ![][flag_HK] [[- Hibiki-]](https://osu.ppy.sh/users/5413624), ![][flag_HK] [[-Hibiki -]](https://osu.ppy.sh/users/9313951) |
-|**Lowkey Steez** | ![][flag_AU] [Jordan The Bear](https://osu.ppy.sh/users/7477458), ![][flag_AU] [uyghti](https://osu.ppy.sh/users/3641404), ![][flag_AU] [Monk Gyatso](https://osu.ppy.sh/users/4012086) |
-|**Let’s Obtain This Grain** | ![][flag_US] [Evan1](https://osu.ppy.sh/users/11951699), ![][flag_US] [Adan](https://osu.ppy.sh/users/8130565), ![][flag_US] [tux_frog](https://osu.ppy.sh/users/11951702) |
-|**De drie Jo's** | ![][flag_NL] [Mr HeliX](https://osu.ppy.sh/users/2330619), ![][flag_NL] [wooz](https://osu.ppy.sh/users/6888206), ![][flag_NL] [Damnjelly](https://osu.ppy.sh/users/1666355) |
-|**Double Siusiaczki** | ![][flag_PL] [Szago](https://osu.ppy.sh/users/2827078), ![][flag_PL] [-yeXa-](https://osu.ppy.sh/users/10344658) |
-|**Splendid Hentai Booty** | ![][flag_FI] [Urnukka](https://osu.ppy.sh/users/4765619), ![][flag_DE] [LwL](https://osu.ppy.sh/users/3556856), ![][flag_SE] [Ham Solo](https://osu.ppy.sh/users/3338630) |
-|**Souljaboii** | ![][flag_GB] [coulrulner1](https://osu.ppy.sh/users/13318606), ![][flag_GB] [Quantifiable](https://osu.ppy.sh/users/7102193) |
-|**흠** | ![][flag_KR] [Mya](https://osu.ppy.sh/users/2868952), ![][flag_KR] [Gambler](https://osu.ppy.sh/users/11415230), ![][flag_KR] [Ansol](https://osu.ppy.sh/users/7302146) |
-|**Birkano** | ![][flag_AR] [Maariianoo](https://osu.ppy.sh/users/6371395), ![][flag_AR] [-Birke-](https://osu.ppy.sh/users/3265658) |
-|**Miss Generators** | ![][flag_NL] [Turbotondel](https://osu.ppy.sh/users/9930215), ![][flag_NL] [PatyYe-](https://osu.ppy.sh/users/3929829), ![][flag_BG] [[Ted]](https://osu.ppy.sh/users/9717848) |
-|**invandrarna** | ![][flag_SE] [zhichu](https://osu.ppy.sh/users/4766629), ![][flag_DE] [silverin0](https://osu.ppy.sh/users/9099735), ![][flag_SE] [Lord Grim](https://osu.ppy.sh/users/6788374) |
-|**Coventry Convent** | ![][flag_GB] [Elit3](https://osu.ppy.sh/users/10086758), ![][flag_GB] [Rumon](https://osu.ppy.sh/users/4000985) |
-|**2 Autis** | ![][flag_ID] [Zexen](https://osu.ppy.sh/users/9102451), ![][flag_ID] [NoVaLian](https://osu.ppy.sh/users/6459827), ![][flag_ID] [Seox](https://osu.ppy.sh/users/3793938) |
-|**Wapitulas** | ![][flag_AR] [Penguo](https://osu.ppy.sh/users/4389490), ![][flag_AR] [Arua](https://osu.ppy.sh/users/5038837), ![][flag_AR] [Nykke](https://osu.ppy.sh/users/8181950) |
-|**Haven't you heard? we are the twins** | ![][flag_CA] [Bowlcut](https://osu.ppy.sh/users/4118327), ![][flag_KR] [silverlightcs](https://osu.ppy.sh/users/9862564) |
-|**Moe Watchers** | ![][flag_US] [Hot Cocoa](https://osu.ppy.sh/users/4986705), ![][flag_CA] [trevrashar](https://osu.ppy.sh/users/7031287), ![][flag_GB] [Dosh](https://osu.ppy.sh/users/7689172) |
-|**yousangumin** | ![][flag_KR] [ftg](https://osu.ppy.sh/users/2128311), ![][flag_KR] [ddm](https://osu.ppy.sh/users/7910282), ![][flag_KR] [239](https://osu.ppy.sh/users/3261991) |
-|**dont know** | ![][flag_AR] [-Urushihara-](https://osu.ppy.sh/users/6169195), ![][flag_BR] [Astris](https://osu.ppy.sh/users/6173856) |
-|**yooo whats goodie eh** | ![][flag_CA] [Vespirit](https://osu.ppy.sh/users/5425046), ![][flag_CA] [neuro](https://osu.ppy.sh/users/3737401) |
-|**succducc** | ![][flag_DE] [Coco senpai](https://osu.ppy.sh/users/2386274), ![][flag_DE] [Kawaii Kaneki](https://osu.ppy.sh/users/3344333), ![][flag_DE] [Gracidea](https://osu.ppy.sh/users/6254279) |
-|**short breads** | ![][flag_US] [Tekkito](https://osu.ppy.sh/users/7075211), ![][flag_US] [theking1212](https://osu.ppy.sh/users/3205313), ![][flag_US] [ikyy](https://osu.ppy.sh/users/10292384) |
-|**FutaLovers** | ![][flag_CO] [ElMick33](https://osu.ppy.sh/users/5458323), ![][flag_CO] [NecropedoSS](https://osu.ppy.sh/users/6273616), ![][flag_CO] [cahsun](https://osu.ppy.sh/users/6043627) |
-|**egg** | ![][flag_US] [Rysenen](https://osu.ppy.sh/users/8530170), ![][flag_CA] [FluffyEcho](https://osu.ppy.sh/users/8543980), ![][flag_US] [biscuithime](https://osu.ppy.sh/users/6567833) |
-|**Furfags OwO** | ![][flag_ES] [RivenXLukario](https://osu.ppy.sh/users/9582556), ![][flag_DE] [Umbre](https://osu.ppy.sh/users/2766034), ![][flag_BR] [[ Max ]](https://osu.ppy.sh/users/8162936) |
-|**le Pepega** | ![][flag_RU] [HullPerse](https://osu.ppy.sh/users/9469381), ![][flag_NO] [Jonbaron](https://osu.ppy.sh/users/4360885), ![][flag_SE] [momo015](https://osu.ppy.sh/users/5825443) |
+| **Jelosefied** | ![][flag_GB] [deanio97](https://osu.ppy.sh/users/3284292), ![][flag_IL] [My Waifu Holo](https://osu.ppy.sh/users/10822717) |
+| **tikkayes** | ![][flag_FI] [tikkanen](https://osu.ppy.sh/users/7341081), ![][flag_FI] [Yes](https://osu.ppy.sh/users/6567244) |
+| **osu! schmosu!** | ![][flag_GB] [-Roxas](https://osu.ppy.sh/users/1986262), ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983), ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050) |
+| **KATIUSZA** | ![][flag_RU] [\_NotSoFast\_](https://osu.ppy.sh/users/4663676), ![][flag_PL] [Zabijaka](https://osu.ppy.sh/users/3526708), ![][flag_PL] [ZBUKU](https://osu.ppy.sh/users/3669758) |
+| **https:/<!---->/puu.sh/CML6I/8e0e9c5219.png** | ![][flag_DE] [Veth](https://osu.ppy.sh/users/1715441), ![][flag_DE] [okinamo](https://osu.ppy.sh/users/3765989), ![][flag_DE] [Knalli](https://osu.ppy.sh/users/8147403) |
+| **Pats** | ![][flag_PL] [Hedzio](https://osu.ppy.sh/users/8028264), ![][flag_PL] [Reazen](https://osu.ppy.sh/users/3053670), ![][flag_PL] [Pawlyk here](https://osu.ppy.sh/users/2095976) |
+| **Fat sack of cat crap** | ![][flag_NZ] [HashBrownDoyler](https://osu.ppy.sh/users/5975025), ![][flag_US] [asneakyfatcat](https://osu.ppy.sh/users/5458499) |
+| **big gem slappers** | ![][flag_LT] [shineroo](https://osu.ppy.sh/users/4360718), ![][flag_NL] [Lazer](https://osu.ppy.sh/users/1799925) |
+| **A League of Our Own** | ![][flag_NZ] [Blujae](https://osu.ppy.sh/users/10613885), ![][flag_US] [_windex](https://osu.ppy.sh/users/7107711) |
+| **Order of the Black Knights** | ![][flag_RU] [AD_GOD](https://osu.ppy.sh/users/7121899), ![][flag_RU] [Zelepupka](https://osu.ppy.sh/users/10324595), ![][flag_RU] [Liswiera](https://osu.ppy.sh/users/9356954) |
+| **Flyg slem** | ![][flag_SE] [Reedkatt](https://osu.ppy.sh/users/8335950), ![][flag_SE] [FlySlime](https://osu.ppy.sh/users/3876402) |
+| **NumZyo009** | ![][flag_US] [Num5119](https://osu.ppy.sh/users/5198060), ![][flag_US] [BearZyo](https://osu.ppy.sh/users/6116759), ![][flag_US] [Ninjaadrian009](https://osu.ppy.sh/users/7017724) |
+| **@Zenzi#8087 CS?** | ![][flag_DE] [Bakugo-](https://osu.ppy.sh/users/4990127), ![][flag_DE] [Zenzi](https://osu.ppy.sh/users/7307130), ![][flag_DE] [Sylvarus](https://osu.ppy.sh/users/4505918) |
+| **You’re cute uwu** | ![][flag_DE] [[Lucky]](https://osu.ppy.sh/users/1303685), ![][flag_DE] [DokiPon](https://osu.ppy.sh/users/3283468), ![][flag_IS] [davidercool](https://osu.ppy.sh/users/4043420) |
+| **taiko** | ![][flag_US] [closed](https://osu.ppy.sh/users/5116922), ![][flag_US] [dragonworm](https://osu.ppy.sh/users/11464752) |
+| **:sunflower:** | ![][flag_FR] [TLQ_Yoshii](https://osu.ppy.sh/users/7157133), ![][flag_GB] [DeltaZero](https://osu.ppy.sh/users/6472042), ![][flag_AU] [loveleft](https://osu.ppy.sh/users/9240047) |
+| **JMIH TEAM** | ![][flag_RU] [slivkigames1](https://osu.ppy.sh/users/11240921), ![][flag_RU] [HOMEPON](https://osu.ppy.sh/users/11978105), ![][flag_KZ] [d4rkymode](https://osu.ppy.sh/users/12743301) |
+| **deranker fan club** | ![][flag_CA] [trevrasher](https://osu.ppy.sh/users/3893420), ![][flag_PL] [Bartek22830](https://osu.ppy.sh/users/6404027), ![][flag_GB] [majoreh](https://osu.ppy.sh/users/7959222) |
+| **Thank You** | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445), ![][flag_IL] [Xilver15](https://osu.ppy.sh/users/3099689), ![][flag_US] [Conyoh](https://osu.ppy.sh/users/4844496) |
+| **idk** | ![][flag_PL] [pajwoj](https://osu.ppy.sh/users/4899393), ![][flag_GB] [Nega](https://osu.ppy.sh/users/3181083), ![][flag_LT] [PainSinger](https://osu.ppy.sh/users/697843) |
+| **sleepy squad** | ![][flag_CA] [PayneTrain](https://osu.ppy.sh/users/10275038), ![][flag_CA] [Saltystick](https://osu.ppy.sh/users/2165408) |
+| **HibikiLover** | ![][flag_HK] [[- Hibiki-]](https://osu.ppy.sh/users/5413624), ![][flag_HK] [[-Hibiki -]](https://osu.ppy.sh/users/9313951) |
+| **Lowkey Steez** | ![][flag_AU] [Jordan The Bear](https://osu.ppy.sh/users/7477458), ![][flag_AU] [uyghti](https://osu.ppy.sh/users/3641404), ![][flag_AU] [Monk Gyatso](https://osu.ppy.sh/users/4012086) |
+| **Let’s Obtain This Grain** | ![][flag_US] [Evan1](https://osu.ppy.sh/users/11951699), ![][flag_US] [Adan](https://osu.ppy.sh/users/8130565), ![][flag_US] [tux_frog](https://osu.ppy.sh/users/11951702) |
+| **De drie Jo's** | ![][flag_NL] [Mr HeliX](https://osu.ppy.sh/users/2330619), ![][flag_NL] [wooz](https://osu.ppy.sh/users/6888206), ![][flag_NL] [Damnjelly](https://osu.ppy.sh/users/1666355) |
+| **Double Siusiaczki** | ![][flag_PL] [Szago](https://osu.ppy.sh/users/2827078), ![][flag_PL] [-yeXa-](https://osu.ppy.sh/users/10344658) |
+| **Splendid Hentai Booty** | ![][flag_FI] [Urnukka](https://osu.ppy.sh/users/4765619), ![][flag_DE] [LwL](https://osu.ppy.sh/users/3556856), ![][flag_SE] [Ham Solo](https://osu.ppy.sh/users/3338630) |
+| **Souljaboii** | ![][flag_GB] [coulrulner1](https://osu.ppy.sh/users/13318606), ![][flag_GB] [Quantifiable](https://osu.ppy.sh/users/7102193) |
+| **흠** | ![][flag_KR] [Mya](https://osu.ppy.sh/users/2868952), ![][flag_KR] [Gambler](https://osu.ppy.sh/users/11415230), ![][flag_KR] [Ansol](https://osu.ppy.sh/users/7302146) |
+| **Birkano** | ![][flag_AR] [Maariianoo](https://osu.ppy.sh/users/6371395), ![][flag_AR] [-Birke-](https://osu.ppy.sh/users/3265658) |
+| **Miss Generators** | ![][flag_NL] [Turbotondel](https://osu.ppy.sh/users/9930215), ![][flag_NL] [PatyYe-](https://osu.ppy.sh/users/3929829), ![][flag_BG] [[Ted]](https://osu.ppy.sh/users/9717848) |
+| **invandrarna** | ![][flag_SE] [zhichu](https://osu.ppy.sh/users/4766629), ![][flag_DE] [silverin0](https://osu.ppy.sh/users/9099735), ![][flag_SE] [Lord Grim](https://osu.ppy.sh/users/6788374) |
+| **Coventry Convent** | ![][flag_GB] [Elit3](https://osu.ppy.sh/users/10086758), ![][flag_GB] [Rumon](https://osu.ppy.sh/users/4000985) |
+| **2 Autis** | ![][flag_ID] [Zexen](https://osu.ppy.sh/users/9102451), ![][flag_ID] [NoVaLian](https://osu.ppy.sh/users/6459827), ![][flag_ID] [Seox](https://osu.ppy.sh/users/3793938) |
+| **Wapitulas** | ![][flag_AR] [Penguo](https://osu.ppy.sh/users/4389490), ![][flag_AR] [Arua](https://osu.ppy.sh/users/5038837), ![][flag_AR] [Nykke](https://osu.ppy.sh/users/8181950) |
+| **Haven't you heard? we are the twins** | ![][flag_CA] [Bowlcut](https://osu.ppy.sh/users/4118327), ![][flag_KR] [silverlightcs](https://osu.ppy.sh/users/9862564) |
+| **Moe Watchers** | ![][flag_US] [Hot Cocoa](https://osu.ppy.sh/users/4986705), ![][flag_CA] [trevrashar](https://osu.ppy.sh/users/7031287), ![][flag_GB] [Dosh](https://osu.ppy.sh/users/7689172) |
+| **yousangumin** | ![][flag_KR] [ftg](https://osu.ppy.sh/users/2128311), ![][flag_KR] [ddm](https://osu.ppy.sh/users/7910282), ![][flag_KR] [239](https://osu.ppy.sh/users/3261991) |
+| **dont know** | ![][flag_AR] [-Urushihara-](https://osu.ppy.sh/users/6169195), ![][flag_BR] [Astris](https://osu.ppy.sh/users/6173856) |
+| **yooo whats goodie eh** | ![][flag_CA] [Vespirit](https://osu.ppy.sh/users/5425046), ![][flag_CA] [neuro](https://osu.ppy.sh/users/3737401) |
+| **succducc** | ![][flag_DE] [Coco senpai](https://osu.ppy.sh/users/2386274), ![][flag_DE] [Kawaii Kaneki](https://osu.ppy.sh/users/3344333), ![][flag_DE] [Gracidea](https://osu.ppy.sh/users/6254279) |
+| **short breads** | ![][flag_US] [Tekkito](https://osu.ppy.sh/users/7075211), ![][flag_US] [theking1212](https://osu.ppy.sh/users/3205313), ![][flag_US] [ikyy](https://osu.ppy.sh/users/10292384) |
+| **FutaLovers** | ![][flag_CO] [ElMick33](https://osu.ppy.sh/users/5458323), ![][flag_CO] [NecropedoSS](https://osu.ppy.sh/users/6273616), ![][flag_CO] [cahsun](https://osu.ppy.sh/users/6043627) |
+| **egg** | ![][flag_US] [Rysenen](https://osu.ppy.sh/users/8530170), ![][flag_CA] [FluffyEcho](https://osu.ppy.sh/users/8543980), ![][flag_US] [biscuithime](https://osu.ppy.sh/users/6567833) |
+| **Furfags OwO** | ![][flag_ES] [RivenXLukario](https://osu.ppy.sh/users/9582556), ![][flag_DE] [Umbre](https://osu.ppy.sh/users/2766034), ![][flag_BR] [[ Max ]](https://osu.ppy.sh/users/8162936) |
+| **le Pepega** | ![][flag_RU] [HullPerse](https://osu.ppy.sh/users/9469381), ![][flag_NO] [Jonbaron](https://osu.ppy.sh/users/4360885), ![][flag_SE] [momo015](https://osu.ppy.sh/users/5825443) |
 
 [flag_AU]: /wiki/shared/flag/AU.gif
 [flag_BR]: /wiki/shared/flag/BR.gif

--- a/wiki/Tournaments/T2T/2019/en.md
+++ b/wiki/Tournaments/T2T/2019/en.md
@@ -21,7 +21,7 @@ The **TAG2 Tournament 2019** (***T2T 2019***) was an international Tag Team VS. 
 | Quarterfinals | 2019-04-20/2019-04-21 |
 | Semifinals | 2019-04-27/2019-04-28 |
 | Finals | 2019-05-04/2019-05-05 |
-| Grand Finals | 2019-05-11/2019-05-12 |
+| Grand Finals | 2019-05-18/2019-05-19 |
 
 ## Prizes
 
@@ -55,19 +55,189 @@ The TAG2 Tournament 2019 was run by various community members by distributing th
 
 ## Mappools
 
+### Grand Finals
+**[Download the mappack here! (254 MB)](https://drive.google.com/open?id=1H-kqXt2rWPbv7js7jrUSI9riPS2pu7gy)**
+
+- NoMod
+  - [sana - Packet Hero (Fuccho) [Broccoly's Extra]](https://osu.ppy.sh/beatmapsets/404910#osu/944864)
+  - [DM Ashura - deltaMAX (rustbell) [Challenge]](https://osu.ppy.sh/beatmapsets/18315#osu/106965)
+  - [Getty vs. DJ DiA - DropZ-Line- (Realazy) [Sing's Master]](https://osu.ppy.sh/beatmapsets/727049#osu/1674139)
+  - [xi - xi TAG compilation (Riviclia) [FREEDOM DIVE]](https://osu.ppy.sh/b/687084)
+  - [System of a Down - Vicinity of Obscenity (Larto) [Impossible]](https://osu.ppy.sh/beatmapsets/13768#osu/50712)
+  - [Two Door Cinema Club - Undercover Martyn (Topoi) [topoi's Last Time]](https://osu.ppy.sh/beatmapsets/734705#osu/1551121)
+- Hidden
+  - [sasakure.UK - Good Bye, Mr. Jack (Xilver15) [ReMiX]](https://osu.ppy.sh/beatmapsets/586425#osu/1241924)
+  - [twiddy - Live from the Bowling Alley (squirrelpascals) [Timmy's 10th Birthday Party!!!]](https://osu.ppy.sh/beatmapsets/873671#osu/1826150)
+  - [Konuko - Toumei Elegy (Awaken) [Skystar's Tragic Love Extra]](https://osu.ppy.sh/beatmapsets/219380#osu/790048)
+- HardRock
+  - [Natsume Chiaki - Hanairo Biyori (rinsukir) [Awaken's Challenge]](https://osu.ppy.sh/beatmapsets/143397#osu/509510)
+  - [LeaF - I (Maddy) [Terror]](https://osu.ppy.sh/beatmapsets/99244#osu/264090)
+  - [The Prodigy - Smack My Bitch Up (whymeman) [Ass Kicking]](https://osu.ppy.sh/beatmapsets/24949#osu/89171)
+- DoubleTime
+  - [Nightcore - Ravers Fantasy (LoweH) [Lizbeth's Fantasy]](https://osu.ppy.sh/beatmapsets/11558#osu/57382)
+  - [RIP SLYME - Super Shooter (Rizia) [Super Collab]](https://osu.ppy.sh/beatmapsets/296116#osu/665006)
+  - [Meramipop - Star Breaker (galvenize) [Suta]](https://osu.ppy.sh/beatmapsets/27238#osu/91476)
+  - [ITO KASHITARO - Hyakka Ryouran (appleeaterx) [Expert]](https://osu.ppy.sh/beatmapsets/617188#osu/1301421)
+- FreeMod
+  - [Savage Garden - I Want You (mtmcl) [Ridiculous]](https://osu.ppy.sh/beatmapsets/4548#osu/24428)
+  - [Shawn Wasabi + YDG feat. YUNG GEMMY - Burnt Rice (Aiobahn & Jh-Anu Remix) (handsome) [Master]](https://osu.ppy.sh/beatmapsets/519256#osu/1103732)
+  - [LIQU@. - Yotogibanashi no Kamikakushi (Kyubey) [Miryokuteki na Shijuu Kekkai]](https://osu.ppy.sh/beatmapsets/236396#osu/547566)
+  - [Black Hole - Pluto (7odoa) [Challenge]](https://osu.ppy.sh/beatmapsets/45074#osu/146957)
+- Tiebreaker
+  - [DragonForce - Extraction Zone (Woey) [The Zone]](https://osu.ppy.sh/beatmapsets/903585#osu/1886274)
+
+### Finals
+**[Download the mappack here! (220 MB)](https://drive.google.com/file/d/1wIcJdNsReVUXxJ6LEJR5Co1A3k9CGg_o)**
+
+- NoMod
+  - [Carpenter Brut - Anarchy Road (Voyen) [2070]](https://osu.ppy.sh/beatmapsets/345086#osu/762207)
+  - [UNDEAD CORPORATION - Kasha no Sakebu Yori ni (Xexxar) [idke's Combustion]](https://osu.ppy.sh/b/1845407)
+  - [lapix - Labyrinth (Akali) [Who's the fucking gangster?]](https://osu.ppy.sh/beatmapsets/615878#osu/1299008)
+  - [Seiryu - Ultramarine (RLC) [fanzhen's Extra]](https://osu.ppy.sh/beatmapsets/107377#osu/281390)
+  - [Tanya Degurechaff (CV: Yuki Aoi) - Los! Los! Los! (DJPop) [TAG2]](https://osu.ppy.sh/beatmapsets/875387#osu/1829402)
+  - [Niko - Made of Fire (lesjuh) [Oni]](https://osu.ppy.sh/beatmapsets/10112#osu/40017)
+- Hidden
+  - [TSUNKU - Kumitate Koujou (CookieBite) [Ameth's Scale]](https://osu.ppy.sh/beatmapsets/504165#osu/1077307)
+  - [rerulili, Moja ft.Rib - Seisou Bakuretsu Boy (Midge) [mark lee]](https://osu.ppy.sh/beatmapsets/526508#osu/1117247)
+  - [yuikonnu - Ghost Rule (Len) [Sonnyc's Insane]](https://osu.ppy.sh/beatmapsets/440650#osu/1573659)
+- HardRock
+  - [IOSYS - Club Ibuki in Break All (TheMefisto) [Extra Stage]](https://osu.ppy.sh/beatmapsets/751755#osu/1582549)
+  - [Gekidan Hitotose - Curtain Call!!!!! (Left) [fieryrage & Left's Ex]](https://osu.ppy.sh/beatmapsets/633693#osu/1344836)
+  - [Wagakki Band - Senbonzakura (pkk) [Death Blossom]](https://osu.ppy.sh/beatmapsets/427508#osu/922916)
+- DoubleTime
+  - [IOSYS - Chanteikku Sanyousei no Itazura Daisensou (Kochiya Sanae) [Lunatic]](https://osu.ppy.sh/beatmapsets/24448#osu/92188)
+  - [Sana - Terekakushi Shishunki (litoluna) [Insane]](https://osu.ppy.sh/beatmapsets/202677#osu/479354)
+  - [Xe vs. cYsmix - Youkai Festival Shrine Road (Mirash) [Collab Lunatic]](https://osu.ppy.sh/beatmapsets/582274#osu/1232252)
+- FreeMod
+  - [Yunomi - Mentai Cosmic (alacat) [Extra]](https://osu.ppy.sh/beatmapsets/436773#osu/940706)
+  - [goreshit - beautiful loli thing (kiri09) [little 09]](https://osu.ppy.sh/beatmapsets/172546#osu/416971)
+  - [Frederic - oddloop (n0ah) [oldnoob]](https://osu.ppy.sh/beatmapsets/536872#osu/1142960)
+- Tiebreaker
+  - [Armin van Buuren vs. Vini Vici feat. Hilight Tribe - Great Spirit (Extended Mix) (IceKalt) [Tribal Echoes]](https://osu.ppy.sh/beatmapsets/765801#osu/1610046)
+
+### Semifinals
+**[Download the mappack here! (135 MB)](https://drive.google.com/open?id=14d7uqSQRP5uBNV_LYp50hDk2tBaT2rUf)**
+
+- NoMod
+  - [Reol - Asymmetry (Gaia) [captin's Extra]](https://osu.ppy.sh/beatmapsets/292077#osu/679779)
+  - [onoken - K8107 (MaridiuS) [Red Another]](https://osu.ppy.sh/beatmapsets/807396#osu/1694521)
+  - [TatshMusicCircle - Raikou -3rd Desire- (Kite) [Extra]](https://osu.ppy.sh/beatmapsets/143316#osu/1836851)
+  - [PUP - Mabu (Hobbes2) [Extreme]](https://osu.ppy.sh/beatmapsets/762836#osu/1603957)
+  - [YURRY CANON - Nadeshiko color Heart (kwk) [Saturnalize's Extra]](https://osu.ppy.sh/beatmapsets/682996#osu/1463294)
+  - [succducc - me & u (Nathan) [together]](https://osu.ppy.sh/beatmapsets/699749#osu/1481624)
+- Hidden
+  - [Amane - BOOZEHOUND (den0saur) [old? new?]](https://osu.ppy.sh/beatmapsets/854235#osu/1785185)
+  - [Indica - Pahinta Tanaan (Morbon) [Mene pois]](https://osu.ppy.sh/beatmapsets/419466#osu/907760)
+  - [Chitose Sara - Merry Merry Go Round (SHOT MUSIC Asterisk Remix) (Settia) [Remix]](https://osu.ppy.sh/beatmapsets/535279#osu/1133815)
+- HardRock
+  - [nao - Dimension tripper!!!! ([Minakami Yuki]) [Supreme]](https://osu.ppy.sh/beatmapsets/126749#osu/321973)
+  - [dark cat - STARS ALIGN (Nozhomi) [Shooting Star]](https://osu.ppy.sh/beatmapsets/606998#osu/1282215)
+  - [Foreground Eclipse - I Bet You'll Forget That Even If You Noticed That (Seni) [Extra]](https://osu.ppy.sh/beatmapsets/601135#osu/1398002)
+- DoubleTime
+  - [ClariS - Connect (bakabaka) [Insane]](https://osu.ppy.sh/beatmapsets/26116#osu/88302)
+  - [SYNC.ART'S feat. Nakamura Meiko - Sword of Valiant (Sandpig) [Lunatic]](https://osu.ppy.sh/beatmapsets/25001#osu/89576)
+  - [Touyama Nao - Magical Mah-jongg World (Fycho) [Insane]](https://osu.ppy.sh/beatmapsets/74687#osu/259519)
+- FreeMod
+  - [Hatsune Miku - Sakura Zensen Ijou Nashi (Lalarun) [Ijou Nashi]](https://osu.ppy.sh/beatmapsets/32021#osu/104945)
+  - [Major Lazer - Sua Cara (feat. Anitta & Pabllo Vittar) (handsome) [byfar's extra]](https://osu.ppy.sh/beatmapsets/720615#osu/1665735)
+  - [Shin Hae Chul - Sticks and Stones (Bikko) [Madness]](https://osu.ppy.sh/beatmapsets/18826#osu/66514)
+- Tiebreaker
+  - [shoujo byou - Gareki no Shuuon (Kibbleru) [Flore Albo]](https://osu.ppy.sh/beatmapsets/618290#osu/1303380)
+
+### Quarterfinals
+**[Download the mappack here! (118 MB)](https://drive.google.com/open?id=1VDfbJoi26YwyCe28gELupkxGkJnnhuIe)**
+
+- NoMod
+  - [DECO*27 - First Storm -Japanese Version- (RepL4y) [Asami's Expert]](https://osu.ppy.sh/beatmapsets/808175#osu/1785865)
+  - [Nanahoshi Kangengakudan - Meikaruza (pkk) [Extra]](https://osu.ppy.sh/beatmapsets/302756#osu/701033)
+  - [Aoki Chihiro - Kodou (09kami) [MMMMMMMMaster!!!!!!]](https://osu.ppy.sh/beatmapsets/687511#osu/1454845)
+  - [ESTi - HELIX (Edit ver.) (Catzzye) [EX+]](https://osu.ppy.sh/beatmapsets/730814#osu/1804040)
+  - [EGOIST - Eiyuu Unmei no Uta (TV Edit) (Handsome) [yf's Insane]](https://osu.ppy.sh/beatmapsets/637050#osu/1426311)
+- Hidden
+  - [SHIKI - Pure Ruby (tsuka) [Another]](https://osu.ppy.sh/beatmapsets/39325#osu/125448)
+  - [Renard - Da Nu Nuttah (GamerX4life) [Nogard]](https://osu.ppy.sh/beatmapsets/62665#osu/205282)
+  - [LeaF - MEPHISTO (Alumetorz) [Extra]](https://osu.ppy.sh/beatmapsets/106212#osu/278451)
+- HardRock
+  - [Fear, and Loathing in Las Vegas - Swing It!! (Guy) [Extra]](https://osu.ppy.sh/beatmapsets/204159#osu/482147)
+  - [Momoi Haruko - Luka Luka Night Fever (Lunah) [Lissette's Insane]](https://osu.ppy.sh/beatmapsets/21724#osu/83925)
+- DoubleTime
+  - [Suzuki Konomi - THERE IS A REASON (Doormat) [KALIBE'S INSANE]](https://osu.ppy.sh/beatmapsets/641718#osu/1385091)
+  - [Flo Rida - Run ft. RedFoo of LMFAO (Speed Up Ver.) (ohad1881) [A Mystery's Insane]](https://osu.ppy.sh/beatmapsets/283731#osu/682966)
+  - [senya - Kimi to Dareka no Yasashisa ni (kakifly) [Affection]](https://osu.ppy.sh/beatmapsets/250337#osu/596161)
+- FreeMod
+  - [Suzuki Konomi - Blow out (Kalibe) [Linadeft's Extra]](https://osu.ppy.sh/beatmapsets/617203#osu/1324163)
+  - [Apocalyptica - Hall of the Mountain King (pishifat) [VI]](https://osu.ppy.sh/beatmapsets/340399#osu/753100)
+  - [Wiklund - Billy Boogie (yeahyeahyeahhh) [16 bits?!]](https://osu.ppy.sh/beatmapsets/9040#osu/36547)
+  - [M2U feat. Guriri - Magnolia (-kevincela-) [AngelHoney's ExtrA]](https://osu.ppy.sh/beatmapsets/128645#osu/367175)
+- Tiebreaker
+  - [t+pazolite feat. Rizna - Distorted Lovesong (RLC) [Love]](https://osu.ppy.sh/beatmapsets/81694#osu/226605)
+
+### Round of 16
+**[Download the mappack here! (134 MB)](https://drive.google.com/open?id=1UoUgV1rhczD19S14dRmlajWKXGo5AwX7)**
+
+- NoMod
+  - [t+pazolite - cheatreal (caren_sk) [RLC's Extra]](https://osu.ppy.sh/beatmapsets/88180#osu/442170)
+  - [Function Phantom - Paradox (byfar) [Sing's Another]](https://osu.ppy.sh/beatmapsets/824125#osu/1734156)
+  - [wa. - Black Lotus (Realazy) [fanzhen's Insane]](https://osu.ppy.sh/beatmapsets/679918#osu/1440976)
+  - [A.SAKA - Nanatsu Issenzakura (yf_bmp) [Expert]](https://osu.ppy.sh/beatmapsets/513731#osu/1091511)
+  - [Glamour of the Kill - A Hope in Hell (ykcarrot) [Hopeless]](https://osu.ppy.sh/beatmapsets/31814#osu/104389)
+- Hidden
+  - [SHK - Identity Part 4 (AngelHoney) [Insane]](https://osu.ppy.sh/beatmapsets/39428#osu/125702)
+  - [TSUNKU - Remix 10 Perfect Version (ktgster) [ezpz]](https://osu.ppy.sh/beatmapsets/597994#osu/1264052)
+  - [cYsmix - Manic (Bonsai) [Extra]](https://osu.ppy.sh/beatmapsets/361214#osu/804683)
+- HardRock
+  - [Blackhole - Lagomorphic (happy623) [Lagomorph]](https://osu.ppy.sh/beatmapsets/74664#osu/211889)
+  - [UNISON SQUARE GARDEN - Sakura no Ato (all quartets lead to the?) (TV Size) (Nevo) [Glaceon's Insane]](https://osu.ppy.sh/beatmapsets/565004#osu/1872246)
+  - [ZUN - Year-Round Absorbed Curiosity (saymun) [Insane]](https://osu.ppy.sh/beatmapsets/19515#osu/68581)
+- DoubleTime
+  - [Yuuhei Satellite - Overwrite to Ingenuousness (Leorda) [Lunatic]](https://osu.ppy.sh/beatmapsets/59133#osu/177425)
+  - [Kozato - 45nen no Yukizakura (LoliSora) [Hyper]](https://osu.ppy.sh/beatmapsets/50771#osu/155931)
+  - [ClariS - Anata ni FIT (Guy) [Insane]](https://osu.ppy.sh/beatmapsets/47708#osu/148653)
+- FreeMod
+  - [Hanataba - Night of Knights (v2b) [DJPop's Extra Stage]](https://osu.ppy.sh/beatmapsets/5445#osu/26726)
+  - [Akiyama Uni - Kanpan Tasogare Shinbun (09kami) [Extra]](https://osu.ppy.sh/beatmapsets/388036#osu/848084)
+  - [GRANRODEO - Can Do (TV Size) (Monstrata) [Extra: Murasakibara]](https://osu.ppy.sh/beatmapsets/493273#osu/1051587)
+- Tiebreaker
+  - [Camellia - Bassline Yatteru? w (Mir) [Line Line Line]](https://osu.ppy.sh/beatmapsets/715913#osu/1512691)
+
+### Group Stage
+
+**[Download the mappack here! (124 MB)](https://drive.google.com/open?id=1F4FqZEzF3J5-HDhl30rzlgXmxivMegAu)**
+
+- NoMod
+  - [iojjj - Akui to Ai no Sukima no Puzzle (Okoratu) [Diplomatic Immunity]](https://osu.ppy.sh/beatmapsets/147430#osu/517595)
+  - [SEVENTEEN - VERY NICE (Nattu) [NATSU & EUNY'S AJU EXTRA]](https://osu.ppy.sh/beatmapsets/618500#osu/1312697)
+  - [KAKU P-MODEL - Big Brother (Voli) [Challenge]](https://osu.ppy.sh/beatmapsets/472440#osu/1009530)
+  - [Powerless - Frey's Philosophy (My Angel Azusa) [Flask's Insane]](https://osu.ppy.sh/beatmapsets/550588#osu/1187297)
+  - [Nanahoshi Kangengakudan feat.Matsushita - Dance Number o Tomo ni (pkk) [deetz' Insane]](https://osu.ppy.sh/beatmapsets/353398#osu/821336)
+- Hidden
+  - [Acme Iku - chaosmaid (demo) (qilliam) [chaosmaid]](https://osu.ppy.sh/beatmapsets/38720#osu/123872)
+  - [An - artcore JINJA (Flower) [Lunatic]](https://osu.ppy.sh/beatmapsets/114987#osu/297411)
+- HardRock
+  - [Project Grimoire - Caliburne ~Story of the Legendary sword~ (Mikkuri) [iyasine's Insane]](https://osu.ppy.sh/beatmapsets/335665#osu/747240)
+  - [Omoi - Chiisana Koi no Uta (Synth Rock Cover) (val0108) [Insane]](https://osu.ppy.sh/beatmapsets/609189#osu/1419961)
+- DoubleTime
+  - [livetune feat. Hatsune Miku - Tell Your World (Colin Hou) [Hard]](https://osu.ppy.sh/beatmapsets/42110#osu/147605)
+  - [Red Velvet - Russian Roulette (Natsu) [Insane]](https://osu.ppy.sh/beatmapsets/510568#osu/1089041)
+- FreeMod
+  - [Madotsuki@ - Ikanaide (sheela901) [Insane]](https://osu.ppy.sh/beatmapsets/315799#osu/703905)
+  - [IOSYS - RE:Usatei (OzzyOzrock) [Lunatic]](https://osu.ppy.sh/beatmapsets/31343#osu/103020)
+- Tiebreaker
+  - **[t+pazolite - Nous (Chocopikel) [Destruction]](https://osu.ppy.sh/beatmapsets/42669#osu/134130)**
+
 ### Qualifiers
 
 **[Download the mappack here! (33 MB)](https://puu.sh/D4s4A/a995511d8a.zip)**
 
 - NoMod
-  - [Railgun Roulette (VIP) \[LowBot's Insane\] \(NielPerry\)](https://osu.ppy.sh/beatmapsets/694402#osu/1501410)
-  - [xi - Aragami \[Another\] \(Sayaka-\)](https://osu.ppy.sh/beatmapsets/225377#osu/529358)
+  - [Railgun Roulette (VIP) (NielPerry) [LowBot's Insane]](https://osu.ppy.sh/beatmapsets/694402#osu/1501410)
+  - [xi - Aragami (Sayaka-) [Another]](https://osu.ppy.sh/beatmapsets/225377#osu/529358)
 - Hidden
-  - [Putin's Boner \[Alphabet's Insane\] \(Exile-\)](https://osu.ppy.sh/beatmapsets/339939#osu/752560)
+  - [Putin's Boner (Exile-) [Alphabet's Insane]](https://osu.ppy.sh/beatmapsets/339939#osu/752560)
 - HardRock
-  - [Shawn Wasabi - Marble Soda \[Insane\] \(Exa\)](https://osu.ppy.sh/beatmapsets/313718#osu/700321)
+  - [Shawn Wasabi - (Exa) Marble Soda [Insane]](https://osu.ppy.sh/beatmapsets/313718#osu/700321)
 - DoubleTime
-  - [Megpoid GUMI - Nisemono no Uta \[Hard\] \(raririn\)](https://osu.ppy.sh/beatmapsets/45843#osu/142989)
+  - [Megpoid GUMI - (raririn) Nisemono no Uta [Hard]](https://osu.ppy.sh/beatmapsets/45843#osu/142989)
 
 ---
 

--- a/wiki/Tournaments/T2T/2019/en.md
+++ b/wiki/Tournaments/T2T/2019/en.md
@@ -295,33 +295,33 @@ The TAG2 Tournament 2019 was run by various community members.
 | **Furfags OwO** | ![][flag_ES] [RivenXLukario](https://osu.ppy.sh/users/9582556), ![][flag_DE] [Umbre](https://osu.ppy.sh/users/2766034), ![][flag_BR] [[ Max ]](https://osu.ppy.sh/users/8162936) |
 | **le Pepega** | ![][flag_RU] [HullPerse](https://osu.ppy.sh/users/9469381), ![][flag_NO] [Jonbaron](https://osu.ppy.sh/users/4360885), ![][flag_SE] [momo015](https://osu.ppy.sh/users/5825443) |
 
-[flag_AU]: /wiki/shared/flag/AU.gif
-[flag_BR]: /wiki/shared/flag/BR.gif
-[flag_CA]: /wiki/shared/flag/CA.gif
-[flag_DE]: /wiki/shared/flag/DE.gif
-[flag_FI]: /wiki/shared/flag/FI.gif
-[flag_FR]: /wiki/shared/flag/FR.gif
-[flag_GB]: /wiki/shared/flag/GB.gif
-[flag_HK]: /wiki/shared/flag/HK.gif
-[flag_IL]: /wiki/shared/flag/IL.gif
-[flag_IS]: /wiki/shared/flag/IS.gif
-[flag_KZ]: /wiki/shared/flag/KZ.gif
-[flag_LT]: /wiki/shared/flag/LT.gif
-[flag_MY]: /wiki/shared/flag/MY.gif
-[flag_NL]: /wiki/shared/flag/NL.gif
-[flag_NO]: /wiki/shared/flag/NO.gif
-[flag_NZ]: /wiki/shared/flag/NZ.gif
-[flag_PL]: /wiki/shared/flag/PL.gif
-[flag_RU]: /wiki/shared/flag/RU.gif
-[flag_SE]: /wiki/shared/flag/SE.gif
-[flag_TR]: /wiki/shared/flag/TR.gif
-[flag_US]: /wiki/shared/flag/US.gif
-[flag_KR]: /wiki/shared/flag/KR.gif
-[flag_AR]: /wiki/shared/flag/AR.gif
-[flag_VN]: /wiki/shared/flag/VN.gif
-[flag_GR]: /wiki/shared/flag/GR.gif
-[flag_ID]: /wiki/shared/flag/ID.gif
-[flag_BG]: /wiki/shared/flag/BG.gif
-[flag_ES]: /wiki/shared/flag/ES.gif
-[flag_CO]: /wiki/shared/flag/CO.gif
-[flag_CH]: /wiki/shared/flag/CH.gif
+[flag_AR]: /wiki/shared/flag/AR.gif "Argentina"
+[flag_AU]: /wiki/shared/flag/AU.gif "Australia"
+[flag_BG]: /wiki/shared/flag/BG.gif "Bulgaria"
+[flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CH]: /wiki/shared/flag/CH.gif "Switzerland"
+[flag_CO]: /wiki/shared/flag/CO.gif "Colombia"
+[flag_DE]: /wiki/shared/flag/DE.gif "Germany"
+[flag_ES]: /wiki/shared/flag/ES.gif "Spain"
+[flag_FI]: /wiki/shared/flag/FI.gif "Finland"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "United Kingdom"
+[flag_GR]: /wiki/shared/flag/GR.gif "Greece"
+[flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
+[flag_ID]: /wiki/shared/flag/ID.gif "Indonesia"
+[flag_IL]: /wiki/shared/flag/IL.gif "Israel"
+[flag_IS]: /wiki/shared/flag/IS.gif "Iceland"
+[flag_KR]: /wiki/shared/flag/KR.gif "South Korea"
+[flag_KZ]: /wiki/shared/flag/KZ.gif "Kazakhstan"
+[flag_LT]: /wiki/shared/flag/LT.gif "Lithuania"
+[flag_MY]: /wiki/shared/flag/MY.gif "Malaysia"
+[flag_NL]: /wiki/shared/flag/NL.gif "Netherlands"
+[flag_NO]: /wiki/shared/flag/NO.gif "Norway"
+[flag_NZ]: /wiki/shared/flag/NZ.gif "New Zealand"
+[flag_PL]: /wiki/shared/flag/PL.gif "Poland"
+[flag_RU]: /wiki/shared/flag/RU.gif "Russian Federation"
+[flag_SE]: /wiki/shared/flag/SE.gif "Sweden"
+[flag_TR]: /wiki/shared/flag/TR.gif "Turkey"
+[flag_US]: /wiki/shared/flag/US.gif "United States"
+[flag_VN]: /wiki/shared/flag/VN.gif "Vietnam"

--- a/wiki/Tournaments/T2T/2019/en.md
+++ b/wiki/Tournaments/T2T/2019/en.md
@@ -76,8 +76,8 @@ The TAG2 Tournament 2019 was run by various community members.
   - [The Prodigy - Smack My Bitch Up (whymeman) [Ass Kicking]](https://osu.ppy.sh/beatmapsets/24949#osu/89171)
 - DoubleTime
   - [Nightcore - Ravers Fantasy (LoweH) [Lizbeth's Fantasy]](https://osu.ppy.sh/beatmapsets/11558#osu/57382)
-  - [RIP SLYME - Super Shooter (Rizia) [Super Collab]](https://osu.ppy.sh/beatmapsets/296116#osu/665006)
-  - [Meramipop - Star Breaker (galvenize) [Suta]](https://osu.ppy.sh/beatmapsets/27238#osu/91476)
+  - [RIP SLYME - Super Shooter (galvenize) [Super Collab (T2T Edit)]](. "Deleted beatmap (#2033721)")
+  - [Meramipop - Star Breaker (Rizia) [Suta]](https://osu.ppy.sh/beatmapsets/296116#osu/665006)
   - [ITO KASHITARO - Hyakka Ryouran (appleeaterx) [Expert]](https://osu.ppy.sh/beatmapsets/617188#osu/1301421)
 - FreeMod
   - [Savage Garden - I Want You (mtmcl) [Ridiculous]](https://osu.ppy.sh/beatmapsets/4548#osu/24428)
@@ -85,7 +85,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [LIQU@. - Yotogibanashi no Kamikakushi (Kyubey) [Miryokuteki na Shijuu Kekkai]](https://osu.ppy.sh/beatmapsets/236396#osu/547566)
   - [Black Hole - Pluto (7odoa) [Challenge]](https://osu.ppy.sh/beatmapsets/45074#osu/146957)
 - Tiebreaker
-  - [DragonForce - Extraction Zone (Woey) [The Zone]](https://osu.ppy.sh/beatmapsets/903585#osu/1886274)
+  - **[DragonForce - Extraction Zone (Woey) [The Zone]](https://osu.ppy.sh/beatmapsets/903585#osu/1886274)**
 
 ### Finals
 
@@ -100,7 +100,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [Niko - Made of Fire (lesjuh) [Oni]](https://osu.ppy.sh/beatmapsets/10112#osu/40017)
 - Hidden
   - [TSUNKU - Kumitate Koujou (CookieBite) [Ameth's Scale]](https://osu.ppy.sh/beatmapsets/504165#osu/1077307)
-  - [rerulili, Moja ft.Rib - Seisou Bakuretsu Boy (Midge) [mark lee]](https://osu.ppy.sh/beatmapsets/526508#osu/1117247)
+  - [Rib - Seisou Bakuretsu Boy (Midge) [mark lee]](https://osu.ppy.sh/beatmapsets/526508#osu/1117247)
   - [yuikonnu - Ghost Rule (Len) [Sonnyc's Insane]](https://osu.ppy.sh/beatmapsets/440650#osu/1573659)
 - HardRock
   - [IOSYS - Club Ibuki in Break All (TheMefisto) [Extra Stage]](https://osu.ppy.sh/beatmapsets/751755#osu/1582549)
@@ -115,7 +115,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [goreshit - beautiful loli thing (kiri09) [little 09]](https://osu.ppy.sh/beatmapsets/172546#osu/416971)
   - [Frederic - oddloop (n0ah) [oldnoob]](https://osu.ppy.sh/beatmapsets/536872#osu/1142960)
 - Tiebreaker
-  - [Armin van Buuren vs. Vini Vici feat. Hilight Tribe - Great Spirit (Extended Mix) (IceKalt) [Tribal Echoes]](https://osu.ppy.sh/beatmapsets/765801#osu/1610046)
+  - **[Armin van Buuren vs. Vini Vici feat. Hilight Tribe - Great Spirit (Extended Mix) (IceKalt) [Tribal Echoes]](https://osu.ppy.sh/beatmapsets/765801#osu/1610046)**
 
 ### Semifinals
 
@@ -145,18 +145,18 @@ The TAG2 Tournament 2019 was run by various community members.
   - [Major Lazer - Sua Cara (feat. Anitta & Pabllo Vittar) (handsome) [byfar's extra]](https://osu.ppy.sh/beatmapsets/720615#osu/1665735)
   - [Shin Hae Chul - Sticks and Stones (Bikko) [Madness]](https://osu.ppy.sh/beatmapsets/18826#osu/66514)
 - Tiebreaker
-  - [shoujo byou - Gareki no Shuuon (Kibbleru) [Flore Albo]](https://osu.ppy.sh/beatmapsets/618290#osu/1303380)
+  - **[shoujo byou - Gareki no Shuuon (Kibbleru) [Flore Albo]](https://osu.ppy.sh/beatmapsets/618290#osu/1303380)**
 
 ### Quarterfinals
 
 **[Download the mappack here! (118 MB)](https://drive.google.com/open?id=1VDfbJoi26YwyCe28gELupkxGkJnnhuIe)**
 
 - NoMod
-  - [DECO*27 - First Storm -Japanese Version- (RepL4y) [Asami's Expert]](https://osu.ppy.sh/beatmapsets/808175#osu/1785865)
+  - [DECO\*27 - First Storm -Japanese Version- (RepL4y) [Asami's Expert]](https://osu.ppy.sh/beatmapsets/808175#osu/1785865)
   - [Nanahoshi Kangengakudan - Meikaruza (pkk) [Extra]](https://osu.ppy.sh/beatmapsets/302756#osu/701033)
   - [Aoki Chihiro - Kodou (09kami) [MMMMMMMMaster!!!!!!]](https://osu.ppy.sh/beatmapsets/687511#osu/1454845)
   - [ESTi - HELIX (Edit ver.) (Catzzye) [EX+]](https://osu.ppy.sh/beatmapsets/730814#osu/1804040)
-  - [EGOIST - Eiyuu Unmei no Uta (TV Edit) (Handsome) [yf's Insane]](https://osu.ppy.sh/beatmapsets/637050#osu/1426311)
+  - [EGOIST - Eiyuu Unmei no Uta (TV Edit) (handsome) [yf's Insane]](https://osu.ppy.sh/beatmapsets/637050#osu/1426311)
 - Hidden
   - [SHIKI - Pure Ruby (tsuka) [Another]](https://osu.ppy.sh/beatmapsets/39325#osu/125448)
   - [Renard - Da Nu Nuttah (GamerX4life) [Nogard]](https://osu.ppy.sh/beatmapsets/62665#osu/205282)
@@ -174,7 +174,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [Wiklund - Billy Boogie (yeahyeahyeahhh) [16 bits?!]](https://osu.ppy.sh/beatmapsets/9040#osu/36547)
   - [M2U feat. Guriri - Magnolia (-kevincela-) [AngelHoney's ExtrA]](https://osu.ppy.sh/beatmapsets/128645#osu/367175)
 - Tiebreaker
-  - [t+pazolite feat. Rizna - Distorted Lovesong (RLC) [Love]](https://osu.ppy.sh/beatmapsets/81694#osu/226605)
+  - **[t+pazolite feat. Rizna - Distorted Lovesong (RLC) [Love]](https://osu.ppy.sh/beatmapsets/81694#osu/226605)**
 
 ### Round of 16
 
@@ -203,7 +203,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [Akiyama Uni - Kanpan Tasogare Shinbun (09kami) [Extra]](https://osu.ppy.sh/beatmapsets/388036#osu/848084)
   - [GRANRODEO - Can Do (TV Size) (Monstrata) [Extra: Murasakibara]](https://osu.ppy.sh/beatmapsets/493273#osu/1051587)
 - Tiebreaker
-  - [Camellia - Bassline Yatteru? w (Mir) [Line Line Line]](https://osu.ppy.sh/beatmapsets/715913#osu/1512691)
+  - **[Camellia - Bassline Yatteru? w (Mir) [Line Line Line]](https://osu.ppy.sh/beatmapsets/715913#osu/1512691)**
 
 ### Group Stage
 
@@ -211,7 +211,7 @@ The TAG2 Tournament 2019 was run by various community members.
 
 - NoMod
   - [iojjj - Akui to Ai no Sukima no Puzzle (Okoratu) [Diplomatic Immunity]](https://osu.ppy.sh/beatmapsets/147430#osu/517595)
-  - [SEVENTEEN - VERY NICE (Nattu) [NATSU & EUNY'S AJU EXTRA]](https://osu.ppy.sh/beatmapsets/618500#osu/1312697)
+  - [SEVENTEEN - VERY NICE (Natsu) [NATSU & EUNY'S AJU EXTRA]](https://osu.ppy.sh/beatmapsets/618500#osu/1312697)
   - [KAKU P-MODEL - Big Brother (Voli) [Challenge]](https://osu.ppy.sh/beatmapsets/472440#osu/1009530)
   - [Powerless - Frey's Philosophy (My Angel Azusa) [Flask's Insane]](https://osu.ppy.sh/beatmapsets/550588#osu/1187297)
   - [Nanahoshi Kangengakudan feat.Matsushita - Dance Number o Tomo ni (pkk) [deetz' Insane]](https://osu.ppy.sh/beatmapsets/353398#osu/821336)
@@ -219,7 +219,7 @@ The TAG2 Tournament 2019 was run by various community members.
   - [Acme Iku - chaosmaid (demo) (qilliam) [chaosmaid]](https://osu.ppy.sh/beatmapsets/38720#osu/123872)
   - [An - artcore JINJA (Flower) [Lunatic]](https://osu.ppy.sh/beatmapsets/114987#osu/297411)
 - HardRock
-  - [Project Grimoire - Caliburne ~Story of the Legendary sword~ (Mikkuri) [iyasine's Insane]](https://osu.ppy.sh/beatmapsets/335665#osu/747240)
+  - [Project Grimoire - Caliburne \~Story of the Legendary sword\~ (Mikkuri) [iyasine's Insane]](https://osu.ppy.sh/beatmapsets/335665#osu/747240)
   - [Omoi - Chiisana Koi no Uta (Synth Rock Cover) (val0108) [Insane]](https://osu.ppy.sh/beatmapsets/609189#osu/1419961)
 - DoubleTime
   - [livetune feat. Hatsune Miku - Tell Your World (Colin Hou) [Hard]](https://osu.ppy.sh/beatmapsets/42110#osu/147605)
@@ -235,14 +235,14 @@ The TAG2 Tournament 2019 was run by various community members.
 **[Download the mappack here! (33 MB)](https://puu.sh/D4s4A/a995511d8a.zip)**
 
 - NoMod
-  - [Railgun Roulette (VIP) (NielPerry) [LowBot's Insane]](https://osu.ppy.sh/beatmapsets/694402#osu/1501410)
+  - [Camellia vs Akira Complex - Railgun Roulette (VIP) (NeilPerry) [LowBot's Insane]](https://osu.ppy.sh/beatmapsets/694402#osu/1501410)
   - [xi - Aragami (Sayaka-) [Another]](https://osu.ppy.sh/beatmapsets/225377#osu/529358)
 - Hidden
-  - [Putin's Boner (Exile-) [Alphabet's Insane]](https://osu.ppy.sh/beatmapsets/339939#osu/752560)
+  - [Helblinde - Putin's Boner (Hanczer) [Alphabet's Insane]](https://osu.ppy.sh/beatmapsets/339939#osu/752560)
 - HardRock
-  - [Shawn Wasabi - (Exa) Marble Soda [Insane]](https://osu.ppy.sh/beatmapsets/313718#osu/700321)
+  - [Shawn Wasabi - Marble Soda (Exa) [Insane]](https://osu.ppy.sh/beatmapsets/313718#osu/700321)
 - DoubleTime
-  - [Megpoid GUMI - (raririn) Nisemono no Uta [Hard]](https://osu.ppy.sh/beatmapsets/45843#osu/142989)
+  - [Megpoid GUMI - Nisemono no Uta (raririn) [Hard]](https://osu.ppy.sh/beatmapsets/45843#osu/142989)
 
 ## Participants
 


### PR DESCRIPTION
Sorry for this very late PR of the updated T2T 2019 wiki page
* Adds all mappools from Round of 32 to Grand Finals
* Updates the schedule to reflect the schedule of the actual tournament
* Fixed up the formatting for the Group Stage pool