### PR TITLE
[TR] Add Account support team and update related articles

### DIFF
--- a/wiki/Bot_account/tr.md
+++ b/wiki/Bot_account/tr.md
@@ -1,6 +1,4 @@
 ---
-outdated: true
-outdated_since: 2b3040251f1f4876dba46e9c7e01045a7c8ccfc0
 tags:
   - bot accounts
   - chat bot
@@ -53,7 +51,7 @@ E-postanın içeriği aşağıdakileri içermelidir:
 - Kaynak koduna ve dökümantasyona giden bir link
 - Botun ne yaptığını anlatan kısa bir özet
 
-Hesap destek ekibi talebinizi gözden geçirecektir. Eğer talebiniz reddedildiyse, nedeni tarafınıza bildirilecektir. Eğer talebiniz onaylandıysa, sizin adınıza bir bot hesabı oluşturulacak ve nasıl kullanılacağı ile ilgili talimatlar size iletilecektir.
+[Hesap destek ekibi](/wiki/People/The_Team/Account_support_team) talebinizi gözden geçirecektir. Eğer talebiniz reddedildiyse, nedeni tarafınıza bildirilecektir. Eğer talebiniz onaylandıysa, sizin adınıza bir bot hesabı oluşturulacak ve nasıl kullanılacağı ile ilgili talimatlar size iletilecektir.
 
 ## Ek bilgiler
 

--- a/wiki/Do_you_really_want_to_ask_peppy/tr.md
+++ b/wiki/Do_you_really_want_to_ask_peppy/tr.md
@@ -1,8 +1,3 @@
----
-outdated: true
-outdated_since: 2b3040251f1f4876dba46e9c7e01045a7c8ccfc0
----
-
 # Gerçekten peppy'e sormak istiyor musunuz?
 
 Selamlar! peppy sizin onunla derhal iletişime geçme isteğinizi anlıyor, ancak öncelikle sizden buranın ondan yardım ya da destek istemek için doğru bir yer **olmadığını** anlamanızı istiyor. Kendisi osu! desteğini kişisel mesajlardan ayrı tutmakta ve ayrıca forum özel mesajlarına ayak uydurmayı oldukça zor bulmaktadır. Bundan ötürü sizden aşağıdaki seçeneklerden birini yapmanızı istiyor:
@@ -13,7 +8,7 @@ Selamlar! peppy sizin onunla derhal iletişime geçme isteğinizi anlıyor, anca
 
 ## Genel osu! desteği
 
-Hesap sorunları, ödeme problemleri, ban takipleri, turnuvalar ile ilgili sorular ve **osu!'da yardım gerektiren herhangi bir şey** için, lütfen [accounts@ppy.sh](mailto:accounts@ppy.sh) adresine (hesap konulu sorular) ya da [osu@ppy.sh](mailto:osu@ppy.sh) adresine (geri kalan her şey) e-posta gönderin.
+Hesap sorunları, ödeme problemleri, ban takipleri, turnuvalar ile ilgili sorular veya **osu!'da yardım gerektiren herhangi bir şey** için, lütfen [accounts@ppy.sh](mailto:accounts@ppy.sh) adresine (hesap konulu sorular) ya da [osu@ppy.sh](mailto:osu@ppy.sh) adresine (geri kalan her şey) e-posta göndererek [hesap destek ekibiyle](/wiki/People/The_Team/Account_support_team) iletişime geçin.
 
 ## peppy'e ulaşmak
 

--- a/wiki/Help_Centre/Account_Restrictions/tr.md
+++ b/wiki/Help_Centre/Account_Restrictions/tr.md
@@ -1,8 +1,3 @@
----
-outdated: true
-outdated_since: 2b3040251f1f4876dba46e9c7e01045a7c8ccfc0
----
-
 # Hesap kısıtlamaları
 
 Kısıtlama, anormal, şüpheli ya da kuralları çiğneyecek davranış gösteren hesaplara uygulanan bir topluluktan uzaklaştırma durumudur.
@@ -23,7 +18,7 @@ Aşağıdaki özellikler kısıtlanmış hesaplar için devre dışıdır:
 Eğer hesabınız kısıtlandıysa, panik yapmayın. Lütfen bu adımları izleyin:
 
 - **24 saat bekleyin.** Bazı kısıtlamalar otomatik sürecin sonucudur. Biz bu kısıtlamaları her gün kontrol ederken, lütfen 24 saat bekleyin - eğer kısıtlamanız hatalıysa belirtilen süre içinde kalkacaktır.
-- **Destek ekibimizle iletişime geçin.** Eğer hesabınız belirtilen süreden sonra kısıtlı kalırsa, lütfen kısıtlamanızla ilgili detayları sormak için **hesabınıza bağlı e-postadan** [accounts@ppy.sh](mailto:accounts@ppy.sh) adresine bir e-posta gönderin. Kullanıcı adınızı, hesabınızın kısıtlanmasına neden olduğunu düşündüğünüz detaylar ile birlikte eklediğinizden emin olun. Bize ne kadar çok anlatırsanız, sorunu sonuçlandırmamız o kadar kolay olur.
+- **[Hesap destek ekibimizle](/wiki/People/The_Team/Account_support_team) iletişime geçin.** Eğer hesabınız belirtilen süreden sonra kısıtlı kalırsa, lütfen kısıtlamanızla ilgili detayları sormak için **hesabınıza bağlı e-postadan** [accounts@ppy.sh](mailto:accounts@ppy.sh) adresine bir e-posta gönderin. Kullanıcı adınızı, hesabınızın kısıtlanmasına neden olduğunu düşündüğünüz detaylar ile birlikte eklediğinizden emin olun. Bize ne kadar çok anlatırsanız, sorunu sonuçlandırmamız o kadar kolay olur.
 - Eğer kısıtlanmanızın hatalı olduğundan son derece eminseniz, hemen bize ulaşın ki sorununuzu görüşebilelim.
 
 Eğer hesabınız [kuralları](/wiki/rules) çiğnediği için kısıtlandıysa, itiraz göndermenize izin verilmeden önce üç aylık katı bir bekleme süresi uygulanacaktır.

--- a/wiki/People/The_Team/Account_support_team/tr.md
+++ b/wiki/People/The_Team/Account_support_team/tr.md
@@ -1,0 +1,38 @@
+# Hesap destek ekibi
+
+*Birtakım alt forumları modere eden ekip için, bakınız: [Destek Ekibi](/wiki/People/The_Team/Support_Team)*
+
+**Hesap destek ekibi** kullanıcı hesaplarını yönetirken, aynı zamanda susturulma ve kısıtlanma itirazlarını kabul eden bir grup kişiden oluşur.
+
+## İrtibat noktaları
+
+Bu ekibe **yalnızca** [support@ppy.sh](mailto:support@ppy.sh), [accounts@ppy.sh](mailto:accounts@ppy.sh), veya [privacy@ppy.sh](mailto:privacy@ppy.sh) adreslerine e-posta göndererek ulaşılabilir. Ekip üyelerini istenmeyen dikkatten uzak tutmak adına onların kimlikleri gizli tutulur.
+
+Desteğin e-postanıza göz atması genellikle birkaç gün sürer. Eğer bir hafta içerisinde herhangi bir yanıt gelmezse, konuyla ilgili öncekini takiben yeni bir mesaj göndermeniz tavsiye edilir.
+
+## Rol ve görevler
+
+*Ana başlık: [Yardım Merkezi](/wiki/Help_Centre)*
+
+*Ayrıca bakınız: [Hesap Kısıtlamaları](/wiki/Help_Centre/Account_Restrictions)*
+
+Erişiminizin ötesindeki hesap ile ilişkili konular hakkında bu ekiple irtibata geçmelisiniz. Lütfen sorununuz hakkında olabildiğince fazla detay vermeyi unutmayın ve e-postayı osu! hesabınızla eşleşen e-posta adresinizden gönderdiğinizden emin olun.
+
+### [accounts@ppy.sh](mailto:accounts@ppy.sh)
+
+- Susturulma ve profil içerik kaldırılmaları dahil, [hesabınıza uygulanan kısıtlamalara karşı itirazlar](/wiki/Help_Centre/Account_Restrictions).
+- [İtiraf etmek istediğiniz](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play#what-can-i-do-if-i've-broken-the-rules?) olumsuz davranışlar.
+- osu! hesabınızla ilişkili [e-postanıza olan erişimi kaybetmeniz](/wiki/Help_Centre#sign-in), veya hesabınızın çalınması.
+- Kullanıcı adı [geri çevirme veya ufak yazım düzeltmeleri](/wiki/Help_Centre#name-changes).
+- [Bot hesabı başvuruları](/wiki/Bot_Account).
+
+### [support@ppy.sh](mailto:support@ppy.sh)
+
+- [osu!store](https://osu.ppy.sh/store/listing) üzerinden yapılan siparişlerle ilgili [ödeme sorunları](/wiki/en/Help_Centre#supporter).
+- [Bağlantı sorunları](/wiki/Help_Centre#online-features) gibi, [Yardım forumunda](https://osu.ppy.sh/community/forums/5) düzeltilemeyen teknik sorunlar.
+- [Bir moderatörün davranışları](/wiki/Reporting_Bad_Behaviour#can-i-report-a-moderator?) hakkındaki şikayetler.
+
+### [privacy@ppy.sh](mailto:privacy@ppy.sh)
+
+- [Veri talepleri](/wiki/Legal/Privacy#data-controller) veya gizlilik endişeleri.
+- AB vatandaşları için ([GDPR](https://tr.wikipedia.org/wiki/Genel_Veri_Koruma_Y%C3%B6netmeli%C4%9Fi "Vikipedi") kapsamında) **kalıcı** [hesap kaldırma talepleri](/wiki/Legal/Privacy#your-rights-and-control).

--- a/wiki/People/The_Team/Support_Team/tr.md
+++ b/wiki/People/The_Team/Support_Team/tr.md
@@ -1,28 +1,25 @@
----
-outdated: true
-outdated_since: c1175ba788c488eb294b1b04c55a6dee798009de
----
-
 # Destek Ekibi
 
-**Destek Ekibi** (aynı zamanda **Destek Ekibi Redux** olarak da bilinir, hesap destek ekibi ve aynı isimde olan "Destek Ekibi" ile karıştırılmamalıdır.) osu! ekibi içerisinde daha çok birkaç alt forumun moderasyonu ile ilgilenir: [Geliştirme](https://osu.ppy.sh/community/forums/2), [Oynanış & Sıralama](https://osu.ppy.sh/community/forums/13) ([Turnuvalar](https://osu.ppy.sh/community/forums/55) ve [Mapleme Teknikleri](https://osu.ppy.sh/community/forums/61) hariç), [Temalar](https://osu.ppy.sh/community/forums/15), [Özellik İstekleri](https://osu.ppy.sh/community/forums/4), ve [Yardım](https://osu.ppy.sh/community/forums/5).
+*Hesapları yöneten ekip için, bakınız: [Hesap destek ekibi](/wiki/People/The_Team/Account_support_team)*
 
-## Görev ve Sorumluluklar
+**Destek Ekibi**, aynı zamanda **Destek Ekibi Redux** olarak da bilinir, osu! ekibinin birtakım alt forumların moderasyonundan sorumlu üyeleridir. Bu forumlar şu şekilde sıralanır: [Geliştirme](https://osu.ppy.sh/community/forums/2), [Oynanış & Sıralama](https://osu.ppy.sh/community/forums/13) ([Turnuvalar](https://osu.ppy.sh/community/forums/55) ve [Mapleme Teknikleri](https://osu.ppy.sh/community/forums/61) hariç), [Temalar](https://osu.ppy.sh/community/forums/15), [Özellik İstekleri](https://osu.ppy.sh/community/forums/4), ve [Yardım](https://osu.ppy.sh/community/forums/5).
+
+## Rol ve sorumluluklar
 
 Destek ekibi şunlar ile sorumludur:
 
 1. Bug bildirimlerini geliştiricilerin görmesi ve çözmesi için test etmek/doğrulamak.
-2. [Özellik İstekleri](https://osu.ppy.sh/community/forums/4) ve [Yardım](https://osu.ppy.sh/community/forums/5) altforumlarındaki başlıkları, onları *Çözüldü*, *Doğrulandı*, *Geçersiz*, *Kopya*, ve/veya *Eklendi* diye işaretleyek düzenler.
+2. [Özellik İstekleri](https://osu.ppy.sh/community/forums/4) ve [Yardım](https://osu.ppy.sh/community/forums/5) altforumlarındaki başlıkları *Çözüldü*, *Doğrulandı*, *Geçersiz*, *Kopya*, ve/veya *Eklendi* diye işaretleyerek düzenler.
 
-Eğer birinin bahsi geçen altforumlarda yardıma ihtiyacı olursa, ilk olarak onlara başvurmalı.
+Eğer bir kimse bahsi geçen alt forumlarda yardıma ihtiyaç duyarsa, ilk olarak onlara başvurmalıdır.
 
-## Takım Üyeleri
+## Takım üyeleri
 
-[Destek ekibi sayfası](https://osu.ppy.sh/groups/22), tüm ekip üyelerini listeler.
+[Destek Ekibi grup sayfası](https://osu.ppy.sh/groups/22) tüm ekip üyelerini listeler.
 
-*Not: Aksi belirtilmedikçe bütün Destek Ekibi üyeleri İngilizce konuşur.*
+*Not: Tüm Destek Ekibi üyeleri, aksi not edilmediği sürece, belirtilen dillerin yanısıra İngilizce de konuşabilirler.*
 
-| İsim | Ek Diller |
+| İsim | Ek diller |
 | :-- | :-- |
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  |

--- a/wiki/People/The_Team/tr.md
+++ b/wiki/People/The_Team/tr.md
@@ -5,8 +5,6 @@ tags:
   - osu! team
   - staff
   - team osu!
-outdated: true
-outdated_since: 1175fe79cab9897bca0e60ff7056c7a1a2510bfe
 ---
 
 # Ekip
@@ -39,6 +37,8 @@ Aşağıdaki listelenen kişiler **osu!team** çekirdek kadrosunu oluşturmakta,
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Genel ev bekçisi, turnuva asistanı, wiki idarecisi |
 | ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Tehlike altındaki tür |
 
+Yukarıdakilere ek olarak, [hesap destek ekibi](Account_support_team) erişiminizin ötesindeki konularda size yardımcı olmak için bulunurlar.
+
 ## Kullanıcı grupları
 
 Aşağıdakiler osu!'nun sürdürülmesine yardımcı olan osu! topluluk üyelerinden oluşturulmuş kullanıcı gruplarıdır. Bu kullanıcıların çoğu forumdaki renklerinden, oyun-içi sohbet renklerinden, profil ünvanları, ve/veya profil rozetlerinden ayırt edilebilir.
@@ -64,7 +64,7 @@ Aşağıdakiler osu!'nun sürdürülmesine yardımcı olan osu! topluluk üyeler
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu! geliştiricisi, oyun-içi sohbet için IRC entegrasyonu sağlayıcı, site sorumlusu. [Blog](http://blog.echo.sh/) |
 | ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | osu! Coffee Hour sunucusu, Dünya Kupası yayıncısı, turnuva organizatörü |
 | ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | osu! geliştiricisi, osz2 ve p2p backend sağlayıcısı |
-| ![][flag_US] Jim | Orijinal site tasarımcısı. [Brave New Games](http://www.bravegamer.com/) |
+| ![][flag_US] Jim | Orijinal site tasarımcısı, sitenin ilk zamanlarındaki hosting sağlayıcısı. [Brave New Games](http://www.bravegamer.com/) |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Dünya Kupası organizatörü ve yöneticisi, QAT lideri, topluluk yöneticisi |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Destansı tema tasarımcısı, varsayılan tema ve ikon seti katkısı. [DeviantArt](https://luigihann.deviantart.com/) |
 | ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | osu! geliştiricisi, mm sliderlarının mucidi |


### PR DESCRIPTION
- Add Turkish locale for [Account support team](https://osu.ppy.sh/wiki/en/People/The_Team/Account_support_team) article.
- Update [Support Team](https://osu.ppy.sh/wiki/tr/People/The_Team/Support_Team), [Account Restrictions](https://osu.ppy.sh/wiki/tr/Help_Centre/Account_Restrictions), [The Team](https://osu.ppy.sh/wiki/tr/People/The_Team), [Bot Account](https://osu.ppy.sh/wiki/tr/Bot_account), and [Do you really want to ask peppy?](https://osu.ppy.sh/wiki/tr/Do_you_really_want_to_ask_peppy) articles.
  - Additionally, the `Support_Team` article has been revised and partially rewritten in order to unify the style used across the other usergroup articles.