### PR TITLE
Correctly update last update date of privacy policy

### DIFF
--- a/wiki/Legal/Privacy/en.md
+++ b/wiki/Legal/Privacy/en.md
@@ -4,7 +4,7 @@ legal: true
 
 # osu! privacy policy
 
-Last Updated 25th May 2018. [View history here](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Privacy/en.md)
+Last Updated 24th August 2020. [View history here](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Privacy/en.md)
 
 In addition to this policy, please also make sure to visit and understand our [Terms of Service](https://osu.ppy.sh/legal/terms).
 


### PR DESCRIPTION
The update date in the page wasn't updated despite the content having several updates. The result is the translations say "outdated" despite having same "last update" date compared to English.

Either this or just remove the sentence completely leaving only link to the history page.