### PR TITLE
[ID] Update group-info and related articles

### DIFF
--- a/meta/group-info/id.yaml
+++ b/meta/group-info/id.yaml
@@ -8,7 +8,7 @@ alumni:
     dev: osu!dev
     media: pereka cipta osu!media
     support: Support Team
-    tournaments: turnamen
+    tournaments: manajemen turnamen
 gmt:
   all_mods: seluruh moderator
   areas:
@@ -19,7 +19,7 @@ gmt:
     dev: pengembangan osu!
     player: dukungan pengguna
     support: dukungan teknis
-    tournaments: turnamen
+    tournaments: manajemen turnamen
     wiki: administrasi osu!wiki
 nat:
   areas:
@@ -33,6 +33,7 @@ languages:
   bg: Bulgaria
   bn: Bengal
   ca: Katalan
+  da: Denmark
   de: Jerman
   el: Yunani
   es: Spanyol

--- a/wiki/People/The_Team/Global_Moderation_Team/id.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/id.md
@@ -54,14 +54,14 @@ Halaman daftar [Global Moderation Team](https://osu.ppy.sh/groups/4).
 | ![][flag_DE] [Clobohne](https://osu.ppy.sh/users/499343) | Jerman | Moderasi chat |
 | ![][flag_AR] [Darksonic](https://osu.ppy.sh/users/570042) | Spanyol | Moderasi chat, moderasi forum, moderasi beatmap |
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  | Moderasi chat, dukungan teknis, moderasi beatmap |
-| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanyol | Turnamen, moderasi beatmap |
+| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Spanyol | Manajemen turnamen, moderasi beatmap |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  | Dukungan teknis |
 | ![][flag_BR] [Edward](https://osu.ppy.sh/users/5618109) | Portugis, Jepang | Moderasi chat |
 | ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) |  | Dukungan pengguna |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | Prancis | Moderasi chat, moderasi forum, moderasi beatmap |
 | ![][flag_PL] [Galkan](https://osu.ppy.sh/users/169570) | Polandia | Moderasi chat |
 | ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) |  | Moderasi chat, moderasi beatmap |
-| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Spanyol | Turnamen |
+| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Spanyol | Manajemen turnamen |
 | ![][flag_HK] [kanpakyin](https://osu.ppy.sh/users/394326) | Kanton, Mandarin, Jepang | Moderasi chat |
 | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533) | Rusia | Moderasi chat, moderasi beatmap |
 | ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | Prancis, Rusia | Moderasi chat |
@@ -76,7 +76,7 @@ Halaman daftar [Global Moderation Team](https://osu.ppy.sh/groups/4).
 | ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | Jerman | Moderasi forum, moderasi beatmap |
 | ![][flag___] [osu!team](https://osu.ppy.sh/users/4341397) |  | Anggota inti osu!team |
 | ![][flag_PH] [Osu Tatakae Ouendan](https://osu.ppy.sh/users/594210) | Tagalog | Moderasi chat |
-| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | Jerman | Turnamen, moderasi beatmap |
+| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | Jerman | Manajemen turnamen, moderasi beatmap |
 | ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983) | Prancis | Moderasi chat, moderasi forum, moderasi beatmap |
 | ![][flag_PT] [Pereira006](https://osu.ppy.sh/users/537344) | Portugis | Moderasi chat |
 | ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | Spanyol | Moderasi chat, administrasi osu!wiki |

--- a/wiki/People/The_Team/osu!_Alumni/id.md
+++ b/wiki/People/The_Team/osu!_Alumni/id.md
@@ -1,8 +1,8 @@
 # osu! Alumni
 
-**osu! Alumni** adalah mereka yang dikenal karena kontribusi-kontribusi yang telah berpindah. Ketika bahan sudah tersedia kami akan menegakkan sebuah patung untuk setiap member di alun-alun kota.
+**osu! Alumni** merupakan sosok-sosok pendahulu yang telah banyak berjasa kepada osu! pada masanya masing-masing. Seandainya kami memiliki sumber daya yang memadai, kami tidak akan segan untuk mendirikan patung-patung sebagai bentuk penghormatan bagi nama-nama yang tertera di bawah ini.
 
-Halaman daftar [osu! Alumni](https://osu.ppy.sh/groups/16).
+Daftar anggota osu! Alumni selengkapnya juga dapat dilihat pada [laman grup osu! Alumni](https://osu.ppy.sh/groups/16).
 
 | Nama | Posisi |
 | :-- | :-- |
@@ -84,7 +84,7 @@ Halaman daftar [osu! Alumni](https://osu.ppy.sh/groups/16).
 | ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, Chat Moderator, QAT |
 | ![][flag_RU] [h3k1ru](https://osu.ppy.sh/users/291211) | GMT |
 | ![][flag_NL] [happy30](https://osu.ppy.sh/users/27767) | BAT |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Turnamen |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Manajemen Turnamen |
 | ![][flag_MY] [HeatKai](https://osu.ppy.sh/users/332555) | BAT, Chat Moderator |
 | ![][flag_TR] [heyronii](https://osu.ppy.sh/users/5642779) | GMT |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | GMT |

--- a/wiki/People/The_Team/osu!_Alumni/id.md
+++ b/wiki/People/The_Team/osu!_Alumni/id.md
@@ -84,7 +84,7 @@ Daftar anggota osu! Alumni selengkapnya juga dapat dilihat pada [laman grup osu!
 | ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, Chat Moderator, QAT |
 | ![][flag_RU] [h3k1ru](https://osu.ppy.sh/users/291211) | GMT |
 | ![][flag_NL] [happy30](https://osu.ppy.sh/users/27767) | BAT |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Manajemen Turnamen |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Manajemen turnamen |
 | ![][flag_MY] [HeatKai](https://osu.ppy.sh/users/332555) | BAT, Chat Moderator |
 | ![][flag_TR] [heyronii](https://osu.ppy.sh/users/5642779) | GMT |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | GMT |


### PR DESCRIPTION
I noticed the other day that in group-info.yaml the string "`tournament`" has been changed into "`tournament management`" so I made this PR in order to catch up with the change.

Also made some updates/cleanups to the pages that are directly being affected by it (Global Moderation Team and osu! Alumni accordingly)