### PR TITLE
Update Alumni listing and Spotlights managers

### DIFF
--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -22,7 +22,7 @@ The Beatmap Spotlights project is run by various community members across all ga
 | Role | Members |
 | :-- | :-- |
 | Project lead | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) |
-| Project manager | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870), ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284), ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) |
+| Project manager | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870), ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) |
 | Website manager | ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_US] [Snowleopard](https://osu.ppy.sh/users/3790227) |
 
 ## Curators

--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -22,7 +22,7 @@ The Beatmap Spotlights project is run by various community members across all ga
 | Role | Members |
 | :-- | :-- |
 | Project lead | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) |
-| Project manager | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870), ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) |
+| Project manager | ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) |
 | Website manager | ![][flag_PL] [Venix](https://osu.ppy.sh/users/5999631), ![][flag_US] [Snowleopard](https://osu.ppy.sh/users/3790227) |
 
 ## Curators

--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -176,7 +176,6 @@ The project lead has changed several times in its history. ![][flag_US] [Sapphir
 Renamed to [Beatmap Spotlights](https://osu.ppy.sh/home/news/2017-03-18-introducing-to-you-spotlights) in March 2017, the system itself stayed mostly consistent while adding additional rewards like medals and enhancing the presentation of the Beatmap Spotlights furtherly. During an internal overhaul of the Quality Assurance Team, the responsibility for the project has been reassigned to ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) and re-implemented a community-based selection team. In November 2018, the frequency of the Spotlights have been changed to a [seasonal release cycle](https://osu.ppy.sh/home/news/2018-11-01-beatmap-spotlights-summer-2018). In March 2020, ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) rejoined the project lead together with Kurokami, both reworking it into a new shape and assembling a new team of osu! curators.
 
 [flag_AU]: /wiki/shared/flag/AU.gif "Australia"
-[flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
 [flag_CN]: /wiki/shared/flag/CN.gif "China"
 [flag_DE]: /wiki/shared/flag/DE.gif "Germany"

--- a/wiki/People/The_Team/osu!_Alumni/en.md
+++ b/wiki/People/The_Team/osu!_Alumni/en.md
@@ -114,7 +114,6 @@ The [osu! Alumni group page](https://osu.ppy.sh/groups/16) lists all of the memb
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Chat Moderator |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Chat Moderator |

--- a/wiki/People/The_Team/osu!_Alumni/es.md
+++ b/wiki/People/The_Team/osu!_Alumni/es.md
@@ -116,7 +116,6 @@ Los **osu! Alumni** son miembros retirados o inactivos que realizaron importante
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Moderador del Chat |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Moderador del Chat |

--- a/wiki/People/The_Team/osu!_Alumni/id.md
+++ b/wiki/People/The_Team/osu!_Alumni/id.md
@@ -114,7 +114,6 @@ Halaman daftar [osu! Alumni](https://osu.ppy.sh/groups/16).
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Chat Moderator |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Chat Moderator |

--- a/wiki/People/The_Team/osu!_Alumni/pt-br.md
+++ b/wiki/People/The_Team/osu!_Alumni/pt-br.md
@@ -118,7 +118,6 @@ A [página de grupo dos osu! Alumni](https://osu.ppy.sh/groups/16) listam todos 
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Moderador de Chat |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Moderador de Chat |

--- a/wiki/People/The_Team/osu!_Alumni/ru.md
+++ b/wiki/People/The_Team/osu!_Alumni/ru.md
@@ -114,7 +114,6 @@
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Модератор чата |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Модератор чата |

--- a/wiki/People/The_Team/osu!_Alumni/tr.md
+++ b/wiki/People/The_Team/osu!_Alumni/tr.md
@@ -114,7 +114,6 @@
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Sohbet Moderatörü |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT, GMT, QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT, QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | Sohbet Moderatörü |

--- a/wiki/People/The_Team/osu!_Alumni/zh.md
+++ b/wiki/People/The_Team/osu!_Alumni/zh.md
@@ -121,7 +121,6 @@ tags:
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | 聊天室管理员 |
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | BAT，GMT，QAT |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | QAT |
-| ![][flag_BR] [Kuron-kun](https://osu.ppy.sh/users/2697284) | GMT，QAT |
 | ![][flag_CL] [Kylecito](https://osu.ppy.sh/users/488) | BAT |
 | ![][flag_CA] [Kytoxid](https://osu.ppy.sh/users/98460) | BAT |
 | ![][flag_RU] [La Cataline](https://osu.ppy.sh/users/301279) | 聊天室管理员 |

--- a/wiki/Staff_Log/2020/en.md
+++ b/wiki/Staff_Log/2020/en.md
@@ -463,6 +463,7 @@ Abbreviations for user groups are used throughout this log:
 - 2020-11-15: Removed [Maeglwn](https://osu.ppy.sh/users/2440936) from **osu! Alumni**
 - 2020-11-16: Added [Intermezzo](https://osu.ppy.sh/users/136842) to **osu! Alumni**
 - 2020-11-16: Removed [Flanster](https://osu.ppy.sh/users/447818) from **GMT**
+- 2020-11-16: Removed [Kuron-kun](https://osu.ppy.sh/users/2697284) from **osu! Alumni**
 
 ### Beatmap Nominators
 
@@ -485,4 +486,4 @@ Abbreviations for user groups are used throughout this log:
 - 2020-11-06: Removed [Kawawa](https://osu.ppy.sh/users/4647754) from **BN**
 - 2020-11-14: Removed [incandescence](https://osu.ppy.sh/users/6256027) from **Probationary BN**
 
-<!-- last update: 2020-11-16 00:00 UTC removed flanster from gmt -->
+<!-- last update: 2020-11-16 12:30 UTC removed kuron-kun from alumni -->


### PR DESCRIPTION
Apparently, Kuron-kun's removal wasn't addressed during the last staff listing update.
- Removed [Kuron-kun](https://osu.ppy.sh/users/2697284) from osu! Alumni and Spotlights managers
- Removed [Chaos](https://osu.ppy.sh/users/2628870) from Spotlights managers
- Updated Staff Log