### PR TITLE
[EN/RU] Specify osu!lazer users unlisted in IRC clients

### DIFF
--- a/wiki/Internet_Relay_Chat/en.md
+++ b/wiki/Internet_Relay_Chat/en.md
@@ -82,4 +82,4 @@ Users connected via osu! client or web site have no prefix.
 
 ### Someone sends messages, but they are not in the list of channel users!
 
-They are using [the web version of chat](https://osu.ppy.sh/community/chat).
+They are either using [the web version of chat](https://osu.ppy.sh/community/chat) or connected via [osu!lazer](https://github.com/ppy/osu "GitHub").

--- a/wiki/Internet_Relay_Chat/ru.md
+++ b/wiki/Internet_Relay_Chat/ru.md
@@ -80,4 +80,4 @@
 
 ### Человек пишет в чат, но я не вижу его ник в списке пользователей на канале
 
-Он использует [веб-чат](https://osu.ppy.sh/community/chat) для отправки сообщений.
+Он отправляет сообщения через [веб-чат](https://osu.ppy.sh/community/chat) или [osu!lazer](https://github.com/ppy/osu "GitHub").


### PR DESCRIPTION
- Add the information regarding osu!lazer users are not listed within the online user lists of IRC clients. 
- Update Russian locale accordingly.