### PR TITLE
Cleanup osu! World Cup #2 wiki article

### DIFF
--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -10,78 +10,51 @@ tags:
 
 ![OWC #2 logo](img/logo.png)
 
-The **osu! World Cup #2** (***OWC #2***) was a country-based osu! tournament hosted by the [osu! team](/wiki/People/The_Team). It was the second installment of the osu! World Cup.
+The **osu! World Cup #2** (***OWC #2***), also commonly known as **osu! World Cup 2011** (***OWC 2011***), was a single elimination country-based osu! tournament organized by various osu! community members under the provision of the [osu! team](/wiki/People/The_Team). It was the second installment of the osu! World Cup.
+
+## Tournament schedule
+
+| Event | Timestamp |
+| --: | :-- |
+| Registration phase | 2011-10-29/2011-11-20 |
+| Group Stage week 1 | 2011-11-21/2011-11-27 |
+| Group Stage week 2 | 2011-11-28/2011-12-04 |
+| Group Stage week 3 | 2011-12-05/2011-12-11 |
+| *Winter break* | 2011-12-12/2012-01-01 |
+| Round of 16 | 2012-01-02/2012-01-08 |
+| Quarterfinals | 2012-01-09/2012-02-05 |
+| Semifinals | 2012-02-06/2012-03-04 |
+| Finals | 2012-03-05/2012-03-25 |
 
 ## Prizes
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag, unique profile badge |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of osu!supporter tag |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag for each team member, unique profile badge |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 1 month of osu!supporter tag for each team member |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag for each team member |
 
 ![](img/badge.jpg "OWC #2 winner badge")
 
-## Organisation
+## Organization
 
 The osu! World Cup #2 was run by various community members.
 
 | Position | Members |
 | :-- | :-- |
 | Manager | ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917), ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) |
-| Mappool selector | ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993), ![][flag_DE] [Dangaard](https://osu.ppy.sh/users/19488), ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917), ![][flag_SE] [Gabi](https://osu.ppy.sh/users/57057), ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679), ![][flag_US] [SapphireGhost](https://osu.ppy.sh/users/388602) |
-| Streamer | ![][flag_NL] [dlovan](https://osu.ppy.sh/users/190684), ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359), ![][flag_AR] [Metro](https://osu.ppy.sh/users/306737), ![][flag_CA] [YodaSnipe](https://osu.ppy.sh/users/673746) |
+| Streamer | ![][flag_JP] [dvorak](https://osu.ppy.sh/users/271359), ![][flag_NL] [dlovan](https://osu.ppy.sh/users/190684), ![][flag_AR] [Metro](https://osu.ppy.sh/users/306737), ![][flag_CA] [YodaSnipe](https://osu.ppy.sh/users/673746) |
+| Mappool selector | ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917)¹, ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679), ![][flag_GB] [Natteke](https://osu.ppy.sh/users/157177), ![][flag_TW] [Alace](https://osu.ppy.sh/users/25993), ![][flag_DE] [Dangaard](https://osu.ppy.sh/users/19488), ![][flag_SE] [Gabi](https://osu.ppy.sh/users/57057), ![][flag_US] [SapphireGhost](https://osu.ppy.sh/users/388602), ![][flag_GB] [jericho2442](https://osu.ppy.sh/users/88904) |
+| Graphic designer | ![][flag_CN] [Anticloud](https://osu.ppy.sh/users/411137) |
+
+¹ ![][flag_PL] *[fartownik](https://osu.ppy.sh/users/56917), who prior to his mappool selecting duties was also participating as a player for* ![][flag_PL] *Poland in the tournament, was admitted to the mappool selectors from the Semifinals onwards after Poland's elimination from the tournament.*
 
 ## Links
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/65535)
+- [Livestream link (livestream.com)](https://livestream.com/osuworldcup)
+- [Livestream link (Own3d.tv)](https://www.own3d.tv/MetroAR)
 - [Pre-tournament interviews](https://docs.google.com/document/d/1xgR7cfCf1yZD1j90_ObGKccS_9OMA6rDHhYJy8uRxNE/edit)
-
-## Participants
-
-|  | Country | Members |
-| :-: | :-: | :-- |
-| ![][flag_AR] | **Argentina** | **[Wishy22](https://osu.ppy.sh/users/495477)**, [Ever17](https://osu.ppy.sh/users/173114), [Darksonic](https://osu.ppy.sh/users/570042), [Glazbom](https://osu.ppy.sh/users/608277), [Metro](https://osu.ppy.sh/users/306737), [Salvage](https://osu.ppy.sh/users/242119) |
-| ![][flag_AU] | **Australia** | **Mizorex <!-- missing -->**, [damiaanzx](https://osu.ppy.sh/users/635030), [Frankcons](https://osu.ppy.sh/users/594006), [Hark](https://osu.ppy.sh/users/43265), [Mikey](https://osu.ppy.sh/users/979780), [Neko\_Lover](https://osu.ppy.sh/users/596535) |
-| ![][flag_AT] | **Austria** | **[-Lennox-](https://osu.ppy.sh/users/489103)**, HakkeroHakkero <!-- missing -->, [Hanyuu](https://osu.ppy.sh/users/73480), [M A R I O](https://osu.ppy.sh/users/594424), [novaaa](https://osu.ppy.sh/users/953405), [Snowball](https://osu.ppy.sh/users/152238) |
-| ![][flag_BR] | **Brazil** | **[Blue Dragon](https://osu.ppy.sh/users/19048)**, [antsu](https://osu.ppy.sh/users/92953), [Caco](https://osu.ppy.sh/users/635173), [fabriciorby](https://osu.ppy.sh/users/209664), [K3nsh1n\_H1mur4](https://osu.ppy.sh/users/197834), [Katsuri](https://osu.ppy.sh/users/701726) |
-| ![][flag_BG] | **Bulgaria** | **[Lolicore Flandre](https://osu.ppy.sh/users/447818)**, [ColdChester](https://osu.ppy.sh/users/483663), [las7h0p3](https://osu.ppy.sh/users/113972), [Orihara Izaya](https://osu.ppy.sh/users/513842), [r-Beatz](https://osu.ppy.sh/users/472311), [werewolf0girl](https://osu.ppy.sh/users/213292) |
-| ![][flag_CA] | **Canada** | **[FurukawaPan](https://osu.ppy.sh/users/32067)**, [Glass](https://osu.ppy.sh/users/228532), [Satonaka](https://osu.ppy.sh/users/767009), [shaNk](https://osu.ppy.sh/users/905124), [SilentWings](https://osu.ppy.sh/users/118992), [YodaSnipe](https://osu.ppy.sh/users/673746) |
-| ![][flag_CL] | **Chile** | **[nVidi4x](https://osu.ppy.sh/users/203181)**, [Art-FzTT](https://osu.ppy.sh/users/248453), [b1choO](https://osu.ppy.sh/users/461132), [b4ss\_](https://osu.ppy.sh/users/493712), [Ignacio](https://osu.ppy.sh/users/2881294), [Mesita](https://osu.ppy.sh/users/201459) |
-| ![][flag_DK] | **Denmark** | **Emaal <!-- missing -->**, [BongHat](https://osu.ppy.sh/users/369746), [Circlemuncher](https://osu.ppy.sh/users/873335), [m4w11](https://osu.ppy.sh/users/509620), [PlasticSmoothie](https://osu.ppy.sh/users/296565) |
-| ![][flag_FI] | **Finland** | **[ragelewa](https://osu.ppy.sh/users/475021)**, [ethox](https://osu.ppy.sh/users/441380), [heintsi](https://osu.ppy.sh/users/63185), [Orkel](https://osu.ppy.sh/users/39385), [Sutsuka](https://osu.ppy.sh/users/29089), [Zapy](https://osu.ppy.sh/users/251395) |
-| ![][flag_FR] | **France** | **[Odaril](https://osu.ppy.sh/users/113005)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [Kanna](https://osu.ppy.sh/users/366059), [Mustaash](https://osu.ppy.sh/users/1669213), [XPJ38](https://osu.ppy.sh/users/273531) |
-| ![][flag_DE] | **Germany** | **[DoKoLP](https://osu.ppy.sh/users/537084)**, Asozial <!-- missing -->, [Blacky](https://osu.ppy.sh/users/268788), [Scanlatione](https://osu.ppy.sh/users/393337), [ShadowSoul](https://osu.ppy.sh/users/494970), [SuperCracker](https://osu.ppy.sh/users/145639) |
-| ![][flag_HK] | **Hong Kong** | **[KanaRin](https://osu.ppy.sh/users/310747)**, [henry04213](https://osu.ppy.sh/users/793536), [HineX](https://osu.ppy.sh/users/13854), Kirito470 <!-- missing -->, [Miu Matsuoka](https://osu.ppy.sh/users/10641), [Pokie](https://osu.ppy.sh/users/207340) |
-| ![][flag_HU] | **Hungary** | **[Kuroi Mato](https://osu.ppy.sh/users/584921)**, [higurush](https://osu.ppy.sh/users/602159), [Kozuki Kallen](https://osu.ppy.sh/users/816305), [TaylorXIII](https://osu.ppy.sh/users/351814), [tasli](https://osu.ppy.sh/users/59650), [TsukishimaKirari x\]](https://osu.ppy.sh/users/816358) |
-| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](https://osu.ppy.sh/users/346320), [gatitoneku](https://osu.ppy.sh/users/363377), [xeqta](https://osu.ppy.sh/users/524530) |
-| ![][flag_JP] | **Japan** | **[SiLviA](https://osu.ppy.sh/users/409747)**, [Apricot](https://osu.ppy.sh/users/438547), [Flute](https://osu.ppy.sh/users/211278), [Iris](https://osu.ppy.sh/users/758181), [Sinch](https://osu.ppy.sh/users/360552), [val0108](https://osu.ppy.sh/users/243917) |
-| ![][flag_LV] | **Latvia** | **[\_Angel](https://osu.ppy.sh/users/341851)**, [GummyChan](https://osu.ppy.sh/users/757683), [LoGo](https://osu.ppy.sh/users/750382), [Vmx](https://osu.ppy.sh/users/967501) |
-| ![][flag_MY] | **Malaysia** | **[akupp](https://osu.ppy.sh/users/249825)**, [Gon](https://osu.ppy.sh/users/583765), [RhaiizoN](https://osu.ppy.sh/users/758295), [The 08 team\_Bourdon](https://osu.ppy.sh/users/275686), [xsrsbsns](https://osu.ppy.sh/users/414427), [zenki0013](https://osu.ppy.sh/users/89646) |
-| ![][flag_NL] | **Netherlands** | **[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308), [zozozofun](https://osu.ppy.sh/users/58727) |
-| ![][flag_NZ] | **New Zealand** | **[jiantz](https://osu.ppy.sh/users/330252)**, [Bob\_the\_Cat](https://osu.ppy.sh/users/121470), [deadbeat](https://osu.ppy.sh/users/128370), [Kiiwa](https://osu.ppy.sh/users/231111), [kwk](https://osu.ppy.sh/users/365586), [numot123](https://osu.ppy.sh/users/282930) |
-| ![][flag_NO] | **Norway** | **[kriers](https://osu.ppy.sh/users/333241)**, [AndreasHD](https://osu.ppy.sh/users/369956), [CXu](https://osu.ppy.sh/users/84841), [Danzai](https://osu.ppy.sh/users/73852), [KinomiCandy](https://osu.ppy.sh/users/375143), [Oscarface92](https://osu.ppy.sh/users/284347) |
-| ![][flag_PH] | **Philippines** | **C L O U D <!-- missing -->**, [jannnnnn](https://osu.ppy.sh/users/818399), [dayun10](https://osu.ppy.sh/users/570310), [Osu Tatakae Ouendan](https://osu.ppy.sh/users/594210), [Pizzicatto](http://osu.ppy.sh/users/692610), [usagijirosan](https://osu.ppy.sh/users/714230) |
-| ![][flag_PL] | **Poland** | **[fartownik](https://osu.ppy.sh/users/56917)**, [Kubu](https://osu.ppy.sh/users/29130), [Piotrekol](https://osu.ppy.sh/users/304520), [rEdo](https://osu.ppy.sh/users/49329), [White Wolf](https://osu.ppy.sh/users/39828) |
-| ![][flag_PT] | **Portugal** | **Mikutard <!-- missing -->**, cococococo7528 <!-- missing -->, [JonnyThatJonny](https://osu.ppy.sh/users/201290), [makkura](https://osu.ppy.sh/users/344086), [Maraiga](https://osu.ppy.sh/users/213335), [Pereira006](https://osu.ppy.sh/users/537344) |
-| ![][flag_RU] | **Russian Federation** | **[Akai-](https://osu.ppy.sh/users/649471)**, 646kapeh640 <!-- missing -->, [cr1m](https://osu.ppy.sh/users/803766), [Kert](https://osu.ppy.sh/users/119933), [Rost94](https://osu.ppy.sh/users/490568), [Vpalach](https://osu.ppy.sh/users/232729) |
-| ![][flag_KR] | **South Korea** | **[KRZY](https://osu.ppy.sh/users/114017)**, [CheEZ](https://osu.ppy.sh/users/272117), [K i R i K a R u](https://osu.ppy.sh/users/139670), mnto <!-- missing -->, [Reisen Udongein](https://osu.ppy.sh/users/232942), [Remilia-Scarlet](https://osu.ppy.sh/users/602783) |
-| ![][flag_SE] | **Sweden** | **[Hanyuu-chan](https://osu.ppy.sh/users/881369)**, [failboat](https://osu.ppy.sh/users/276074), [Gyuunyu](https://osu.ppy.sh/users/799102), [Holmir](https://osu.ppy.sh/users/453435), [m4w11](https://osu.ppy.sh/users/509620), [Nidert](https://osu.ppy.sh/users/817211) |
-| ![][flag_TW] | **Taiwan** | **[Saya-Honmei](https://osu.ppy.sh/users/2865291)**, [SnowWhite](https://osu.ppy.sh/users/50265), [Tomoka Rin](https://osu.ppy.sh/users/125308), [wizoza83098](https://osu.ppy.sh/users/164156), [YuyuKo sama](https://osu.ppy.sh/users/234788), [ZRush](https://osu.ppy.sh/users/398097) |
-| ![][flag_TH] | **Thailand** | **[NonxE](https://osu.ppy.sh/users/319312)**, [aumu1995](https://osu.ppy.sh/users/235752), [bufo](https://osu.ppy.sh/users/141605), [blackspell](https://osu.ppy.sh/users/601173), [Frostmourne](https://osu.ppy.sh/users/199669), [termerys](https://osu.ppy.sh/users/84964) |
-| ![][flag_UA] | **Ukraine** | **[Gorlum](https://osu.ppy.sh/users/347635)**, [\[milky\]](https://osu.ppy.sh/users/288597), [rockleejkooo](https://osu.ppy.sh/users/384003), [uljjang](https://osu.ppy.sh/users/3784417) |
-| ![][flag_US] | **United States** | **[Kyou-kun](https://osu.ppy.sh/users/285711)**, [Cyclone](https://osu.ppy.sh/users/18589), [david huhh](https://osu.ppy.sh/users/278954), [geckogates](https://osu.ppy.sh/users/252524), [Lybydose](https://osu.ppy.sh/users/64501) |
-| ![][flag_UY] | **Uruguay** | **[maay](https://osu.ppy.sh/users/160970)**, [AlrdyExists](https://osu.ppy.sh/users/407022), [GonixZ](https://osu.ppy.sh/users/612622), [H1ko](https://osu.ppy.sh/users/58710), [Snepif](https://osu.ppy.sh/users/408088), [Z e o n](https://osu.ppy.sh/users/539876) |
-| ![][flag_VN] | **Vietnam** | **[Misuzu-san](https://osu.ppy.sh/users/358563)**, [BridgetteLSatellizer](https://osu.ppy.sh/users/854083), [JerryC](https://osu.ppy.sh/users/279278), [kira\_lacus1995](https://osu.ppy.sh/users/996435), [Shin1801](https://osu.ppy.sh/users/604492), [xLightningx](https://osu.ppy.sh/users/1007806) |
-
-## Groups
-
-| Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H |
-| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
-| ![][flag_AU] Australia | ![][flag_HU] Hungary | ![][flag_ID] Indonesia | ![][flag_CA] Canada | ![][flag_CL] Chile | ![][flag_FI] Finland | ![][flag_BR] Brazil | ![][flag_AR] Argentina |
-| ![][flag_DK] Denmark | ![][flag_NO] Netherlands | ![][flag_NO] Norway | ![][flag_HK] Hong Kong | ![][flag_FR] France | ![][flag_MY] Malaysia | ![][flag_BG] Bulgaria | ![][flag_AT] Austria |
-| ![][flag_DE] Germany | ![][flag_NZ] New Zealand | ![][flag_PL] Poland | ![][flag_KR] South Korea | ![][flag_LV] Latvia | ![][flag_RU] Russian Federation | ![][flag_SE] Sweden | ![][flag_TH] Thailand |
-| ![][flag_JP] Japan | ![][flag_PH] Philippines | ![][flag_UA] Ukraine | ![][flag_VN] Vietnam | ![][flag_PT] Portugal | ![][flag_UY] Uruguay | ![][flag_TW] Taiwan | ![][flag_US] United States |
 
 ## Podium
 
@@ -89,17 +62,81 @@ This competition has come to an end and resulted in the following podium:
 
 | Placing | Team |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_KR] **South Korea** (**[KRZY](https://osu.ppy.sh/users/114017)**, [CheEZ](https://osu.ppy.sh/users/272117), [K i R i K a R u](https://osu.ppy.sh/users/139670), mnto <!-- missing -->, [Reisen Udongein](https://osu.ppy.sh/users/232942), [Remilia-Scarlet](https://osu.ppy.sh/users/602783)) |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_JP] **Japan** (**[SiLviA](https://osu.ppy.sh/users/409747)**, [Apricot](https://osu.ppy.sh/users/438547), [Flute](https://osu.ppy.sh/users/211278), [Iris](https://osu.ppy.sh/users/758181), [Sinch](https://osu.ppy.sh/users/360552), [val0108](https://osu.ppy.sh/users/243917)) |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_BR] **Brazil** (**[Blue Dragon](https://osu.ppy.sh/users/19048)**, [antsu](https://osu.ppy.sh/users/92953), [Caco](https://osu.ppy.sh/users/635173), [fabriciorby](https://osu.ppy.sh/users/209664), [K3nsh1n\_H1mur4](https://osu.ppy.sh/users/197834), [Katsuri](https://osu.ppy.sh/users/701726)) |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_KR] **South Korea** (**[KRZY](https://osu.ppy.sh/users/114017)**, [CheEZ](https://osu.ppy.sh/users/272117), [K i R i K a R u](https://osu.ppy.sh/users/139670), [moneto](https://osu.ppy.sh/users/242788), [Reisen Udongein](https://osu.ppy.sh/users/232942), [Remilia-Scarlet](https://osu.ppy.sh/users/602783)) |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_JP] **Japan** (**[SiLviA](https://osu.ppy.sh/users/409747)**, [Apricot](https://osu.ppy.sh/users/438547), [Flute](https://osu.ppy.sh/users/211278), [Iris](https://osu.ppy.sh/users/758181), [Sinch](https://osu.ppy.sh/users/360552), [tobaku2784](https://osu.ppy.sh/users/113855), *[val0108](https://osu.ppy.sh/users/243917)¹*) |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_BR] **Brazil** (**[Blue Dragon](https://osu.ppy.sh/users/19048)**, [antsu](https://osu.ppy.sh/users/92953), [Caco](https://osu.ppy.sh/users/635173), [fabriciorby](https://osu.ppy.sh/users/209664), [Fumi-chan](https://osu.ppy.sh/users/181432), [Katsuri](https://osu.ppy.sh/users/701726), *[K3nsh1n\_H1mur4](https://osu.ppy.sh/users/197834)¹*, *[Asterio](https://osu.ppy.sh/users/803906)²*, *[gabaeba](https://osu.ppy.sh/users/867902)²*) |
+
+¹ *Denotes players that were being brought in either as an extra player, a substitute player, an emergency reserve player during the running of the Group Stage.*
+
+² *Denotes players that were being brought in as a substitute player prior to the beginning of the knock-out stages.*
 
 ![OWC #2 bracket](img/bracket.jpg)
+
+## Participants
+
+|  | Country | Members |
+| :-: | :-: | :-- |
+| ![][flag_AR] | **Argentina** | **[Wishy22](https://osu.ppy.sh/users/495477)**, [Ever17](https://osu.ppy.sh/users/173114), [Darksonic](https://osu.ppy.sh/users/570042), [Glazbom](https://osu.ppy.sh/users/608277), [Metro](https://osu.ppy.sh/users/306737), [Salvage](https://osu.ppy.sh/users/242119), *[Hernan](https://osu.ppy.sh/users/516680)²* |
+| ![][flag_AU] | **Australia** | **[Mizorex](https://osu.ppy.sh/users/591469)**, [damiaanzx](https://osu.ppy.sh/users/635030), [Frankcons](https://osu.ppy.sh/users/594006), [Hark](https://osu.ppy.sh/users/43265), [Mikey](https://osu.ppy.sh/users/979780), [Neko\_Lover](https://osu.ppy.sh/users/596535) |
+| ![][flag_AT] | **Austria** | **[-Lennox-](https://osu.ppy.sh/users/489103)**, [Hakkero](https://osu.ppy.sh/users/177913), [Hanyuu](https://osu.ppy.sh/users/73480), [M A R I O](https://osu.ppy.sh/users/594424), [novaaa](https://osu.ppy.sh/users/953405), [Snowball](https://osu.ppy.sh/users/152238) |
+| ![][flag_BR] | **Brazil** | **[Blue Dragon](https://osu.ppy.sh/users/19048)**, [antsu](https://osu.ppy.sh/users/92953), [Caco](https://osu.ppy.sh/users/635173), [fabriciorby](https://osu.ppy.sh/users/209664), [Fumi-chan](https://osu.ppy.sh/users/181432), [Katsuri](https://osu.ppy.sh/users/701726), *[K3nsh1n\_H1mur4](https://osu.ppy.sh/users/197834)¹*, *[Asterio](https://osu.ppy.sh/users/803906)²*, *[gabaeba](https://osu.ppy.sh/users/867902)²* |
+| ![][flag_BG] | **Bulgaria** | **[Lolicore Flandre](https://osu.ppy.sh/users/447818)**, [ColdChester](https://osu.ppy.sh/users/483663), [las7h0p3](https://osu.ppy.sh/users/113972), [Orihara Izaya](https://osu.ppy.sh/users/513842), [r-Beatz](https://osu.ppy.sh/users/472311), [werewolf0girl](https://osu.ppy.sh/users/213292) |
+| ![][flag_CA] | **Canada** | **[FurukawaPan](https://osu.ppy.sh/users/32067)**, [Glass](https://osu.ppy.sh/users/228532), [Satonaka](https://osu.ppy.sh/users/767009), [shaNk](https://osu.ppy.sh/users/905124), [SilentWings](https://osu.ppy.sh/users/118992), [YodaSnipe](https://osu.ppy.sh/users/673746), *[RB\_Oliver](https://osu.ppy.sh/users/229206)²*, *[those](https://osu.ppy.sh/users/557166)²* |
+| ![][flag_CL] | **Chile** | **[nVidi4x](https://osu.ppy.sh/users/203181)**, [Art-FzTT](https://osu.ppy.sh/users/248453), [b1choO](https://osu.ppy.sh/users/461132), [b4ss\_](https://osu.ppy.sh/users/493712), [Ignacio](https://osu.ppy.sh/users/2881294), [Mesita](https://osu.ppy.sh/users/201459) |
+| ![][flag_DK] | **Denmark** | **[Emaal](https://osu.ppy.sh/users/85070)**, [BongHat](https://osu.ppy.sh/users/369746), [Circlemuncher](https://osu.ppy.sh/users/873335), [m4w11](https://osu.ppy.sh/users/509620), [PlasticSmoothie](https://osu.ppy.sh/users/296565), *[DennisGG](https://osu.ppy.sh/users/1008997)¹* |
+| ![][flag_FI] | **Finland** | **[ragelewa](https://osu.ppy.sh/users/475021)**, [ethox](https://osu.ppy.sh/users/441380), [heintsi](https://osu.ppy.sh/users/63185), [Orkel](https://osu.ppy.sh/users/39385), [Sutsuka](https://osu.ppy.sh/users/29089), [Zapy](https://osu.ppy.sh/users/251395), *[Valentiino](https://osu.ppy.sh/users/918773)¹* |
+| ![][flag_FR] | **France** | **[Odaril](https://osu.ppy.sh/users/113005)**, [\_LRJ\_](https://osu.ppy.sh/users/284905), [galvenize](https://osu.ppy.sh/users/381444), [Kanna](https://osu.ppy.sh/users/366059), [Mustaash](https://osu.ppy.sh/users/1669213), [XPJ38](https://osu.ppy.sh/users/273531), *[Maestro](https://osu.ppy.sh/users/472848)¹* |
+| ![][flag_DE] | **Germany** | **[DoKoLP](https://osu.ppy.sh/users/537084)**, [Blacky](https://osu.ppy.sh/users/268788)³, [Scanlatione](https://osu.ppy.sh/users/393337), [ShadowSoul](https://osu.ppy.sh/users/494970), [Shael](https://osu.ppy.sh/users/132308), [SuperCracker](https://osu.ppy.sh/users/145639), *[-libili-](https://osu.ppy.sh/users/706289)¹*, *[Azosial](https://osu.ppy.sh/users/833594)¹*, *[Neruell](https://osu.ppy.sh/users/112257)²*, *[Tom94](https://osu.ppy.sh/users/1857058)²* |
+| ![][flag_HK] | **Hong Kong** | **[KanaRin](https://osu.ppy.sh/users/310747)**, [henry04213](https://osu.ppy.sh/users/793536), [HineX](https://osu.ppy.sh/users/13854), [Kirito47](http://osu.ppy.sh/users/545514), [Miu Matsuoka](https://osu.ppy.sh/users/10641), [Pokie](https://osu.ppy.sh/users/207340), *[-\[L\]ightz](https://osu.ppy.sh/users/707840)¹* |
+| ![][flag_HU] | **Hungary** | **[Kuroi Mato](https://osu.ppy.sh/users/584921)**, [higurush](https://osu.ppy.sh/users/602159), [Kozuki Kallen](https://osu.ppy.sh/users/816305), [TaylorXIII](https://osu.ppy.sh/users/351814), [tasli](https://osu.ppy.sh/users/59650), [TsukishimaKirari x\]](https://osu.ppy.sh/users/816358) |
+| ![][flag_ID] | **Indonesia** | **[Hakeru Prismriver](https://osu.ppy.sh/users/345422)**, [awell](https://osu.ppy.sh/users/341298), [awesomewithin](https://osu.ppy.sh/users/81652), [dNextGen](https://osu.ppy.sh/users/346320), [gatitoneku](https://osu.ppy.sh/users/363377), [xeqta](https://osu.ppy.sh/users/524530) |
+| ![][flag_JP] | **Japan** | **[SiLviA](https://osu.ppy.sh/users/409747)**, [Apricot](https://osu.ppy.sh/users/438547), [Flute](https://osu.ppy.sh/users/211278), [Iris](https://osu.ppy.sh/users/758181), [Sinch](https://osu.ppy.sh/users/360552), [tobaku2784](https://osu.ppy.sh/users/113855), *[val0108](https://osu.ppy.sh/users/243917)¹* |
+| ![][flag_LV] | **Latvia** | **[\_Angel](https://osu.ppy.sh/users/341851)**, [GummyChan](https://osu.ppy.sh/users/757683), [LoGo](https://osu.ppy.sh/users/750382), [Vmx](https://osu.ppy.sh/users/967501) |
+| ![][flag_MY] | **Malaysia** | **[akupp](https://osu.ppy.sh/users/249825)**, [Gon](https://osu.ppy.sh/users/583765), [RhaiizoN](https://osu.ppy.sh/users/758295), [The 08 team\_Bourdon](https://osu.ppy.sh/users/275686), [xsrsbsns](https://osu.ppy.sh/users/414427), [zenki0013](https://osu.ppy.sh/users/89646) |
+| ![][flag_NL] | **Netherlands** | **[GladiOol](https://osu.ppy.sh/users/23326)**, [Awoken](https://osu.ppy.sh/users/256802), [eddieee](https://osu.ppy.sh/users/260284), [Henkie](https://osu.ppy.sh/users/16944), [Lesjuh](https://osu.ppy.sh/users/44308), [zozozofun](https://osu.ppy.sh/users/58727) |
+| ![][flag_NZ] | **New Zealand** | **[jiantz](https://osu.ppy.sh/users/330252)**, [Bob\_the\_Cat](https://osu.ppy.sh/users/121470), [deadbeat](https://osu.ppy.sh/users/128370), [Kiiwa](https://osu.ppy.sh/users/231111), [kwk](https://osu.ppy.sh/users/365586), [numot123](https://osu.ppy.sh/users/282930) |
+| ![][flag_NO] | **Norway** | **[kriers](https://osu.ppy.sh/users/333241)**, [AndreasHD](https://osu.ppy.sh/users/369956), [CXu](https://osu.ppy.sh/users/84841), [Danzai](https://osu.ppy.sh/users/73852), [Druidianna](https://osu.ppy.sh/users/682834), [KinomiCandy](https://osu.ppy.sh/users/375143), *[Oscarface92](https://osu.ppy.sh/users/284347)¹* |
+| ![][flag_PH] | **Philippines** | **[Mystgun](https://osu.ppy.sh/users/720029)**, [jannnnnn](https://osu.ppy.sh/users/818399), [dayun10](https://osu.ppy.sh/users/570310), [Osu Tatakae Ouendan](https://osu.ppy.sh/users/594210), [Pizzicatto](http://osu.ppy.sh/users/692610), [usagijirosan](https://osu.ppy.sh/users/714230) |
+| ![][flag_PL] | **Poland** | **[fartownik](https://osu.ppy.sh/users/56917)**, [Kubu](https://osu.ppy.sh/users/29130), [Piotrekol](https://osu.ppy.sh/users/304520), [rEdo](https://osu.ppy.sh/users/49329), [White Wolf](https://osu.ppy.sh/users/39828), *[Niko-](https://osu.ppy.sh/users/175141)²* |
+| ![][flag_PT] | **Portugal** | **[creativ](https://osu.ppy.sh/users/280158)**, [cococococo](https://osu.ppy.sh/users/715052), [JonnyThatJonny](https://osu.ppy.sh/users/201290), [makkura](https://osu.ppy.sh/users/344086), [Maraiga](https://osu.ppy.sh/users/213335), [Pereira006](https://osu.ppy.sh/users/537344) |
+| ![][flag_RU] | **Russian Federation** | **[Akai-](https://osu.ppy.sh/users/649471)**, [cr1m](https://osu.ppy.sh/users/803766), [kapehh](https://osu.ppy.sh/users/360958), [Kert](https://osu.ppy.sh/users/119933), [Rost94](https://osu.ppy.sh/users/490568), [Vpalach](https://osu.ppy.sh/users/232729), *[BinGOSU3](https://osu.ppy.sh/users/610462)²* |
+| ![][flag_KR] | **South Korea** | **[KRZY](https://osu.ppy.sh/users/114017)**, [CheEZ](https://osu.ppy.sh/users/272117), [K i R i K a R u](https://osu.ppy.sh/users/139670), [moneto](https://osu.ppy.sh/users/242788), [Reisen Udongein](https://osu.ppy.sh/users/232942), [Remilia-Scarlet](https://osu.ppy.sh/users/602783) |
+| ![][flag_SE] | **Sweden** | **[theowest](https://osu.ppy.sh/users/60604)**, [failboat](https://osu.ppy.sh/users/276074), [Gyuunyu](https://osu.ppy.sh/users/799102), [Hanyuu-chan](https://osu.ppy.sh/users/881369), [Holmir](https://osu.ppy.sh/users/453435), [Nidert](https://osu.ppy.sh/users/817211), *[m4w11](https://osu.ppy.sh/users/509620)¹* |
+| ![][flag_TW] | **Taiwan** | **[Saya-Honmei](https://osu.ppy.sh/users/2865291)**, [SnowWhite](https://osu.ppy.sh/users/50265), [Tomoka Rin](https://osu.ppy.sh/users/125308), [wizoza83098](https://osu.ppy.sh/users/164156), [YuyuKo sama](https://osu.ppy.sh/users/234788), [ZRush](https://osu.ppy.sh/users/398097) |
+| ![][flag_TH] | **Thailand** | **[Frostmourne](https://osu.ppy.sh/users/199669)**, [aumu1995](https://osu.ppy.sh/users/235752), [bufo](https://osu.ppy.sh/users/141605), [blackspell](https://osu.ppy.sh/users/601173), [NonxE](https://osu.ppy.sh/users/319312), [termerys](https://osu.ppy.sh/users/84964), *[0OoMickeyoO0](http://osu.ppy.sh/users/317494)¹* |
+| ![][flag_UA] | **Ukraine** | **[Gorlum](https://osu.ppy.sh/users/347635)**, [\[milky\]](https://osu.ppy.sh/users/288597), [rockleejkooo](https://osu.ppy.sh/users/384003), [uljjang](https://osu.ppy.sh/users/3784417), *[Granje](https://osu.ppy.sh/users/496387)²* |
+| ![][flag_US] | **United States** | **[Kyou-kun](https://osu.ppy.sh/users/285711)**, [Cyclone](https://osu.ppy.sh/users/18589), [david huhh](https://osu.ppy.sh/users/278954), [Derekku](https://osu.ppy.sh/users/91341), [geckogates](https://osu.ppy.sh/users/252524), [Lybydose](https://osu.ppy.sh/users/64501) |
+| ![][flag_UY] | **Uruguay** | **[maay](https://osu.ppy.sh/users/160970)**, [AlrdyExists](https://osu.ppy.sh/users/407022), [GonixZ](https://osu.ppy.sh/users/612622), [H1ko](https://osu.ppy.sh/users/58710), [Snepif](https://osu.ppy.sh/users/408088), [Z e o n](https://osu.ppy.sh/users/539876) |
+| ![][flag_VN] | **Vietnam** | **[Misuzu-san](https://osu.ppy.sh/users/358563)**, [BridgetteLSatellizer](https://osu.ppy.sh/users/854083), [JerryC](https://osu.ppy.sh/users/279278), [kira\_lacus1995](https://osu.ppy.sh/users/996435), [xLightningx](https://osu.ppy.sh/users/1007806), *[Shin1801](https://osu.ppy.sh/users/604492)¹* |
+
+¹ *Denotes players that were being brought in either as an extra player, a substitute player, an emergency reserve player during the running of the Group Stage.*
+
+² *Denotes players that were being brought in as a substitute player prior to the beginning of the knock-out stages.*
+
+³ *Despite having the ![][flag_CH] Swiss flag on their profile, [Blacky](https://osu.ppy.sh/users/268788) was given a special discretion by the Tournament Management to represent ![][flag_DE] Germany in the tournament.*
+
+## Groups
+
+| Group A | Group B | Group C | Group D | Group E | Group F | Group G | Group H |
+| :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| ![][flag_AU] Australia | ![][flag_HU] Hungary | ![][flag_ID] Indonesia | ![][flag_CA] Canada | ![][flag_CL] Chile | ![][flag_FI] Finland | ![][flag_BR] Brazil | ![][flag_AR] Argentina |
+| ![][flag_DK] Denmark | ![][flag_NL] Netherlands | ![][flag_NO] Norway | ![][flag_HK] Hong Kong | ![][flag_FR] France | ![][flag_MY] Malaysia | ![][flag_BG] Bulgaria | ![][flag_AT] Austria |
+| ![][flag_DE] Germany | ![][flag_NZ] New Zealand | ![][flag_PL] Poland | ![][flag_KR] South Korea | ![][flag_LV] Latvia | ![][flag_RU] Russian Federation | ![][flag_SE] Sweden | ![][flag_TH] Thailand |
+| ![][flag_JP] Japan | ![][flag_PH] Philippines | ![][flag_UA] Ukraine | ![][flag_VN] Vietnam | ![][flag_PT] Portugal | ![][flag_UY] Uruguay | ![][flag_TW] Taiwan | ![][flag_US] United States |
 
 ## Mappools
 
 ### Finals
 
+*In addition of nine other new maps, the Finals mappool also saw all of the six previously featured Tiebreaker maps from earlier rounds returning as NoMod picks.*
+
 - NoMod
+  - [supercell - Rock 'n' Roll Nan Desu no (Garven) \[Insane\]](https://osu.ppy.sh/beatmapsets/27807#osu/93021) -- *(Group Stage week 1 Tiebreaker)*
+  - [Okui Masami - God Speed (ykcarrot) \[Insane\]](https://osu.ppy.sh/beatmapsets/28140#osu/93947) -- *(Group Stage week 2 Tiebreaker)*
+  - [Hommarju feat. R.Cena - Chousai Kenbo Sengen (galvenize) \[Insane\]](https://osu.ppy.sh/beatmapsets/30012#osu/99342) -- *(Group Stage week 3 Tiebreaker)*
+  - [Hatsune Miku - Rubik's Cube (rui) \[7x7x7\]](https://osu.ppy.sh/beatmapsets/33651#osu/114635) -- *(Round of 16 Tiebreaker)*
+  - [Nanamori-chu \* Goraku-bu - My Pace de Ikimashou (bakabaka) \[Yuri\]](https://osu.ppy.sh/beatmapsets/36569#osu/118226) -- *(Quarterfinals Tiebreaker)*
+  - [DJ Fresh - Gold Dust (galvenize) \[Insane\]](https://osu.ppy.sh/beatmapsets/28107#osu/93842) -- *(Semifinals Tiebreaker)*
   - [44teru-k - F.I (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmapsets/25828#osu/106033)
   - [Sound Horizon - Raijin no Hidariude (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmapsets/16792#osu/60089)
   - [Yousei Teikoku - Mischievous of Alice (Furawa) \[Alice\]](https://osu.ppy.sh/beatmapsets/35546#osu/142356)
@@ -109,12 +146,6 @@ This competition has come to an end and resulted in the following podium:
   - [Eoin O' Broin - Deep Space (galvenize) \[Another\]](https://osu.ppy.sh/beatmapsets/25098#osu/85550)
   - [Dio ft. Sef - Tijdmachine (GladiOol) \[Lesjuh! '11\]](https://osu.ppy.sh/beatmapsets/6997#osu/129875)
   - [Seiryu X Donald - Time to Donald (James) \[Another\]](https://osu.ppy.sh/beatmapsets/6950#osu/30613)
-  - [supercell - Rock 'n' Roll Nan Desu no (Garven) \[Insane\]](https://osu.ppy.sh/beatmapsets/27807#osu/93021)
-  - [Okui Masami - God Speed (ykcarrot) \[Insane\]](https://osu.ppy.sh/beatmapsets/28140#osu/93947)
-  - [Hommarju feat. R.Cena - Chousai Kenbo Sengen (galvenize) \[Insane\]](https://osu.ppy.sh/beatmapsets/30012#osu/99342)
-  - [Hatsune Miku - Rubik's Cube (rui) \[7x7x7\]](https://osu.ppy.sh/beatmapsets/33651#osu/114635)
-  - [Nanamori-chu \* Goraku-bu - My Pace de Ikimashou (bakabaka) \[Yuri\]](https://osu.ppy.sh/beatmapsets/36569#osu/118226)
-  - [DJ Fresh - Gold Dust (galvenize) \[Insane\]](https://osu.ppy.sh/beatmapsets/28107#osu/93842)
 - Tiebreaker
   - **[Fear, and Loathing in Las Vegas - Just Awake (gowww) \[Insane\]](https://osu.ppy.sh/beatmapsets/44527#osu/139446)**
 
@@ -178,7 +209,7 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[Hatsune Miku - Rubik's Cube (rui) \[7x7x7\]](https://osu.ppy.sh/beatmapsets/33651#osu/114635)**
 
-### Group Stage (Round 3)
+### Group Stage week 3
 
 - NoMod
   - [Ruru Ichinose - Hinarin's Relation of Misfortune (Mafiamaster) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/12344#osu/46486)
@@ -198,7 +229,7 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[Hommarju feat. R.Cena - Chousai Kenbo Sengen (galvenize) \[Insane\]](https://osu.ppy.sh/beatmapsets/30012#osu/99342)**
 
-### Group Stage (Round 2)
+### Group Stage week 2
 
 - NoMod
   - [Jun.A - The Refrain of the Lovely Great War (KanbeKotori) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/24325#osu/82734)
@@ -218,7 +249,7 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[Okui Masami - God Speed (ykcarrot) \[Insane\]](https://osu.ppy.sh/beatmapsets/28140#osu/93947)**
 
-### Group Stage (Round 1)
+### Group Stage week 1
 
 - NoMod
   - [Hatsune Miku - BadBye (goodbye) \[GoodBye\]](https://osu.ppy.sh/beatmapsets/30939#osu/101916)
@@ -238,26 +269,250 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[supercell - Rock 'n' Roll Nan Desu no (Garven) \[Insane\]](https://osu.ppy.sh/beatmapsets/27807#osu/93021)**
 
+## Match Results
+
+### Finals
+
+Sunday, 11 March 2012 (Grand Final):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_JP] Japan | 1 | **4** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/2845562) |
+
+Saturday, 24 March 2012 (3rd Place Playoff):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_BR] **Brazil** | **4** | 2 | ![][flag_RU] Russian Federation | [#1](https://osu.ppy.sh/community/matches/2947666) |
+
+### Semifinals
+
+Thursday, 16 February 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_RU] Russian Federation | 0 | **4** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/2649676) |
+
+Tuesday, 28 February 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_JP] **Japan** | **4** | 0 | ![][flag_BR] Brazil | *win by default* |
+
+### Quarterfinals
+
+Saturday, 14 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_TW] Taiwan | 0 | **3** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/2398122) |
+
+Sunday, 15 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_JP] **Japan** | **3** | 0 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/2406540) |
+
+Sunday, 29 January 2012:
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_KR] **South Korea** | **3** | 1 | ![][flag_NL] Netherlands | [#1](https://osu.ppy.sh/community/matches/2513557) |
+| ![][flag_FR] France | 2 | **3** | ![][flag_BR] **Brazil** | [#1](https://osu.ppy.sh/community/matches/2516621) |
+
+### Round of 16
+
+Saturday, 7 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_JP] **Japan** | **3** | 0 | ![][flag_HU] Hungary | [#1](https://osu.ppy.sh/community/matches/2347178) |
+| ![][flag_KR] **South Korea** | **3** | 0 | ![][flag_UA] Ukraine | [#1](https://osu.ppy.sh/community/matches/2347528) |
+| ![][flag_AR] Argentina | 0 | **3** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/2348743) |
+
+Sunday, 8 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_NL] **Netherlands** | **3** | 1 | ![][flag_DE] Germany | [#1](https://osu.ppy.sh/community/matches/2350372) |
+| ![][flag_PL] **Poland** | **3** | 1 | ![][flag_CA] Canada | [#1](https://osu.ppy.sh/community/matches/2350703) |
+| ![][flag_FR] **France** | **3** | 1 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/2356557) |
+| ![][flag_RU] **Russian Federation** | **3** | 0 | ![][flag_CL] Chile | *win by default* |
+
+Friday, 13 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| ![][flag_BR] **Brazil** | **3** | 1 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/2385313) |
+
+### Group Stage (Week 3)
+
+Saturday, 10 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| B | ![][flag_HU] Hungary | 2 | **3** | ![][flag_PH] **Philippines** | [#1](https://osu.ppy.sh/community/matches/2158061) |
+| C | ![][flag_NO] Norway | 1 | **3** | ![][flag_UA] **Ukraine** | [#1](https://osu.ppy.sh/community/matches/2159578) |
+| A | ![][flag_DE] Germany | 1 | **3** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/2157518) |
+
+Sunday, 11 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| C | ![][flag_ID] Indonesia | 2 | **3** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/2165756) |
+| G | ![][flag_BG] Bulgaria | 2 | **3** | ![][flag_SE] **Sweden** | [#1](https://osu.ppy.sh/community/matches/2167101) |
+| B | ![][flag_NL] **Netherlands** | **3** | 0 | ![][flag_NZ] New Zealand | [#1](https://osu.ppy.sh/community/matches/2161430) |
+| D | ![][flag_HK] Hong Kong | 0 | **3** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/2164241) |
+| H | ![][flag_AT] Austria | 1 | **3** | ![][flag_TH] **Thailand** | [#1](https://osu.ppy.sh/community/matches/2165511) |
+| E | ![][flag_CL] **Chile** | **3** | 1 | ![][flag_LV] Latvia | [#1](https://osu.ppy.sh/community/matches/2167760) |
+| A | ![][flag_AU] Australia | 0 | **3** | ![][flag_DK] **Denmark** | *win by default* |
+| F | ![][flag_RU] **Russian Federation** | **3** | 0 | ![][flag_UY] Uruguay | *win by default* |
+| D | ![][flag_CA] **Canada** | **3** | 0 | ![][flag_VN] Vietnam | *win by default* |
+
+Saturday, 17 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| E | ![][flag_FI] Finland | 0 | **3** | ![][flag_MY] **Malaysia** | [#1](hhttps://osu.ppy.sh/community/matches/2203425) |
+
+Sunday, 18 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| E | ![][flag_FR] **France** | **3** | 2 | ![][flag_PT] Portugal | [#1](https://osu.ppy.sh/community/matches/2204816) |
+| H | ![][flag_AR] **Argentina** | **3** | 0 | ![][flag_US] United States | [#1](https://osu.ppy.sh/community/matches/2206788) |
+| G | ![][flag_BR] **Brazil** | **3** | 0 | ![][flag_TW] Taiwan | [#1](https://osu.ppy.sh/community/matches/2243425) |
+
+### Group Stage (Week 2)
+
+Saturday, 3 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| G | ![][flag_BR] **Brazil** | **3** | 1 | ![][flag_SE] Sweden | [#1](https://osu.ppy.sh/community/matches/2114825) |
+
+Sunday, 4 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| F | ![][flag_MY] Malaysia | 2 | **3** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/2121617) |
+| C | ![][flag_PL] **Poland** | **3** | 2 | ![][flag_UA] Ukraine | [#1](https://osu.ppy.sh/community/matches/2115216) |
+| B | ![][flag_HU] Hungary | 0 | **3** | ![][flag_NL] **Netherlands** | [#1](https://osu.ppy.sh/community/matches/2115634) |
+| E | ![][flag_CL] **Chile** | **3** | 1 | ![][flag_PT] Portugal | [#1](https://osu.ppy.sh/community/matches/2116719) |
+| B | ![][flag_NZ] **New Zealand** | **3** | 1 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/2119360) |
+| A | ![][flag_DK] Denmark | 0 | **3** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/2120514) |
+| C | ![][flag_ID] Indonesia | 0 | **3** | ![][flag_NO] **Norway** | [#1](https://osu.ppy.sh/community/matches/2121720) |
+| H | ![][flag_AR] **Argentina** | **3** | 2 | ![][flag_TH] Thailand | [#1](https://osu.ppy.sh/community/matches/2122773) |
+| E | ![][flag_FR] **France** | **3** | 1 | ![][flag_LV] Latvia | [#1](https://osu.ppy.sh/community/matches/2123433) |
+| A | ![][flag_AU] Australia | 1 | **3** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/2121680) |
+| D | ![][flag_KR] **South Korea** | **3** | 0 | ![][flag_VN] Vietnam | *win by default* |
+
+Monday, 5 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| G | ![][flag_BG] Bulgaria | 0 | **3** | ![][flag_TW] **Taiwan** | *win by default* |
+
+Tuesday, 6 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| F | ![][flag_FI] **Finland** | **3** | 0 | ![][flag_UY] Uruguay | [#1](https://osu.ppy.sh/community/matches/2129293) |
+
+Saturday, 10 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| D | ![][flag_CA] **Canada** | **3** | 1 | ![][flag_HK] Hong Kong | [#1](https://osu.ppy.sh/community/matches/2159276) |
+| H | ![][flag_AT] Austria | 1 | **3** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/2161204) |
+
+### Group Stage (Week 1)
+
+Saturday, 19 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| B | ![][flag_NL] **Netherlands** | **3** | 0 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/2022860) |
+| F | ![][flag_FI] Finland | 2 | **3** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/2025129) |
+| A | ![][flag_AU] Australia | 0 | **3** | ![][flag_JP] **Japan** | [#1](https://osu.ppy.sh/community/matches/2022006) |
+| C | ![][flag_ID] Indonesia | 1 | **3** | ![][flag_UA] **Ukraine** | [#1](https://osu.ppy.sh/community/matches/2023842) |
+| G | ![][flag_BR] **Brazil** | **3** | 0 | ![][flag_BG] Bulgaria | [#1](https://osu.ppy.sh/community/matches/2026764) |
+| A | ![][flag_DK] Denmark | 0 | **3** | ![][flag_DE] **Germany** | [#1](https://osu.ppy.sh/community/matches/2026370) |
+
+Sunday, 20 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| E | ![][flag_CL] Chile | 1 | **3** | ![][flag_FR] **France** | [#1](https://osu.ppy.sh/community/matches/2027339) |
+| H | ![][flag_TH] Thailand | 0 | **3** | ![][flag_US] **United States** | [#1](https://osu.ppy.sh/community/matches/2028163) |
+| B | ![][flag_HU] **Hungary** | **3** | 1 | ![][flag_NZ] New Zealand | [#1](https://osu.ppy.sh/community/matches/2030888) |
+| D | ![][flag_HK] **Hong Kong** | **3** | 0 | ![][flag_VN] Vietnam | [#1](https://osu.ppy.sh/community/matches/2031284) |
+| F | ![][flag_UY] Uruguay | 2 | **3** | ![][flag_MY] **Malaysia** | [#1](https://osu.ppy.sh/community/matches/2033451) |
+
+Monday, 21 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| B | ![][flag_AR] **Argentina** | **3** | 2 | ![][flag_AU] Austria | [#1](https://osu.ppy.sh/community/matches/2034560) |
+
+Friday, 25 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| C | ![][flag_NO] Norway | 2 | **3** | ![][flag_PL] **Poland** | [#1](https://osu.ppy.sh/community/matches/2056490) |
+
+Saturday, 26 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| G | ![][flag_SE] Sweden | 0 | **3** | ![][flag_TW] **Taiwan** | [#1](https://osu.ppy.sh/community/matches/2067611) |
+| E | ![][flag_LV] Latvia | 0 | **3** | ![][flag_PT] **Portugal** | [#1](https://osu.ppy.sh/community/matches/2070120) |
+
+Sunday, 27 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| D | ![][flag_CA] Canada | 1 | **3** | ![][flag_KR] **South Korea** | [#1](https://osu.ppy.sh/community/matches/2072809) |
+
 ## Ruleset
 
 ### Tournament rules
 
-1. No more team than 1 from 1 country can sign-up to the tournament.
-2. All of the team players' flag in the profile must be the same as their country's. However, it can be got around in special cases.
-3. Any form of unfair behaviour (such as cheating, insulting other players, racism) will be punished with an immediate banishment of the player/the team from the tournament.
+1. The osu! World Cup is a 4v4, country-based team tournament played on the osu! game mode.
+2. Beatmap scoring is based on **[ScoreV1](/wiki/Score#scorev1)**.
+3. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance one before the actual matches take place. Only these beatmaps will be used during the respective matches. 
+   - One beatmap will be a tiebreaker beatmap. This beatmap will only be played in case of a tie.
+4. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions)).
+5. If no staff is available, the match will be postponed.
+6. If the beatmap ends in a draw, the map will be nullified.
+7. If a player disconnects, their scores will not be counted towards their team's total.
+8. Beatmaps cannot be reused in the same match unless the map was nullified.
+9. If a team fails to bring in the required minimum of 4 players to a match, the corresponding match can either be:
+   - Postponed by a maximum time of 10 minutes under the opposing team and the Tournament Management's discretion.
+   - Continued in either a 2v2 or 3v3 setting under the opposing team and the Tournament Management's discretion.
+   - Declared as a forfeited match where the opposing team gets automatically awarded a Win by Default.     
+10. Exchanging players during a match is allowed without limitations.
+    - **If a map rematch is required, exchanging players is not allowed. With the Tournament Management's discretion, an exception can be made if the previous roster is unavailable to play.**
+11. Lag is not a valid reason to nullify a beatmap.
+12. All players are supposed to keep the match running fluently and without delays. Penalties can be issued to the players if they cause excessive match delays.
+13. If a player disconnects between maps and the team cannot provide a replacement, the match can be delayed 10 minutes at maximum.
+14. All players and staffs must be treated with respect. Instructions of the Tournament Management are to be followed. Decisions labeled as final are not to be objected.
+15. Disrupting the match by foul play, insulting and provoking other players or staffs, delaying the match or other deliberate inappropriate misbehavior is strictly prohibited.
+16. Unexpected incidents are to be handled by the Tournament Management.
+17. Penalties for violating the tournament rules may include:
+    - Exclusion of specific players for one beatmap
+    - Exclusion of specific players for an entire match
+    - Declaring the match as Lost by Default
+    - Disqualification from the entire tournament
+    - Disqualification from the current and future official tournaments until appealed
+    - Any modification of these rules will be announced.
 
 ### Tournament registration
 
-1. The country will be represented by the captain, which will choose its players. The captain will be chosen in the forum national thread/IRC talk by the trusted members. Basic English language knowledge is required from the person of captain.
-2. To sign up, you need AT LEAST 4 players in the team. You can though sign-up with additional 2 players as the back-up in case of first players' absence. To sign-up simply post the team outline in this thread.
-3. The sign-up time lasts from the day of 28th October to 21st November, 23:59 GMT+0 (3 weeks + 3 days).
-4. The sign-ups automatically stop after reaching 32 participants.
-5. If there's more attention to the tournament than we expect, the number of participants might be raised.
-
-An example of sign-up post:
+1. In order to be registered for the tournament, a representative of each country will have to propose a team roster comprising of 4-6 players in the discussion thread following a template set by the Tournament Management as follows:
 
 ```
-Country name:
+Country Name: (...)
+
 Captain: Nickname1
 Player1: Nickname2
 Player2: Nickname3
@@ -265,39 +520,68 @@ Player3: Nickname4
 --------------------------
 Back-up Player1: Nickname5
 Back-up Player2: Nickname6
+
+Time Zone: (...)
 ```
 
-Time zone: GMT+0 (if you don't know your time zone, visit [this site](https://www.timeanddate.com/worldclock/))
-
-### Stage instructions
-
-1. We are looking for 32 teams from 32 countries. If there are less participants than we want, the tournament will be modeled according to the reached number.
-2. In the first stage, the teams will be divided into 8 groups of 4 team in each one.
-3. All the teams from each group will face each other.
-4. 2 teams with the largest amount of points are being promoted to the 1/16 Cup Stage.
+2. Each team may only consist of players who share the same national flag.
+   - Special exceptions may be made under the discretion of the Tournament Management.
+3. To ensure valid and serious registrations, every proposed team roster will be checked by the Tournament Management.
+4. All accepted teams will be announced in the discussion thread after the Registration Phase.
+   - **A team should have at least 4 players registered in order to be eligible to participate.**
+5. Once a team roster has been accepted, it remains locked for the rest of the tournament. No further changes may be made to it except on these following occasions:
+   - In the Group Stage, **prior to either a team's first match or 2011-11-21 GMT +0** (whichever comes first), teams may freely substitute players in to and out from the initially accepted roster. Teams that are still short from the 6 players allowance are also able to bring in extra players within this time period. After either one of both the aforementioned conditions has been fulfilled, teams may no longer change their roster for the rest of the Group Stage unless there's an extraordinary circumstance which requires teams to bring in an emergency reserve player.
+   - **Prior to the beginning of the knock-out stages**, teams that are still active in the tournament are allowed to introduce a maximum of two new players to substitute in for two other prior members of the team with the Tournament Management's approval.
+6. Mappool selectors are not eligible to participate as players in this tournament.
 
 ### Match instructions
 
-1. 15 minutes before the match, the captains must contact each other and confirm the ready to play and the amount of players.
-2. During the match, there must be 8 players on the server hosted by one of the captains, 4 players from each team.
-3. One of the players (captain would be preferred) must capture screenshots of all of the map results.
-4. Each round, the staff will announce the list of 15 beatmaps, from which the captains will be able to choose. 1 team chooses 2 beatmaps to play, however, we'd prefer if you prepare the third and fourth choice in case the opposed team chooses same maps. That means you play to 3 maps won.
-5. In the case of a draw, an extra choosen map is played.
-6. The settings of the server will be: osu! standard mode, "Team vs" mode and win condition: score.
-7. The only allowed mod in-game is No Video.
-8. The country with best total score on the map wins.
-9. After the match, a captain of one of the teams must send a PM to fartownik or NatsumeRin with link to the Multiplayer History of the game and screenshots from all of the maps. If any of the captains won't do it, the match will be cancelled and a re-match will be needed.
-10. The players can freely change themselves between the maps.
+1. A member of the Tournament Management will create a multiplayer room 15 minutes in advance. Players must gather during this period.
+   - Room settings are osu!, Team-Vs., Win Condition: 'Score'. Room name must be "OWC2: (TeamRed) vs (TeamBlue)".
+   - The team mentioned first in the room name must be the red team, the team mentioned second in the room name must be the blue team.
+2. As osu! World Cup #2 features no formal referee, **both team captains are expected to referee the match by themselves from inside the multiplayer lobby**. If there are any suspected irregularities during the run of the match, the concerned team captain may file a report in the discussion thread which will be investigated by the Tournament Management in due time.
+3. Map banning **does not apply** in the entirety of the tournament.
+4. Each team must have 4 players for each map. They can be exchanged freely after a map is concluded.
+5. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
+6. Each captain must use the "!roll" command once in #multiplayer.
+   - The captain with the higher roll decides which team **picks** first.
+7. The results of eatch match will be posted on the discussion thread after the match has been concluded by either of the team captains.
 
-### Ruleset changes
+### Stage instructions
 
-Changes in the rules aside from [OWC #1](/wiki/Tournaments/OWC/1).
+1. In the Group Stage, the teams will be divided into 8 groups of 4 teams at random.
+   - To ensure fairness, the drawing process will be [publicly livestreamed](http://www.livestream.com/natteke).
+2. All the teams from each group will face each other over the course of three weeks.
+3. Rankings of each group are determined by sorting the results of each team's performance in the following priority:
+   - Most matches won.
+   - Have higher `{(the number of beatmaps won) - (the number of beatmaps defeated)}`.
+   - Most beatmaps won.
+   - **Winner of the match played previously between the tied teams.**
+   - In the event of a triple tie:
+     - Have higher `∑{(total score difference) / (maximum score)}`.
+     - Winner of the rematch.
+4. The top two teams of each group will move on to the knock-out stages following [this matchup bracket set by the Tournament Management](img/bracket.jpg).   
+   - The knock-out stages are played under the Single Elimination system.
 
-1. 3 maps won by one of the teams gives them a match win. Not 2 maps like it was in the 1st edition.
-2. The final maps will be chosen more carefully this time.
-3. The teams will be divided into 8 groups of 4 teams each. 2 teams with the largest amount of points passes into the next stage.
-4. The additional back-up players are not necessary, but we still prefer if you have at least 1 if there's a possibility.
-5. Timezone needed in the post of team sign-up.
+#### Winning conditions
+
+- The Group Stage, Round of 16, and Quartefinals matches will be played in a Best-of-5 matchup configuration (first team to 3 points wins).
+- The Semifinals and the Finals matches will be played in a Best-of-7 matchup configuration (first team to 4 points wins).
+
+### Mappool instructions
+
+1. There will be a different mappool for every stage.
+2. All the maps in the mappool (including the Tiebreaker) will be played without any modifications enabled (NoMod).
+3. Each mappool will all consist of 15 NoMod maps + 1 Tiebreaker map.
+
+### Scheduling instructions
+
+1. Each stage will be held on its respective timeframe set by the Tournament Management.
+2. Scheduling will be handled by the Tournament Management. Schedules will be released on the Sunday before the first matches of the stage.
+3. **Reschedules will only be considered if both teams agree to a time. This needs to be done and notified to the Tournament Management before the particular match takes place.**
+4. **Reschedules may only be requested by a team captain.**
+   - **Do not ask for a reschedule unless it is absolutely necessary. The Tournament Management has the right to decline the request.**
+5. Captains are responsible for their teams' availability. The greater team size exists to ensure every team can provide at least four players for each match. If teams can not provide four players for a match, the match will be considered forfeited.
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentina"
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"
@@ -305,12 +589,14 @@ Changes in the rules aside from [OWC #1](/wiki/Tournaments/OWC/1).
 [flag_BG]: /wiki/shared/flag/BG.gif "Bulgaria"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CH]: /wiki/shared/flag/CH.gif "Switzerland"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"
 [flag_CN]: /wiki/shared/flag/CN.gif "China"
 [flag_DE]: /wiki/shared/flag/DE.gif "Germany"
 [flag_DK]: /wiki/shared/flag/DK.gif "Denmark"
 [flag_FI]: /wiki/shared/flag/FI.gif "Finland"
 [flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "United Kingdom"
 [flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
 [flag_HU]: /wiki/shared/flag/HU.gif "Hungary"
 [flag_ID]: /wiki/shared/flag/ID.gif "Indonesia"

--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -452,7 +452,7 @@ Monday, 21 November 2011:
 
 | Group | Team 1 |  |  | Team 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| B | ![][flag_AR] **Argentina** | **3** | 2 | ![][flag_AU] Austria | [#1](https://osu.ppy.sh/community/matches/2034560) |
+| B | ![][flag_AR] **Argentina** | **3** | 2 | ![][flag_AT] Austria | [#1](https://osu.ppy.sh/community/matches/2034560) |
 
 Friday, 25 November 2011:
 
@@ -479,11 +479,11 @@ Sunday, 27 November 2011:
 
 1. The osu! World Cup is a 4v4, country-based team tournament played on the osu! game mode.
 2. Beatmap scoring is based on **[ScoreV1](/wiki/Score#scorev1)**.
-3. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance one before the actual matches take place. Only these beatmaps will be used during the respective matches. 
+3. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance before the actual matches take place. Only these beatmaps will be used during the respective matches. 
    - One beatmap will be a tiebreaker beatmap. This beatmap will only be played in case of a tie.
 4. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions)).
 5. If no staff is available, the match will be postponed.
-6. If the beatmap ends in a draw, the map will be nullified.
+6. If a beatmap ends in a draw, the map will be nullified.
 7. If a player disconnects, their scores will not be counted towards their team's total.
 8. Beatmaps cannot be reused in the same match unless the map was nullified.
 9. If a team fails to bring in the required minimum of 4 players to a match, the corresponding match can either be:
@@ -495,8 +495,8 @@ Sunday, 27 November 2011:
 11. Lag is not a valid reason to nullify a beatmap.
 12. All players are supposed to keep the match running fluently and without delays. Penalties can be issued to the players if they cause excessive match delays.
 13. If a player disconnects between maps and the team cannot provide a replacement, the match can be delayed 10 minutes at maximum.
-14. All players and staffs must be treated with respect. Instructions of the Tournament Management are to be followed. Decisions labeled as final are not to be objected.
-15. Disrupting the match by foul play, insulting and provoking other players or staffs, delaying the match or other deliberate inappropriate misbehavior is strictly prohibited.
+14. All players and the staff must be treated with respect. Instructions of the Tournament Management are to be followed. Decisions labeled as final are not to be objected.
+15. Disrupting the match by foul play, insulting and provoking other players or the staff, delaying the match, or other deliberate inappropriate misbehavior is strictly prohibited.
 16. Unexpected incidents are to be handled by the Tournament Management.
 17. Penalties for violating the tournament rules may include:
     - Exclusion of specific players for one beatmap
@@ -530,7 +530,7 @@ Time Zone: (...)
 4. All accepted teams will be announced in the discussion thread after the Registration Phase.
    - **A team should have at least 4 players registered in order to be eligible to participate.**
 5. Once a team roster has been accepted, it remains locked for the rest of the tournament. No further changes may be made to it except on these following occasions:
-   - In the Group Stage, **prior to either a team's first match or 2011-11-21 GMT +0** (whichever comes first), teams may freely substitute players in to and out from the initially accepted roster. Teams that are still short from the 6 players allowance are also able to bring in extra players within this time period. After either one of both the aforementioned conditions has been fulfilled, teams may no longer change their roster for the rest of the Group Stage unless there's an extraordinary circumstance which requires teams to bring in an emergency reserve player.
+   - In the Group Stage, **prior to either a team's first match or 2011-11-21 GMT +0** (whichever comes first), teams may freely substitute players in to and out from the initially accepted roster. Teams that are still short from the 6 players allowance are also able to bring in extra players within this time period. After either one of both the aforementioned conditions have been fulfilled, teams may no longer change their roster for the rest of the Group Stage unless there's an extraordinary circumstance which requires teams to bring in an emergency reserve player.
    - **Prior to the beginning of the knock-out stages**, teams that are still active in the tournament are allowed to introduce a maximum of two new players to substitute in for two other prior members of the team with the Tournament Management's approval.
 6. Mappool selectors are not eligible to participate as players in this tournament.
 
@@ -543,9 +543,9 @@ Time Zone: (...)
 3. Map banning **does not apply** in the entirety of the tournament.
 4. Each team must have 4 players for each map. They can be exchanged freely after a map is concluded.
 5. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
-6. Each captain must use the "!roll" command once in #multiplayer.
+6. Each captain must use the `!roll` command once in `#multiplayer`.
    - The captain with the higher roll decides which team **picks** first.
-7. The results of eatch match will be posted on the discussion thread after the match has been concluded by either of the team captains.
+7. The results of each match will be posted on the discussion thread after the match has been concluded by either of the team captains.
 
 ### Stage instructions
 
@@ -560,13 +560,13 @@ Time Zone: (...)
    - In the event of a triple tie:
      - Have higher `∑{(total score difference) / (maximum score)}`.
      - Winner of the rematch.
-4. The top two teams of each group will move on to the knock-out stages following [this matchup bracket set by the Tournament Management](img/bracket.jpg).   
+4. The top two teams of each group will move on to the knock-out stages following [the matchup bracket set by the Tournament Management](img/bracket.jpg).   
    - The knock-out stages are played under the Single Elimination system.
 
 #### Winning conditions
 
-- The Group Stage, Round of 16, and Quartefinals matches will be played in a Best-of-5 matchup configuration (first team to 3 points wins).
-- The Semifinals and the Finals matches will be played in a Best-of-7 matchup configuration (first team to 4 points wins).
+- The Group Stage, Round of 16, and Quartefinals matches will be played in a Best-of-5 matchup configuration (first team to reach 3 points wins).
+- The Semifinals and the Finals matches will be played in a Best-of-7 matchup configuration (first team to reach 4 points wins).
 
 ### Mappool instructions
 
@@ -578,7 +578,7 @@ Time Zone: (...)
 
 1. Each stage will be held on its respective timeframe set by the Tournament Management.
 2. Scheduling will be handled by the Tournament Management. Schedules will be released on the Sunday before the first matches of the stage.
-3. **Reschedules will only be considered if both teams agree to a time. This needs to be done and notified to the Tournament Management before the particular match takes place.**
+3. **Reschedules will only be considered if both teams agree to a time. This needs to be done and communicated to the Tournament Management before the particular match takes place.**
 4. **Reschedules may only be requested by a team captain.**
    - **Do not ask for a reschedule unless it is absolutely necessary. The Tournament Management has the right to decline the request.**
 5. Captains are responsible for their teams' availability. The greater team size exists to ensure every team can provide at least four players for each match. If teams can not provide four players for a match, the match will be considered forfeited.


### PR DESCRIPTION
continuation of [#4731](http://github.com/ppy/osu-wiki/pull/4731). i genuinely thought this would be easier to clean up than OWC #1 tho, but in reality this is much **much** ***much*** harder to clean up as OWC #2's documentation is just one very big mess 😢

some changes in this pr include :

- added match results (ngl this is an absolute **nightmare** to compile -- as this OWC didn't feature a formal referee and all teams are expected to "self-referee" their own matches, most of the match reports are just people posting mp links in the forum thread without any indication of who won the match or what was the final score. in the end i had to rely on various external resources in order to get this section properly filled)

![image](https://user-images.githubusercontent.com/36564236/104116266-8ee4a800-5349-11eb-8183-e04e96ff16c8.png)

![image](https://user-images.githubusercontent.com/36564236/104116264-8d1ae480-5349-11eb-83b1-af8955e9070f.png)

- reworked the team listing (this OWC was also notorious for allowing many substitutions to be made while the tournament was ongoing; i've scoured the thread and added many names that were evidently participating in the tournament but weren't mentioned in the opening post for one reason or another. hopefully i didn't miss anyone)
- added missing profile links using web.archive.org (~~with the exception of Portugal's cococococo in which i can't find any trace of them whatsoever~~ nvm found it)
- added tournament schedule (rough estimation, based on the forum timestamp of the posts)
- added clarification about the Finals mappool structure
- added proper tournament staff roster
- reworked the ruleset section to be more in line with modern tournament ruleset writing standards
- added clarification that the tournament was run by various community members with the provision of the osu!team (instead of "being directly run by the osu!team" as currently indicated)
- applied bunch of other minor tweaks and improvements