### PR TITLE
Add Beatmap Spotlights Season 3: Winter 2021 Playlists B

### DIFF
--- a/news/2021-01-18-beatmap-spotlights-season-3-winter-2021.md
+++ b/news/2021-01-18-beatmap-spotlights-season-3-winter-2021.md
@@ -44,7 +44,7 @@ The applications will remain open for at least 2 weeks (ending at 1st February 2
 
 You can check the finalized leaderboard for the previous season [here](https://docs.google.com/spreadsheets/d/e/2PACX-1vQ0_p56oQ2FcpYQoVKSZVhvFR7hX3tX7l0nUpCqlvTmBIEyDh0RdzjIg6WbjXTTtiA5-E4bd0aLxAV8/pubhtml).
 
-The Winter Season 2021 leaderboard will be available over at the [Beatmap Spotlights Season Winter 2021](/wiki/Beatmap_Spotlights/Seasons/Winter_2021) wiki article once the first batch of lobbies conclude in the coming weeks.
+The Winter Season 2021 leaderboard will be available over at the [Beatmap Spotlights Season Winter 2021](/wiki/Beatmap_Spotlights/Seasons/2021_Winter) wiki article once the first batch of lobbies conclude in the coming weeks.
 
 ## Rewards
 

--- a/wiki/Beatmap_Spotlights/Seasons/2021_Winter/en.md
+++ b/wiki/Beatmap_Spotlights/Seasons/2021_Winter/en.md
@@ -51,6 +51,14 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Nekomata Master+ - Kung-fu Empire (Damnae) \[Backdrop\]](https://osu.ppy.sh/beatmapsets/173288#osu/418725)
 - [ELECTROCUTICA feat. F9 - Triplaneta (deetz) \[FALL\]](https://osu.ppy.sh/beatmapsets/1010927#osu/2116069)
 
+#### Playlist B
+
+- [Shimotsuki Haruka - SilentFlame (Gust) \[Pata-Mon's Hard\]](https://osu.ppy.sh/beatmapsets/662675#osu/1412483)
+- [Foreground Eclipse - Noble (EvilElvis) \[Insane\]](https://osu.ppy.sh/beatmapsets/313282#osu/699391)
+- [himawari - AIRI (Kibbleru) \[Inflorescence\]](https://osu.ppy.sh/beatmapsets/718072#osu/1518305)
+- [Shimotsuki Haruka - Chant de Verite (ScubDomino) \[Euphorie\]](https://osu.ppy.sh/beatmapsets/1204933#osu/2508958)
+- [JYOCHO - Taiyou to Kurashite Kita (dsco) \[Bloom\]](https://osu.ppy.sh/beatmapsets/600881#osu/1269564)
+
 ### osu!taiko
 
 #### Playlist A
@@ -60,6 +68,14 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Umeboshi Chazuke - Dutch Courage! (Ulqui) \[Oni\]](https://osu.ppy.sh/beatmapsets/1224146#taiko/2547507)
 - [cillia - Uta o Utau Hito (mintong89) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/1135401#taiko/2526997)
 - [Morimori Atsushi - Toono Gensou Monogatari (MRM REMIX) (Charlotte) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/812992#taiko/2236133)
+
+#### Playlist B
+
+- [LeaF - Wizdomiot (SKSalt) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/352682#taiko/777196)
+- [x0o0x\_ - ------ (nyanmi-1828) \[Oni\]](https://osu.ppy.sh/beatmapsets/1128229#taiko/2358776)
+- [siqlo - parsley (komasy) \[Oni\]](https://osu.ppy.sh/beatmapsets/1296126#taiko/2689206)
+- [C-Show - On the FM (Nofool) \[Oni\]](https://osu.ppy.sh/beatmapsets/568544#taiko/1205385)
+- [Silentroom - GLITCH SWITCH (komasy) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/1225733#taiko/2549098)
 
 ### osu!catch
 
@@ -71,6 +87,14 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [M2U - Wicked Fate (JeirYagtama) \[Sadistic Fate\]](https://osu.ppy.sh/beatmapsets/754692#fruits/1588796) +HD
 - [Noisia - Running Blind (Spectator) \[Team South Korea's Overdose\]](https://osu.ppy.sh/beatmapsets/1293035#fruits/2684716)
 
+#### Playlist B
+
+- [Fractal Dreamers - Ex Nihilo (wonjae) \[Hyperion's Platter\]](https://osu.ppy.sh/beatmapsets/1254879#fruits/2613384)
+- [FELT - Goldrop (Lust) \[Spec's Rain\]](https://osu.ppy.sh/beatmapsets/204927#fruits/506395)
+- [Uinyasu, Occhoko Bunny - Aa Kenran no Yume ga Gotoku (Epsilon Remix) (-Luminate) \[Rain\]](https://osu.ppy.sh/beatmapsets/1044161#fruits/2534547)
+- [LukHash - WINTER ERROR (Rocma) \[Overdose\]](https://osu.ppy.sh/beatmapsets/1031668#fruits/2157306) +HD
+- [TERRASPEX - AMAZING BREAK (Spectator) \[KYUARE SPEC'S INVASION\]](https://osu.ppy.sh/beatmapsets/727329#fruits/1535572)
+
 ### osu!mania
 
 #### Playlist A
@@ -80,3 +104,11 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Tou Chi Chen - Secret Kakuranger TEKINA Remix (-Kamikaze-) \[Zenx's 7K Hard\]](https://osu.ppy.sh/beatmapsets/378669#mania/829079)
 - [xi - Happy End of the World (Blocko) \[Fullerene's 4K Catastrophic Shift\]](https://osu.ppy.sh/beatmapsets/171880#mania/431260)
 - [Camellia as "Reverse of Riot" - Completeness Under Incompleteness ("true prooF" Long ver.) (Monheim) \[Spectral\]](https://osu.ppy.sh/beatmapsets/1134132#mania/2568205)
+
+#### Playlist B
+
+- [Acrnym - Knife (Cokiiplay) \[Hard\]](https://osu.ppy.sh/beatmapsets/809495#mania/1969891)
+- [Akira Complex - Ether Strike ('Divine Mercy' Extended) (Kamuy) \[insane\]](https://osu.ppy.sh/beatmapsets/1252656#mania/2603935)
+- [aaaa - Bokutachi no Tabi to Epilogue.\[Long ver.\] (Daikyu) \[Final Voyage\]](https://osu.ppy.sh/beatmapsets/381334#mania/834266)
+- [toby fox - Spear of Justice (Manheim) \[Insane\]](https://osu.ppy.sh/beatmapsets/1044193#mania/2571378)
+- [PSYQUI - Hype feat. Such (Remuring) \[Touch Pop\]](https://osu.ppy.sh/beatmapsets/1229330#mania/2555999)


### PR DESCRIPTION
\+ a fix for a broken hyperlink url that i noticed on [the Beatmap Spotlights Season 3: Winter 2021 newspost](http://osu.ppy.sh/home/news/2021-01-18-beatmap-spotlights-season-3-winter-2021)