### PR TITLE
Trim loose closing div tag from osu!weekly #100 newspost

### DIFF
--- a/news/2017-04-15-osuweekly-100.md
+++ b/news/2017-04-15-osuweekly-100.md
@@ -24,7 +24,7 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 
 **Woah there peppy, you haven't caught your breath since [starting up the osu!dev blog again](https://blog.ppy.sh/back-in-business!/)!** A flurry of updates made to the osu!lazer client saw the long awaited revival of the osu!dev blog last week. To say that signs of life have been emerging from the well established outlet of development news would be an understatement of massive proportions. Ever since the 9th of April, a new post has been made every day. If you want to prevent yourself from being hopelessly behind on the times, I recommend you go check out the new jekyll powered blog before it's too late!
 
-<iframe width = "560" height = "315" src="//streamable.com/s/52yju/fxqmvb" frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen scrolling="no"></iframe><script async src="//v.embedcdn.com/v1/embed.js"></script></div>
+<iframe width = "560" height = "315" src="//streamable.com/s/52yju/fxqmvb" frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen scrolling="no"></iframe><script async src="//v.embedcdn.com/v1/embed.js"></script>
 
 *from [ppy blog - 2017 04 14](https://blog.ppy.sh/2017-04-14/)*
 


### PR DESCRIPTION
Was messing up formatting on site due to closing the news-post-wrapping `<div class="osu-md osu-md--news">` element prematurely.