### PR TITLE
Fix broken table in osu! World Cup #2 wiki article

### DIFF
--- a/wiki/Tournaments/OWC/2/en.md
+++ b/wiki/Tournaments/OWC/2/en.md
@@ -314,6 +314,7 @@ Sunday, 15 January 2012:
 | ![][flag_JP] **Japan** | **3** | 0 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/2406540) |
 
 Sunday, 29 January 2012:
+
 | Team 1 |  |  | Team 2 | Match link |
 | --: | :-: | :-: | :-- | :-- |
 | ![][flag_KR] **South Korea** | **3** | 1 | ![][flag_NL] Netherlands | [#1](https://osu.ppy.sh/community/matches/2513557) |


### PR DESCRIPTION
related to the other pr that was recently merged (https://github.com/ppy/osu-wiki/pull/4754).

apparently there's a table in the article that appears to be fine in GitHub's rich view (and was also deemed okay by remark) but when it got merged in the wiki it got broke somehow 🤔

![image](https://user-images.githubusercontent.com/36564236/105526023-6f1f8d80-5d14-11eb-8fee-22bf8ef91574.png)

![image](https://user-images.githubusercontent.com/36564236/105526039-734bab00-5d14-11eb-93fa-1f7a7f2eb6b4.png)
