### PR TITLE
Recapitulate number of new FAs announced in 2020 on Featured Artist articles

### DIFF
--- a/wiki/Featured_Artists/en.md
+++ b/wiki/Featured_Artists/en.md
@@ -25,7 +25,8 @@ New featured artist releases per year:
 - **2017:** 11
 - **2018:** 20
 - **2019:** 31
-- **2020:** *to be determined*
+- **2020:** 65
+- **2021:** *to be determined*
 
 New featured artists are announced weekly on osu!'s [news feed](https://osu.ppy.sh/home/news). Most announcements include a list of the artist's licensed songs and a link to their featured artist page, though some announcements are paired with mapping contests or beatmaps created by the [Mappers' Guild](/wiki/Mappers_Guild).
 

--- a/wiki/Featured_Artists/id.md
+++ b/wiki/Featured_Artists/id.md
@@ -25,7 +25,8 @@ Berikut merupakan jumlah Featured Artist baru yang ditambahkan ke dalam katalog 
 - **2017:** 11
 - **2018:** 20
 - **2019:** 31
-- **2020:** *belum ditentukan*
+- **2020:** 65
+- **2021:** *belum ditentukan*
 
 Featured Artist baru akan diumumkan setiap minggunya pada kolom [berita](https://osu.ppy.sh/home/news) yang tertera pada laman utama situs web osu!. Pada umumnya, pengumuman suatu Featured Artist baru akan mencakup cuplikan lagu-lagu dari musisi yang bersangkutan beserta dengan informasi seputar kontes mapping yang menggunakan lagu-lagu dari musisi tersebut atau beatmap-beatmap terkait yang dibuat oleh para anggota [Mappers' Guild](/wiki/Mappers_Guild) apabila ada.
 

--- a/wiki/Featured_Artists/nl.md
+++ b/wiki/Featured_Artists/nl.md
@@ -26,7 +26,8 @@ Aantal nieuwe aanbevolen artiest uitgaven per jaar:
 - **2017:** 11
 - **2018:** 20
 - **2019:** 31
-- **2020:** *nog te bepalen*
+- **2020:** 65
+- **2021:** *nog te bepalen*
 
 Nieuwe aanbevolen artiesten worden wekelijks aangekondigd op osu!'s [newsfeed](https://osu.ppy.sh/home/news). De meeste aankondigingen bevatten een lijst van de nummers waarvoor osu! een licentie kreeg en een link naar hun aanbevolen artiest pagina. Sommige aankondigingen zijn ook gepaard met beatmappingwedstrijden of beatmaps die gemaakt werden door de [Mappers' Gilde](/wiki/Mappers_Guild).
 

--- a/wiki/Featured_Artists/tr.md
+++ b/wiki/Featured_Artists/tr.md
@@ -25,7 +25,8 @@ Her yıl yeni çıkan featured artistler:
 - **2017:** 11
 - **2018:** 20
 - **2019:** 31
-- **2020:** *belli değil*
+- **2020:** 65
+- **2021:** *belli değil*
 
 Yeni featured artistler haftalık olarak osu!'nun [haber kaynağında](https://osu.ppy.sh/home/news) duyurulur. Çoğu duyuru sanatçının lisanslı şarkılarının bir listesini ve onların featured artist sayfasına bir linki içerir, lakin bazı duyurular mapleme yarışmaları veya [Mappers' Guild](/wiki/Mappers_Guild) tarafından oluşturulan beatmapler ile eşleştirilir.
 


### PR DESCRIPTION
in accordance with [#4681](http://github.com/ppy/osu-wiki/pull/4681) announcing that Aitsuki Nakuru would be the last Featured Artist of 2020.

![image](https://user-images.githubusercontent.com/36564236/103150108-54a0d580-47a3-11eb-9488-3a4d8e9e2bd1.png)

in total there are 65 new FAs throughout the year, with the first being [Rivers of Nihil](http://osu.ppy.sh/home/news/2020-01-07-new-featured-artist-rivers-of-nihil) (artists/[63](http://osu.ppy.sh/beatmaps/artists/63)) and the last being [Aitsuki Nakuru](http://osu.ppy.sh/home/news/2020-12-26-new-featured-artist-aitsuki-nakuru) (artists/[127](http://osu.ppy.sh/beatmaps/artists/127)).