### PR TITLE
Terms of Service & Community Rules Update: Volunteer responsibility, reporting abuse & keeping it clean

### DIFF
--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -67,11 +67,11 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified perilod of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 

--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -57,8 +57,8 @@ Instances of abusive, harassing, or otherwise unacceptable behavior by any volun
 
 The community leaders who have access to this inbox are named as:
 
-* [peppy](https://osu.ppy.sh/users/2) ([pe@ppy.sh](mailto:pe@ppy.sh))
-* [Ephemeral](https://osu.ppy.sh/users/102335) ([ephemeral@ppy.sh](mailto:ephemeral@ppy.sh))
+- [peppy](https://osu.ppy.sh/users/2) ([pe@ppy.sh](mailto:pe@ppy.sh))
+- [Ephemeral](https://osu.ppy.sh/users/102335) ([ephemeral@ppy.sh](mailto:ephemeral@ppy.sh))
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -2,54 +2,38 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+Examples of behavior that contributes to a positive environment for our community include:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
 Community leaders have the right and responsibility to remove, edit or reject other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
@@ -62,66 +46,43 @@ The community leaders who have access to this inbox are named as:
 
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified perilod of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by 
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
 at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org

--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit or reject other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior by any volunteer contributors may be reported to the osu!team via email at [abuse@ppy.sh](mailto:abuse@ppy.sh).
+
+The community leaders who have access to this inbox are named as:
+
+* [peppy](https://osu.ppy.sh/users/2) ([pe@ppy.sh](mailto:pe@ppy.sh))
+* [Ephemeral](https://osu.ppy.sh/users/102335) ([ephemeral@ppy.sh](mailto:ephemeral@ppy.sh))
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -2,8 +2,7 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 

--- a/wiki/Contributor_Code_of_Conduct/en.md
+++ b/wiki/Contributor_Code_of_Conduct/en.md
@@ -77,7 +77,7 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -90,9 +90,12 @@ osu! contains a number of volunteer teams at any given point in time that are dr
 - The Global Moderation Team
 - The Support Team
 
-No users below the age of 18 may attain or retain membership in any of the volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (``support@ppy.sh``) where appropriate proof of identity documents are sighted.
+Certain groups from this list are considered as "elevated volunteer teams" and have heavier requirements for participation. These are listed as follows:
 
-Should you become a member of any of the teams listed above, you agree to follow the [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in full as adapted for this service from the [Contributor Covenant version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+- The Global Moderation Team
+- The Nomination Assessment Team
+
+No users below the age of 18 may attain or retain membership in any of the elevated volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (``support@ppy.sh``) where appropriate proof of identity documents are sighted.
 
 ## PRIVACY POLICIES
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -84,13 +84,13 @@ osu! reserves the right to remove Content and User Submissions without prior not
 
 osu! contains a number of volunteer teams at any given point in time that are drawn directly from the community. These teams are often invested with extra permissions and access to functions that ordinary users do not have in order to facilitate the community-driven aspect of the game. These officially supported teams are as follows:
 
-* The Beatmap Nominator Group
-* The Tournament Staff
-* The Nomination Assessment Team
-* The Global Moderation Team
-* The Support Team
+- The Beatmap Nominator Group
+- The Tournament Staff
+- The Nomination Assessment Team
+- The Global Moderation Team
+- The Support Team
 
-No users below the age of 18 may attain or retain membership in any of the volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (support@ppy.sh) where appropriate proof of identity documents are sighted.
+No users below the age of 18 may attain or retain membership in any of the volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (``support@ppy.sh``) where appropriate proof of identity documents are sighted.
 
 Should you become a member of any of the teams listed above, you agree to follow the [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in full as adapted for this service from the [Contributor Covenant version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -80,6 +80,20 @@ osu! does not endorse any User Submission or any opinion, recommendation, or adv
 osu! does not permit copyright infringing activities and infringement of intellectual property rights on its Website, and osu! will remove all Content and User Submissions if properly notified that such Content or User Submission infringes on another's intellectual property rights.
 osu! reserves the right to remove Content and User Submissions without prior notice.
 
+## YOUR RESPONSIBILITIES IN VOLUNTEER POSITIONS
+
+osu! contains a number of volunteer teams at any given point in time that are drawn directly from the community. These teams are often invested with extra permissions and access to functions that ordinary users do not have in order to facilitate the community-driven aspect of the game. These officially supported teams are as follows:
+
+* The Beatmap Nominator Group
+* The Tournament Staff
+* The Nomination Assessment Team
+* The Global Moderation Team
+* The Support Team
+
+No users below the age of 18 may attain or retain membership in any of the volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (support@ppy.sh) where appropriate proof of identity documents are sighted.
+
+Should you become a member of any of the teams listed above, you agree to follow the [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in full as adapted for this service from the [Contributor Covenant version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+
 ## PRIVACY POLICIES
 
 osu! finds your privacy most important, and we value your use of our services.

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -4,7 +4,7 @@ legal: true
 
 # osu! terms of service
 
-Last Updated 25th May 2018. [View history here](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Terms/en.md)
+Last Updated 17th November 2020. [View history here](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Terms/en.md)
 
 **ppy Pty Ltd** is offering you a service, which is conditioned on your acceptance, without any modification whatsoever to the following terms, conditions, and notices.
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -82,20 +82,12 @@ osu! reserves the right to remove Content and User Submissions without prior not
 
 ## YOUR RESPONSIBILITIES IN VOLUNTEER POSITIONS
 
-osu! contains a number of volunteer teams at any given point in time that are drawn directly from the community. These teams are often invested with extra permissions and access to functions that ordinary users do not have in order to facilitate the community-driven aspect of the game. These officially supported teams are as follows:
-
-- The Beatmap Nominator Group
-- The Tournament Staff
-- The Nomination Assessment Team
-- The Global Moderation Team
-- The Support Team
-
-Certain groups from this list are considered as "elevated volunteer teams" and have heavier requirements for participation. These are listed as follows:
+osu! contains a number of volunteer teams at any given point in time that are drawn directly from the community. Certain teams require extra permissions and access in order to facilitate the community-driven aspect of the game. Such teams are as follows:
 
 - The Global Moderation Team
 - The Nomination Assessment Team
 
-No users below the age of 18 may attain or retain membership in any of the elevated volunteer positions outlined above. The age of an applying user will be confirmed via a short process with osu! support (``support@ppy.sh``) where appropriate proof of identity documents are sighted.
+No users below the age of 18 may attain membership in any of the teams listed above.
 
 ## PRIVACY POLICIES
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -84,8 +84,8 @@ osu! reserves the right to remove Content and User Submissions without prior not
 
 osu! contains a number of volunteer teams at any given point in time that are drawn directly from the community. Certain teams require extra permissions and access in order to facilitate the community-driven aspect of the game. Such teams are as follows:
 
-- The Global Moderation Team
-- The Nomination Assessment Team
+- [The Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team)
+- [The Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team)
 
 No users below the age of 18 may attain membership in any of the teams listed above.
 

--- a/wiki/Legal/Terms/en.md
+++ b/wiki/Legal/Terms/en.md
@@ -4,7 +4,7 @@ legal: true
 
 # osu! terms of service
 
-Last Updated 17th November 2020. [View history here](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Terms/en.md)
+Last Updated 17th November 2020. [View history](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Terms/en.md)
 
 **ppy Pty Ltd** is offering you a service, which is conditioned on your acceptance, without any modification whatsoever to the following terms, conditions, and notices.
 

--- a/wiki/People/The_Team/Global_Moderation_Team/en.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/en.md
@@ -11,7 +11,7 @@ The **Global Moderation Team** (formerly known as the Global Mod Team, Administr
 
 **All Global Moderators are sworn to uphold [the Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in addition to the normal [Community Rules](/wiki/Rules).**
 
-If you encounter any member of the Global Moderation Team acting inappropriately (or acting in violation of the Contributor Code of Conduct), please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
+If you encounter any member of the Global Moderation Team acting inappropriately (or acting in violation of the Contributor Code of Conduct), please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [Reporting Abuse](/wiki/Reporting_Bad_Behaviour/Abuse).
 
 ## Roles and responsibilities
 

--- a/wiki/People/The_Team/Global_Moderation_Team/en.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/en.md
@@ -11,7 +11,7 @@ The **Global Moderation Team** (formerly known as the Global Mod Team, Administr
 
 **All Global Moderators are sworn to uphold [the Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in addition to the normal [Community Rules](/wiki/Rules).**
 
-If you encounter any member of the Global Moderator Team acting inappropriately (or acting in violation of the Contributor Code of Conduct), please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
+If you encounter any member of the Global Moderation Team acting inappropriately (or acting in violation of the Contributor Code of Conduct), please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
 
 ## Roles and responsibilities
 

--- a/wiki/People/The_Team/Global_Moderation_Team/en.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/en.md
@@ -9,6 +9,10 @@ tags:
 
 The **Global Moderation Team** (formerly known as the Global Mod Team, Administrators, or GreenBAT), commonly referred to as **GMT**, are members of the community who are focused primarily on player moderation and issues pertinent to the team and the community at large.
 
+**All Global Moderators are sworn to uphold [the Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in addition to the normal [Community Rules](/wiki/Rules).**
+
+If you encounter any member of the Global Moderator Team acting inappropriately (or acting in violation of the Contributor Code of Conduct), please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
+
 ## Roles and responsibilities
 
 The Global Moderation Team is responsible for the welfare of the chat and forum, and takes care of interactions within the community. They should be approached with any questions pertaining the moderation aspect of the game, which would include (but is not limited to) issues with chat (e.g. silences or harassment) and the forum (e.g. spam or inappropriate comments).

--- a/wiki/People/The_Team/Nomination_Assessment_Team/en.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/en.md
@@ -11,7 +11,7 @@ Members of the NAT are distinguished by their red username and user title. Like 
 
 **All members of the Nomination Assessment Team are sworn to uphold [the Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in addition to the normal [Community Rules](/wiki/Rules).**
 
-If you encounter any member of the Nomination Assessment Team acting inappropriately, please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
+If you encounter any member of the Nomination Assessment Team acting inappropriately, please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [Reporting Abuse](/wiki/Reporting_Bad_Behaviour/Abuse).
 
 ## Responsibilities
 

--- a/wiki/People/The_Team/Nomination_Assessment_Team/en.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/en.md
@@ -9,6 +9,10 @@ The **Nomination Assessment Team** (***NAT***) are the moderators of the [Beatma
 
 Members of the NAT are distinguished by their red username and user title. Like the [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*), they have site-wide moderation permissions and a dark red username in the game's chat channels.
 
+**All members of the Nomination Assessment Team are sworn to uphold [the Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) in addition to the normal [Community Rules](/wiki/Rules).**
+
+If you encounter any member of the Nomination Assessment Team acting inappropriately, please contact [abuse@ppy.sh](mailto:abuse@ppy.sh) at once with as much information as possible. For more details, see [this article](/wiki/Reporting_Bad_Behaviour/Abuse).
+
 ## Responsibilities
 
 The NAT are responsible for a variety of mapping-related tasks that can be separated into four subcategories:

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -43,7 +43,7 @@ If the post still isn't gone within a reasonable timeframe, please send an email
 
 ### On a public osu! related Discord server
 
-Immediately block the user by right-clicking their username and selecting ``Block`` in the drop-down list that appears.
+Immediately block the user by right-clicking their username and selecting `Block` in the drop-down list that appears.
 
 Afterwards, contact the administrators of the server at once by looking for someone at the very top of the users list and let them know what's happened. If you can't figure out who is an administrator, look for someone with a crown next to their name - they are the server owner and are responsible for what happens within it.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -51,6 +51,16 @@ Should this abuse continue and the administrators do nothing about it, [please n
 
 In addition, if you know the osu! username of the person bothering you, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible and it will be investigated promptly.
 
+### On a Twitter linked to an osu! user's profile
+
+Click the three dots in the top right of the problem tweet and click 'Report Tweet'. Make sure to follow the prompts and read them carefully. You might also want to [read this link](https://help.twitter.com/en/safety-and-security/report-abusive-behavior) for more information on the process.
+
+Afterwards, either block or mute the user in question by clicking the three dots in the top right of their tweet (if you're using the website or mobile client). Consult [this link](https://help.twitter.com/en/using-twitter/blocking-and-unblocking-accounts) for more information.
+
+Please be aware that the person you block will be aware that you have blocked them if they check your Twitter profile. If you are worried this will make the problem worse elsewhere, mute them instead. This will still remove their tweets from your timeline and prevent you from seeing any more content from them, but they will still be able to see all the tweets you make and can comment on them.
+
+If the tweet is from an account which is linked to an osu! player's profile via our website (it will appear underneath their avatar and join date beside a stylized bird icon), please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing a copy of the tweet in image form wherever possible, and any other information you can think of.
+
 ## A member of one of the volunteer teams (NAT, GMT, BN) is approaching/talking/acting towards me inappropriately!
 
 Send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible **immediately**.

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -4,7 +4,7 @@
 
 Please do.
 
-If you're uncomfortable enough that you're reading this page, please contact us at once at [abuse@ppy.sh](mailto:abuse@ppy.sh) with as much detail about your problem as you can.
+If you're uncomfortable enough that you're reading this page, please contact us at once at [abuse@ppy.sh](mailto:abuse@ppy.sh) with as much detail about your problem as possible.
 
 We have zero tolerance towards any sort of unwanted sexual attention or advances in this community.
 
@@ -25,7 +25,7 @@ Immediately block the user by right-clicking their username and selecting `Ignor
 
 You should also report them immediately by clicking the `Report User` button and filling in the prompts.
 
-If you feel the remarks/advances were highly inappropriate or you are an underage user, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
+If you feel the remarks/advances were highly inappropriate or you are an underage user, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible.
 
 ### In a public post on the osu! forums
 
@@ -37,17 +37,17 @@ Click the button with an envelope in it just below the user's country flag. This
 
 Paste a link to the forum post that contains the problematic content and tell the GMT a little bit about what's going on. They will remove the post for you as soon as they are able.
 
-You can also report the post by opening up your game and typing `!report <person> <problem>`, where  `<person>` is the username of the person causing you problems, and `<problem>` is the link to the post followed by a short explanation.
+You can also report the post by opening up your game and typing `!report <person> <problem>`, where  `<person>` is the username of the person causing you problems, and `<problem>` is the link to the post followed by a short explanation. If there are spaces in the person's username, please replace them with underscores (`_`).
 
-If the post still isn't gone within a reasonable timeframe, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
+If the post still isn't gone within a reasonable timeframe, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible.
 
-### On a public osu! related Discord server
+### On a public osu!–related Discord server
 
 Immediately block the user by right-clicking their username and selecting `Block` in the drop-down list that appears.
 
 Afterwards, contact the administrators of the server at once by looking for someone at the very top of the users list and let them know what's happened. If you can't figure out who is an administrator, look for someone with a crown next to their name - they are the server owner and are responsible for what happens within it.
 
-Should this abuse continue and the administrators do nothing about it, [please notify the Discord Trust & Safety team by filing out a report using this link.](https://dis.gd/request)
+Should this abuse continue and the administrators do nothing about it, [please notify the Discord Trust & Safety team by filing out a report](https://dis.gd/request).
 
 In addition, if you know the osu! username of the person bothering you, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible and it will be investigated promptly.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -61,7 +61,7 @@ Please be aware that the person you block will be aware that you have blocked th
 
 If the tweet is from an account which is linked to an osu! player's profile via our website (it will appear underneath their avatar and join date beside a stylized bird icon), please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing a copy of the tweet in image form wherever possible, and any other information you can think of.
 
-## A member of one of the volunteer teams (NAT, GMT, BN) is approaching/talking/acting towards me inappropriately!
+## A member of one of the volunteer teams (NAT, GMT) is approaching/talking/acting towards me inappropriately!
 
 Send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible **immediately**.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -21,9 +21,9 @@ Scroll through the sub-headings below to find out what to do, depending on where
 
 ### In the in-game chat
 
-Immediately block the user by right-clicking their username and selecting ``Ignore User``.
+Immediately block the user by right-clicking their username and selecting `Ignore User`.
 
-You should also report them immediately by clicking the ``Report User`` button and filling in the prompts.
+You should also report them immediately by clicking the `Report User` button and filling in the prompts.
 
 If you feel the remarks/advances were highly inappropriate or you are an underage user, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -53,11 +53,11 @@ In addition, if you know the osu! username of the person bothering you, please s
 
 ### On a Twitter linked to an osu! user's profile
 
-Click the three dots in the top right of the problem tweet and click 'Report Tweet'. Make sure to follow the prompts and read them carefully. You might also want to [read this link](https://help.twitter.com/en/safety-and-security/report-abusive-behavior) for more information on the process.
+Click the three dots in the top right of the problem tweet and click 'Report Tweet'. Make sure to follow the prompts and read them carefully. You might also want to read [Twitter's guide on reporting abusive behaviour](https://help.twitter.com/en/safety-and-security/report-abusive-behavior) for more information on the process.
 
-Afterwards, either block or mute the user in question by clicking the three dots in the top right of their tweet (if you're using the website or mobile client). Consult [this link](https://help.twitter.com/en/using-twitter/blocking-and-unblocking-accounts) for more information.
+Afterwards, either block or mute the user in question by clicking the three dots in the top right of their tweet (if you're using the website or mobile client). Consult [Twitter's guide on blocking accounts](https://help.twitter.com/en/using-twitter/blocking-and-unblocking-accounts) for more information.
 
-Please be aware that the person you block will be aware that you have blocked them if they check your Twitter profile. If you are worried this will make the problem worse elsewhere, mute them instead. This will still remove their tweets from your timeline and prevent you from seeing any more content from them, but they will still be able to see all the tweets you make and can comment on them.
+Please be aware that the person will see you have blocked them if they check your Twitter profile. If you are worried this will make the problem worse elsewhere, mute them instead. This will remove their tweets from your timeline and prevent you from seeing any more content from them, but they will still be able to see and comment on all the tweets you make.
 
 If the tweet is from an account which is linked to an osu! player's profile via our website (it will appear underneath their avatar and join date beside a stylized bird icon), please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing a copy of the tweet in image form wherever possible, and any other information you can think of.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -1,6 +1,6 @@
 # Reporting Abuse
 
-## I don't know if I should report this or not...
+## I don't know if I should report this or not
 
 Yes, you should!
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -37,7 +37,7 @@ Click the button with an envelope in it just below the user's country flag. This
 
 Paste a link to the forum post that contains the problematic content and tell the GMT a little bit about what's going on. They will remove the post for you as soon as they are able.
 
-You can also report the post by opening up your game and typing ``!report <person> <problem>``, where  ``<person>`` is the username of the person causing you problems, and ``<problem>`` is the link to the post followed by a short explanation.
+You can also report the post by opening up your game and typing `!report <person> <problem>`, where  `<person>` is the username of the person causing you problems, and `<problem>` is the link to the post followed by a short explanation.
 
 If the post still isn't gone within a reasonable timeframe, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -51,7 +51,7 @@ Should this abuse continue and the administrators do nothing about it, [please n
 
 In addition, if you know the osu! username of the person bothering you, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible and it will be investigated promptly.
 
-## A member of one of the volunteer teams (NAT, GMT) is approaching/talking/acting towards me inappropriately!
+## A member of one of the volunteer teams (NAT, GMT, BN) is approaching/talking/acting towards me inappropriately!
 
 Send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible **immediately**.
 

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -1,0 +1,66 @@
+# Reporting Abuse
+
+## I don't know if I should report this or not...
+
+Yes, you should!
+
+If you're uncomfortable enough that you're reading this page, please contact us at once at [abuse@ppy.sh](mailto:abuse@ppy.sh) with as much detail about your problem as you can.
+
+We have zero tolerance towards any sort of unwanted sexual attention or advances in this community.
+
+The abuse email address is only seen by these two users:
+
+- [peppy](https://osu.ppy.sh/users/2) (the creator of the game)
+- [Ephemeral](https://osu.ppy.sh/users/102335) (the community manager)
+
+Nothing you send to [abuse@ppy.sh](mailto:abuse@ppy.sh) will ever be shared with anybody else other than those two people.
+
+## Someone's made inappropriate sexual advances or remarks towards me!
+
+Scroll through the sub-headings below to find out what to do, depending on where this all happened.
+
+### In the in-game chat
+
+Immediately block the user by right-clicking their username and selecting ``Ignore User``.
+
+You should also report them immediately by clicking the ``Report User`` button and filling in the prompts.
+
+If you feel the remarks/advances were highly inappropriate or you are an underage user, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
+
+### In a public post on the osu! forums
+
+Report the post to any member of our [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) as soon as possible.
+
+To do so, click the username of any GMT member in the list on that page. This will take you to their profile. If you are unsure of who to click, just use [this link instead](https://osu.ppy.sh/users/102335).
+
+Click the button with an envelope in it just below the user's country flag. This will take you to the chat screen.
+
+Paste a link to the forum post that contains the problematic content and tell the GMT a little bit about what's going on. They will remove the post for you as soon as they are able.
+
+You can also report the post by opening up your game and typing ``!report <person> <problem>``, where  ``<person>`` is the username of the person causing you problems, and ``<problem>`` is the link to the post followed by a short explanation.
+
+If the post still isn't gone within a reasonable timeframe, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as you can.
+
+### On a public osu! related Discord server
+
+Immediately block the user by right-clicking their username and selecting ``Block`` in the drop-down list that appears.
+
+Afterwards, contact the administrators of the server at once by looking for someone at the very top of the users list and let them know what's happened. If you can't figure out who is an administrator, look for someone with a crown next to their name - they are the server owner and are responsible for what happens within it.
+
+Should this abuse continue and the administrators do nothing about it, [please notify the Discord Trust & Safety team by filing out a report using this link.](https://dis.gd/request)
+
+In addition, if you know the osu! username of the person bothering you, please send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible and it will be investigated promptly.
+
+## A member of one of the volunteer teams (NAT, GMT) is approaching/talking/acting towards me inappropriately!
+
+Send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing as much information as possible **immediately**.
+
+If anything you want to include makes you feel embarrassed, please blank it out. This includes screenshots, chat logs, basically anything you can attach to an email.
+
+We'll look into it as soon as we can.
+
+## Someone I know is being abused by a member of the volunteer teams (NAT, GMT) but is too afraid to speak up!
+
+Send an email to [abuse@ppy.sh](mailto:abuse@ppy.sh) containing everything you know with as much evidence as you can get.
+
+If you don't have any evidence but only stories or rumors that you believe are substantial enough to act on, please send us an email anyway. We take complaints like this very seriously and will look deeply into every report.

--- a/wiki/Reporting_Bad_Behaviour/Abuse/en.md
+++ b/wiki/Reporting_Bad_Behaviour/Abuse/en.md
@@ -2,7 +2,7 @@
 
 ## I don't know if I should report this or not
 
-Yes, you should!
+Please do.
 
 If you're uncomfortable enough that you're reading this page, please contact us at once at [abuse@ppy.sh](mailto:abuse@ppy.sh) with as much detail about your problem as you can.
 

--- a/wiki/Rules/en.md
+++ b/wiki/Rules/en.md
@@ -9,7 +9,7 @@ These rules are the basis from which we help keep the osu! community a fun and w
 3. **Be good to each other.** Harassment or other antagonism has no place within the osu! community. We're here to click circles, beat drums, catch fruit, and hit up to eighteen keys at once, not to be assholes to each other.
 4. **Don't be a douche.** If at any point you are uncertain as to whether you are breaking this rule, you probably are.
 5. **We are an all-ages community.** This means that 18+/[NSFW](https://en.wikipedia.org/wiki/Not_safe_for_work) content such as drug use or topics of a sexual nature are not welcome here.
-6. **Keep it clean.** osu! is not the place for dating or flirting. Using sexual language, imagery or making advances on other members of the community in public or private is NOT okay. If you ever feel uncomfortable with how someone is talking to you, [report it to us confidentially](/wiki/Reporting_Bad_Behaviour/Abuse) so we can help you and potentially prevent others from being affected.
+6. **Keep it clean.** osu! is not the place for dating or flirting. Using sexual language, imagery or making unwanted advances on other members of the community in public or private is NOT okay. If you ever feel uncomfortable with how someone is talking to you, [report it to us confidentially](/wiki/Reporting_Bad_Behaviour/Abuse) so we can help you (and potentially prevent others from being affected).
 7. **Where the rules do not prevail, common sense shall.** The administration has explicit discretion to apply their judgment on this as they see fit.
 
 ## In-game chat rules

--- a/wiki/Rules/en.md
+++ b/wiki/Rules/en.md
@@ -8,8 +8,9 @@ These rules are the basis from which we help keep the osu! community a fun and w
 2. **Play fair.** Using third-party utilities of any kind to get any sort of advantage is not okay. This includes things like macro programs, aim-assist programs, timescale modification, and so on. If a program is doing something to help you play the game that you should be doing yourself, it isn't okay!
 3. **Be good to each other.** Harassment or other antagonism has no place within the osu! community. We're here to click circles, beat drums, catch fruit, and hit up to eighteen keys at once, not to be assholes to each other.
 4. **Don't be a douche.** If at any point you are uncertain as to whether you are breaking this rule, you probably are.
-5. **We are an all-ages community.** This means that 18+/[NSFW](https://en.wikipedia.org/wiki/Not_safe_for_work) content such as drug use or topics of a sexual nature are not welcome here. Exceptions are made where appropriate for this, but generally speaking, keep it clean.
-6. **Where the rules do not prevail, common sense shall.** The administration has explicit discretion to apply their judgment on this as they see fit.
+5. **We are an all-ages community.** This means that 18+/[NSFW](https://en.wikipedia.org/wiki/Not_safe_for_work) content such as drug use or topics of a sexual nature are not welcome here.
+6. **Keep it clean.** osu! is not the place for dating or flirting. Using sexual language, imagery or making advances on other members of the community in public or private is NOT okay. If you ever feel uncomfortable with how someone is talking to you, [report it to us confidentially](/wiki/Reporting_Bad_Behaviour/Abuse) so we can help you and potentially prevent others from being affected.
+7. **Where the rules do not prevail, common sense shall.** The administration has explicit discretion to apply their judgment on this as they see fit.
 
 ## In-game chat rules
 


### PR DESCRIPTION
This is a heavily revised version of a previous PR and contains a small addition to the Terms of Service, a new Community Rule, an article detailing how to report inappropriate conduct to a new, private inbox and explicit requirement for the NAT and GMT to abide by the new Contributor Code of Conduct.

Summary:

- New Community Rule `#6`: Keep it clean. This rule broadly disallows any form of flirting or sexual advances targeted towards other members of the community either publicly or privately. Please read into the nuance of this before getting upset about it.
- A new Reporting Abuse article has been added which refers to abuse@ppy.sh, a new inbox manned only by peppy and myself which promises total privacy and anonymity when dealing with sensitive complaints.
- _Admission_ to the NAT or GMT requires a user to be at least 18 years of age. *Existing underage members are currently unaffected.*
- The NAT and GMT are now required to be bound to the Contributor Code of Conduct in all terms. A grandfathering process which determines age and affirms a moderator's commitment to this new code will be organized in the coming days after approval.
