### PR TITLE
Clean up the osu! World Cup #1 wiki article

### DIFF
--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -21,7 +21,7 @@ The **osu! World Cup #1** (***OWC #1***) was a single elimination country-based 
 | Round of 16 | 2011-03-01/2011-03-07 |
 | Quarterfinals | 2011-03-08/2011-03-22 |
 | Semifinals | 2011-03-23/2011-03-29 |
-| 3rd Place Playoff & Finals | 2011-03-30/2011-04-11 |
+| Finals | 2011-03-30/2011-04-11 |
 
 ## Prizes
 
@@ -33,7 +33,7 @@ The **osu! World Cup #1** (***OWC #1***) was a single elimination country-based 
 
 ![](img/badge.jpg "OWC #1 winner badge")
 
-Aside from the main prizes listed above, the Tournament Management also decided to separately award all members of the ![][flag_JP] Japanese team 1 month of osu!supporter tag each in the wake of the [2011 Tōhoku earthquake](https://en.wikipedia.org/wiki/2011_T%C5%8Dhoku_earthquake_and_tsunami) incident.
+Aside from the main prizes listed above, the Tournament Management has also decided to separately award all members of the ![][flag_JP] Japanese team with 1 month of osu!supporter tag in the wake of the [2011 Tōhoku earthquake](https://en.wikipedia.org/wiki/2011_T%C5%8Dhoku_earthquake_and_tsunami) incident.
 
 ## Organization
 
@@ -43,7 +43,7 @@ The osu! World Cup #1 was run by various community members.
 | :-: | :-- |
 | Host/Manager | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377) |
 | Streamer | ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359) |
-| Map Selector | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377), ![][flag_AU] [m980](https://osu.ppy.sh/users/3288), ![][flag_DE] [Larto](https://osu.ppy.sh/users/12328), ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993) |
+| Mappool selector | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377), ![][flag_AU] [m980](https://osu.ppy.sh/users/3288), ![][flag_DE] [Larto](https://osu.ppy.sh/users/12328), ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993) |
 | Referee | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377), ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341), ![][flag_ES] [Beuchi-chan](https://osu.ppy.sh/users/67192) |
 
 ## Links

--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -10,74 +10,47 @@ tags:
 
 ![OWC #1 logo](img/logo.png)
 
-The **osu! World Cup #1** (***OWC #1***) was a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It was the first installment of the osu! World Cup.
+The **osu! World Cup #1** (***OWC #1***) was a single elimination country-based osu! tournament that was being run by various osu! community members under the provision of the [osu! team](/wiki/People/The_Team). It was the first installment of the osu! World Cup.
 
 ## Tournament schedule
 
-- The OWC started at 2011-02-21.
-- All matches were played from 15:00 to 22:00 (UTC+0), from Thursday to Sunday.
+| Event | Timestamp |
+| --: | :-- |
+| Registration Phase | 2011-01-31/2011-02-21 |
+| Round of 32 | 2011-02-22/2011-02-28 |
+| Round of 16 | 2011-03-01/2011-03-07 |
+| Quarterfinals | 2011-03-08/2011-03-22 |
+| Semifinals | 2011-03-23/2011-03-29 |
+| 3rd Place Playoff & Finals | 2011-03-30/2011-04-11 |
 
 ## Prizes
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag, unique profile badge |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of osu!supporter tag |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag |
-| *Special* | 1 month of osu!supporter tag |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag for each team member, unique profile badge |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of osu!supporter tag for each team member |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag for each team member |
 
 ![](img/badge.jpg "OWC #1 winner badge")
 
-## Organisation
+Aside from the main prizes listed above, the Tournament Management also decided to separately award all members of the ![][flag_JP] Japanese team 1 month of osu!supporter tag each in the wake of the [2011 Tōhoku earthquake](https://en.wikipedia.org/wiki/2011_T%C5%8Dhoku_earthquake_and_tsunami) incident.
+
+## Organization
 
 The osu! World Cup #1 was run by various community members.
 
-- ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993)
-- ![][flag_ES] [Beuchi-chan](https://osu.ppy.sh/users/67192)
-- ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341)
-- ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359)
-- ![][flag_DE] [Larto](https://osu.ppy.sh/users/12328)
-- ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377)
-- ![][flag_AU] [m980](https://osu.ppy.sh/users/3288)
+| Position | Member(s) |
+| :-: | :-- |
+| Host/Manager | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377) |
+| Streamer | ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359) |
+| Map Selector | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377), ![][flag_AU] [m980](https://osu.ppy.sh/users/3288), ![][flag_DE] [Larto](https://osu.ppy.sh/users/12328), ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993) |
+| Referee | ![][flag_IT] [Lunah](https://osu.ppy.sh/users/1227377), ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341), ![][flag_ES] [Beuchi-chan](https://osu.ppy.sh/users/67192) |
 
 ## Links
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/45412)
-- [Match recaps](https://osu.ppy.sh/community/forums/topics/45412?n=803)
-- [Finals recap](https://www.mediafire.com/file/ab6j6k4ihtp25o2) - provided by [dvorak](https://osu.ppy.sh/users/271359)
-
-## Participants
-
-|  | Country | Members |
-| :-: | :-: | :-- |
-| ![][flag_AT] | **Austria** | **[TouhouNerd](https://osu.ppy.sh/users/396056)**, [Hanyuu](https://osu.ppy.sh/users/73480), [Nharox](https://osu.ppy.sh/users/6794), [Snowball](https://osu.ppy.sh/users/152238), unbelievable <!-- missing --> |
-| ![][flag_AR] | **Argentina** | **[Wishy22](https://osu.ppy.sh/users/495477)**, [Grisuh](https://osu.ppy.sh/users/221500), [lota78](https://osu.ppy.sh/users/50727), [RocknRolla](https://osu.ppy.sh/users/135622), [Vivere](https://osu.ppy.sh/users/101521), [violentt](https://osu.ppy.sh/users/87231) |
-| ![][flag_BR] | **Brazil** | **[fabriciorby](https://osu.ppy.sh/users/209664)**, [Antsu](https://osu.ppy.sh/users/92953), [Blue Dragon](https://osu.ppy.sh/users/19048), [Coy](https://osu.ppy.sh/users/150434), [Guerra](https://osu.ppy.sh/users/271144), [Poisonchan](https://osu.ppy.sh/users/227881) |
-| ![][flag_CA] | **Canada** | **[FurukawaPan](https://osu.ppy.sh/users/32067)**, [Ever 14](https://osu.ppy.sh/users/507051), [Hiyorin](https://osu.ppy.sh/users/493961), [Soulclenz](https://osu.ppy.sh/users/190109), [timotmcc](https://osu.ppy.sh/users/41809), [yanggaog](https://osu.ppy.sh/users/129119) |
-| ![][flag_CL] | **Chile** | **[nVidi4x](https://osu.ppy.sh/users/203181)**, [Art-FzTT](https://osu.ppy.sh/users/248453), [ElxBeta](https://osu.ppy.sh/users/75515), [Mesita](https://osu.ppy.sh/users/201459), [netofe](https://osu.ppy.sh/users/324198) |
-| ![][flag_CN] | **China** | **[kiddly](https://osu.ppy.sh/users/74937)**, [xierbaliti](https://osu.ppy.sh/users/34044), [KanbeKotori](https://osu.ppy.sh/users/107426), [Sprosive](https://osu.ppy.sh/users/227717), [lzy](https://osu.ppy.sh/users/135567), [Brother\_Lu](https://osu.ppy.sh/users/700309) |
-| ![][flag_DO] | **Dominican Republic** | **[Lissette](https://osu.ppy.sh/users/19835)**, [jmt\_3](https://osu.ppy.sh/users/317242), [Lizbeth](https://osu.ppy.sh/users/21970), [Magestix](https://osu.ppy.sh/users/50885) |
-| ![][flag_FI] | **Finland** | **[heintsi](https://osu.ppy.sh/users/63185)**, [Lanttu](https://osu.ppy.sh/users/57448), [morovaa](https://osu.ppy.sh/users/127777), [Mukku](https://osu.ppy.sh/users/71756), [Orkel](https://osu.ppy.sh/users/39385), [Sutsuka](https://osu.ppy.sh/users/29089) |
-| ![][flag_FR] | **France** | **[maestro delphine](https://osu.ppy.sh/users/472848)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [JesusYamato](https://osu.ppy.sh/users/482442), [Shiro](https://osu.ppy.sh/users/113005), Yomi <!-- missing --> |
-| ![][flag_DE] | **Germany** | **[Shael](https://osu.ppy.sh/users/132308)**, [eMJaReL](https://osu.ppy.sh/users/65761), [Jalatiphra](https://osu.ppy.sh/users/94386), [LuniaFreak](https://osu.ppy.sh/users/473895), [Neruell](https://osu.ppy.sh/users/112257), [Shinespark](https://osu.ppy.sh/users/126293) |
-| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](http://osu.ppy.sh/users/346320), [intermu](https://osu.ppy.sh/users/193198), [Rasyad95](https://osu.ppy.sh/users/157956) |
-| ![][flag_IT] | **Italy** | **[Card N'FoRcE](https://osu.ppy.sh/users/3936)**, [\[Takuya\]](https://osu.ppy.sh/users/342372), Kr4t0ss88 <!-- missing -->, [Lunah](https://osu.ppy.sh/users/1227377), [osuplayer111](https://osu.ppy.sh/users/33599), [Valde](https://osu.ppy.sh/users/208531) |
-| ![][flag_JP] | **Japan** | **[MeRcYyy](https://osu.ppy.sh/users/75595)**, [Ozouni](https://osu.ppy.sh/users/69600), [Rigeru](https://osu.ppy.sh/users/61154), [Rorry](https://osu.ppy.sh/users/198574), [SiLviA](https://osu.ppy.sh/users/409747), [taNa](https://osu.ppy.sh/users/61101) |
-| ![][flag_MO] | **Macau** | **[Ballance](https://osu.ppy.sh/users/165946)**, [\_\_\_\_\_B](https://osu.ppy.sh/users/247901), [starpun1](https://osu.ppy.sh/users/144523), [wl01939929](https://osu.ppy.sh/users/456163), [xinhe](https://osu.ppy.sh/users/252936) |
-| ![][flag_MY] | **Malaysia** | **[The 08 team\_Bourdon](https://osu.ppy.sh/users/275686)**, [akupp](https://osu.ppy.sh/users/249825), [DragonSparta](https://osu.ppy.sh/users/216909), [Crimson\_SoulZ](https://osu.ppy.sh/users/91320), mekadon <!-- missing -->, [mycyber](https://osu.ppy.sh/users/187910) |
-| ![][flag_NL] | **Netherlands** | **[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [happy30](https://osu.ppy.sh/users/27767), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308) |
-| ![][flag_NZ] | **New Zealand** | **[NumoT123](https://osu.ppy.sh/users/282930)**, Acidsky- <!-- missing -->, [deadbeat](https://osu.ppy.sh/users/128370), [jiantz](https://osu.ppy.sh/users/330252), [SkyE-](https://osu.ppy.sh/users/114796), [toejamms](https://osu.ppy.sh/users/231111) |
-| ![][flag_PH] | **Philippines** | **[dayun10](https://osu.ppy.sh/users/570310)**, [bakaloidsky](https://osu.ppy.sh/users/504885), [blacksymbian](https://osu.ppy.sh/users/53956), [jockeytiyan](https://osu.ppy.sh/users/133618), [nachopiggy](https://osu.ppy.sh/users/95637), [WyndII](https://osu.ppy.sh/users/46538) |
-| ![][flag_PL] | **Poland** | **[ShaggoN](https://osu.ppy.sh/users/39129)**, [fartownik](https://osu.ppy.sh/users/56917), [kuburaczek](https://osu.ppy.sh/users/29130), [Niko-](https://osu.ppy.sh/users/175141), [rEdo](https://osu.ppy.sh/users/49329), [White Wolf](https://osu.ppy.sh/users/39828) |
-| ![][flag_PT] | **Portugal** | **[JonnyThatJonny](https://osu.ppy.sh/users/201290)**, [creativ](https://osu.ppy.sh/users/280158), [makkura](https://osu.ppy.sh/users/344086), [sttailruby12](https://osu.ppy.sh/users/213335) |
-| ![][flag_RU] | **Russian Federation** | **[GaShiK](https://osu.ppy.sh/users/227643)**, [Akai-](https://osu.ppy.sh/users/649471), CracK <!-- missing -->, [Kotya](https://osu.ppy.sh/users/297551), [larch](https://osu.ppy.sh/users/296787), [TKiller](https://osu.ppy.sh/users/113027) |
-| ![][flag_KR] | **South Korea** | **[KRZY](https://osu.ppy.sh/users/114017)**, [Binjip](https://osu.ppy.sh/users/261694), [Cookiezi](https://osu.ppy.sh/users/124493), [ehRh](https://osu.ppy.sh/users/272117), [M A I D](https://osu.ppy.sh/users/216472), [Reisen Udongein](https://osu.ppy.sh/users/232942) |
-| ![][flag_ES] | **Spain** | **[X\_Ray](https://osu.ppy.sh/users/160937)**, [choche](https://osu.ppy.sh/users/239850), [hyperluigi](https://osu.ppy.sh/users/43921), [Lionheart69](https://osu.ppy.sh/users/88152), [migul](https://osu.ppy.sh/users/423217), [Skullboss](http://osu.ppy.sh/users/48527) |
-| ![][flag_SE] | **Sweden** | **[beko1994](https://osu.ppy.sh/users/310548)**, [Darkoff](https://osu.ppy.sh/users/131072), [palinus](https://osu.ppy.sh/users/214706), [Saten-san](https://osu.ppy.sh/users/444506), [Vikkez](https://osu.ppy.sh/users/235215), [Xgor](https://osu.ppy.sh/users/98661) |
-| ![][flag_TW] | **Taiwan** | **[Uan](https://osu.ppy.sh/users/147623)**, [0222101916](https://osu.ppy.sh/users/122650), [FuNnY--](https://osu.ppy.sh/users/398097), [NanaDesu](https://osu.ppy.sh/users/163474), [Rucker](https://osu.ppy.sh/users/147515), [Tomoka Rin](https://osu.ppy.sh/users/125308) |
-| ![][flag_UA] | **Ukraine** | **[Gorlum](https://osu.ppy.sh/users/347635)**, [gef](https://osu.ppy.sh/users/226175), [Mosya](https://osu.ppy.sh/users/77835), [RainForce](https://osu.ppy.sh/users/192251), [rockleejkooo](https://osu.ppy.sh/users/384003) |
-| ![][flag_GB] | **United Kingdom** | **[Doomsday](https://osu.ppy.sh/users/18983)**, aevv <!-- missing -->, [DiamondCrash](https://osu.ppy.sh/users/123790), [jericho2442](https://osu.ppy.sh/users/88904), [Natteke](https://osu.ppy.sh/users/157177) |
-| ![][flag_US] | **United States** | **[Lybydose](https://osu.ppy.sh/users/64501)**, [Cyclone](https://osu.ppy.sh/users/18589), [ebacho](https://osu.ppy.sh/users/129932), [Mafiamaster](https://osu.ppy.sh/users/17695), [naptime](http://osu.ppy.sh/users/277682) |
+- [Livestream channel](https://livestream.com/osuworldcup)
+- [Finals recap](https://www.mediafire.com/file/ab6j6k4ihtp25o2) - provided by ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359)
 
 ## Podium
 
@@ -88,15 +61,61 @@ This competition has come to an end and resulted in the following podium:
 | ![Gold crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_TW] **Taiwan** (**[Uan](https://osu.ppy.sh/users/147623)**, [0222101916](https://osu.ppy.sh/users/122650), [FuNnY--](https://osu.ppy.sh/users/398097), [NanaDesu](https://osu.ppy.sh/users/163474), [Rucker](https://osu.ppy.sh/users/147515), [Tomoka Rin](https://osu.ppy.sh/users/125308)) |
 | ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_NL] **Netherlands** (**[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [happy30](https://osu.ppy.sh/users/27767), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308)) |
 | ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_KR] **South Korea** (**[KRZY](https://osu.ppy.sh/users/114017)**, [Binjip](https://osu.ppy.sh/users/261694), [Cookiezi](https://osu.ppy.sh/users/124493), [ehRh](https://osu.ppy.sh/users/272117), [M A I D](https://osu.ppy.sh/users/216472), [Reisen Udongein](https://osu.ppy.sh/users/232942)) |
-| *Special* | ![][flag_JP] **Japan** (**[MeRcYyy](https://osu.ppy.sh/users/75595)**, [Ozouni](https://osu.ppy.sh/users/69600), [Rigeru](https://osu.ppy.sh/users/61154), [Rorry](https://osu.ppy.sh/users/198574), [SiLviA](https://osu.ppy.sh/users/409747), [taNa](https://osu.ppy.sh/users/61101)) |
 
 ![OWC #1 bracket](img/bracket.jpg)
+
+## Participants
+
+|  | Country | Members |
+| :-: | :-: | :-- |
+| ![][flag_AT]/![][flag_DE] | **Austria - Germany** | **[TouhouNerd](https://osu.ppy.sh/users/396056)**, [Hanyuu](https://osu.ppy.sh/users/73480), [Nharox](https://osu.ppy.sh/users/6794), [Snowball](https://osu.ppy.sh/users/152238), unbelievable <!-- missing --> |
+| ![][flag_AR] | **Argentina** | **[Wishy22](https://osu.ppy.sh/users/495477)**, [Grisuh](https://osu.ppy.sh/users/221500), [lota78](https://osu.ppy.sh/users/50727), [RocknRolla](https://osu.ppy.sh/users/135622), [Vivere](https://osu.ppy.sh/users/101521), [violentt](https://osu.ppy.sh/users/87231) |
+| ![][flag_BR] | **Brazil** | **[fabriciorby](https://osu.ppy.sh/users/209664)**, [Antsu](https://osu.ppy.sh/users/92953), [Blue Dragon](https://osu.ppy.sh/users/19048), [Coy](https://osu.ppy.sh/users/150434), [Guerra](https://osu.ppy.sh/users/271144), [Poisonchan](https://osu.ppy.sh/users/227881) |
+| ![][flag_CA] | **Canada** | **[FurukawaPan](https://osu.ppy.sh/users/32067)**, [Ever 14](https://osu.ppy.sh/users/507051), [Hiyorin](https://osu.ppy.sh/users/493961), [Soulclenz](https://osu.ppy.sh/users/190109), [timotmcc](https://osu.ppy.sh/users/41809), [yanggaog](https://osu.ppy.sh/users/129119) |
+| ![][flag_CL] | **Chile** | **[nVidi4x](https://osu.ppy.sh/users/203181)**, [Art-FzTT](https://osu.ppy.sh/users/248453), [ElxBeta](https://osu.ppy.sh/users/75515), [Mesita](https://osu.ppy.sh/users/201459), [netofe](https://osu.ppy.sh/users/324198) |
+| ![][flag_CN] | **China** | **[kiddly](https://osu.ppy.sh/users/74937)**, [xierbaliti](https://osu.ppy.sh/users/34044), [KanbeKotori](https://osu.ppy.sh/users/107426), [Sprosive](https://osu.ppy.sh/users/227717), [lzy](https://osu.ppy.sh/users/135567), [Brother\_Lu](https://osu.ppy.sh/users/700309) |
+| ![][flag_DO] | **Dominican Republic** | **[Lissette](https://osu.ppy.sh/users/19835)**, [jmt\_3](https://osu.ppy.sh/users/317242), [Lizbeth](https://osu.ppy.sh/users/21970), [Magestix](https://osu.ppy.sh/users/50885) |
+| ![][flag_FI] | **Finland** | **[heintsi](https://osu.ppy.sh/users/63185)**, [Lanttu](https://osu.ppy.sh/users/57448), [morovaa](https://osu.ppy.sh/users/127777), [Mukku](https://osu.ppy.sh/users/71756), [Orkel](https://osu.ppy.sh/users/39385), [Sutsuka](https://osu.ppy.sh/users/29089) |
+| ![][flag_FR] | **France** | **[maestro delphine](https://osu.ppy.sh/users/472848)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [JesusYamato](https://osu.ppy.sh/users/482442), [Shiro](https://osu.ppy.sh/users/113005), Yomi <!-- missing --> |
+| ![][flag_DE] | **Germany** | **[Shael](https://osu.ppy.sh/users/132308)**, [eMJaReL](https://osu.ppy.sh/users/65761), [Jalatiphra](https://osu.ppy.sh/users/94386), [LuniaFreak](https://osu.ppy.sh/users/473895), [Neruell](https://osu.ppy.sh/users/112257), [Shinespark](https://osu.ppy.sh/users/126293) |
+| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](http://osu.ppy.sh/users/346320), [intermu](https://osu.ppy.sh/users/193198), [Rasyad95](https://osu.ppy.sh/users/157956) |
+| ![][flag_IT] | **Italy** | **[Card N'FoRcE](https://osu.ppy.sh/users/3936)**, [\[Takuya\]](https://osu.ppy.sh/users/342372), kr4t0s88<!-- missing -->, [Lunah](https://osu.ppy.sh/users/1227377), [osuplayer111](https://osu.ppy.sh/users/33599), [Valde](https://osu.ppy.sh/users/208531) |
+| ![][flag_JP] | **Japan** | **[MeRcYyy](https://osu.ppy.sh/users/75595)**, [Ozouni](https://osu.ppy.sh/users/69600), [Rigeru](https://osu.ppy.sh/users/61154), [Rorry](https://osu.ppy.sh/users/198574), [SiLviA](https://osu.ppy.sh/users/409747), [taNa](https://osu.ppy.sh/users/61101) |
+| ![][flag_MO] | **Macau** | **[Ballance](https://osu.ppy.sh/users/165946)**, [\_\_\_\_\_B](https://osu.ppy.sh/users/247901), [starpun1](https://osu.ppy.sh/users/144523), [wl01939929](https://osu.ppy.sh/users/456163), [xinhe](https://osu.ppy.sh/users/252936) |
+| ![][flag_MY] | **Malaysia** | **[The 08 team\_Bourdon](https://osu.ppy.sh/users/275686)**, [akupp](https://osu.ppy.sh/users/249825), [DragonSparta](https://osu.ppy.sh/users/216909), [Crimson\_SoulZ](https://osu.ppy.sh/users/91320), mekadon<!-- missing -->, [mycyber](https://osu.ppy.sh/users/187910) |
+| ![][flag_NL] | **Netherlands** | **[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [happy30](https://osu.ppy.sh/users/27767), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308) |
+| ![][flag_NZ] | **New Zealand** | **[NumoT123](https://osu.ppy.sh/users/282930)**, [Acidsky-](https://osu.ppy.sh/users/116608), [deadbeat](https://osu.ppy.sh/users/128370), [jiantz](https://osu.ppy.sh/users/330252), [SkyE-](https://osu.ppy.sh/users/114796), [toejamms](https://osu.ppy.sh/users/231111) |
+| ![][flag_PH] | **Philippines** | **[dayun10](https://osu.ppy.sh/users/570310)**, [bakaloidsky](https://osu.ppy.sh/users/504885), [blacksymbian](https://osu.ppy.sh/users/53956), [jockeytiyan](https://osu.ppy.sh/users/133618), [nachopiggy](https://osu.ppy.sh/users/95637), [WyndII](https://osu.ppy.sh/users/46538) |
+| ![][flag_PL] | **Poland** | **[ShaggoN](https://osu.ppy.sh/users/39129)**, [fartownik](https://osu.ppy.sh/users/56917), [kuburaczek](https://osu.ppy.sh/users/29130), [Niko-](https://osu.ppy.sh/users/175141), [rEdo](https://osu.ppy.sh/users/49329), [White Wolf](https://osu.ppy.sh/users/39828) |
+| ![][flag_PT] | **Portugal** | **[JonnyThatJonny](https://osu.ppy.sh/users/201290)**, [creativ](https://osu.ppy.sh/users/280158), [makkura](https://osu.ppy.sh/users/344086), [sttailruby12](https://osu.ppy.sh/users/213335) |
+| ![][flag_RU] | **Russian Federation** | **[GaShiK](https://osu.ppy.sh/users/227643)**, [Akai-](https://osu.ppy.sh/users/649471), CracK<!-- missing -->, [Kotya](https://osu.ppy.sh/users/297551), [larch](https://osu.ppy.sh/users/296787), [TKiller](https://osu.ppy.sh/users/113027) |
+| ![][flag_KR] | **South Korea** | **[KRZY](https://osu.ppy.sh/users/114017)**, [Binjip](https://osu.ppy.sh/users/261694), [Cookiezi](https://osu.ppy.sh/users/124493), [ehRh](https://osu.ppy.sh/users/272117), [M A I D](https://osu.ppy.sh/users/216472), [Reisen Udongein](https://osu.ppy.sh/users/232942) |
+| ![][flag_ES] | **Spain** | **[X\_Ray](https://osu.ppy.sh/users/160937)**, [choche](https://osu.ppy.sh/users/239850), [hyperluigi](https://osu.ppy.sh/users/43921), [Lionheart69](https://osu.ppy.sh/users/88152), [migul](https://osu.ppy.sh/users/423217), [Skullboss](http://osu.ppy.sh/users/48527) |
+| ![][flag_SE] | **Sweden** | **[beko1994](https://osu.ppy.sh/users/310548)**, [Darkoff](https://osu.ppy.sh/users/131072), [palinus](https://osu.ppy.sh/users/214706), [Saten-san](https://osu.ppy.sh/users/444506), [Vikkez](https://osu.ppy.sh/users/235215), [Xgor](https://osu.ppy.sh/users/98661) |
+| ![][flag_TW] | **Taiwan** | **[Uan](https://osu.ppy.sh/users/147623)**, [0222101916](https://osu.ppy.sh/users/122650), [FuNnY--](https://osu.ppy.sh/users/398097), [NanaDesu](https://osu.ppy.sh/users/163474), [Rucker](https://osu.ppy.sh/users/147515), [Tomoka Rin](https://osu.ppy.sh/users/125308) |
+| ![][flag_UA] | **Ukraine** | **[Gorlum](https://osu.ppy.sh/users/347635)**, [gef](https://osu.ppy.sh/users/226175), [Mosya](https://osu.ppy.sh/users/77835), [RainForce](https://osu.ppy.sh/users/192251), [rockleejkooo](https://osu.ppy.sh/users/384003) |
+| ![][flag_GB] | **United Kingdom** | **[Doomsday](https://osu.ppy.sh/users/18983)**, aevv<!-- missing -->, [DiamondCrash](https://osu.ppy.sh/users/123790), [jericho2442](https://osu.ppy.sh/users/88904), [Natteke](https://osu.ppy.sh/users/157177) |
+| ![][flag_US] | **United States** | **[Lybydose](https://osu.ppy.sh/users/64501)**, [Cyclone](https://osu.ppy.sh/users/18589), [ebacho](https://osu.ppy.sh/users/129932), [Mafiamaster](https://osu.ppy.sh/users/17695), [naptime](http://osu.ppy.sh/users/277682) |
 
 ## Mappools
 
 ### Finals
 
-- NoMod (played in order)
+- NoMod (*to be played in order*)
+  - [Minibosses - Castlevania (m980) \[owc Finals\]](http://www.mediafire.com/file/twuti02311dk6ip/Minibosses+-+Castlevania.osz/file)
+  - [Various Artists - osu! Stream Compilation (Natteke) \[EXE\]](https://osu.ppy.sh/beatmapsets/25403#osu/86044)
+  - [Shiki mixed by Djsmalls - Air (MegaManEXE) \[Best map ever created\]](https://osu.ppy.sh/beatmapsets/13008#osu/48386)
+  - [Nico Nico Douga - U.N. Owen Was Her? (Reikin) \[Ronald Mix\]](https://osu.ppy.sh/beatmapsets/1785#osu/21010)
+  - [07th Expansion - rog-limitation (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmapsets/14994#osu/54581)
+  - [Amuro vs Killer - Mei (v2b) \[Another\]](https://osu.ppy.sh/beatmapsets/8965#osu/36290)
+  - [m-flo loves CHEMISTRY - Astrosexy (mtmcl) \[Sexy\]](https://osu.ppy.sh/beatmapsets/13244#osu/49101)
+  - [Renard - Banned Forever (Blue Dragon) \[Lesjuh\]](https://osu.ppy.sh/beatmapsets/16349#osu/64266)    
+- Tiebreaker
+  - **[IOSYS - Usatei (Card N'FoRcE) \[RUN!!\]](https://osu.ppy.sh/beatmapsets/3959#osu/22993)**
+
+### 3rd Place Playoffs
+
+- NoMod (*to be played in order*)
   - [Glasslake - Driving Lazy Bee (darrihuka) \[DaRRi MIx\]](https://osu.ppy.sh/beatmapsets/3861#osu/22759)
   - [YUI - Sea (VanMoNky) \[Senior\]](https://osu.ppy.sh/beatmapsets/13021#osu/48422)
   - [Suzaku - Anisakis -somatic mutation type "Forza" (tsukamaete) \[Another\]](https://osu.ppy.sh/beatmapsets/15579#osu/56347)
@@ -108,7 +127,7 @@ This competition has come to an end and resulted in the following podium:
 
 ### Semifinals
 
-- NoMod (played in order)
+- NoMod (*to be played in order*)
   - [COOL&CREATE - Rapid Ensemble (Doomsday93) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/13235#osu/49067)
   - [Suzaku VS Genbu - Himiko (Mystearica) \[Another\]](https://osu.ppy.sh/beatmapsets/12710#osu/47462)
   - [Susumu Hirasawa - Big Brother (Gens) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/10714#osu/42244)
@@ -160,7 +179,7 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[Seiryu - Time to Air (Alace) \[DaRRi MIx\]](https://osu.ppy.sh/beatmapsets/4597#osu/24594)**
 
-### Group Stage
+### Round of 32
 
 - NoMod
   - [BeForU - Love Shine (James) \[Hard\]](https://osu.ppy.sh/beatmapsets/1300#osu/11091)
@@ -181,33 +200,176 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[Hyadain - Battle with the Four Fiends (mtmcl) \[Sinistro\]](https://osu.ppy.sh/beatmapsets/2619#osu/20019)**
 
+## Match results
+
+### Finals
+
+Friday, 9 April 2011 (Grand Final):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_NL] Netherlands | 1 | **4** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/494834) |
+
+Friday, 9 April 2011 (3rd Place Playoff):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_CL] Chile | 0 | **4** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/498398) |
+
+### Semifinals
+
+Saturday, 27 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_TW] **Taiwan** | **4** | 3 | ![][flag_KR] South Korea | [#1](https://osu.ppy.sh/community/matches/403908) |
+| ![][flag_NL] **Netherlands** | **4** | 0 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/415277) |
+
+### Quarterfinals
+
+Friday, 19 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_PL] Poland | 0 | **3** | ![][flag_NL] **Netherlands** | [#1](https://osu.ppy.sh/community/matches/354944) |
+
+Saturday, 20 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_KR] **South Korea** | **3** | 0 | ![][flag_JP] Japan | *win by default* |
+
+Sunday, 21 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_IT] Italy | 0 | **3** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/368813) |
+| ![][flag_US] United States | 0 | **3** | ![][flag_CL] **Chile** | [#1](https://osu.ppy.sh/community/matches/372799) |
+
+### Round of 16
+
+Friday, 5 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_JP] **Japan** | **2** | 0 | ![][flag_NZ] New Zealand | [#1](https://osu.ppy.sh/community/matches/275730) [#2](https://osu.ppy.sh/community/matches/275932) |
+| ![][flag_NL] **Netherlands** | **2** | 0 | ![][flag_UA] Ukraine | [#1](https://osu.ppy.sh/community/matches/278742) |
+| ![][flag_TW] **Taiwan** | **2** | 0 | ![][flag_AT]/![][flag_DE] Austria - Germany | [#1](https://osu.ppy.sh/community/matches/277597) |
+
+Saturday, 6 March 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_CL] **Chile** | **2** | 0 | ![][flag_DO] Dominican Republic | [#1](https://osu.ppy.sh/community/matches/287746) |
+| ![][flag_KR] **South Korea** | **2** | 0 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/284533) |
+| ![][flag_GB] United Kingdom | 0 | **2** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/287601) |
+| ![][flag_PL] **Poland** | **2** | 0 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/285669) |
+| ![][flag_IT] **Italy** | **2** | 0 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/287090) |
+
+### Round of 32
+
+Thursday, 25 February 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_AT]/![][flag_DE] **Austria - Germany** | **2** | 0 | ![][flag_MO] Macau | [#1](https://osu.ppy.sh/community/matches/230254) |
+| ![][flag_ID] Indonesia | 1 | **2** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/229277) |
+| ![][flag_PH] Philippines | 0 | **2** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/228885) |
+
+Friday, 26 February 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_KR] **South Korea** | **2** | 1 | ![][flag_CN] China | [#1](https://osu.ppy.sh/community/matches/236416) |
+| ![][flag_DE] **Germany** | **2** | 0 | ![][flag_RU] Russia | [#1](https://osu.ppy.sh/community/matches/237905) |
+| ![][flag_PT] Portugal | 0 | **2** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/238693) |
+
+Saturday, 27 February 2011:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_AR] Argentina | 1 | **2** | ![][flag_DO] **Dominican Republic** | [#1](https://osu.ppy.sh/community/matches/247903) |
+| ![][flag_UA] **Ukraine** | **2** | 0 | ![][flag_SE] Sweden | [#1](https://osu.ppy.sh/community/matches/246481) |
+| ![][flag_ES] Spain | 0 | **2** | ![][flag_FR] **France** | [#1](https://osu.ppy.sh/community/matches/246819) |
+| ![][flag_BR] Brazil | 0 | **2** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/247409) |
+| ![][flag_CL] **Chile** | **2** | 1 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/247736) |
+| ![][flag_NL] **Netherlands** | **2** | 0 | ![][flag_FI] Finland | [#1](https://osu.ppy.sh/community/matches/246577) |
+
 ## Ruleset
 
 ### Tournament rules
 
-1. One of two captains must post the link of the multiplayer history after the match, you can find it when you join the room into the chat.
-2. If a team not present during the match, that team will be disqualified. Opposing team is obliged to wait for at least 15 minutes for the team to show up.
-3. Any form of cheating will be punished with the disqualification of the team and ban of the cheating player.
+1. The osu! World Cup is a 4v4, country-based team tournament played on the osu! game mode.
+2. Beatmap scoring is based on **[ScoreV1](/wiki/Score#scorev1)**.
+3. Teams will compete against each other following [this bracket set by the Tournament Management](img/bracket.jpg) using the Single Elimination system.
+4. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance on the Sunday before the actual matches take place. Only these beatmaps will be used during the respective matches. 
+   - One beatmap will be a tiebreaker beatmap. This beatmap will only be played in case of a tie.
+5. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions)).
+6. If no staff or referee is available, the match will be postponed.
+7. If the beatmap ends in a draw, the map will be nullified.
+8. If a player disconnects, their scores will not be counted towards their team's total.
+9. Beatmaps cannot be reused in the same match unless the map was nullified.
+10. If less than the minimum required players attend, the maximum time the match can be postponed is 10 minutes.
+11. Exchanging players during a match is allowed without limitations.
+    - **If a map rematch is required, exchanging players is not allowed. With the referee's discretion, an exception can be made if the previous roster is unavailable to play.**
+12. Lag is not a valid reason to nullify a beatmap.
+13. All players are supposed to keep the match running fluently and without delays. Penalties can be issued to the players if they cause excessive match delays.
+14. If a player disconnects between maps and the team cannot provide a replacement, the match can be delayed 10 minutes at maximum.
+15. All players and referees must be treated with respect. Instructions of the referees and Tournament Management are to be followed. Decisions labeled as final are not to be objected.
+16. Disrupting the match by foul play, insulting and provoking other players or referees, delaying the match or other deliberate inappropriate misbehavior is strictly prohibited.
+17. Unexpected incidents are handled by the Tournament Management. Referees may allow higher tolerance depending on the circumstances. This is up to their discretion.
+18. Penalties for violating the tournament rules may include:
+    - Exclusion of specific players for one beatmap
+    - Exclusion of specific players for an entire match
+    - Declaring the match as Lost by Default
+    - Disqualification from the entire tournament
+    - Disqualification from the current and future official tournaments until appealed
+    - Any modification of these rules will be announced.
 
-### Instructions
+### Tournament registration
 
-1. The first stage of the cup is divided depending on continent.
-   - Example: Europe country vs Europe country (Poland vs Portugal).
-2. All matches follow knockout tournament rule.
-3. 32 countries. If not enough countries, cup's stages will be modeled based on the number reached.
-4. Each country's decision will be represented by a "captain" who will choose the members of the team and will inform players about the timetables.
-5. Captains will be chosen by language specific topics or discussions in IRC specific language channels made by trusted players/staffs.
-6. Teams should made up of 4 players and 2 backups in case one or more players are not available to play.
+1. In order to be registered for the tournament, a representative of each country will have to propose a team roster comprising of 4-6 players in the discussion thread.
+   - Registering a team that represents multiple countries are allowed under a discretion of the Tournament Management.
+2. To ensure valid and serious registrations, every proposed team roster will be checked by the Tournament Management.
+3. All accepted teams will be announced in the discussion thread after the Registration Phase.
+   - **A team should have at least 4 players registered in order to be eligible to participate.**
+4. Staff members are not eligible to participate as players in this tournament.
 
 ### Match instructions
 
-1. For each round, a list of 15 Beatmaps will be given chosen by a staff member of the tournament(a non-player). Countries can choose one of these beatmaps to play for a match (I recommend you prepare another choice in case your opponent chooses the same map) of the round. Beatmap packs containing the 15 beatmaps for every round will be created for convenience.
-2. The matches will be played in a private room created by one of the two competing captains.
-3. Settings will be osu! standard, 4 vs 4 players, "Team VS" mode and Win condition: "Score".
-4. The country with highest team total score (total score of all players) will win the map.
-5. The only mod accepted is No Video.
-6. In the case of a 1-1 draw, there will be a default tiebreaker map that decided by the cup staff.
-7. When a team fails, the other team automatically wins the match.
+1. A referee will create a multiplayer room 15 minutes in advance. Players must gather during this period.
+   - Room settings are osu!, Team-Vs., Win Condition: 'Score'. Room name must be "OWC: (TeamRed) vs (TeamBlue)".
+   - The team mentioned first in the room name must be the red team, the team mentioned second in the room name must be the blue team.
+2. Map banning **does not apply** in the entirety of the tournament.
+3. Each team must have 4 players for each map. They can be exchanged freely after a map is concluded.
+4. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
+5. Each captain must use the "!roll" command once in #multiplayer.
+   - The captain with the higher roll decides which team **picks** first.
+6. The results of eatch match will be posted on the discussion thread after the match has been concluded by the responsible referees.
+
+#### Winning conditions
+
+- The Round of 32 and Round of 16 will be played in a Best-of-3 matchup configuration (first team to 2 points wins).
+- The Quarterfinals will be played in a Best-of-5 matchup configuration (first team to 3 points wins).
+- The Semifinals and the Finals will be played in a Best-of-7 matchup configuration (first team to 4 points wins).
+
+### Mappool instructions
+
+1. There will be a different mappool for every stage.
+2. All the maps in the mappool (including the TieBreaker) will be played without any modifications enabled (NoMod).
+3. Each mappool has a specific size depending on the stage.
+   - The Round of 32, Round of 16, and the Quarterfinals will all have 15 NoMod maps (to be picked in any order) + 1 Tiebreaker map.
+   - The Semifinals and the 3rd Place Playoffs will both have 6 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
+   - The Finals will have 8 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
+
+### Scheduling instructions
+
+1. Each stage will be held on **a single weekend**.   
+2. Scheduling will be handled by the Tournament Management. Schedules will be released on the Sunday before the first matches of the stage.
+3. **Reschedules will only be considered if both teams agree to a time. This needs to be done and notified to the Tournament Management before the particular match takes place.**
+4. **Reschedules may only be requested by a team captain.**
+   - **Do not ask for a reschedule unless it is absolutely necessary. The Tournament Management has the right to decline the request.**
+5. Captains are responsible for their teams' availability. The greater team size exists to ensure every team can provide at least four players for each match. If teams can not provide four players for a match, the match will be considered forfeited.
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentina"
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"

--- a/wiki/Tournaments/OWC/1/en.md
+++ b/wiki/Tournaments/OWC/1/en.md
@@ -10,7 +10,7 @@ tags:
 
 ![OWC #1 logo](img/logo.png)
 
-The **osu! World Cup #1** (***OWC #1***) was a single elimination country-based osu! tournament that was being run by various osu! community members under the provision of the [osu! team](/wiki/People/The_Team). It was the first installment of the osu! World Cup.
+The **osu! World Cup #1** (***OWC #1***) was a single elimination country-based osu! tournament run by various osu! community members under the provision of the [osu! team](/wiki/People/The_Team). It was the first installment of the osu! World Cup.
 
 ## Tournament schedule
 
@@ -68,7 +68,7 @@ This competition has come to an end and resulted in the following podium:
 
 |  | Country | Members |
 | :-: | :-: | :-- |
-| ![][flag_AT]/![][flag_DE] | **Austria - Germany** | **[TouhouNerd](https://osu.ppy.sh/users/396056)**, [Hanyuu](https://osu.ppy.sh/users/73480), [Nharox](https://osu.ppy.sh/users/6794), [Snowball](https://osu.ppy.sh/users/152238), unbelievable <!-- missing --> |
+| ![][flag_AT]/![][flag_DE] | **Austria - Germany** | **[TouhouNerd](https://osu.ppy.sh/users/396056)**, [Hanyuu](https://osu.ppy.sh/users/73480), [Nharox](https://osu.ppy.sh/users/6794), [Snowball](https://osu.ppy.sh/users/152238), [unbelievable](https://osu.ppy.sh/users/491021) |
 | ![][flag_AR] | **Argentina** | **[Wishy22](https://osu.ppy.sh/users/495477)**, [Grisuh](https://osu.ppy.sh/users/221500), [lota78](https://osu.ppy.sh/users/50727), [RocknRolla](https://osu.ppy.sh/users/135622), [Vivere](https://osu.ppy.sh/users/101521), [violentt](https://osu.ppy.sh/users/87231) |
 | ![][flag_BR] | **Brazil** | **[fabriciorby](https://osu.ppy.sh/users/209664)**, [Antsu](https://osu.ppy.sh/users/92953), [Blue Dragon](https://osu.ppy.sh/users/19048), [Coy](https://osu.ppy.sh/users/150434), [Guerra](https://osu.ppy.sh/users/271144), [Poisonchan](https://osu.ppy.sh/users/227881) |
 | ![][flag_CA] | **Canada** | **[FurukawaPan](https://osu.ppy.sh/users/32067)**, [Ever 14](https://osu.ppy.sh/users/507051), [Hiyorin](https://osu.ppy.sh/users/493961), [Soulclenz](https://osu.ppy.sh/users/190109), [timotmcc](https://osu.ppy.sh/users/41809), [yanggaog](https://osu.ppy.sh/users/129119) |
@@ -76,33 +76,33 @@ This competition has come to an end and resulted in the following podium:
 | ![][flag_CN] | **China** | **[kiddly](https://osu.ppy.sh/users/74937)**, [xierbaliti](https://osu.ppy.sh/users/34044), [KanbeKotori](https://osu.ppy.sh/users/107426), [Sprosive](https://osu.ppy.sh/users/227717), [lzy](https://osu.ppy.sh/users/135567), [Brother\_Lu](https://osu.ppy.sh/users/700309) |
 | ![][flag_DO] | **Dominican Republic** | **[Lissette](https://osu.ppy.sh/users/19835)**, [jmt\_3](https://osu.ppy.sh/users/317242), [Lizbeth](https://osu.ppy.sh/users/21970), [Magestix](https://osu.ppy.sh/users/50885) |
 | ![][flag_FI] | **Finland** | **[heintsi](https://osu.ppy.sh/users/63185)**, [Lanttu](https://osu.ppy.sh/users/57448), [morovaa](https://osu.ppy.sh/users/127777), [Mukku](https://osu.ppy.sh/users/71756), [Orkel](https://osu.ppy.sh/users/39385), [Sutsuka](https://osu.ppy.sh/users/29089) |
-| ![][flag_FR] | **France** | **[maestro delphine](https://osu.ppy.sh/users/472848)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [JesusYamato](https://osu.ppy.sh/users/482442), [Shiro](https://osu.ppy.sh/users/113005), Yomi <!-- missing --> |
+| ![][flag_FR] | **France** | **[maestro delphine](https://osu.ppy.sh/users/472848)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [JesusYamato](https://osu.ppy.sh/users/482442), [Shiro](https://osu.ppy.sh/users/113005), [Yomi](https://osu.ppy.sh/users/366059) |
 | ![][flag_DE] | **Germany** | **[Shael](https://osu.ppy.sh/users/132308)**, [eMJaReL](https://osu.ppy.sh/users/65761), [Jalatiphra](https://osu.ppy.sh/users/94386), [LuniaFreak](https://osu.ppy.sh/users/473895), [Neruell](https://osu.ppy.sh/users/112257), [Shinespark](https://osu.ppy.sh/users/126293) |
-| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](http://osu.ppy.sh/users/346320), [intermu](https://osu.ppy.sh/users/193198), [Rasyad95](https://osu.ppy.sh/users/157956) |
-| ![][flag_IT] | **Italy** | **[Card N'FoRcE](https://osu.ppy.sh/users/3936)**, [\[Takuya\]](https://osu.ppy.sh/users/342372), kr4t0s88<!-- missing -->, [Lunah](https://osu.ppy.sh/users/1227377), [osuplayer111](https://osu.ppy.sh/users/33599), [Valde](https://osu.ppy.sh/users/208531) |
+| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](https://osu.ppy.sh/users/346320), [intermu](https://osu.ppy.sh/users/193198), [Rasyad95](https://osu.ppy.sh/users/157956) |
+| ![][flag_IT] | **Italy** | **[Card N'FoRcE](https://osu.ppy.sh/users/3936)**, [\[Takuya\]](https://osu.ppy.sh/users/342372), [kr4t0s88](https://osu.ppy.sh/users/40737), [Lunah](https://osu.ppy.sh/users/1227377), [osuplayer111](https://osu.ppy.sh/users/33599), [Valde](https://osu.ppy.sh/users/208531) |
 | ![][flag_JP] | **Japan** | **[MeRcYyy](https://osu.ppy.sh/users/75595)**, [Ozouni](https://osu.ppy.sh/users/69600), [Rigeru](https://osu.ppy.sh/users/61154), [Rorry](https://osu.ppy.sh/users/198574), [SiLviA](https://osu.ppy.sh/users/409747), [taNa](https://osu.ppy.sh/users/61101) |
 | ![][flag_MO] | **Macau** | **[Ballance](https://osu.ppy.sh/users/165946)**, [\_\_\_\_\_B](https://osu.ppy.sh/users/247901), [starpun1](https://osu.ppy.sh/users/144523), [wl01939929](https://osu.ppy.sh/users/456163), [xinhe](https://osu.ppy.sh/users/252936) |
-| ![][flag_MY] | **Malaysia** | **[The 08 team\_Bourdon](https://osu.ppy.sh/users/275686)**, [akupp](https://osu.ppy.sh/users/249825), [DragonSparta](https://osu.ppy.sh/users/216909), [Crimson\_SoulZ](https://osu.ppy.sh/users/91320), mekadon<!-- missing -->, [mycyber](https://osu.ppy.sh/users/187910) |
+| ![][flag_MY] | **Malaysia** | **[The 08 team\_Bourdon](https://osu.ppy.sh/users/275686)**, [akupp](https://osu.ppy.sh/users/249825), [DragonSparta](https://osu.ppy.sh/users/216909), [Crimson\_SoulZ](https://osu.ppy.sh/users/91320), [mekadon](https://osu.ppy.sh/users/157835), [mycyber](https://osu.ppy.sh/users/187910) |
 | ![][flag_NL] | **Netherlands** | **[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [happy30](https://osu.ppy.sh/users/27767), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308) |
 | ![][flag_NZ] | **New Zealand** | **[NumoT123](https://osu.ppy.sh/users/282930)**, [Acidsky-](https://osu.ppy.sh/users/116608), [deadbeat](https://osu.ppy.sh/users/128370), [jiantz](https://osu.ppy.sh/users/330252), [SkyE-](https://osu.ppy.sh/users/114796), [toejamms](https://osu.ppy.sh/users/231111) |
 | ![][flag_PH] | **Philippines** | **[dayun10](https://osu.ppy.sh/users/570310)**, [bakaloidsky](https://osu.ppy.sh/users/504885), [blacksymbian](https://osu.ppy.sh/users/53956), [jockeytiyan](https://osu.ppy.sh/users/133618), [nachopiggy](https://osu.ppy.sh/users/95637), [WyndII](https://osu.ppy.sh/users/46538) |
 | ![][flag_PL] | **Poland** | **[ShaggoN](https://osu.ppy.sh/users/39129)**, [fartownik](https://osu.ppy.sh/users/56917), [kuburaczek](https://osu.ppy.sh/users/29130), [Niko-](https://osu.ppy.sh/users/175141), [rEdo](https://osu.ppy.sh/users/49329), [White Wolf](https://osu.ppy.sh/users/39828) |
 | ![][flag_PT] | **Portugal** | **[JonnyThatJonny](https://osu.ppy.sh/users/201290)**, [creativ](https://osu.ppy.sh/users/280158), [makkura](https://osu.ppy.sh/users/344086), [sttailruby12](https://osu.ppy.sh/users/213335) |
-| ![][flag_RU] | **Russian Federation** | **[GaShiK](https://osu.ppy.sh/users/227643)**, [Akai-](https://osu.ppy.sh/users/649471), CracK<!-- missing -->, [Kotya](https://osu.ppy.sh/users/297551), [larch](https://osu.ppy.sh/users/296787), [TKiller](https://osu.ppy.sh/users/113027) |
+| ![][flag_RU] | **Russian Federation** | **[GaShiK](https://osu.ppy.sh/users/227643)**, [Akai-](https://osu.ppy.sh/users/649471), [CracK](https://osu.ppy.sh/users/119933), [Kotya](https://osu.ppy.sh/users/297551), [larch](https://osu.ppy.sh/users/296787), [TKiller](https://osu.ppy.sh/users/113027) |
 | ![][flag_KR] | **South Korea** | **[KRZY](https://osu.ppy.sh/users/114017)**, [Binjip](https://osu.ppy.sh/users/261694), [Cookiezi](https://osu.ppy.sh/users/124493), [ehRh](https://osu.ppy.sh/users/272117), [M A I D](https://osu.ppy.sh/users/216472), [Reisen Udongein](https://osu.ppy.sh/users/232942) |
-| ![][flag_ES] | **Spain** | **[X\_Ray](https://osu.ppy.sh/users/160937)**, [choche](https://osu.ppy.sh/users/239850), [hyperluigi](https://osu.ppy.sh/users/43921), [Lionheart69](https://osu.ppy.sh/users/88152), [migul](https://osu.ppy.sh/users/423217), [Skullboss](http://osu.ppy.sh/users/48527) |
+| ![][flag_ES] | **Spain** | **[X\_Ray](https://osu.ppy.sh/users/160937)**, [choche](https://osu.ppy.sh/users/239850), [hyperluigi](https://osu.ppy.sh/users/43921), [Lionheart69](https://osu.ppy.sh/users/88152), [migul](https://osu.ppy.sh/users/423217), [Skullboss](https://osu.ppy.sh/users/48527) |
 | ![][flag_SE] | **Sweden** | **[beko1994](https://osu.ppy.sh/users/310548)**, [Darkoff](https://osu.ppy.sh/users/131072), [palinus](https://osu.ppy.sh/users/214706), [Saten-san](https://osu.ppy.sh/users/444506), [Vikkez](https://osu.ppy.sh/users/235215), [Xgor](https://osu.ppy.sh/users/98661) |
 | ![][flag_TW] | **Taiwan** | **[Uan](https://osu.ppy.sh/users/147623)**, [0222101916](https://osu.ppy.sh/users/122650), [FuNnY--](https://osu.ppy.sh/users/398097), [NanaDesu](https://osu.ppy.sh/users/163474), [Rucker](https://osu.ppy.sh/users/147515), [Tomoka Rin](https://osu.ppy.sh/users/125308) |
 | ![][flag_UA] | **Ukraine** | **[Gorlum](https://osu.ppy.sh/users/347635)**, [gef](https://osu.ppy.sh/users/226175), [Mosya](https://osu.ppy.sh/users/77835), [RainForce](https://osu.ppy.sh/users/192251), [rockleejkooo](https://osu.ppy.sh/users/384003) |
-| ![][flag_GB] | **United Kingdom** | **[Doomsday](https://osu.ppy.sh/users/18983)**, aevv<!-- missing -->, [DiamondCrash](https://osu.ppy.sh/users/123790), [jericho2442](https://osu.ppy.sh/users/88904), [Natteke](https://osu.ppy.sh/users/157177) |
-| ![][flag_US] | **United States** | **[Lybydose](https://osu.ppy.sh/users/64501)**, [Cyclone](https://osu.ppy.sh/users/18589), [ebacho](https://osu.ppy.sh/users/129932), [Mafiamaster](https://osu.ppy.sh/users/17695), [naptime](http://osu.ppy.sh/users/277682) |
+| ![][flag_GB] | **United Kingdom** | **[Doomsday](https://osu.ppy.sh/users/18983)**, [aevv](https://osu.ppy.sh/users/390955), [DiamondCrash](https://osu.ppy.sh/users/123790), [jericho2442](https://osu.ppy.sh/users/88904), [Natteke](https://osu.ppy.sh/users/157177) |
+| ![][flag_US] | **United States** | **[Lybydose](https://osu.ppy.sh/users/64501)**, [Cyclone](https://osu.ppy.sh/users/18589), [ebacho](https://osu.ppy.sh/users/129932), [Mafiamaster](https://osu.ppy.sh/users/17695), [naptime](https://osu.ppy.sh/users/277682) |
 
 ## Mappools
 
 ### Finals
 
 - NoMod (*to be played in order*)
-  - [Minibosses - Castlevania (m980) \[owc Finals\]](http://www.mediafire.com/file/twuti02311dk6ip/Minibosses+-+Castlevania.osz/file)
+  - [Minibosses - Castlevania (m980) \[owc Finals\]](https://www.mediafire.com/file/twuti02311dk6ip/Minibosses+-+Castlevania.osz/file)
   - [Various Artists - osu! Stream Compilation (Natteke) \[EXE\]](https://osu.ppy.sh/beatmapsets/25403#osu/86044)
   - [Shiki mixed by Djsmalls - Air (MegaManEXE) \[Best map ever created\]](https://osu.ppy.sh/beatmapsets/13008#osu/48386)
   - [Nico Nico Douga - U.N. Owen Was Her? (Reikin) \[Ronald Mix\]](https://osu.ppy.sh/beatmapsets/1785#osu/21010)


### PR DESCRIPTION
as it stands a lot of core information on the osu! World Cup #1 wiki article are either incorrect or missing altogether; this pr aims to fill that gap based on all the stuffs i've gathered and researched on this particular topic.

some changes in this pr include : 

- added match results (they were *veeeeeery* scattered throughout the forum thread but thankfully all the required information are still able to be gathered through some sort of workaround in one way or another)
- added tournament schedule (rough estimation, based on the forum timestamp of the referee's posts)
- added missing Finals mappool (the current version of the article wrongly assumed that the Finals and the 3rd Place Playoffs match are using the same mappool)
- added proper tournament staff roster
- reworked the ruleset section to be more in line with modern tournament ruleset writing standards
- added clarification that the tournament was run by various community members with the provision of the osu!team (instead of "being directly run by the osu!team" as currently indicated)
- added proper context for Team Japan's "special" supporter tag prize (they didn't get the supporter tag by winning a "special match" as currently indicated)
- applied bunch of other minor tweaks and improvements