### PR TITLE
Cleanup Catch The Beat World Cup wiki article

### DIFF
--- a/wiki/Tournaments/CWC/1/en.md
+++ b/wiki/Tournaments/CWC/1/en.md
@@ -43,7 +43,17 @@ The Catch the Beat World Cup was run by various osu!catch community members.
 ## Links
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/63296)
-- [Livestream link](https://de.justin.tv/inoodle)
+- [Livestream link](https://de.justin.tv/inoodle "Justin.tv")
+
+## Podium
+
+This competition has come to an end and resulted in the following podium:
+
+| Placing | Team |
+| :-: | :-- |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | **China** (![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128)) |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | **half manual player team** (![][flag_TW] **[madaoB](https://osu.ppy.sh/users/8174275)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [Flanet](https://osu.ppy.sh/users/891388), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285)) |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | **Chile** (![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889)) |
 
 ## Participants
 
@@ -78,16 +88,6 @@ The Catch the Beat World Cup was run by various osu!catch community members.
 | B | State(s) of the Art | CFC | Hungary CTB | #filipino | Old School |
 | C | Team Nub | half manual player team | Red Fury | German Hentai's | Indonesia II |
 | D | Chile | China | French fruit overdose club | CatchTheHungarians | Korea |
-
-## Podium
-
-This competition has come to an end and resulted in the following podium:
-
-| Placing | Team |
-| :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | **China** (![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128)) |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | **half manual player team** (![][flag_TW] **[madaoB](https://osu.ppy.sh/users/8174275)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [Flanet](https://osu.ppy.sh/users/891388), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285)) |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | **Chile** (![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889)) |
 
 ## Mappools
 
@@ -371,21 +371,21 @@ Sunday, 6 November 2011:
 2. Beatmap scoring is based on **[ScoreV1](/wiki/Score#scorev1)**.
 3. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance before the actual matches take place. Only these beatmaps will be used during the respective matches. 
    - One beatmap will be a tiebreaker beatmap. This beatmap will only be played in case of a tie.
-4. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions)).
+4. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions) for more information).
 5. If no staff is available, the match will be postponed.
-6. If a beatmap ends in a draw, the map will be nullified.
+6. If a beatmap ends in a draw, it will be nullified.
 7. If a player disconnects, their scores will not be counted towards their team's total.
-8. Beatmaps cannot be reused in the same match unless the map was nullified.
-9. If a team fails to bring in the required minimum of three players to a match, the corresponding match can either be declared as a forfeited match where the opposing team gets automatically awarded with a Win by Default.     
+8. Beatmaps cannot be reused in the same match unless said beatmap was nullified.
+9. If a team fails to bring in the required minimum of three players to a match, the corresponding match can be declared as a forfeited match where the opposing team gets automatically awarded with a Win by Default.     
 10. Exchanging players during a match is allowed without limitations.
-    - **If a map rematch is required, exchanging players is not allowed. With the Tournament Management's discretion, an exception can be made if the previous roster is unavailable to play.**
+    - **If a rematch is required, exchanging players is not allowed. With the Tournament Management's discretion, an exception can be made if the previous roster is unavailable to play.**
 11. Lag is not a valid reason to nullify a beatmap.
-12. All players are supposed to keep the match running fluently and without delays. Penalties can be issued to the players if they cause excessive match delays.
-13. If a player disconnects between maps and the team cannot provide a replacement, the match can be delayed by 10 minutes at most.
+12. All players are expected to keep the match running fluently and without delays. Penalties can and will be issued to the players if they cause excessive match delays.
+13. If a player disconnects between beatmaps and the team cannot provide a replacement, the match can be delayed by 10 minutes at most.
 14. All players and the staff must be treated with respect. Instructions of the Tournament Management are to be followed. Decisions labeled as final are not to be objected.
-15. Disrupting the match by foul play, insulting and provoking other players or the staff, delaying the match, or other deliberate inappropriate misbehavior is strictly prohibited.
+15. Disrupting the match by foul play, insulting or provoking other players or the staff, delaying the match, or other deliberate and inappropriate misbehavior is strictly prohibited.
 16. Unexpected incidents are to be handled by the Tournament Management.
-17. Penalties for violating the tournament rules may include:
+17. Penalties for violating the tournament rules may include the following:
     - Exclusion of specific players for one beatmap
     - Exclusion of specific players for an entire match
     - Declaring the match as Lost by Default
@@ -395,7 +395,7 @@ Sunday, 6 November 2011:
 
 ### Tournament registration
 
-1. In order to be registered for the tournament, a representative of each team will have to propose a team roster comprising of 3-4 players in the discussion thread following a template set by the Tournament Management as follows:
+1. In order to be registered for the tournament, a representative of each team will have to propose a team roster comprising of three to four players in the discussion thread following a template set by the Tournament Management as follows:
 
 ```
 Team Name: (...)
@@ -418,10 +418,10 @@ Time Zone: (...)
 
 1. A member of the Tournament Management will create a multiplayer room 15 minutes in advance. Players must gather during this period.
    - Room settings are osu!catch, Team-Vs., Win Condition: 'Score'. Room name must be "CWC: (TeamRed) vs (TeamBlue)".
-   - The team mentioned first in the room name must be the red team, the team mentioned second in the room name must be the blue team.
+   - The team mentioned first in the room name must be set as the red team and the team mentioned second in the room name must be set as the blue team.
 2. As the Catch the Beat World Cup features no formal referee, **both team captains are expected to referee the match by themselves from inside the multiplayer lobby**. If there are any suspected irregularities during the run of the match, the concerned team captain may file a report in the discussion thread which will be investigated by the Tournament Management in due time.
-3. Map banning **does not apply** in the entirety of the tournament.
-4. Each team must have three players for each map. They can be exchanged freely after a map is concluded.
+3. Beatmap banning **does not apply** in the entirety of the tournament.
+4. Each team must have three players for each beatmap. Players can be exchanged and substituted freely between beatmaps.
 5. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
 6. Each captain must use the `!roll` command once in `#multiplayer`.
    - The captain with the higher roll decides which team **picks** first.
@@ -458,12 +458,12 @@ Time Zone: (...)
 ### Mappool instructions
 
 1. There will be a different mappool for every stage.
-2. All the maps in the mappool (including the Tiebreaker) will be played without any modifications enabled (NoMod).
-3. Each mappool has a specific size depending on the stage.
-   - The Group Stage weeks will all feature 9 NoMod maps (to be picked in any order) + 1 Tiebreaker map.
-   - The Quarterfinals will feature 4 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
-   - The Semifinals will feature 6 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
-   - The Finals will feature 8 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.   
+2. All beatmaps in the mappool (including the Tiebreaker) will be played without any modifications enabled (NoMod).
+3. Each mappool has a specific size depending on the stage:
+   - All Group Stage weeks will feature nine NoMod maps (to be picked in any order) plus one Tiebreaker map.
+   - The Quarterfinals will feature four NoMod maps (**to be played in the order determined by the Tournament Management**) plus one Tiebreaker map.
+   - The Semifinals will feature six NoMod maps (**to be played in the order determined by the Tournament Management**) plus one Tiebreaker map.
+   - The Finals will feature eight NoMod maps (**to be played in the order determined by the Tournament Management**) plus one Tiebreaker map.   
 
 ### Scheduling instructions
 

--- a/wiki/Tournaments/CWC/1/en.md
+++ b/wiki/Tournaments/CWC/1/en.md
@@ -5,82 +5,79 @@ tags:
 
 # Catch the Beat World Cup
 
-The **Catch the Beat World Cup** (***CWC***) was a team-based osu!catch tournament hosted by the [osu! team](/wiki/People/The_Team). It was the first installment of the osu!catch World Cup.
+The **Catch the Beat World Cup** (***CWC***) was a single elimination team-based osu!catch tournament organized by various osu! community members. Despite not being hosted by (or being run under the direct provision of) the [osu!team](/wiki/People/The_Team), it was formally considered as the first installment of the osu!catch World Cup tournament series.
 
 ## Tournament schedule
 
 | Event | Timestamp |
 | --: | :-- |
 | Registration phase | 2011-09-30/2011-11-01 |
-| Round 1 | 2011-11-04/2011-11-06 |
-| Round 2 | 2011-11-11/2011-11-13 |
-| Round 3 | 2011-11-18/2011-11-20 |
-| Round 4 | 2011-11-25/2011-11-27 |
-| Round 5 | 2011-12-02/2011-12-04 |
-| Quarterfinals | 2012-01-07/2011-01-08 |
-| Semifinals | 2012-01-14/2011-01-15 |
-| Finals | 2012-02-05 |
+| Group Stage week 1 | 2011-11-02/2011-11-06 |
+| Group Stage week 2 | 2011-11-07/2011-11-13 |
+| Group Stage week 3 | 2011-11-14/2011-11-20 |
+| Group Stage week 4 | 2011-11-21/2011-11-27 |
+| Group Stage week 5 | 2011-11-28/2011-12-04 |
+| *Winter break* | 2011-12-05/2011-12-31 |
+| Quarterfinals | 2012-01-01/2011-01-08 |
+| Semifinals | 2012-01-09/2011-01-15 |
+| Finals | 2011-01-16/2012-02-05 |
 
 ## Prizes
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 2 months of osu!supporter tag |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 6 months of osu!supporter tag for each team member |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 2 months of osu!supporter tag for each team member |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 1 month of osu!supporter tag for each team member |
 
-*Note: 1 month of osu!supporter tag was also given to the backup member of the winning team.*
-
-## Organisation
+## Organization
 
 The Catch the Beat World Cup was run by various osu!catch community members.
 
-- ![][flag_KR] [CLSW](https://osu.ppy.sh/users/531253)
-- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565)
-- ![][flag_RU] [Louis Cyphre](https://osu.ppy.sh/users/186243)
-- ![][flag_IT] [NeoRainier](https://osu.ppy.sh/users/326049)
-- ![][flag_DE] [Nyan-Zapo](https://osu.ppy.sh/users/480676)
-- ![][flag_CA] [weezy47](https://osu.ppy.sh/users/67211)
-- ![][flag_SG] [ZHSteven](https://osu.ppy.sh/users/142413)
+| Position | Member(s) |
+| :-: | :-- |
+| Host/Manager | ![][flag_KR] [CLSW](https://osu.ppy.sh/users/531253), ![][flag_DE] [Nyan-Zapo](https://osu.ppy.sh/users/480676) |
+| Helper | ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565), ![][flag_IT] [NeoRainier](https://osu.ppy.sh/users/326049), ![][flag_CA] [Weezy](https://osu.ppy.sh/users/67211), ![][flag_SG] [ZHSteven](https://osu.ppy.sh/users/142413), ![][flag_RU] [Louis Cyphre](https://osu.ppy.sh/users/186243) |
+| Streamer | ![][flag_CA] [Sumaki](https://osu.ppy.sh/users/207916) |
 
 ## Links
 
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/63296)
+- [Livestream link](https://de.justin.tv/inoodle)
 
 ## Participants
 
-| Team | Region | Members |
+| Team name | Region | Members |
 | :-- | :-- | :-- |
-| **#filipino** | Philippines | ![][flag_PH] **[blacksymbian](https://osu.ppy.sh/users/53956)**, ![][flag_PH] [Cielo](https://osu.ppy.sh/users/413417), ![][flag_PH] [Jdle07](https://osu.ppy.sh/users/552716), ![][flag_PH] [thOnz](https://osu.ppy.sh/users/679399) |
-| **CatchTheHungarians** | Europe | ![][flag_HU] **[Shauni8](https://osu.ppy.sh/users/260933)**, ![][flag_HU] [Kriszteeee](https://osu.ppy.sh/users/470764), ![][flag_HU] [Norbi](https://osu.ppy.sh/users/106822), ![][flag_HU] [tuzgu](https://osu.ppy.sh/users/333129) |
-| **CFC** | Asia/America | ![][flag_KR] **[KRZY](https://osu.ppy.sh/users/114017)**, ![][flag_KR] [ElectricShock](https://osu.ppy.sh/users/436413), ![][flag_KR] [GuruK](https://osu.ppy.sh/users/568941), ![][flag_KR] [Kuzino](https://osu.ppy.sh/users/158552) |
-| **Champion The Beat** | Taiwan, Korea | ![][flag_TW] **[Uan](https://osu.ppy.sh/users/147623)**, ![][flag_TW] [- Emp4y -](https://osu.ppy.sh/users/654296), ![][flag_TW] [bossandy](https://osu.ppy.sh/users/360437), ![][flag_KR] [SS\_Kanzaki](https://osu.ppy.sh/users/430337) |
-| **Chile** | America | ![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889) |
-| **China** | China | ![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128) |
-| **French fruit overdose club** | France | ![][flag_FR] **[Drafura](https://osu.ppy.sh/users/326099)**, ![][flag_FR] [Badis](https://osu.ppy.sh/users/559308), ![][flag_FR] [Lendrix](https://osu.ppy.sh/users/471169), ![][flag_FR] [Tensude](https://osu.ppy.sh/users/87482) |
-| **German Hentai's** | Germany | ![][flag_DE] **[NoteKuroi](https://osu.ppy.sh/users/186642)**, ![][flag_DE] [DeathXHunter](https://osu.ppy.sh/users/186642), ![][flag_DE] [Nyan-Zapo](https://osu.ppy.sh/users/480676), ![][flag_DE] [Valetine](https://osu.ppy.sh/users/526634) |
-| **half manual player team** | Taiwan |  ![][flag_TW] **[Flanet](https://osu.ppy.sh/users/891388)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285), ![][flag_TW] [madaoB](https://osu.ppy.sh/users/8174275) |
-| **Hungary CTB** | Europe | ![][flag_HU] **[TaylorXIII](https://osu.ppy.sh/users/351814)**, ![][flag_HU] [Felhoo](https://osu.ppy.sh/users/129350), ![][flag_HU] [Kuroi Mato](https://osu.ppy.sh/users/584921), ![][flag_HU] [Petya](https://osu.ppy.sh/users/476796) |
-| **Indonesia** | Asia | ![][flag_ID] **[Lady Vamps](https://osu.ppy.sh/users/611642)**, ![][flag_ID] [Ableh\_ZZZ](https://osu.ppy.sh/users/917216), ![][flag_ID] [-Newbie-](https://osu.ppy.sh/users/434914), ![][flag_ID] [r3yn41d0](https://osu.ppy.sh/users/500032) |
-| **Indonesia2** | Indonesia | ![][flag_ID] **[Yumi14](https://osu.ppy.sh/users/844165)**, ![][flag_ID] [AeroRange](https://osu.ppy.sh/users/405659), ![][flag_ID] [Devil\_Cosmo](https://osu.ppy.sh/users/689079), ![][flag_ID] [Varri Naufalb](https://osu.ppy.sh/users/1174508) |
-| **Korea** | Korea | ![][flag_KR] **[Spectator](https://osu.ppy.sh/users/702598)**, ![][flag_KR] [CLSW](https://osu.ppy.sh/users/531253), ![][flag_KR] [CTB user](https://osu.ppy.sh/users/462488), Speedy Cat <!-- missing player --> |
+| **#filipino** | South East Asia | ![][flag_PH] **[blacksymbian](https://osu.ppy.sh/users/53956)**, ![][flag_PH] [Cielo](https://osu.ppy.sh/users/413417), ![][flag_PH] [Jdle07](https://osu.ppy.sh/users/552716), ![][flag_PH] [thOnz](https://osu.ppy.sh/users/679399) |
+| **CatchTheHungarians** | Central Europe | ![][flag_HU] **[Shauni8](https://osu.ppy.sh/users/260933)**, ![][flag_HU] [Kriszteeee](https://osu.ppy.sh/users/470764), ![][flag_HU] [Norbi](https://osu.ppy.sh/users/106822), ![][flag_HU] [tuzgu](https://osu.ppy.sh/users/333129) |
+| **CFC** | East Asia | ![][flag_KR] **[KRZY](https://osu.ppy.sh/users/114017)**, ![][flag_KR] [ElectricShock](https://osu.ppy.sh/users/436413), ![][flag_KR] [GuruK](https://osu.ppy.sh/users/568941), ![][flag_KR] [Kuzino](https://osu.ppy.sh/users/158552) |
+| **Champion The Beat** | East Asia | ![][flag_TW] **[Uan](https://osu.ppy.sh/users/147623)**, ![][flag_TW] [- Emp4y -](https://osu.ppy.sh/users/654296), ![][flag_TW] [bossandy](https://osu.ppy.sh/users/360437), ![][flag_KR] [SS\_Kanzaki](https://osu.ppy.sh/users/430337) |
+| **Chile** | South America | ![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889) |
+| **China** | East Asia | ![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128) |
+| **French fruit overdose club** | Western Europe | ![][flag_FR] **[Drafura](https://osu.ppy.sh/users/326099)**, ![][flag_FR] [Badis](https://osu.ppy.sh/users/559308), ![][flag_FR] [Lendrix](https://osu.ppy.sh/users/471169), ![][flag_FR] [Tensude](https://osu.ppy.sh/users/87482) |
+| **German Hentai's** | Central Europe | ![][flag_DE] **[NoteKuroi](https://osu.ppy.sh/users/186642)**, ![][flag_DE] [DeathXHunter](https://osu.ppy.sh/users/186642), ![][flag_DE] [Nyan-Zapo](https://osu.ppy.sh/users/480676), ![][flag_DE] [Valetine](https://osu.ppy.sh/users/526634) |
+| **half manual player team** | East Asia | ![][flag_TW] **[madaoB](https://osu.ppy.sh/users/8174275)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [Flanet](https://osu.ppy.sh/users/891388), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285) |
+| **Hungary CTB** | Central Europe | ![][flag_HU] **[TaylorXIII](https://osu.ppy.sh/users/351814)**, ![][flag_HU] [Felhoo](https://osu.ppy.sh/users/129350), ![][flag_HU] [Kuroi Mato](https://osu.ppy.sh/users/584921), ![][flag_HU] [Petya](https://osu.ppy.sh/users/476796) |
+| **Indonesia** | South East Asia | ![][flag_ID] **[Lady Vamps](https://osu.ppy.sh/users/611642)**, ![][flag_ID] [Ableh\_ZZZ](https://osu.ppy.sh/users/917216), ![][flag_ID] [-Newbie-](https://osu.ppy.sh/users/434914), ![][flag_ID] [r3yn41d0](https://osu.ppy.sh/users/500032) |
+| **Indonesia II** | South East Asia | ![][flag_ID] **[Yumi14](https://osu.ppy.sh/users/844165)**, ![][flag_ID] [AeroRange](https://osu.ppy.sh/users/405659), ![][flag_ID] [Devil\_Cosmo](https://osu.ppy.sh/users/689079), ![][flag_ID] [Varri Naufalb](https://osu.ppy.sh/users/1174508) |
+| **Korea** | East Asia | ![][flag_KR] **[Spectator](https://osu.ppy.sh/users/702598)**, ![][flag_KR] [CLSW](https://osu.ppy.sh/users/531253), ![][flag_KR] [CTB user](https://osu.ppy.sh/users/462488), ![][flag_KR] [Speedy Cat](https://osu.ppy.sh/users/351634) |
 | **Lone wolfs** | North America | ![][flag_US] **[sk8terpoke](https://osu.ppy.sh/users/1039632)**, ![][flag_US] [Bolio](https://osu.ppy.sh/users/14670458), ![][flag_US] [DeathxShinigami](https://osu.ppy.sh/users/49516), ![][flag_US] [Gfbrd](https://osu.ppy.sh/users/107857) |
-| **Old School** | Europe | ![][flag_ES] **[CriticalDex](https://osu.ppy.sh/users/130466)**, Emaal, ![][flag_BE] [joseph](https://osu.ppy.sh/users/212579), ![][flag_MX] [Salwinjack](https://osu.ppy.sh/users/219084) |
-| **Red Fury** | Europe | ![][flag_ES] **[Deif](https://osu.ppy.sh/users/318565)**, ![][flag_PE] [AleZer0](https://osu.ppy.sh/users/214574), ![][flag_ES] [mikhe](https://osu.ppy.sh/users/47842), ![][flag_ES] [raimoncortese](https://osu.ppy.sh/users/609627) |
-| **State(s) of the Art** | North/South America | ![][flag_US] **[Senyo](https://osu.ppy.sh/users/207928)**, ![][flag_US] [AroundTheManhole](https://osu.ppy.sh/users/307626), ![][flag_CO] [k4mm3r](https://osu.ppy.sh/users/286570), ![][flag_US] [pieguyn](https://osu.ppy.sh/users/107485) |
-| **Team Nub** | Canada | ![][flag_CA] **[Sumaki](https://osu.ppy.sh/users/207916)**, ![][flag_CA] [jonnypui](https://osu.ppy.sh/users/182084), ![][flag_CA] [Kitsunemimi](https://osu.ppy.sh/users/100037), ![][flag_CA] [Weezy](https://osu.ppy.sh/users/67211) |
-| **The Hidden Ones** | Belarus, Czech Republic, Italy | ![][flag_CZ] **[katsek](https://osu.ppy.sh/users/522623)**, ![][flag_BY] [jekasa](https://osu.ppy.sh/users/792196), ![][flag_IT] [NeoRainier](https://osu.ppy.sh/users/326049) |
-| **Viciados em Crack** | South America | **Artificial Children**, ![][flag_BR] [Kakarotto](https://osu.ppy.sh/users/259383), ![][flag_BR] [Kazuo](https://osu.ppy.sh/users/516093), Takamura |
+| **Old School** | Western Europe/Central Europe/North America | ![][flag_ES] **[CriticalDex](https://osu.ppy.sh/users/130466)**, ![][flag_DK] [Emaal](https://osu.ppy.sh/users/85070), ![][flag_BE] [joseph](https://osu.ppy.sh/users/212579), ![][flag_MX] [Salwinjack](https://osu.ppy.sh/users/219084) |
+| **Red Fury** | Western Europe/South America | ![][flag_ES] **[Deif](https://osu.ppy.sh/users/318565)**, ![][flag_PE] [AleZer0](https://osu.ppy.sh/users/214574), ![][flag_ES] [mikhe](https://osu.ppy.sh/users/47842), ![][flag_ES] [raimoncortese](https://osu.ppy.sh/users/609627) |
+| **State(s) of the Art** | North America/South America | ![][flag_US] **[Senyo](https://osu.ppy.sh/users/207928)**, ![][flag_US] [AroundTheManhole](https://osu.ppy.sh/users/307626), ![][flag_CO] [k4mm3r](https://osu.ppy.sh/users/286570), ![][flag_US] [pieguyn](https://osu.ppy.sh/users/107485) |
+| **Team Nub** | North America | ![][flag_CA] **[Sumaki](https://osu.ppy.sh/users/207916)**, ![][flag_CA] [jonnypui](https://osu.ppy.sh/users/182084), ![][flag_CA] [Kitsunemimi](https://osu.ppy.sh/users/100037), ![][flag_CA] [Weezy](https://osu.ppy.sh/users/67211) |
+| **The Hidden Ones** | Central Europe/Eastern Europe | ![][flag_CZ] **[katsek](https://osu.ppy.sh/users/522623)**, ![][flag_BY] [jekasa](https://osu.ppy.sh/users/792196), ![][flag_IT] [NeoRainier](https://osu.ppy.sh/users/326049) |
+| **Viciados em Crack** | South America | ![][flag_BR] **[Artificial Children](https://osu.ppy.sh/users/588199)**, ![][flag_BR] [Kakarotto](https://osu.ppy.sh/users/259383), ![][flag_BR] [Kazuo](https://osu.ppy.sh/users/516093), ![][flag_BR] [Takamura](https://osu.ppy.sh/users/1041213) |
 
 ## Groups
 
-| Group 1 | Group 2 | Group 3 | Group 4 |
-| :-- | :-- | :-- | :-- |
-| The Hidden Ones | State(s) of the Art | Team Nub | Chile |
-| Viciados em Crack | CFC | half manual player team | China |
-| Champion The Beat | Hungary CTB | Red Fury | French fruit overdose club |
-| Indonesia | #filipino | German Hentai's | CatchTheHungarians |
-| Lone wolf | Old School | Indonesia2 | Korea |
+| Group | Seed 1 | Seed 2 | Seed 3 | Seed 4 | Seed 5 |
+| :--  | :--  | :-- | :-- | :-- | :-- |
+| A | The Hidden Ones | Viciados em Crack | Champion The Beat | Indonesia | Lone wolfs |
+| B | State(s) of the Art | CFC | Hungary CTB | #filipino | Old School |
+| C | Team Nub | half manual player team | Red Fury | German Hentai's | Indonesia II |
+| D | Chile | China | French fruit overdose club | CatchTheHungarians | Korea |
 
 ## Podium
 
@@ -88,66 +85,69 @@ This competition has come to an end and resulted in the following podium:
 
 | Placing | Team |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_CN] **China** (![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128)) |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_TW] **half manual player team** (![][flag_TW] **[Flanet](https://osu.ppy.sh/users/891388)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285), ![][flag_TW] [madaoB](https://osu.ppy.sh/users/8174275)) |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_CL] **Chile** (![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889)) |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | **China** (![][flag_CN] **[hy1hy1hy](https://osu.ppy.sh/users/243877)**, ![][flag_CN] [Dusk](https://osu.ppy.sh/users/533210), ![][flag_HK] [HineX](https://osu.ppy.sh/users/13854), ![][flag_CN] [joynama](https://osu.ppy.sh/users/169128)) |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | **half manual player team** (![][flag_TW] **[madaoB](https://osu.ppy.sh/users/8174275)**, ![][flag_TW] [allen22604358](https://osu.ppy.sh/users/84921), ![][flag_TW] [Flanet](https://osu.ppy.sh/users/891388), ![][flag_TW] [H i M e J i](https://osu.ppy.sh/users/732285)) |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | **Chile** (![][flag_CL] **[eldnl](https://osu.ppy.sh/users/285756)**, ![][flag_CL] [Dark\_Diego](https://osu.ppy.sh/users/723787), ![][flag_ES] [Daxmaster](https://osu.ppy.sh/users/264914), ![][flag_CL] [MoodyRPG](https://osu.ppy.sh/users/464889)) |
 
 ## Mappools
 
 ### Finals
 
-- NoMod
-  - SUPER STAR -MITSURU- - THANK YOU FOR PLAYING \[CWC competition\]
+- NoMod (*to be played in order*)
+  - [SUPER STAR -MITSURU- - THANK YOU FOR PLAYING (ZHSteven) \[CWC competition\]](https://osu.ppy.sh/beatmapsets/42694#fruits/275691)
   - [S.S.H. - Intersect Thunderbolt (Deif) \[Thunderbolt\]](https://osu.ppy.sh/beatmapsets/43027#fruits/135142)
-  - [PRASTIK DANCEFLOOR - Session 9 -Chronicles- \[2Q\]](https://puu.sh/ccsl)
+  - [PRASTIK DANCEFLOOR - Session 9 -Chronicles- (Kuzino) \[2Q\]](https://puu.sh/ccsl)
   - [KAZE.o2SE - Earth Quake (ZHSteven) \[CTB pro competition\]](https://osu.ppy.sh/beatmapsets/31297#fruits/102923)
-  - [NicoNico Chorus - World's End Dancehall \[CLSPEC Adieu Special\]](https://puu.sh/eykZ)
+  - [NicoNico Chorus - World's End Dancehall (CLSW) \[CLSPEC Adieu Special\]](https://puu.sh/eykZ)
   - [Shoichiro Sakamoto - Eye of Aeon (KanaRin) \[Kana's CTB\]](https://puu.sh/1g0e)
-  - [LEAF XCEED Music Division - Fur Elise \[Extra CtB Stage\]](https://puu.sh/HiC)
-  - [Yousei Teikoku - Kokou no Sousei \[Verdi's TAG2\]](https://puu.sh/f6oX)
-  - Ryu\* - I'm so Happy \[Shana's Madness CTB\]
+  - [LEAF XCEED Music Division - Fur Elise (Louis Cyphre) \[Extra CtB Stage\]](https://puu.sh/HiC)
+  - [Yousei Teikoku - Kokou no Sousei (Verdisphaena) \[Verdi's TAG2\]](https://puu.sh/f6oX)
+- Tiebreaker  
+  - **[Ryu\* - I'm so Happy (\[JPSNS\]Shana) \[Shana's Madness CTB\]](https://osu.ppy.sh/beatmapsets/30006#fruits/99319)**
 
 ### Semifinals
 
-- NoMod
+- NoMod (*to be played in order*)
   - [BACK-ON - flyaway \[Tales of\] Remix (ztrot) \[FLYAWAY!!!\]](https://osu.ppy.sh/beatmapsets/11620#fruits/44782)
   - [Demetori - Solar Sect of Mystic Wisdom \~ Nuclear Fusion (Louis Cyphre) \[Atomic\]](https://osu.ppy.sh/beatmapsets/20125#fruits/91037)
-  - [Basshunter - Ievan Polkka Trance Remix (Starrodkirby86, Beuchi-chan) \[BeuKirby\]](https://osu.ppy.sh/beatmapsets/10406#fruits/66246)
+  - [Basshunter - Ievan Polkka Trance Remix (Teara) \[BeuKirby\]](https://osu.ppy.sh/beatmapsets/10406#fruits/66246)
   - [DCX - Flying High (DJ Splash Remix) (yeahyeahyeahhh) \[InoSane\]](https://osu.ppy.sh/beatmapsets/22194#fruits/76663)
   - [t+pazolite - Against Gilgamesh (Louis Cyphre) \[Ultimate Illusion\]](https://osu.ppy.sh/beatmapsets/39816#fruits/126671)
   - [Susumu Hirasawa - SWITCHED-ON LOTUS (Starrodkirby86) \[KIRBY Mix Deluxe\]](https://osu.ppy.sh/beatmapsets/16457#fruits/58970)
-  - [DystopiaGround - AugoEidEs (happy30) \[Aphotic\]](https://osu.ppy.sh/beatmapsets/24611#fruits/97416)
+- Tiebreaker  
+  - **[DystopiaGround - AugoEidEs (happy30) \[Aphotic\]](https://osu.ppy.sh/beatmapsets/24611#fruits/97416)**
 
 ### Quarterfinals
 
-- NoMod
+- NoMod (*to be played in order*)
   - [IOSYS - Accept Bloody Fate (Louis Cyphre) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/37305#fruits/120066)
-  - [goreshit - MATZcore (Ekoro) \[Lolicore\]](https://osu.ppy.sh/beatmapsets/24388#fruits/83975)
-  - [Hyadain - Hyadain no Joujou Yuujou (TV Size) (Saten-San) \[Saten's SELAMAT PAGI!!\]](https://osu.ppy.sh/beatmapsets/32775#fruits/112586)
+  - [goreshit - MATZcore (\_LRJ\_) \[Lolicore\]](https://osu.ppy.sh/beatmapsets/24388#fruits/83975)
+  - [Hyadain - Hyadain no Joujou Yuujou (TV Size) (Weezy) \[Saten's SELAMAT PAGI!!\]](https://osu.ppy.sh/beatmapsets/32775#fruits/112586)
   - [DJ Sharpnel - Exciting Hyper Highspeed Star (xBubu) \[Highspeed\]](https://osu.ppy.sh/beatmapsets/16619#fruits/62589)
-  - [Level 70 Elite Tauren Chieftain - I Am Murloc (CheeseWarlock) \[Northrend\]](https://osu.ppy.sh/beatmapsets/12030#fruits/45433)
+- Tiebreaker  
+  - **[Level 70 Elite Tauren Chieftain - I Am Murloc (CheeseWarlock) \[Northrend\]](https://osu.ppy.sh/beatmapsets/12030#fruits/45433)**
 
-### Round 5
+### Group Stage week 5
 
 - NoMod
   - [Hatsune Miku - Reversible Doll (NatsumeRin) \[Rin\]](https://osu.ppy.sh/beatmapsets/22773#fruits/78913)
   - [Megpoid GUMI - Poker Face (NatsumeRin) \[Spade\]](https://osu.ppy.sh/beatmapsets/24782#fruits/84801)
   - [Sound Horizon - Shiseru Eiyuutachi no Tatakai (zerosyn) \[Thanatos\]](https://osu.ppy.sh/beatmapsets/8809#fruits/39298)
   - [Hatsune Miku - Hidari Migi -migihidari- (NatsumeRin) \[Rin\]](https://osu.ppy.sh/beatmapsets/24177#fruits/87223)
-  - [Tatsh feat. Sariyajin - FOUR SEASONS OF LONELINESS (gowww) \[gow's Lunatic\]](https://osu.ppy.sh/beatmapsets/28342#fruits/112158)
+  - [Tatsh feat. Sariyajin - FOUR SEASONS OF LONELINESS (ouranhshc) \[gow's Lunatic\]](https://osu.ppy.sh/beatmapsets/28342#fruits/112158)
   - [Yousei Teikoku - Asgard (Lybydose) \[Valhalla\]](https://osu.ppy.sh/beatmapsets/27712#fruits/92780)
   - [xi - Halcyon (gowww) \[Another\]](https://osu.ppy.sh/beatmapsets/20871#fruits/73699)
   - [Demetori - Emotional Skyscraper \~ World's End (Lybydose) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/13204#fruits/48985)
-  - [FamilyMart Jingle (deepsea, ignorethis, Alace, SOGASOGAMO) \[Family Mart is your home\]](https://osu.ppy.sh/beatmapsets/9400#fruits/37658)
+  - [FamilyMart Jingle (deepsea) \[Family Mart is your home\]](https://osu.ppy.sh/beatmapsets/9400#fruits/37658)
 - Tiebreaker
-  - **[Yousei Teikoku - Dare so Ka no Gekka (TV Size) (uranuss8600) \[Uran's CTB\]](https://osu.ppy.sh/beatmapsets/13676#fruits/51945)**
+  - **[Yousei Teikoku - Dare so Ka no Gekka (TV Size) (NatsumeRin) \[Uran's CTB\]](https://osu.ppy.sh/beatmapsets/13676#fruits/51945)**
 
-### Round 4
+### Group Stage week 4
 
 - NoMod
   - [sasakure.UK - Jack-the-Ripper (rustbell) \[JackHasCome!\]](https://osu.ppy.sh/beatmapsets/23907#fruits/81560)
   - [Inspector K - Disconnected Hardkore (CanBlaster Remix) (Snow Note) \[Insane\]](https://osu.ppy.sh/beatmapsets/30485#fruits/100627)
-  - [IOSYS - Okuu's Nuclear Fusion Dojo (v2b) \[v2b's Insane\]](https://osu.ppy.sh/beatmapsets/8442#fruits/37166)
+  - [IOSYS - Okuu's Nuclear Fusion Dojo (Mafiamaster) \[v2b's Insane\]](https://osu.ppy.sh/beatmapsets/8442#fruits/37166)
   - [Shiraishi - Shinsekai (AngelHoney) \[Insane\]](https://osu.ppy.sh/beatmapsets/24634#fruits/83674)
   - [Flobots - Handlebars (-Xero-) \[Holocaust\]](https://osu.ppy.sh/beatmapsets/16091#fruits/58143)
   - [Comp - Gensou no Satellite (Shinxyn) \[Extra\]](https://osu.ppy.sh/beatmapsets/4404#fruits/63875)
@@ -157,37 +157,37 @@ This competition has come to an end and resulted in the following podium:
 - Tiebreaker
   - **[07th Expansion - Final Answer (Shiirn) \[Question\]](https://osu.ppy.sh/beatmapsets/36272#fruits/117232)**
 
-### Round 3
+### Group Stage week 3
 
 - NoMod
-  - [Yousei Teikoku - Torikago (furawa) \[yami\]](https://osu.ppy.sh/beatmapsets/11781#fruits/44746)
-  - [Nekomata Master - Goodbye Heaven (gdeath) \[Another\]](https://osu.ppy.sh/beatmapsets/12688#fruits/48926)
-  - [Ryu* Vs. Sota - Go Beyond! (Sprosive) \[Sp's Darkness\]](https://osu.ppy.sh/beatmapsets/19705#fruits/84398)
-  - [Susumu Hirasawa - Big Brother (Starrodkirby86) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/10714#fruits/42244)
+  - [IOSYS - Taihen na Mono no Shoushitsu (DJPop) \[Kana's CTB\]](https://osu.ppy.sh/beatmapsets/17819#fruits/67504)
+  - [Yousei Teikoku - Torikago (Furawa) \[yami\]](https://osu.ppy.sh/beatmapsets/11781#fruits/44746)
+  - [Nekomata Master - Goodbye Heaven (alvisto) \[Another\]](https://osu.ppy.sh/beatmapsets/12688#fruits/48926)
+  - [Ryu* Vs. Sota - Go Beyond! (yongtw123) \[Sp's Darkness\]](https://osu.ppy.sh/beatmapsets/19705#fruits/84398)
+  - [Susumu Hirasawa - Big Brother (Gens) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/10714#fruits/42244)
   - [Hatsune Miku - Kusaregedou to Chocolate (val0108) \[Insane\]](https://osu.ppy.sh/beatmapsets/25248#fruits/85494)
   - [Megurine Luka - Leia (gowww) \[gowww\]](https://osu.ppy.sh/beatmapsets/29064#fruits/96587)
   - [Hommarju feat. Latte - masterpiece (simplistiC) \[Insane\]](https://osu.ppy.sh/beatmapsets/12483#fruits/47152)
-  - [IOSYS - Taihen na Mono no Shoushitsu (KanaRin) \[Kana's CTB\]](https://osu.ppy.sh/beatmapsets/17819#fruits/67504)
   - [Hyadain - Chocobo (mtmcl) \[Gold\]](https://osu.ppy.sh/beatmapsets/4392#fruits/24023)
 - Tiebreaker
   - **[Eoin O' Broin - Deep Space (galvenize) \[Another\]](https://osu.ppy.sh/beatmapsets/25098#fruits/85550)**
 
-### Round 2
+### Group Stage week 2
 
 - NoMod
-  - [Sakakibara Yui - Koi no Honoo (ignorethis) \[ignore's Slider Madness\]](https://osu.ppy.sh/beatmapsets/8511#fruits/35010)
+  - [Sakakibara Yui - Koi no Honoo (quintitem) \[ignore's Slider Madness\]](https://osu.ppy.sh/beatmapsets/8511#fruits/35010)
   - [DJ YOSHITAKA - ALBIDA (Nakagawa-Kanon) \[Extreme\]](https://osu.ppy.sh/beatmapsets/19561#fruits/77810)
   - [TAKA respect for J.S.B - Ubertreffen (kiddly) \[Another\]](https://osu.ppy.sh/beatmapsets/15740#fruits/56830)
   - [LEAF XCEED Music Division - Fur Elise (Louis Cyphre) \[Champion\]](https://osu.ppy.sh/beatmapsets/23916#fruits/81594)
   - [Hatsune Miku - Unhappy Refrain (NatsumeRin) \[Rin\]](https://osu.ppy.sh/beatmapsets/30128#fruits/105534)
   - [Furries in a Blender - Ridorii (-Lennox-) \[Insane\]](https://osu.ppy.sh/beatmapsets/29727#fruits/98496)
   - [supercell - Rock 'n' Roll Nan Desu no (Garven) \[Insane\]](https://osu.ppy.sh/beatmapsets/27807#fruits/93021)
-  - [Rhapsody - Emerald Sword (Duoprism) \[Extreme\]](https://osu.ppy.sh/beatmapsets/3198#fruits/25580)
+  - [Rhapsody - Emerald Sword (Reikin) \[Extreme\]](https://osu.ppy.sh/beatmapsets/3198#fruits/25580)
   - [IOSYS - Border of Death (Nakagawa-Kanon) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/14107#fruits/53380)
 - Tiebreaker
   - **[wa. remixed celas - Suishou-Sekai \~Fracture\~ (soulfear) \[Another\]](https://osu.ppy.sh/beatmapsets/28984#fruits/96358)**
 
-### Round 1
+### Group Stage week 1
 
 - NoMod
   - [DJ YOSHITAKA - FLOWER (TKiller) \[Intense\]](https://osu.ppy.sh/beatmapsets/29996#fruits/104635)
@@ -195,53 +195,284 @@ This competition has come to an end and resulted in the following podium:
   - [Syrsa - Mad Machine (Louis Cyphre) \[Champion\]](https://osu.ppy.sh/beatmapsets/33052#fruits/107875)
   - [yak\_won - Lucid (soulfear) \[Extra\]](https://osu.ppy.sh/beatmapsets/15898#fruits/85852)
   - [TuTuWan - Wo Ge Zai Guang Dian (v2b) \[Qi Shi Ma\]](https://osu.ppy.sh/beatmapsets/12034#fruits/52940)
-  - [SHK - Weep Irish (fartownik) \[Another\]](https://osu.ppy.sh/beatmapsets/28545#fruits/95360)
-  - [NH22 - Corrosion (Cecilia) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/17044#fruits/60941)
+  - [SHK - Weep Irish (AngelHoney) \[Another\]](https://osu.ppy.sh/beatmapsets/28545#fruits/95360)
+  - [NH22 - Corrosion (Lena) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/17044#fruits/60941)
   - [HTT - Girls in Wonderland (wcx19911123) \[Insane\]](https://osu.ppy.sh/beatmapsets/34427#fruits/111902)
   - [Len - U.N. Owen was her? (Louis Cyphre) \[Insane\]](https://osu.ppy.sh/beatmapsets/22699#fruits/78171)
 - Tiebreaker
-  - **[chum - Genesis of Aquarion (Starrodkirby86) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/16782#fruits/60858)**
+  - **[chum - Genesis of Aquarion (Lena) \[KIRBY Mix\]](https://osu.ppy.sh/beatmapsets/16782#fruits/60858)**
+
+## Match Results
+
+## Finals
+
+Saturday, 4 February 2012 (3rd Place Playoff):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| Team Nub | 4 | **5** | **Chile** | [#1](https://osu.ppy.sh/community/matches/2563701) |
+
+Sunday, 5 February 2012 (Grand Final):
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| half manual player team | 2 | **5** | **China** | [#1](https://osu.ppy.sh/community/matches/2568176) |
+
+## Semifinals
+
+Sunday, 15 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **half manual player team** | **4** | 2 | Chile | [#1](https://osu.ppy.sh/community/matches/2407118) |
+| Team Nub | 3 | **4** | **China** | [#1](https://osu.ppy.sh/community/matches/2457722) |
+
+### Quarterfinals
+
+Saturday, 7 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| The Hidden Ones | 2 | **3** | **half manual player team** | [#1](https://osu.ppy.sh/community/matches/2347251) |
+
+Sunday, 8 January 2012:
+
+| Team 1 |  |  | Team 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **Team Nub** | **3** | 0 | Viciados em Crack | [#1](https://osu.ppy.sh/community/matches/2359587) |
+| CFC | 1 | **3** | **China** | [#1](https://osu.ppy.sh/community/matches/2354049) |
+| **Chile** | **3** | 0 | State(s) of the Art | *win by default* |
+
+### Group Stage week 5
+
+Saturday, 3 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| A | **Viciados em Crack** | **2** | 0 | Indonesia | [#1](https://osu.ppy.sh/community/matches/2114282) |
+| B | **CFC** | **2** | 0 | Old School | *win by default* |
+| D | **French fruit overdose club** | **2** | 0 | Korea | *win by default* |
+
+Sunday, 4 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| C | **Team Nub** | **2** | 0 | Indonesia II | [#1](https://osu.ppy.sh/community/matches/2118576) |
+| B | **State(s) of the Art** | **2** | 1 | CFC | [#1](https://osu.ppy.sh/community/matches/2117966) |
+| C | **Red Fury** | **2** | 0 | German Hentai's | [#1](https://osu.ppy.sh/community/matches/2124209) |
+| B | **#filipino** | **2** | 0 | Old School | *win by default* |
+| D | **Catch The Hungarians** | **2** | 0 | Korea | *win by default* |
+
+Monday, 5 December 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| B | **State(s) of the Art** | **2** | 1 | Hungary CTB | [#1](https://osu.ppy.sh/community/matches/2123665) |
+| D | Chile | *N/A* | *N/A* | China | *not played¹* |
+
+¹ *As per the Tournament Management's decision ([\[1\]](https://osu.ppy.sh/community/forums/posts/1184327) [\[2\]](https://osu.ppy.sh/community/forums/posts/1206142) [\[3\]](https://osu.ppy.sh/community/forums/posts/1187916)), the Chile vs. China match was not played.*
+
+### Group Stage week 4
+
+Saturday, 26 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| C | **Red Fury** | **2** | 0 | Indonesia II | [#1](https://osu.ppy.sh/community/matches/2067433) |
+| B | **Hungary CTB** | **2** | 0 | #filipino | [#1](https://osu.ppy.sh/community/matches/2067417) |
+| C | **Team Nub** | **2** | 1 | half manual player team | [#1](https://osu.ppy.sh/community/matches/2069308) |
+
+Sunday, 27 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| C | **China** | **2** | 0 | Korea | [#1](https://osu.ppy.sh/community/matches/2073501) |
+| A | **The Hidden Ones** | **2** | 0 | Indonesia | [#1](https://osu.ppy.sh/community/matches/2076184) |
+| A | **Viciados em Crack** | **2** | 0 | Champion The Beat | [#1](https://osu.ppy.sh/community/matches/2076779) |
+
+Monday, 28 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| D | **Chile** | **2** | 0 | French fruit overdose club | [#1](https://osu.ppy.sh/community/matches/2078343) |
+
+### Group Stage week 3
+
+Saturday, 19 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| D | **China** | **2** | 0 | French fruit overdose club | [#1](https://osu.ppy.sh/community/matches/2025204) |
+| D | **Chile** | **2** | 0 | Korea | [#1](https://osu.ppy.sh/community/matches/2019448) |
+
+Sunday, 20 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| B | **State(s) of the Art** | **2** | 0 | #filipino | [#1](https://osu.ppy.sh/community/matches/2028008) |
+| C | **half manual player team** | **2** | 1 | Indonesia II | [#1](https://osu.ppy.sh/community/matches/2031700) |
+| A | **The Hidden Ones** | **2** | 0 | Champion The Beat | [#1](https://osu.ppy.sh/community/matches/2031866) |
+| B | **Hungary CTB** | **2** | 1 | Old School | [#1](https://osu.ppy.sh/community/matches/2033446) |
+
+Monday, 21 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| D | **Chile** | **2** | 0 | CatchTheHungarians | [#1](https://osu.ppy.sh/community/matches/2034591) |
+| C | **Team Nub** | **2** | 0 | German Hentai's | [#1](https://osu.ppy.sh/community/matches/2034819) |
+| A | **Indonesia** | **2** | 0 | Lone wolfs | *win by default* |
+
+### Group Stage week 2
+
+Saturday, 12 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| C | **half manual player team** | **2** | 1 | Red Fury | [#1](https://osu.ppy.sh/community/matches/1977802) |
+| D | **China** | **2** | 0 | CatchTheHungarians | [#1](https://osu.ppy.sh/community/matches/1979479) |
+| C | **German Hentai's** | **2** | 0 | Indonesia II | [#1](https://osu.ppy.sh/community/matches/1978912) |
+| A | **Champion The Beat** | **2** | 0 | Indonesia | [#1](https://osu.ppy.sh/community/matches/1978350) |
+
+Sunday, 13 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| B | **CFC** | **2** | 0 | #filipino | [#1](https://osu.ppy.sh/community/matches/1978472) |
+| A | **Viciados em Crack** | **2** | 0 | Lone wolfs | *win by default* |
+
+Monday, 14 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| B | **State(s) of the Art** | **2** | 0 | Old School | [#1](https://osu.ppy.sh/community/matches/1990265) |
+
+### Group Stage week 1
+
+Saturday, 5 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| C | **German Hentai's** | **2** | 0 | half manual player team | [#1](https://osu.ppy.sh/community/matches/1932591) |
+| A | **The Hidden Ones** | **2** | 0 | Viciados em Crack | [#1](https://osu.ppy.sh/community/matches/1934186) |
+
+Sunday, 6 November 2011:
+
+| Group | Team 1 |  |  | Team 2 | Match link |
+| --: | --: | :-: | :-: | :-- | :-- |
+| B | **CFC** | **2** | 0 | Hungary CTB | [#1](https://osu.ppy.sh/community/matches/1930895) |
+| D | **French fruit overdose club** | **2** | 0 | CatchTheHungarians | [#1](https://osu.ppy.sh/community/matches/1942894) |
+| C | **Team Nub** | **2** | 1 | Red Fury | [#1](https://osu.ppy.sh/community/matches/1950105) |
 
 ## Ruleset
 
-### General rules
+### Tournament rules
 
-1. It is a 3 vs 3 Team tournament.
-2. Team size is 3 member and 1 backup member in case someone from the team is missing (if the teams want one).
-3. Teams should be builded with people from the same country. When people missing, the team can team up with another country from the same continent (there are exceptions).
-4. Minimum team number is 16, maximum 32.
-5. No cheating.
-6. If anyone wants to join the staff write me a forum PM.
-7. Maps can be choosed like in Weezy's tournament. Maps will be given on Monday.
+1. The Catch the Beat World Cup is a 3v3, team-based tournament played on the osu!catch game mode.
+2. Beatmap scoring is based on **[ScoreV1](/wiki/Score#scorev1)**.
+3. The beatmaps for each round will be announced by the tournament host on the discussion thread in advance before the actual matches take place. Only these beatmaps will be used during the respective matches. 
+   - One beatmap will be a tiebreaker beatmap. This beatmap will only be played in case of a tie.
+4. The match schedule will be settled by the Tournament Management (see the [scheduling instructions](#scheduling-instructions)).
+5. If no staff is available, the match will be postponed.
+6. If a beatmap ends in a draw, the map will be nullified.
+7. If a player disconnects, their scores will not be counted towards their team's total.
+8. Beatmaps cannot be reused in the same match unless the map was nullified.
+9. If a team fails to bring in the required minimum of three players to a match, the corresponding match can either be declared as a forfeited match where the opposing team gets automatically awarded with a Win by Default.     
+10. Exchanging players during a match is allowed without limitations.
+    - **If a map rematch is required, exchanging players is not allowed. With the Tournament Management's discretion, an exception can be made if the previous roster is unavailable to play.**
+11. Lag is not a valid reason to nullify a beatmap.
+12. All players are supposed to keep the match running fluently and without delays. Penalties can be issued to the players if they cause excessive match delays.
+13. If a player disconnects between maps and the team cannot provide a replacement, the match can be delayed by 10 minutes at most.
+14. All players and the staff must be treated with respect. Instructions of the Tournament Management are to be followed. Decisions labeled as final are not to be objected.
+15. Disrupting the match by foul play, insulting and provoking other players or the staff, delaying the match, or other deliberate inappropriate misbehavior is strictly prohibited.
+16. Unexpected incidents are to be handled by the Tournament Management.
+17. Penalties for violating the tournament rules may include:
+    - Exclusion of specific players for one beatmap
+    - Exclusion of specific players for an entire match
+    - Declaring the match as Lost by Default
+    - Disqualification from the entire tournament
+    - Disqualification from the current and future official tournaments until appealed
+    - Any modification of these rules will be announced.
 
-### Game specific rules
+### Tournament registration
 
-1. A game will be a 3 vs 3 match.
-2. Games will be hold on weekends.
-3. When two of a team are missing the game will still hold (rematches in special cases or when both teams accept it).
-4. When participants know that they cannot attend to the game, please tell it the teamleader or the staff.
-5. Participants will play without mods (NoVideo is allowed).
-6. The maps will be only ranked/approved (there are exceptions!).
-7. A staff member or me will create the game. When nobody of the staff is online, participants have to open the game by themselves.
-8. The leader of a team makes a screen and gives it to a staff member or me. Same with the multiplayerpage.
+1. In order to be registered for the tournament, a representative of each team will have to propose a team roster comprising of 3-4 players in the discussion thread following a template set by the Tournament Management as follows:
 
-### Tournament stages
+```
+Team Name: (...)
+Region: (...)
 
-#### Group phase
+Player 1 (Captain): (...)
+Player 2: (...)
+Player 3: (...)
+Player 4: (...)
 
-1. The first 5 rounds are hold in groups up to 5 teams.
-2. Victory gives 3 points and defeat 1 point.
-3. When really nobody of a team appears the team will gain -3 points.
-4. The first and second in a group are coming into the Quarterfinals.
-5. In the group phase participants' play always 3 map max.
-6. Participants can choose the date of the match by themselves until wednesday, otherwise Tournament Management will choose one.
-7. Automatic rematch when someone disconnects before the first 5 notes of a song (this means participants will replay the map).
-8. A team chooses only **1** map, in case there is a tie, participants must play the Tiebreak map.
+Time Zone: (...)
+```
 
-#### Knockout phase
+2. To ensure valid and serious registrations, all proposed team rosters will be checked by the Tournament Management.
+3. All accepted teams will be announced in the discussion thread after the Registration Phase.
+   - **A team should have at least three players registered in order to be eligible to participate.**
+4. Once a team roster has been accepted, it remains locked for the rest of the tournament. No further changes may be made to it except on extraordinary circumstances under the Tournament Management's approval.
 
-1. Map order is already given.
-2. Participants will play at 5 maps (maximum) in Quarterfinals, 7 in Semifinals, and 9 in Finals.
+### Match instructions
+
+1. A member of the Tournament Management will create a multiplayer room 15 minutes in advance. Players must gather during this period.
+   - Room settings are osu!catch, Team-Vs., Win Condition: 'Score'. Room name must be "CWC: (TeamRed) vs (TeamBlue)".
+   - The team mentioned first in the room name must be the red team, the team mentioned second in the room name must be the blue team.
+2. As the Catch the Beat World Cup features no formal referee, **both team captains are expected to referee the match by themselves from inside the multiplayer lobby**. If there are any suspected irregularities during the run of the match, the concerned team captain may file a report in the discussion thread which will be investigated by the Tournament Management in due time.
+3. Map banning **does not apply** in the entirety of the tournament.
+4. Each team must have three players for each map. They can be exchanged freely after a map is concluded.
+5. Beatmap selection will alternate between each captain selecting a beatmap out of the mappool.
+6. Each captain must use the `!roll` command once in `#multiplayer`.
+   - The captain with the higher roll decides which team **picks** first.
+7. The results of each match will be posted on the discussion thread after the match has been concluded by either of the team captains.
+
+### Stage instructions
+
+1. In the Group Stage, the teams will be divided into four groups of five teams each.
+2. All the teams from each group will face each other over the course of five weeks.
+   - Due to the odd number of teams in each group, all teams **will only be playing on four matchweeks** instead of on all five by default. Team captains are expected to be aware of the schedules announced by the Tournament Management.
+3. Depending on the outcome of a Group Stage match, each team will be alloted Group Stage points to their name as follows:
+   - Winning a match gives the team +3 Group Stage points.
+   - Losing a match gives the team +1 Group Stage point.
+   - Forfeiting a match, either by disqualification or by a Lost by Default, penalizes the team by -3 Group Stage points.
+4. Rankings of each group are determined by sorting the results of each team's performance in the following priority:
+   - Most Group Stage points accumulated.
+   - Most matches won.
+   - Have higher `{(the number of beatmaps won) - (the number of beatmaps defeated)}`.
+   - Most beatmaps won.
+   - **Winner of the match played previously between the tied teams.**
+   - In the event of a triple tie:
+     - Have higher `∑{(total score difference) / (maximum score)}`.
+     - Winner of the rematch.
+5. The top two teams of each group will move on to the knock-out stages following the matchup bracket set by the Tournament Management.   
+   - The knock-out stages are played under the Single Elimination system.
+
+#### Winning conditions
+
+- The Group Stage matches will be played in a Best-of-3 matchup configuration (first team to reach 2 points wins).
+- The Quarterfinals matches will be played in a Best-of-5 matchup configuration (first team to reach 3 points wins).
+- The Semifinals matches will be played in a Best-of-7 matchup configuration (first team to reach 4 points wins).
+- The Finals matches will be played in a Best-of-9 matchup configuration (first team to reach 5 points wins).
+
+### Mappool instructions
+
+1. There will be a different mappool for every stage.
+2. All the maps in the mappool (including the Tiebreaker) will be played without any modifications enabled (NoMod).
+3. Each mappool has a specific size depending on the stage.
+   - The Group Stage weeks will all feature 9 NoMod maps (to be picked in any order) + 1 Tiebreaker map.
+   - The Quarterfinals will feature 4 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
+   - The Semifinals will feature 6 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.
+   - The Finals will feature 8 NoMod maps (**to be played in the order determined by the Tournament Management**) + 1 Tiebreaker map.   
+
+### Scheduling instructions
+
+1. Each stage will be held on its respective timeframe set by the Tournament Management.
+2. Scheduling will be handled by the Tournament Management. Schedules will be released on the Sunday before the first matches of the stage.
+3. **Reschedules will only be considered if both teams agree to a time. This needs to be done and communicated to the Tournament Management before the particular match takes place.**
+4. **Reschedules may only be requested by a team captain.**
+   - **Do not ask for a reschedule unless it is absolutely necessary. The Tournament Management has the right to decline the request.**
+5. Captains are responsible for their teams' availability. The greater team size exists to ensure every team can provide at least three players for each match. If a team is unable to provide three players for a match, the match will be considered forfeited.
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Belgium"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
@@ -252,6 +483,7 @@ This competition has come to an end and resulted in the following podium:
 [flag_CO]: /wiki/shared/flag/CO.gif "Colombia"
 [flag_CZ]: /wiki/shared/flag/CZ.gif "Czech Republic"
 [flag_DE]: /wiki/shared/flag/DE.gif "Germany"
+[flag_DK]: /wiki/shared/flag/DK.gif "Denmark"
 [flag_ES]: /wiki/shared/flag/ES.gif "Spain"
 [flag_FR]: /wiki/shared/flag/FR.gif "France"
 [flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"


### PR DESCRIPTION
continuation of the previous efforts in cleaning up older world cup articles ([#4731](https://github.com/ppy/osu-wiki/pull/4731) and [#4754](https://github.com/ppy/osu-wiki/pull/4754)). 

as the current article is very much covering only the bare minimum this one is much closer to a complete rewrite instead of a cleanup imo, but thankfully all the missing information are still more or less retrievable in one way or another 🥂

some changes in this pr include :

- added match results (from all the match report posts that were being fragmented here and there in the thread)
- added tournament schedule (rough estimation, based on the forum timestamp of the posts)
- reworked the team listing and added missing profile links using web.archive.org
- reworked the mappools so that a) none of the maps are listed as "missing" anymore and b) all mapset hosts are properly credited
- greatly reworked the rulesets to be more in line with modern tournament ruleset writing standards
- added proper tournament staff roster
- added clarification that the tournament was run by various community members (instead of "being directly run by the osu!team" as currently indicated)
- applied bunch of other minor tweaks and improvements
