### PR TITLE
Fix languages listing on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 * text=auto
 *.md text eol=lf
+
+# Fixes languages listing on GitHub
+.remarkrc.js linguist-detectable=false
+news/**/*.md linguist-detectable
+wiki/**/*.md linguist-detectable


### PR DESCRIPTION
this thing

![](https://user-images.githubusercontent.com/9954349/98492352-6d9df900-21ec-11eb-99b3-3ef432d8241b.png)

you can see it working on my master branch where I applied this commit https://github.com/cl8n/osu-wiki