### PR TITLE
Fix formatting issues of osu!weekly articles

### DIFF
--- a/news/2016-11-07-osuweekly-79.md
+++ b/news/2016-11-07-osuweekly-79.md
@@ -49,7 +49,7 @@ As always, we've got tons to cover, so let's stop the dilly dally and get right 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/CvmmkqrV5Jk?rel=0&controls=0" frameborder="0" allowfullscreen></iframe>
 
-**Four mods! Count them! [LukerMaster](https://osu.ppy.sh/users/2093623) set a 4 mod (HDHRDTFL) 98.58% FC on [Mike Greene - Bill Nye the Science Guy Theme Song (Chinese Intro)](https://osu.ppy.sh/beatmaps/932223) and earned 557pp.** A rare sight indeed! Four might be an unlucky number to the Chinese, but there's no way that anything but pure skill nabbed him this tasty score.
+**Four mods! Count them! [LukerMaster](https://osu.ppy.sh/users/2093623) set a 4 mod (HDHRDTFL) 98.58% FC on [Mike Greene - Bill Nye the Science Guy Theme Song (Chinese Intro)](https://osu.ppy.sh/beatmapsets/432314#osu/932223) and earned 557pp.** A rare sight indeed! Four might be an unlucky number to the Chinese, but there's no way that anything but pure skill nabbed him this tasty score.
 
 ![](https://osu.ppy.sh/ss/6502188)
 
@@ -74,7 +74,8 @@ At the same time, it is apparent that the selectors are trying their best to pre
 And finally, we're very happy to announce that Starrodkirby86 has agreed to help out with the osu!weekly by providing us with some puzzling monthly puzzles. Each month, the puzzle type and theme will be different, but for the first month we've decided to go with a simple word search. **The theme is Loved maps - so it could be an artist, a song name, or maybe even a mapper featured in the [Loved map listing](https://osu.ppy.sh/beatmapsets?s=loved).** Proceed with caution, that answer you just found might not be the one you need!
 
 <a href="https://puu.sh/s8n1P/54c0243e36.png"><img src="https://puu.sh/s8n1P/54c0243e36.png" style="height: 50%; width: 50%"></a>
-<p style="text-align:center;"><i>(Click for full size!)</i></p>
+
+*(Click for full size!)*
 
 With OWC now upon us, it looks like a lot of here will be very busy indeed.  As per usual, if you have any suggestions for what you would like to see in the weekly, feel free to drop by the [osu!dev discord](https://discord.gg/ppy) and directly highlight Nyquill or myself (deadbeat) in the #osu-weekly channel. Alternatively, you can also e-mail as usual at [news@ppy.sh](mailto:news@ppy.sh).
 

--- a/news/2016-11-07-osuweekly-79.md
+++ b/news/2016-11-07-osuweekly-79.md
@@ -7,7 +7,8 @@ tumblr_url: http://osunews.tumblr.com/post/152843565683/osuweekly-79
 
 This week's been lively, with a new round of Community Contributors, the OWC Live Drawings and the return of something dating back to the ancient era of the osu!monthly. Whatever could it be? Read on to find out!
 
-<img src="https://puu.sh/nqIAS/05e726ece8.jpg"/>
+![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2016-10-31-osuweekly-78-extra-spooky-edition">Previous</a></td>
 <td align="right"><a href="https://osu.ppy.sh/home/news/2016-11-17-osuweekly-80">Next</a></td>
 </tr></table>

--- a/news/2017-04-15-osuweekly-100.md
+++ b/news/2017-04-15-osuweekly-100.md
@@ -25,8 +25,9 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 
 **Woah there peppy, you haven't caught your breath since [starting up the osu!dev blog again](https://blog.ppy.sh/back-in-business!/)!** A flurry of updates made to the osu!lazer client saw the long awaited revival of the osu!dev blog last week. To say that signs of life have been emerging from the well established outlet of development news would be an understatement of massive proportions. Ever since the 9th of April, a new post has been made every day. If you want to prevent yourself from being hopelessly behind on the times, I recommend you go check out the new jekyll powered blog before it's too late!
 
-<iframe src="//streamable.com/s/52yju/fxqmvb" frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen scrolling="no" style="width: 100%; height: 100%; position: absolute;"></iframe><script async src="//v.embedcdn.com/v1/embed.js"></script></div>
-<p style="text-align:center;"><i>from https://blog.ppy.sh/2017-04-14/</i></p>
+<iframe width = "560" height = "315" src="//streamable.com/s/52yju/fxqmvb" frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen scrolling="no"></iframe><script async src="//v.embedcdn.com/v1/embed.js"></script></div>
+
+*from https://blog.ppy.sh/2017-04-14/*
 
 **That said, what better time is there than now to start helping out with the development of our game?** The open source lazer branch is open to all to contribute to and move forward. Additionally, the new site at [new.ppy.sh](https://osu.ppy.sh/home) is also [open source](https://github.com/ppy/osu-web) and ready for anyone to take a look at. To that end, there is also a [bounty system](https://github.com/ppy/osu-web/issues?q=is%3Aopen+is%3Aissue+label%3Abounty) set up as an incentive for certain tasks, so go see what it's about if you think you have the know-how!  
 

--- a/news/2017-04-15-osuweekly-100.md
+++ b/news/2017-04-15-osuweekly-100.md
@@ -8,9 +8,8 @@ tumblr_url: http://osunews.tumblr.com/post/159587158628/osuweekly-100
 The osu!weekly title is extending its length on the front page by exactly one character! Though the new home page spoils the new header, you're gonna have to read on to find out the extent of what's new in the 100th week (plus/minus a few) since we first started.
 
 ![](https://puu.sh/vkC6i/4adcb2faba.png)
-<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-04-06-osuweekly-99">Previous</a></td>
-<td align="right"><a href="https://osu.ppy.sh/home/news/2017-04-24-osuweekly-101">Next</a></td>
-</tr></table>
+
+<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-04-06-osuweekly-99">Previous</a></td><td align="right"><a href="https://osu.ppy.sh/home/news/2017-04-24-osuweekly-101">Next</a></td></tr></table>
 
 ## Navigation
 
@@ -27,7 +26,7 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 
 <iframe width = "560" height = "315" src="//streamable.com/s/52yju/fxqmvb" frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen scrolling="no"></iframe><script async src="//v.embedcdn.com/v1/embed.js"></script></div>
 
-*from https://blog.ppy.sh/2017-04-14/*
+*from <https://blog.ppy.sh/2017-04-14/>*
 
 **That said, what better time is there than now to start helping out with the development of our game?** The open source lazer branch is open to all to contribute to and move forward. Additionally, the new site at [new.ppy.sh](https://osu.ppy.sh/home) is also [open source](https://github.com/ppy/osu-web) and ready for anyone to take a look at. To that end, there is also a [bounty system](https://github.com/ppy/osu-web/issues?q=is%3Aopen+is%3Aissue+label%3Abounty) set up as an incentive for certain tasks, so go see what it's about if you think you have the know-how!  
 

--- a/news/2017-05-02-osuweekly-102.md
+++ b/news/2017-05-02-osuweekly-102.md
@@ -29,7 +29,7 @@ The days of our current client are numbered! With so much going into the work of
 - [Multi-directional track seeking](https://blog.ppy.sh/2017-04-26/) (new in lazer) in progress!
 - [Hilarious 2D rigid-body physics](https://blog.ppy.sh/2017-04-24/) feat [Tom94](https://osu.ppy.sh/users/tom94) and much much more...
 
-<iframe src="https://streamable.com/s/mb571/sfjnzk" frameborder="0" width="100%" height="100%" allowfullscreen style="width: 100%; height: 100%; position: absolute;"></iframe>
+<iframe width="560" height="315" src="https://streamable.com/s/mb571/sfjnzk" frameborder="0" allowfullscreen></iframe>
 
 **If you're waiting for registrations of CWC to open, don't worry!** I got a tip that we're nearing the beginning of the registration phase extremely soon, so sit tight while we get some final adjustments in place for the formalities!
 

--- a/news/2017-05-02-osuweekly-102.md
+++ b/news/2017-05-02-osuweekly-102.md
@@ -8,9 +8,8 @@ tumblr_url: http://osunews.tumblr.com/post/160239525918/osuweekly-102
 The days of our current client are numbered! With so much going into the work of our new platform, how can you afford to be behind on news? Read on to find out what you have been missing.
 
 ![](http://nyquill.s-ul.eu/5xeN7PLY.png)
-<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-04-24-osuweekly-101">Previous</a></td>
-<td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-11-osuweekly-103">Next</a></td>
-</tr></table>
+
+<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-04-24-osuweekly-101">Previous</a></td><td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-11-osuweekly-103">Next</a></td></tr></table>
 
 ## Navigation
 
@@ -53,33 +52,33 @@ The days of our current client are numbered! With so much going into the work of
 
 <h2 name="score" id="score"><img src="http://nyquill.s-ul.eu/We57rqqm"></h2>
 
-[Vaxei](https://osu.ppy.sh/users/4787150) became one with the night as he set the next HR FC on [DragonForce - Symphony of the Night](https://osu.ppy.sh/beatmaps/985141) with 98.41% to earn himself 600pp. He was serious about wanting to HR FC Blue Zenith. Very serious indeed.
+[Vaxei](https://osu.ppy.sh/users/4787150) became one with the night as he set the next HR FC on [DragonForce - Symphony of the Night](https://osu.ppy.sh/beatmapsets/459901#osu/985141) with 98.41% to earn himself 600pp. He was serious about wanting to HR FC Blue Zenith. Very serious indeed.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/D7Dzk4cSLDk" frameborder="0" allowfullscreen></iframe>
 
-[Cookiezi](https://osu.ppy.sh/users/124493)'s limits are no longer in the ballpark. He just set an unbelievable HDDT SS on [Kanae Asaba - Endless Starlight ~Inochi no Kirameki~ (OP ver.)](https://osu.ppy.sh/beatmaps/1102144?m=0) to earn himself 717pp and the highest ranked SS in terms of pp of all time. 14,000pp now seems believable and we aren't even half way through the year. We're enjoying this ride so far.
+[Cookiezi](https://osu.ppy.sh/users/124493)'s limits are no longer in the ballpark. He just set an unbelievable HDDT SS on [Kanae Asaba - Endless Starlight ~Inochi no Kirameki~ (OP ver.)](https://osu.ppy.sh/beatmapsets/518737#osu/1102144) to earn himself 717pp and the highest ranked SS in terms of pp of all time. 14,000pp now seems believable and we aren't even half way through the year. We're enjoying this ride so far.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/gaDxHqZ09bY" frameborder="0" allowfullscreen></iframe>
 
-[Azer](https://osu.ppy.sh/users/2155578) just set an incredible HDHR FC that is definitely not tied with United! [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmaps/1029562) on Tortured Soul Extra is the difficulty in question as he set a 98.35% HDHR FC to earn 602pp. Take a bow.
+[Azer](https://osu.ppy.sh/users/2155578) just set an incredible HDHR FC that is definitely not tied with United! [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmapsets/482090#osu/1029562) on Tortured Soul Extra is the difficulty in question as he set a 98.35% HDHR FC to earn 602pp. Take a bow.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/OhiEb9jg2QQ" frameborder="0" allowfullscreen></iframe>
 
-And we thought he was done! [Cookiezi](https://osu.ppy.sh/users/124493) amazes us once again with an otherworldly 95.81% HDDT FC on [HoneyWorks - Akatsuki Zukuyo](https://osu.ppy.sh/beatmaps/795627?m=0) to earn himself 776pp. I think the video below will do the talking.
+And we thought he was done! [Cookiezi](https://osu.ppy.sh/users/124493) amazes us once again with an otherworldly 95.81% HDDT FC on [HoneyWorks - Akatsuki Zukuyo](https://osu.ppy.sh/beatmapsets/351280#osu/795627) to earn himself 776pp. I think the video below will do the talking.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/eJ8ab3lbJK0" frameborder="0" allowfullscreen></iframe>
 
-[\_yu68](https://osu.ppy.sh/users/6170507) continues to surprise us with an amazing 99.48% HDDT FC on [fripSide - Last Fortune (pocotan Remix)](https://osu.ppy.sh/beatmaps/936050?m=1) to earn himself 730pp. What can this man not do? Someone make a 20* map for him to FC please.
+[\_yu68](https://osu.ppy.sh/users/6170507) continues to surprise us with an amazing 99.48% HDDT FC on [fripSide - Last Fortune (pocotan Remix)](https://osu.ppy.sh/beatmapsets/433465#taiko/936050) to earn himself 730pp. What can this man not do? Someone make a 20* map for him to FC please.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/NnbivcNCLtY" frameborder="0" allowfullscreen></iframe>
 
 =NOTABLE MENTIONS=
 
-[WubWoofWolf](https://osu.ppy.sh/users/39828) came out of his quiet closet to set a very unique 98.55% HDHR FC on [MitiS & MaHi - Blu (Speed Up Ver.)](https://osu.ppy.sh/beatmaps/736300) to earn himself 406pp, marking the very first HDHR FC on this map.
+[WubWoofWolf](https://osu.ppy.sh/users/39828) came out of his quiet closet to set a very unique 98.55% HDHR FC on [MitiS & MaHi - Blu (Speed Up Ver.)](https://osu.ppy.sh/beatmapsets/261911#osu/736300) to earn himself 406pp, marking the very first HDHR FC on this map.
 
-[Angelsim](https://osu.ppy.sh/users/1777162) took the courageous route and turned on HR on [goreshit - burn this moment into the retina of my eye](https://osu.ppy.sh/beatmaps/791274), taking a staggering 99.83% 1 miss play to earn himself 577pp.
+[Angelsim](https://osu.ppy.sh/users/1777162) took the courageous route and turned on HR on [goreshit - burn this moment into the retina of my eye](https://osu.ppy.sh/beatmapsets/359890#osu/791274), taking a staggering 99.83% 1 miss play to earn himself 577pp.
 
-[Vaxei](https://osu.ppy.sh/users/4787150) sped into another dimension as he took [cillia - FIRST](https://osu.ppy.sh/beatmaps/671750) on Insane and slapped on HDDT to take an amazing 99.30% FC and to earn 431pp on the map at 285BPM.
+[Vaxei](https://osu.ppy.sh/users/4787150) sped into another dimension as he took [cillia - FIRST](https://osu.ppy.sh/beatmapsets/171388#osu/671750) on Insane and slapped on HDDT to take an amazing 99.30% FC and to earn 431pp on the map at 285BPM.
 
 =SCOREWATCH SCORE SHOW=
 

--- a/news/2017-05-18-osuweekly-104.md
+++ b/news/2017-05-18-osuweekly-104.md
@@ -28,7 +28,7 @@ We're headed into an action packed summer kicking development into high gear! Th
 - **Information dialogues now [narrate every change you make](https://blog.ppy.sh/2017-05-16/) to the game via hotkeys!** This was made possible by a new container type that previously did not exist in the osu! client called "On-screen Displays".
 - **Finally, more options are implemented and they are now searchable!** Looks familiar? The new options menu is a rather comparatively recent feature in our old client, so it's no surprise much of the old UX has been retained.
 
-<iframe src="https://streamable.com/s/fxrtd/uxjunu" frameborder="0" width="100%" height="100%" allowfullscreen style="width: 100%; height: 100%; position: absolute;"></iframe>
+<iframe src="https://streamable.com/s/fxrtd/uxjunu" frameborder="0" width="560" height="315" allowfullscreen></iframe>
 
 **We have merged our domains for both the new and old version of the website!** This means that all pages on the new site will now point to the correct live addresses as they will be when we phase out the old, and older pages will be slowly taken offline as their replacements become ready over time. For the time being, [new.ppy.sh](https://new.ppy.sh) will still direct you to the new front page under the primary domain.
 

--- a/news/2017-05-18-osuweekly-104.md
+++ b/news/2017-05-18-osuweekly-104.md
@@ -8,9 +8,8 @@ tumblr_url: http://osunews.tumblr.com/post/160786697913/osuweekly-104
 We're headed into an action packed summer kicking development into high gear! This week, we bid farewell to some old scaffolds the facilitate the construction of our new website. Curious to find out what has changed? Read on to find out!
 
 ![](https://puu.sh/vTpoS/268fc04a78.png)
-<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-05-11-osuweekly-103">Previous</a></td>
-<td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-25-osuweekly-105">Next</a></td>
-</tr></table>
+
+<table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-05-11-osuweekly-103">Previous</a></td><td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-25-osuweekly-105">Next</a></td></tr></table>
 
 ## Navigation
 
@@ -41,31 +40,31 @@ We're headed into an action packed summer kicking development into high gear! Th
 
 <h2 name="score" id="score"><img src="http://nyquill.s-ul.eu/We57rqqm"/></h2>
 
-Starting off the week, [Riviclia](https://osu.ppy.sh/users/1616533) shocked the EZ scene with an amazing 97.98% EZDT FC on [TRUE - Soundscape](https://osu.ppy.sh/beatmaps/1082245) on StarR's Euphonious, landing him 422pp. Yes, that is still his skin. Best skin.
+Starting off the week, [Riviclia](https://osu.ppy.sh/users/1616533) shocked the EZ scene with an amazing 97.98% EZDT FC on [TRUE - Soundscape](https://osu.ppy.sh/beatmapsets/508222#osu/1082245) on StarR's Euphonious, landing him 422pp. Yes, that is still his skin. Best skin.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/X7prz9K83K8" frameborder="0" allowfullscreen></iframe>
 
-[Piggey](https://osu.ppy.sh/users/4163860) continues to shoot up the rankings by setting a crazy 99.14% HDNC FC on [RADWIMPS - Zen Zen Zense (movie ver.)](https://osu.ppy.sh/beatmaps/1091249) on Taki's difficulty, earning an outstanding 616pp and the No. 1 spot (now No. 2 as Rafis sniped it). So this is how chipmunks would sing this song.
+[Piggey](https://osu.ppy.sh/users/4163860) continues to shoot up the rankings by setting a crazy 99.14% HDNC FC on [RADWIMPS - Zen Zen Zense (movie ver.)](https://osu.ppy.sh/beatmapsets/513590#osu/1091249) on Taki's difficulty, earning an outstanding 616pp and the No. 1 spot (now No. 2 as Rafis sniped it). So this is how chipmunks would sing this song.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qSL3z5El4Ws" frameborder="0" allowfullscreen></iframe>
 
-Where did my eyes go? [Mafham](https://osu.ppy.sh/users/3660531) went hysterical and set an unbelievable HD SS on [Scognito - Spelunker](https://osu.ppy.sh/beatmaps/1227265) on the rainbow seizures difficulty. You'd be joking if you said you knew what was going on while watching this.
+Where did my eyes go? [Mafham](https://osu.ppy.sh/users/3660531) went hysterical and set an unbelievable HD SS on [Scognito - Spelunker](https://osu.ppy.sh/beatmapsets/249761#osu/1227265) on the rainbow seizures difficulty. You'd be joking if you said you knew what was going on while watching this.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/2zVyPOorkFY" frameborder="0" allowfullscreen></iframe>
 
-[\[224\]Hyperw7](https://osu.ppy.sh/users/4158549#_general) continues to widen his lead in the osu!catch rankings with a solid 99.61% HR FC on [DJ Totoriott - Chronoxia](https://osu.ppy.sh/beatmaps/926084?m=2), giving him 571pp. Those are some small fruits... er... small squares?
+[\[224\]Hyperw7](https://osu.ppy.sh/users/4158549#_general) continues to widen his lead in the osu!catch rankings with a solid 99.61% HR FC on [DJ Totoriott - Chronoxia](https://osu.ppy.sh/beatmapsets/429184#fruits/926084), giving him 571pp. Those are some small fruits... er... small squares?
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/B7s-2niuRs4" frameborder="0" allowfullscreen></iframe>
 
-[jakads](https://osu.ppy.sh/users/259972) broke the 30,000pp barrier by pulling off a stunning 95.00% DT A rank play on [LeaF - Doppelganger](https://osu.ppy.sh/beatmaps/884617&m=3) on his own difficulty to earn 2402pp. Many congratulations to jakads for being the first person to reach such an impressive milestone.
+[jakads](https://osu.ppy.sh/users/259972) broke the 30,000pp barrier by pulling off a stunning 95.00% DT A rank play on [LeaF - Doppelganger](https://osu.ppy.sh/beatmapsets/407153#mania/884617) on his own difficulty to earn 2402pp. Many congratulations to jakads for being the first person to reach such an impressive milestone.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/AsgCd9bhffU" frameborder="0" allowfullscreen></iframe>
 
 =NOTABLE MENTIONS=
 
-[kablaze](https://osu.ppy.sh/users/3043603) sniped Musty on [Noboru feat.Mitani Nana - Shiroi Yuki no Princess wa](https://osu.ppmiy.sh/b/946082) with a decent 99.35% HDHR FC to give him 553pp.
+[kablaze](https://osu.ppy.sh/users/3043603) sniped Musty on [Noboru feat.Mitani Nana - Shiroi Yuki no Princess wa](https://osu.ppy.sh/beatmapsets/439609#osu/946082) with a decent 99.35% HDHR FC to give him 553pp.
 
-[Blue Dragon](https://osu.ppy.sh/users/19048) ran riot on [Ocelot - TSUBAKI](https://osu.ppy.sh/beatmaps/800237) as he took the No. 2 spot by setting an amazing 98.44% HD FC to earn himself 257pp.
+[Blue Dragon](https://osu.ppy.sh/users/19048) ran riot on [Ocelot - TSUBAKI](https://osu.ppy.sh/beatmapsets/364574#osu/800237) as he took the No. 2 spot by setting an amazing 98.44% HD FC to earn himself 257pp.
 
 ==SCOREWATCH SCORE SHOW==
 


### PR DESCRIPTION
This PR aims to resolve the following:
- oversized iframe embeds found in osu!weekly [\#100](https://osu.ppy.sh/home/news/2017-04-15-osuweekly-100), [\#102](https://osu.ppy.sh/home/news/2017-05-02-osuweekly-102), [\#104](https://osu.ppy.sh/home/news/2017-05-18-osuweekly-104)
- HTML formatted text in osu!weekly [\#100](https://osu.ppy.sh/home/news/2017-04-15-osuweekly-100) causing the rest of the images to be improperly parsed
- banner image of osu!weekly [\#79](https://osu.ppy.sh/home/news/2016-11-07-osuweekly-79) not being formatted in markdown, thereby breaking the whole post

Since I'm not really proficient in HTML, please let me know if any of these changes break some other things that I'm unaware of.