### PR TITLE
Conclude osu! South East Asia Tournament 4

### DIFF
--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -130,7 +130,7 @@ Unofficial tournaments/competitions hosted by the communities.
 | osu! South East Asia Tournament | 2017-12-07 | 2018-02-04 | ![][flag_ID] [smh](https://osu.ppy.sh/users/1629553) | ![][flag_MY] [wuhua](https://osu.ppy.sh/users/2932510) | ![][flag_SG] [Elegant Loli](https://osu.ppy.sh/users/3010281) |
 | [osu! South East Asia Tournament 2](oSEAT/2) | 2018-11-30 | 2019-01-27 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [GSBlank](https://osu.ppy.sh/users/2312106) | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) |
 | [osu! South East Asia Tournament 3](oSEAT/3) | 2019-12-14 | 2020-02-16 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [Rtyzen](https://osu.ppy.sh/users/2439822) | ![][flag_ID] [LoidKun](https://osu.ppy.sh/users/6437601) |
-| [osu! South East Asia Tournament 3](oSEAT/4) | 2020-11-07 | 2021-01-31 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) |
+| [osu! South East Asia Tournament 4](oSEAT/4) | 2020-11-07 | 2021-01-31 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) |
 
 ### ![](/wiki/shared/mode/osu.png) osu! European Tournament
 

--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -130,6 +130,7 @@ Unofficial tournaments/competitions hosted by the communities.
 | osu! South East Asia Tournament | 2017-12-07 | 2018-02-04 | ![][flag_ID] [smh](https://osu.ppy.sh/users/1629553) | ![][flag_MY] [wuhua](https://osu.ppy.sh/users/2932510) | ![][flag_SG] [Elegant Loli](https://osu.ppy.sh/users/3010281) |
 | [osu! South East Asia Tournament 2](oSEAT/2) | 2018-11-30 | 2019-01-27 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [GSBlank](https://osu.ppy.sh/users/2312106) | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) |
 | [osu! South East Asia Tournament 3](oSEAT/3) | 2019-12-14 | 2020-02-16 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [Rtyzen](https://osu.ppy.sh/users/2439822) | ![][flag_ID] [LoidKun](https://osu.ppy.sh/users/6437601) |
+| [osu! South East Asia Tournament 3](oSEAT/4) | 2020-11-07 | 2021-01-31 | ![][flag_ID] [Skydiver](https://osu.ppy.sh/users/4750008) | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) |
 
 ### ![](/wiki/shared/mode/osu.png) osu! European Tournament
 

--- a/wiki/Tournaments/oSEAT/4/en.md
+++ b/wiki/Tournaments/oSEAT/4/en.md
@@ -74,7 +74,7 @@ This competition has come to an end and resulted in the following podium:
 
 ## Participants
 
-Listed below were players who qualified into the Group Stage (along with their respective seeding and group placement) out of 179 registered players in total.
+Listed below are players who qualified into the Group Stage (along with their respective seeding and group placement) out of 179 registered players in total.
 
 | Group | Seed A | Seed B | Seed C | Seed D | Seed E | Seed F |
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |

--- a/wiki/Tournaments/oSEAT/4/en.md
+++ b/wiki/Tournaments/oSEAT/4/en.md
@@ -8,7 +8,7 @@ tags:
 
 ![oSEAT4 logo](img/logo.jpg)
 
-The **osu! South East Asia Tournament 4** (***oSEAT4***) is a double-elimination 1v1 osu! tournament hosted by ![][flag_SG] [phox](https://osu.ppy.sh/users/772295). The tournament is open to all players from all ten [ASEAN member states](https://asean.org/asean/asean-member-states/) (![][flag_BN] Brunei Darussalam, ![][flag_KH] Cambodia, ![][flag_ID] Indonesia, ![][flag_LA] Laos, ![][flag_MY] Malaysia, ![][flag_MM] Myanmar, ![][flag_PH] The Phillipines, ![][flag_SG] Singapore, ![][flag_TH] Thailand, and ![][flag_VN] Vietnam) regardless of rank. It is the 4th installment of the osu! South East Asia Tournament.
+The **osu! South East Asia Tournament 4** (***oSEAT4***) was a double-elimination 1v1 osu! tournament hosted by ![][flag_SG] [phox](https://osu.ppy.sh/users/772295). The tournament was open to all players from all ten [ASEAN member states](https://asean.org/asean/asean-member-states/) (![][flag_BN] Brunei Darussalam, ![][flag_KH] Cambodia, ![][flag_ID] Indonesia, ![][flag_LA] Laos, ![][flag_MY] Malaysia, ![][flag_MM] Myanmar, ![][flag_PH] The Phillipines, ![][flag_SG] Singapore, ![][flag_TH] Thailand, and ![][flag_VN] Vietnam) regardless of rank. It was the 4th installment of the osu! South East Asia Tournament.
 
 ## Tournament schedule
 
@@ -40,7 +40,7 @@ The **osu! South East Asia Tournament 4** (***oSEAT4***) is a double-elimination
 
 ## Organization
 
-oSEAT4 is run by various osu! community members predominantly hailing from South East Asian countries.
+oSEAT4 was run by various osu! community members predominantly hailing from South East Asian countries.
 
 | Position | Member(s) |
 | :-- | :-- |
@@ -62,9 +62,19 @@ oSEAT4 is run by various osu! community members predominantly hailing from South
 - [Livestream channel](https://www.twitch.tv/oseatournament)
 - [Challonge bracket](https://challonge.com/SEAT4)
 
+## Podium
+
+This competition has come to an end and resulted in the following podium:
+
+| Placing | Player |
+| :-: | :-- |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** |
+
 ## Participants
 
-Listed below are players who qualified into the Group Stage (along with their respective seeding and group placement) out of 179 registered players in total.
+Listed below were players who qualified into the Group Stage (along with their respective seeding and group placement) out of 179 registered players in total.
 
 | Group | Seed A | Seed B | Seed C | Seed D | Seed E | Seed F |
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
@@ -327,27 +337,41 @@ Listed below are players who qualified into the Group Stage (along with their re
 
 ## Match results
 
+### Finals week 2
+
+Saturday, 30 January 2021:
+
+| Bracket | Player 1 |  |  | Player 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| Lower | **[megumic](https://osu.ppy.sh/users/7537133)** ![][flag_SG] | **7** | 0 | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) | [#1](https://osu.ppy.sh/community/matches/74553279) |
+
+Sunday, 31 January 2021 (Grand Final):
+
+| Bracket | Player 1 |  |  | Player 2 | Match link |
+| :-: | --: | :-: | :-: | :-- | :-- |
+| Grand Final | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **7** | 3 | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | [#1](https://osu.ppy.sh/community/matches/74637070) |
+
 ### Finals week 1
 
 Saturday, 23 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_SG] [k\_1tty](https://osu.ppy.sh/users/5407620) | 5 | **7** | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | [#1](https://osu.ppy.sh/community/matches/74035356) |
-| Lower | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | **7** | 5 | ![][flag_ID] [Fuma](https://osu.ppy.sh/users/1501956) | [#1](https://osu.ppy.sh/community/matches/74040505) |
+| Lower | [k\_1tty](https://osu.ppy.sh/users/5407620) ![][flag_SG] | 5 | **7** | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | [#1](https://osu.ppy.sh/community/matches/74035356) |
+| Lower | **[MioMilo](https://osu.ppy.sh/users/2199427)** ![][flag_PH] | **7** | 5 | ![][flag_ID] [Fuma](https://osu.ppy.sh/users/1501956) | [#1](https://osu.ppy.sh/community/matches/74040505) |
 
 Sunday, 24 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **7** | 5 | ![][flag_PH] [MioMilo](https://osu.ppy.sh/users/2199427) | [#1](https://osu.ppy.sh/community/matches/74101173) |
-| Upper | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **7** | 4 | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | [#1](https://osu.ppy.sh/community/matches/74118203) |
+| Lower | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **7** | 5 | ![][flag_PH] [MioMilo](https://osu.ppy.sh/users/2199427) | [#1](https://osu.ppy.sh/community/matches/74101173) |
+| Upper | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **7** | 4 | ![][flag_SG] [megumic](https://osu.ppy.sh/users/7537133) | [#1](https://osu.ppy.sh/community/matches/74118203) |
 
 Monday, 25 January 2021 (5th Place Playoff):
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| 5th Place Playoff | ![][flag_SG] [k\_1tty](https://osu.ppy.sh/users/5407620) | 4 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/74121020) |
+| 5th Place Playoff | [k\_1tty](https://osu.ppy.sh/users/5407620) ![][flag_SG] | 4 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/74121020) |
 
 ### Semifinals
 
@@ -355,19 +379,19 @@ Saturday, 16 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_SG] [Rtzero](https://osu.ppy.sh/users/9262462) | 1 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73537088) |
-| Lower | ![][flag_SG] **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** | **7** | 5 | ![][flag_PH] [xidorn](https://osu.ppy.sh/users/7904667) | [#1](https://osu.ppy.sh/community/matches/73535895) |
-| Lower | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | **7** | 3 | ![][flag_MY] [Rampax](https://osu.ppy.sh/users/3995630) | [#1](https://osu.ppy.sh/community/matches/73532116) |
-| Lower | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **7** | 4 | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) | [#1](https://osu.ppy.sh/community/matches/73527013) |
+| Lower | [Rtzero](https://osu.ppy.sh/users/9262462) ![][flag_SG] | 1 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73537088) |
+| Lower | **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** ![][flag_SG] | **7** | 5 | ![][flag_PH] [xidorn](https://osu.ppy.sh/users/7904667) | [#1](https://osu.ppy.sh/community/matches/73535895) |
+| Lower | **[Rtyzen](https://osu.ppy.sh/users/2439822)** ![][flag_SG] | **7** | 3 | ![][flag_MY] [Rampax](https://osu.ppy.sh/users/3995630) | [#1](https://osu.ppy.sh/community/matches/73532116) |
+| Lower | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **7** | 4 | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) | [#1](https://osu.ppy.sh/community/matches/73527013) |
 
 Sunday, 17 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Upper | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | **7** | 2 | ![][flag_PH] [MioMilo](https://osu.ppy.sh/users/2199427) | [#1](https://osu.ppy.sh/community/matches/73609887) |
-| Lower | ![][flag_SG] [\[-Lockon-\]](https://osu.ppy.sh/users/6726331) | 2 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73595095) |
-| Lower | ![][flag_SG] [Rtyzen](https://osu.ppy.sh/users/2439822) | 6 | **7** | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | [#1](https://osu.ppy.sh/community/matches/73596507) |
-| Upper | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **7** | 2 | ![][flag_SG] [k\_1tty](https://osu.ppy.sh/users/5407620) | [#1](https://osu.ppy.sh/community/matches/73606021) |
+| Upper | **[megumic](https://osu.ppy.sh/users/7537133)** ![][flag_SG] | **7** | 2 | ![][flag_PH] [MioMilo](https://osu.ppy.sh/users/2199427) | [#1](https://osu.ppy.sh/community/matches/73609887) |
+| Lower | [\[-Lockon-\]](https://osu.ppy.sh/users/6726331) ![][flag_SG] | 2 | **7** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73595095) |
+| Lower | [Rtyzen](https://osu.ppy.sh/users/2439822) ![][flag_SG] | 6 | **7** | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | [#1](https://osu.ppy.sh/community/matches/73596507) |
+| Upper | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **7** | 2 | ![][flag_SG] [k\_1tty](https://osu.ppy.sh/users/5407620) | [#1](https://osu.ppy.sh/community/matches/73606021) |
 
 ### Quarterfinals
 
@@ -375,37 +399,37 @@ Thursday, 7 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_PH] [Milkteaism](https://osu.ppy.sh/users/9642774) | 0 | **6** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | *win by default* |
+| Lower | [Milkteaism](https://osu.ppy.sh/users/9642774) ![][flag_PH] | 0 | **6** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | *win by default* |
 
 Friday, 8 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | **6** | 0 | ![][flag_PH] [Rammu](https://osu.ppy.sh/users/10652837) | [#1](https://osu.ppy.sh/community/matches/73013107) |
-| Lower | ![][flag_SG] [oneplusone](https://osu.ppy.sh/users/1843447) | 3 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/73006970) |
-| Lower | ![][flag_ID] [Venta](https://osu.ppy.sh/users/11320627) | 0 | **6** | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | *win by default* |
+| Lower | **[Fuma](https://osu.ppy.sh/users/1501956)** ![][flag_ID] | **6** | 0 | ![][flag_PH] [Rammu](https://osu.ppy.sh/users/10652837) | [#1](https://osu.ppy.sh/community/matches/73013107) |
+| Lower | [oneplusone](https://osu.ppy.sh/users/1843447) ![][flag_SG] | 3 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/73006970) |
+| Lower | [Venta](https://osu.ppy.sh/users/11320627) ![][flag_ID] | 0 | **6** | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | *win by default* |
 
 Saturday, 9 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Upper | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | **6** | 5 | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) | [#1](https://osu.ppy.sh/community/matches/73070950) |
-| Lower | ![][flag_PH] [konawiki](https://osu.ppy.sh/users/4003979) | 1 | **6** | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | [#1](https://osu.ppy.sh/community/matches/73021742) |
-| Lower | ![][flag_SG] [Eagle5324](https://osu.ppy.sh/users/11987104) | 4 | **6** | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | [#1](https://osu.ppy.sh/community/matches/73090676) |
-| Lower | ![][flag_MY] **[Tzero](https://osu.ppy.sh/users/6088976)** | **6** | 5 | ![][flag_SG] [SeeL](https://osu.ppy.sh/users/5104320) | [#1](https://osu.ppy.sh/community/matches/73072966) |
-| Lower | ![][flag_MY] [Chiyuu](https://osu.ppy.sh/users/8226107) | 1 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/73081840) |
-| Upper | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | **6** | 3 | ![][flag_SG] [Rtyzen](https://osu.ppy.sh/users/2439822) | [#1](https://osu.ppy.sh/community/matches/73083950) |
-| Lower | ![][flag_MY] **[not\_aweeb](https://osu.ppy.sh/users/9375317)** | **6** | 1 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/73083714) |
+| Upper | **[MioMilo](https://osu.ppy.sh/users/2199427)** ![][flag_PH] | **6** | 5 | ![][flag_ID] [Lifeline](https://osu.ppy.sh/users/11367222) | [#1](https://osu.ppy.sh/community/matches/73070950) |
+| Lower | [konawiki](https://osu.ppy.sh/users/4003979) ![][flag_PH] | 1 | **6** | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | [#1](https://osu.ppy.sh/community/matches/73021742) |
+| Lower | [Eagle5324](https://osu.ppy.sh/users/11987104) ![][flag_SG] | 4 | **6** | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | [#1](https://osu.ppy.sh/community/matches/73090676) |
+| Lower | **[Tzero](https://osu.ppy.sh/users/6088976)** ![][flag_MY] | **6** | 5 | ![][flag_SG] [SeeL](https://osu.ppy.sh/users/5104320) | [#1](https://osu.ppy.sh/community/matches/73072966) |
+| Lower | [Chiyuu](https://osu.ppy.sh/users/8226107) ![][flag_MY] | 1 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/73081840) |
+| Upper | **[megumic](https://osu.ppy.sh/users/7537133)** ![][flag_SG] | **6** | 3 | ![][flag_SG] [Rtyzen](https://osu.ppy.sh/users/2439822) | [#1](https://osu.ppy.sh/community/matches/73083950) |
+| Lower | **[not\_aweeb](https://osu.ppy.sh/users/9375317)** ![][flag_MY] | **6** | 1 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/73083714) |
 
 Sunday, 10 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | **6** | 4 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/73152011) |
-| Upper | ![][flag_SG] **[k\_1tty](https://osu.ppy.sh/users/5407620)** | **6** | 0 | ![][flag_SG] [Rtzero](https://osu.ppy.sh/users/9262462) | [#1](https://osu.ppy.sh/community/matches/73154797) |
-| Lower | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | **6** | 3 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/73160641) |
-| Upper | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **6** | 0 | ![][flag_SG] [\[-Lockon-\]](https://osu.ppy.sh/users/6726331) | [#1](https://osu.ppy.sh/community/matches/73142523) |
-| Lower | ![][flag_MY] [not\_aweeb](https://osu.ppy.sh/users/9375317) | 4 | **6** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73155315) |
+| Lower | **[Rexeez](https://osu.ppy.sh/users/1987591)** ![][flag_ID] | **6** | 4 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/73152011) |
+| Upper | **[k\_1tty](https://osu.ppy.sh/users/5407620)** ![][flag_SG] | **6** | 0 | ![][flag_SG] [Rtzero](https://osu.ppy.sh/users/9262462) | [#1](https://osu.ppy.sh/community/matches/73154797) |
+| Lower | **[Rampax](https://osu.ppy.sh/users/3995630)** ![][flag_MY] | **6** | 3 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/73160641) |
+| Upper | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **6** | 0 | ![][flag_SG] [\[-Lockon-\]](https://osu.ppy.sh/users/6726331) | [#1](https://osu.ppy.sh/community/matches/73142523) |
+| Lower | [not\_aweeb](https://osu.ppy.sh/users/9375317) ![][flag_MY] | 4 | **6** | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | [#1](https://osu.ppy.sh/community/matches/73155315) |
 
 ### Round of 16
 
@@ -413,53 +437,53 @@ Friday, 1 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_SG] **[SeeL](https://osu.ppy.sh/users/5104320)** | **6** | 1 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/2138989) | [#1](https://osu.ppy.sh/community/matches/72638889) |
-| Lower | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | **6** | 0 | ![][flag_VN] [Hoaq](https://osu.ppy.sh/users/7696512) | *win by default* |
+| Lower | **[SeeL](https://osu.ppy.sh/users/5104320)** ![][flag_SG] | **6** | 1 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/2138989) | [#1](https://osu.ppy.sh/community/matches/72638889) |
+| Lower | **[xidorn](https://osu.ppy.sh/users/7904667)** ![][flag_PH] | **6** | 0 | ![][flag_VN] [Hoaq](https://osu.ppy.sh/users/7696512) | *win by default* |
 
 Saturday, 2 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | **6** | 1 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/72649030) |
-| Lower | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | **6** | 2 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/72641490) |
-| Upper | ![][flag_SG] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **6** | 0 | ![][flag_SG] [Eagle5324](https://osu.ppy.sh/users/11987104) | [#1](https://osu.ppy.sh/community/matches/72657027) |
-| Lower | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | **6** | 3 | ![][flag_MY] [Agagak](https://osu.ppy.sh/users/3645490) | [#1](https://osu.ppy.sh/community/matches/72641487) |
-| Lower | ![][flag_US] (![][flag_PH]) [\_Kolin](https://osu.ppy.sh/users/7249644) | 4 | **6** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | [#1](https://osu.ppy.sh/community/matches/72644384) |
-| Lower | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | **6** | 1 | ![][flag_ID] [Suikami](https://osu.ppy.sh/users/1929336) | [#1](https://osu.ppy.sh/community/matches/72647424) |
-| Lower | ![][flag_MY] **[DuoX](https://osu.ppy.sh/users/9560694)** | **6** | 3 | ![][flag_SG] [Hecatia](https://osu.ppy.sh/users/8244635) | [#1](https://osu.ppy.sh/community/matches/72648337) |
-| Upper | ![][flag_MY] [not\_aweeb](https://osu.ppy.sh/users/9375317) | 2 | **6** | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | [#1](https://osu.ppy.sh/community/matches/72644384) |
-| Lower | ![][flag_VN] **[Tuon](https://osu.ppy.sh/users/6673790)** | **6** | 2 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | [#1](https://osu.ppy.sh/community/matches/72650467) |
-| Lower | ![][flag_SG] **[moosepi](https://osu.ppy.sh/users/1868745)** | **6** | 4 | ![][flag_PH] [Xyloz](https://osu.ppy.sh/users/12040280) | [#1](https://osu.ppy.sh/community/matches/72650382) |
-| Lower | ![][flag_SG] **[SeeL](https://osu.ppy.sh/users/5104320)** | **6** | 4 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/72646013) |
-| Upper | ![][flag_SG] **[Rtzero](https://osu.ppy.sh/users/9262462)** | **6** | 5 | ![][flag_PH] [konawiki](https://osu.ppy.sh/users/4003979) | [#1](https://osu.ppy.sh/community/matches/72650519) |
-| Lower | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | **6** | 1 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/72652819) |
-| Lower | ![][flag_PH] **[KagenoKami](https://osu.ppy.sh/users/7246165)** | **6** | 1 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | [#1](https://osu.ppy.sh/community/matches/72653176) |
-| Lower | ![][flag_ID] **[Vinno](https://osu.ppy.sh/users/10717635)** | **6** | 3 | ![][flag_SG] [\_gt](https://osu.ppy.sh/users/8301957) | [#1](https://osu.ppy.sh/community/matches/72639281) |
-| Lower | ![][flag_PH] **[Rammu](https://osu.ppy.sh/users/10652837)** | **6** | 0 | ![][flag_SG] [Walfrid](https://osu.ppy.sh/users/6600809) | *win by default* | 
-| Lower | ![][flag_SG] [Demonical](https://osu.ppy.sh/users/10717635) | 0 | **6** | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | *win by default* |
-| Lower | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | **6** | 0 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | *win by default* |
+| Lower | **[Chiyuu](https://osu.ppy.sh/users/8226107)** ![][flag_MY] | **6** | 1 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/72649030) |
+| Lower | **[Daffy](https://osu.ppy.sh/users/5968633)** ![][flag_ID] | **6** | 2 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/72641490) |
+| Upper | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_SG] | **6** | 0 | ![][flag_SG] [Eagle5324](https://osu.ppy.sh/users/11987104) | [#1](https://osu.ppy.sh/community/matches/72657027) |
+| Lower | **[Deppyforce](https://osu.ppy.sh/users/5286213)** ![][flag_TH] | **6** | 3 | ![][flag_MY] [Agagak](https://osu.ppy.sh/users/3645490) | [#1](https://osu.ppy.sh/community/matches/72641487) |
+| Lower | [\_Kolin](https://osu.ppy.sh/users/7249644) ![][flag_US] (![][flag_PH]) | 4 | **6** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | [#1](https://osu.ppy.sh/community/matches/72644384) |
+| Lower | **[Rexeez](https://osu.ppy.sh/users/1987591)** ![][flag_ID] | **6** | 1 | ![][flag_ID] [Suikami](https://osu.ppy.sh/users/1929336) | [#1](https://osu.ppy.sh/community/matches/72647424) |
+| Lower | **[DuoX](https://osu.ppy.sh/users/9560694)** ![][flag_MY] | **6** | 3 | ![][flag_SG] [Hecatia](https://osu.ppy.sh/users/8244635) | [#1](https://osu.ppy.sh/community/matches/72648337) |
+| Upper | [not\_aweeb](https://osu.ppy.sh/users/9375317) ![][flag_MY] | 2 | **6** | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | [#1](https://osu.ppy.sh/community/matches/72644384) |
+| Lower | **[Tuon](https://osu.ppy.sh/users/6673790)** ![][flag_VN] | **6** | 2 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | [#1](https://osu.ppy.sh/community/matches/72650467) |
+| Lower | **[moosepi](https://osu.ppy.sh/users/1868745)** ![][flag_SG] | **6** | 4 | ![][flag_PH] [Xyloz](https://osu.ppy.sh/users/12040280) | [#1](https://osu.ppy.sh/community/matches/72650382) |
+| Lower | **[SeeL](https://osu.ppy.sh/users/5104320)** ![][flag_SG] | **6** | 4 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/72646013) |
+| Upper | **[Rtzero](https://osu.ppy.sh/users/9262462)** ![][flag_SG] | **6** | 5 | ![][flag_PH] [konawiki](https://osu.ppy.sh/users/4003979) | [#1](https://osu.ppy.sh/community/matches/72650519) |
+| Lower | **[Rampax](https://osu.ppy.sh/users/3995630)** ![][flag_MY] | **6** | 1 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/72652819) |
+| Lower | **[KagenoKami](https://osu.ppy.sh/users/7246165)** ![][flag_PH] | **6** | 1 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | [#1](https://osu.ppy.sh/community/matches/72653176) |
+| Lower | **[Vinno](https://osu.ppy.sh/users/10717635)** ![][flag_ID] | **6** | 3 | ![][flag_SG] [\_gt](https://osu.ppy.sh/users/8301957) | [#1](https://osu.ppy.sh/community/matches/72639281) |
+| Lower | **[Rammu](https://osu.ppy.sh/users/10652837)** ![][flag_PH] | **6** | 0 | ![][flag_SG] [Walfrid](https://osu.ppy.sh/users/6600809) | *win by default* | 
+| Lower | [Demonical](https://osu.ppy.sh/users/10717635) ![][flag_SG] | 0 | **6** | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | *win by default* |
+| Lower | **[zonelouise](https://osu.ppy.sh/users/1492995)** ![][flag_PH] | **6** | 0 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | *win by default* |
 
 Sunday, 3 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_VN] **[Tuon](https://osu.ppy.sh/users/6673790)** | **6** | 4 | ![][flag_ID] [Vinno](https://osu.ppy.sh/users/10717635) | [#1](https://osu.ppy.sh/community/matches/72709279) |
-| Upper | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **6** | 2 | ![][flag_PH] [Milkteaism](https://osu.ppy.sh/users/9642774) | [#1](https://osu.ppy.sh/community/matches/72689767) |
-| Upper | ![][flag_SG] **[k\_1tty](https://osu.ppy.sh/users/5407620)** | **6** | 0 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/72709677) |
-| Lower | ![][flag_TH] [Chorus](https://osu.ppy.sh/users/3504692) | 2 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/72699336) |
-| Upper | ![][flag_SG] **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** | **6** | 2 | ![][flag_ID] [Venta](https://osu.ppy.sh/users/11320627) | [#1](https://osu.ppy.sh/community/matches/72694960) |
-| Upper | ![][flag_SG] [oneplusone](https://osu.ppy.sh/users/1843447) | 1 | **6** | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | [#1](https://osu.ppy.sh/community/matches/72696328) |
-| Lower | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | **6** | 5 | ![][flag_PH] [KagenoKami](https://osu.ppy.sh/users/7246165) | [#1](https://osu.ppy.sh/community/matches/72700966) |
-| Lower | ![][flag_PH] [Senjuro](https://osu.ppy.sh/users/3003839) | 0 | **6** | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | [#1](https://osu.ppy.sh/community/matches/72705148) |
-| Lower | ![][flag_MY] [DuoX](https://osu.ppy.sh/users/9560694) | 1 | **6** | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | [#1](https://osu.ppy.sh/community/matches/72705819) |
-| Lower | ![][flag_PH] **[Rammu](https://osu.ppy.sh/users/10652837)** | **6** | 3 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/72712098) |
-| Lower | ![][flag_ID] [Daffy](https://osu.ppy.sh/users/5968633) | 0 | **6** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | *win by default* |
+| Lower | **[Tuon](https://osu.ppy.sh/users/6673790)** ![][flag_VN] | **6** | 4 | ![][flag_ID] [Vinno](https://osu.ppy.sh/users/10717635) | [#1](https://osu.ppy.sh/community/matches/72709279) |
+| Upper | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **6** | 2 | ![][flag_PH] [Milkteaism](https://osu.ppy.sh/users/9642774) | [#1](https://osu.ppy.sh/community/matches/72689767) |
+| Upper | **[k\_1tty](https://osu.ppy.sh/users/5407620)** ![][flag_SG] | **6** | 0 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/72709677) |
+| Lower | [Chorus](https://osu.ppy.sh/users/3504692) ![][flag_TH] | 2 | **6** | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | [#1](https://osu.ppy.sh/community/matches/72699336) |
+| Upper | **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** ![][flag_SG] | **6** | 2 | ![][flag_ID] [Venta](https://osu.ppy.sh/users/11320627) | [#1](https://osu.ppy.sh/community/matches/72694960) |
+| Upper | [oneplusone](https://osu.ppy.sh/users/1843447) ![][flag_SG] | 1 | **6** | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | [#1](https://osu.ppy.sh/community/matches/72696328) |
+| Lower | **[Rexeez](https://osu.ppy.sh/users/1987591)** ![][flag_ID] | **6** | 5 | ![][flag_PH] [KagenoKami](https://osu.ppy.sh/users/7246165) | [#1](https://osu.ppy.sh/community/matches/72700966) |
+| Lower | [Senjuro](https://osu.ppy.sh/users/3003839) ![][flag_PH] | 0 | **6** | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | [#1](https://osu.ppy.sh/community/matches/72705148) |
+| Lower | [DuoX](https://osu.ppy.sh/users/9560694) ![][flag_MY] | 1 | **6** | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | [#1](https://osu.ppy.sh/community/matches/72705819) |
+| Lower | **[Rammu](https://osu.ppy.sh/users/10652837)** ![][flag_PH] | **6** | 3 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/72712098) |
+| Lower | [Daffy](https://osu.ppy.sh/users/5968633) ![][flag_ID] | 0 | **6** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | *win by default* |
 
 Thursday, 7 January 2021:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Upper | ![][flag_ID] [Fuma](https://osu.ppy.sh/users/1501956) | 1 | **6** | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | [#1](https://osu.ppy.sh/community/matches/72946367) |
+| Upper | [Fuma](https://osu.ppy.sh/users/1501956) ![][flag_ID] | 1 | **6** | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | [#1](https://osu.ppy.sh/community/matches/72946367) |
 
 ### Round of 32
 
@@ -467,58 +491,58 @@ Friday, 25 December 2020:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_ID] **[Fayn](https://osu.ppy.sh/users/5390495)** | **6** | 0 | ![][flag_MY] [verdas123](https://osu.ppy.sh/users/11148851) | [#1](https://osu.ppy.sh/community/matches/72196294) |
+| Lower | **[Fayn](https://osu.ppy.sh/users/5390495)** ![][flag_ID] | **6** | 0 | ![][flag_MY] [verdas123](https://osu.ppy.sh/users/11148851) | [#1](https://osu.ppy.sh/community/matches/72196294) |
 
 Saturday, 26 December 2020:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_SG] [Deze](https://osu.ppy.sh/users/7638335) | 2 | **6** | ![][flag_MY] **[Agagak](https://osu.ppy.sh/users/3645490)** | [#1](https://osu.ppy.sh/community/matches/72245077) |
-| Upper | ![][flag_PH] [KagenoKami](https://osu.ppy.sh/users/7246165) | 5 | **6** | ![][flag_MY] **[not_aweeb](https://osu.ppy.sh/users/9375317)** | [#1](https://osu.ppy.sh/community/matches/72239771) |
-| Lower | ![][flag_SG] **[DVDthe1st](https://osu.ppy.sh/users/2138989)** | **6** | 2 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/8055861) | [#1](https://osu.ppy.sh/community/matches/72241993) |
-| Upper | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | **6** | 3 | ![][flag_SG] [SeeL](https://osu.ppy.sh/users/5104320) | [#1](https://osu.ppy.sh/community/matches/72243687) |
-| Upper | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | **6** | 1 | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) | [#1](https://osu.ppy.sh/community/matches/72253683) |
-| Lower | ![][flag_ID] [Firia](https://osu.ppy.sh/users/9730262) | 0 | **6** | ![][flag_ID] **[Walfrid](https://osu.ppy.sh/users/6600809)** | [#1](https://osu.ppy.sh/community/matches/72245587) |
-| Upper | ![][flag_ID] **[Venta](https://osu.ppy.sh/users/11320627)** | **6** | 2 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/72251162) |
-| Lower | ![][flag_PH] **[Xyloz](https://osu.ppy.sh/users/12040280)** | **6** | 0 | ![][flag_MY] [Computer Badger](https://osu.ppy.sh/users/6893361) | [#1](https://osu.ppy.sh/community/matches/72252104) |
-| Upper | ![][flag_PH] [Rammu](https://osu.ppy.sh/users/10652837) | 4 | **6** | ![][flag_SG] **[Eagle5324](https://osu.ppy.sh/users/11987104)** | [#1](https://osu.ppy.sh/community/matches/72258950) |
-| Lower | ![][flag_ID] **[Suikami](https://osu.ppy.sh/users/1929336)** | **6** | 2 | ![][flag_MY] [Flashback9](https://osu.ppy.sh/users/7714136) | [#1](https://osu.ppy.sh/community/matches/72257518) |
-| Upper | ![][flag_PH] **[konawiki](https://osu.ppy.sh/users/4003979)** | **6** | 3 | ![][flag_ID] [Daffy](https://osu.ppy.sh/users/5968633) | [#1](https://osu.ppy.sh/community/matches/72256145) |
-| Upper | ![][flag_MY] [Chiyuu](https://osu.ppy.sh/users/8226107) | 3 | **6** | ![][flag_SG] **[Rtzero](https://osu.ppy.sh/users/9262462)** | [#1](https://osu.ppy.sh/community/matches/72253478) |
-| Upper | ![][flag_SG] **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** | **6** | 5 | ![][flag_ID] [Vinno](https://osu.ppy.sh/users/10717635) | [#1](https://osu.ppy.sh/community/matches/72253284) |
-| Lower | ![][flag_BN] [Daynem W](https://osu.ppy.sh/users/4699134) | 0 | **6** | ![][flag_SG] **[Hecatia](https://osu.ppy.sh/users/8244635)** | *win by default* |
+| Lower | [Deze](https://osu.ppy.sh/users/7638335) ![][flag_SG] | 2 | **6** | ![][flag_MY] **[Agagak](https://osu.ppy.sh/users/3645490)** | [#1](https://osu.ppy.sh/community/matches/72245077) |
+| Upper | [KagenoKami](https://osu.ppy.sh/users/7246165) ![][flag_PH] | 5 | **6** | ![][flag_MY] **[not_aweeb](https://osu.ppy.sh/users/9375317)** | [#1](https://osu.ppy.sh/community/matches/72239771) |
+| Lower | **[DVDthe1st](https://osu.ppy.sh/users/2138989)** ![][flag_SG] | **6** | 2 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/8055861) | [#1](https://osu.ppy.sh/community/matches/72241993) |
+| Upper | **[MioMilo](https://osu.ppy.sh/users/2199427)** ![][flag_PH] | **6** | 3 | ![][flag_SG] [SeeL](https://osu.ppy.sh/users/5104320) | [#1](https://osu.ppy.sh/community/matches/72243687) |
+| Upper | **[Rtyzen](https://osu.ppy.sh/users/2439822)** ![][flag_SG] | **6** | 1 | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/1987591) | [#1](https://osu.ppy.sh/community/matches/72253683) |
+| Lower | [Firia](https://osu.ppy.sh/users/9730262) ![][flag_ID] | 0 | **6** | ![][flag_ID] **[Walfrid](https://osu.ppy.sh/users/6600809)** | [#1](https://osu.ppy.sh/community/matches/72245587) |
+| Upper | **[Venta](https://osu.ppy.sh/users/11320627)** ![][flag_ID] | **6** | 2 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/72251162) |
+| Lower | **[Xyloz](https://osu.ppy.sh/users/12040280)** ![][flag_PH] | **6** | 0 | ![][flag_MY] [Computer Badger](https://osu.ppy.sh/users/6893361) | [#1](https://osu.ppy.sh/community/matches/72252104) |
+| Upper | [Rammu](https://osu.ppy.sh/users/10652837) ![][flag_PH] | 4 | **6** | ![][flag_SG] **[Eagle5324](https://osu.ppy.sh/users/11987104)** | [#1](https://osu.ppy.sh/community/matches/72258950) |
+| Lower | **[Suikami](https://osu.ppy.sh/users/1929336)** ![][flag_ID] | **6** | 2 | ![][flag_MY] [Flashback9](https://osu.ppy.sh/users/7714136) | [#1](https://osu.ppy.sh/community/matches/72257518) |
+| Upper | **[konawiki](https://osu.ppy.sh/users/4003979)** ![][flag_PH] | **6** | 3 | ![][flag_ID] [Daffy](https://osu.ppy.sh/users/5968633) | [#1](https://osu.ppy.sh/community/matches/72256145) |
+| Upper | [Chiyuu](https://osu.ppy.sh/users/8226107) ![][flag_MY] | 3 | **6** | ![][flag_SG] **[Rtzero](https://osu.ppy.sh/users/9262462)** | [#1](https://osu.ppy.sh/community/matches/72253478) |
+| Upper | **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** ![][flag_SG] | **6** | 5 | ![][flag_ID] [Vinno](https://osu.ppy.sh/users/10717635) | [#1](https://osu.ppy.sh/community/matches/72253284) |
+| Lower | [Daynem W](https://osu.ppy.sh/users/4699134) ![][flag_BN] | 0 | **6** | ![][flag_SG] **[Hecatia](https://osu.ppy.sh/users/8244635)** | *win by default* |
 
 Sunday, 27 December 2020:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_SG] [Lunarsol](https://osu.ppy.sh/users/6622650) | 0 | **6** | ![][flag_VN] **[sindes19](https://osu.ppy.sh/users/11021073)** | [#1](https://osu.ppy.sh/community/matches/72308015) |
-| Lower | ![][flag_MY] **[Auxuelus](https://osu.ppy.sh/users/5414124)** | **6** | 5 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/72313266) |
-| Lower | ![][flag_SG] **[Milk Tee](https://osu.ppy.sh/users/6708955)** | **6** | 0 | ![][flag_PH] [Kagitingan](https://osu.ppy.sh/users/7407323) | [#1](https://osu.ppy.sh/community/matches/72293942) |
-| Upper | ![][flag_US] (![][flag_PH]) [\_Kolin](https://osu.ppy.sh/users/7249644) | 1 | **6** | ![][flag_SG] **[Tzero](https://osu.ppy.sh/users/6088976)** | [#1](https://osu.ppy.sh/community/matches/72304186) |
-| Upper | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **6** | 5 | ![][flag_MY] [Rampax](https://osu.ppy.sh/users/3995630) | [#1](https://osu.ppy.sh/community/matches/72295747) |
-| Upper | ![][flag_SG] **[oneplusone](https://osu.ppy.sh/users/1843447)** | **6** | 2 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/72306030) |
-| Upper | ![][flag_SG] **[k\_1tty](https://osu.ppy.sh/users/5407620)** | **6** | 1 | ![][flag_PH] [xidorn](https://osu.ppy.sh/users/7904667) | [#1](https://osu.ppy.sh/community/matches/72306051) |
-| Upper | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | **6** | 5 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/72313709) |
-| Upper | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **6** | 2 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/72310462) |
-| Lower | ![][flag_MY] [vernonlim](https://osu.ppy.sh/users/10167542) | 0 | **6** | ![][flag_SG] **[moltenfury](https://osu.ppy.sh/users/3395820)** | [#1](https://osu.ppy.sh/community/matches/72311955) |
-| Lower | ![][flag_ID] **[Bunan-](https://osu.ppy.sh/users/2763354)** | **6** | 3 | ![][flag_MY] [heyimcrunchy](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/13067221) |
-| Lower | ![][flag_SG] [m0fum0fu](https://osu.ppy.sh/users/5143605) | 5 | **6** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/72313362) |
-| Upper | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | **6** | 1 | ![][flag_MY] [DuoX](https://osu.ppy.sh/users/9560694) | [#1](https://osu.ppy.sh/community/matches/72310597) |
-| Lower | ![][flag_TH] [- Seen -](https://osu.ppy.sh/users/4699134) | 0 | **6** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | *win by default* |
-| Lower | ![][flag_SG] [woahsia](https://osu.ppy.sh/users/195946) | 0 | **6** | ![][flag_VN] **[Hoaq](https://osu.ppy.sh/users/7696512)** | *win by default* |
+| Lower | [Lunarsol](https://osu.ppy.sh/users/6622650) ![][flag_SG] | 0 | **6** | ![][flag_VN] **[sindes19](https://osu.ppy.sh/users/11021073)** | [#1](https://osu.ppy.sh/community/matches/72308015) |
+| Lower | **[Auxuelus](https://osu.ppy.sh/users/5414124)** ![][flag_MY] | **6** | 5 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/72313266) |
+| Lower | **[Milk Tee](https://osu.ppy.sh/users/6708955)** ![][flag_SG] | **6** | 0 | ![][flag_PH] [Kagitingan](https://osu.ppy.sh/users/7407323) | [#1](https://osu.ppy.sh/community/matches/72293942) |
+| Upper | [\_Kolin](https://osu.ppy.sh/users/7249644) ![][flag_US] (![][flag_PH]) | 1 | **6** | ![][flag_SG] **[Tzero](https://osu.ppy.sh/users/6088976)** | [#1](https://osu.ppy.sh/community/matches/72304186) |
+| Upper | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **6** | 5 | ![][flag_MY] [Rampax](https://osu.ppy.sh/users/3995630) | [#1](https://osu.ppy.sh/community/matches/72295747) |
+| Upper | **[oneplusone](https://osu.ppy.sh/users/1843447)** ![][flag_SG] | **6** | 2 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/72306030) |
+| Upper |  **[k\_1tty](https://osu.ppy.sh/users/5407620)** ![][flag_SG] | **6** | 1 | ![][flag_PH] [xidorn](https://osu.ppy.sh/users/7904667) | [#1](https://osu.ppy.sh/community/matches/72306051) |
+| Upper | **[Fuma](https://osu.ppy.sh/users/1501956)** ![][flag_ID] | **6** | 5 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/72313709) |
+| Upper | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **6** | 2 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/72310462) |
+| Lower | [vernonlim](https://osu.ppy.sh/users/10167542) ![][flag_MY] | 0 | **6** | ![][flag_SG] **[moltenfury](https://osu.ppy.sh/users/3395820)** | [#1](https://osu.ppy.sh/community/matches/72311955) |
+| Lower | **[Bunan-](https://osu.ppy.sh/users/2763354)** ![][flag_ID] | **6** | 3 | ![][flag_MY] [heyimcrunchy](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/13067221) |
+| Lower | [m0fum0fu](https://osu.ppy.sh/users/5143605) ![][flag_SG] | 5 | **6** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/72313362) |
+| Upper | **[megumic](https://osu.ppy.sh/users/7537133)** ![][flag_SG] | **6** | 1 | ![][flag_MY] [DuoX](https://osu.ppy.sh/users/9560694) | [#1](https://osu.ppy.sh/community/matches/72310597) |
+| Lower | [- Seen -](https://osu.ppy.sh/users/4699134) ![][flag_TH] | 0 | **6** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | *win by default* |
+| Lower | [woahsia](https://osu.ppy.sh/users/195946) ![][flag_SG] | 0 | **6** | ![][flag_VN] **[Hoaq](https://osu.ppy.sh/users/7696512)** | *win by default* |
 
 Monday, 28 December 2020:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Lower | ![][flag_MY] [Chizu-kun](https://osu.ppy.sh/users/10288461) | 0 | **6** | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | [#1](https://osu.ppy.sh/community/matches/72361772) |
+| Lower | [Chizu-kun](https://osu.ppy.sh/users/10288461) ![][flag_MY] | 0 | **6** | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | [#1](https://osu.ppy.sh/community/matches/72361772) |
 
 Wednesday, 30 December 2020:
 
 | Bracket | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| Upper | ![][flag_SG] [Demonical](https://osu.ppy.sh/users/5447609) | 0 | **6** | ![][flag_PH] **[Milkteaism](https://osu.ppy.sh/users/9642774)** | *win by default* |
+| Upper | [Demonical](https://osu.ppy.sh/users/5447609) ![][flag_SG] | 0 | **6** | ![][flag_PH] **[Milkteaism](https://osu.ppy.sh/users/9642774)** | *win by default* |
 
 ### Group Stage week 2
 
@@ -526,96 +550,96 @@ Friday, 18 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| G | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | **5** | 0 | ![][flag_MY] [Heya](https://osu.ppy.sh/users/11379332) | [#1](https://osu.ppy.sh/community/matches/71786110) |
-| I | ![][flag_MY] [alphaplay](https://osu.ppy.sh/users/9304966) | 0 | **5** | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | [#1](https://osu.ppy.sh/community/matches/71782839) |
-| K | ![][flag_SG] [RePeaTT](https://osu.ppy.sh/users/11132323) | 4 | **5** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/71776736) |
-| C | ![][flag_MY] [CookieDASH](https://osu.ppy.sh/users/8249895) | 3 | **5** | ![][flag_PH] **[Oooodriiin](https://osu.ppy.sh/users/7223737)** | [#1](https://osu.ppy.sh/community/matches/71776736) |
-| I | ![][flag_SG] **[k\_1tty](https://osu.ppy.sh/users/5407620)** | **5** | 1 | ![][flag_ID] [Suikami](https://osu.ppy.sh/users/1929336) | [#1](https://osu.ppy.sh/community/matches/71776576) |
-| A | ![][flag_ID] [fnayR](https://osu.ppy.sh/users/2800253) | 2 | **5** | ![][flag_SG] **[kirkirs](https://osu.ppy.sh/users/9902622)** | [#1](https://osu.ppy.sh/community/matches/71779488) |
-| H | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | **5** | 0 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/71779990) |
-| P | ![][flag_PH] [ishokuP](https://osu.ppy.sh/users/7309033) | 1 | **5** | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | [#1](https://osu.ppy.sh/community/matches/71779846) |
-| L | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | **5** | 1 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/71779753) |
-| E | ![][flag_SG] **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** | **5** | 2 | ![][flag_MY] [not\_aweeb](https://osu.ppy.sh/users/9375317) | [#1](https://osu.ppy.sh/community/matches/71779566) |
-| M | ![][flag_MY] [Rampax](https://osu.ppy.sh/users/3995630) | 2 | **5** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | [#1](https://osu.ppy.sh/community/matches/71779824) |
-| F | ![][flag_TH] [- Seen -](https://osu.ppy.sh/users/5082392) | 1 | **5** | ![][flag_PH] **[KagenoKami](https://osu.ppy.sh/users/7246165)** | [#1](https://osu.ppy.sh/community/matches/71783318) |
-| D | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7537133)** | **5** | 4 | ![][flag_SG] [Eagle5324](https://osu.ppy.sh/users/11987104) | [#1](https://osu.ppy.sh/community/matches/71785974) |
-| B | ![][flag_MY] **[Sonic-](https://osu.ppy.sh/users/8691555)** | **5** | 4 | ![][flag_ID] [honeymint](https://osu.ppy.sh/users/4796773) | [#1](https://osu.ppy.sh/community/matches/71783048) |
-| D | ![][flag_MY] [heyimcrunchy](https://osu.ppy.sh/users/13067221) | 4 | **5** | ![][flag_MY] **[Auxuelus](https://osu.ppy.sh/users/5414124)** | [#1](https://osu.ppy.sh/community/matches/71783318) |
-| E | ![][flag_SG] **[DVDthe1st](https://osu.ppy.sh/users/2138989)** | **5** | 4 | ![][flag_TH] [Chorus](https://osu.ppy.sh/users/3504692) | [#1](https://osu.ppy.sh/community/matches/71783061) |
-| G | ![][flag_VN] **[Hoaq](https://osu.ppy.sh/users/7696512)** | **5** | 4 | ![][flag_MY] [malaidan](https://osu.ppy.sh/users/14279913) | [#1](https://osu.ppy.sh/community/matches/71783078) |
-| L | ![][flag_MY] **[Tzero](https://osu.ppy.sh/users/6088976)** | **5** | 2 | ![][flag_SG] [m0fum0fu](https://osu.ppy.sh/users/5143605) | [#1](https://osu.ppy.sh/community/matches/71786446) |
-| O | ![][flag_PH] **[konawiki](https://osu.ppy.sh/users/4003979)** | **5** | 2 | ![][flag_PH] [Milkteaism](https://osu.ppy.sh/users/9642774) | [#1](https://osu.ppy.sh/community/matches/71786349) |
-| F | ![][flag_ID] **[Vinno](https://osu.ppy.sh/users/10717635)** | **5** | 3 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/8055861) | [#1](https://osu.ppy.sh/community/matches/71829083) |
-| H | ![][flag_PH] [tiny snek](https://osu.ppy.sh/users/10619389) | 0 | **5** | ![][flag_TH] **[Faken](https://osu.ppy.sh/users/10249166)** | *win by default* |
-| P | ![][flag_SG] **[Demonical](https://osu.ppy.sh/users/5447609)** | **5** | 0 | ![][flag_PH] [Xyloz](https://osu.ppy.sh/users/12040280) | *win by default* |
-| L | ![][flag_SG] **[m0fum0fu](https://osu.ppy.sh/users/5143605)** | **5** | 0 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | *win by default* |
+| G | **[Rexeez](https://osu.ppy.sh/users/1987591)** ![][flag_ID] | **5** | 0 | ![][flag_MY] [Heya](https://osu.ppy.sh/users/11379332) | [#1](https://osu.ppy.sh/community/matches/71786110) |
+| I | [alphaplay](https://osu.ppy.sh/users/9304966) ![][flag_MY] | 0 | **5** | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | [#1](https://osu.ppy.sh/community/matches/71782839) |
+| K | [RePeaTT](https://osu.ppy.sh/users/11132323) ![][flag_SG] | 4 | **5** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/71776736) |
+| C | [CookieDASH](https://osu.ppy.sh/users/8249895) ![][flag_MY] | 3 | **5** | ![][flag_PH] **[Oooodriiin](https://osu.ppy.sh/users/7223737)** | [#1](https://osu.ppy.sh/community/matches/71776736) |
+| I | **[k\_1tty](https://osu.ppy.sh/users/5407620)** ![][flag_SG] | **5** | 1 | ![][flag_ID] [Suikami](https://osu.ppy.sh/users/1929336) | [#1](https://osu.ppy.sh/community/matches/71776576) |
+| A | [fnayR](https://osu.ppy.sh/users/2800253) ![][flag_ID] | 2 | **5** | ![][flag_SG] **[kirkirs](https://osu.ppy.sh/users/9902622)** | [#1](https://osu.ppy.sh/community/matches/71779488) |
+| H | **[Rtyzen](https://osu.ppy.sh/users/2439822)** ![][flag_SG] | **5** | 0 | ![][flag_VN] [Tuon](https://osu.ppy.sh/users/6673790) | [#1](https://osu.ppy.sh/community/matches/71779990) |
+| P | [ishokuP](https://osu.ppy.sh/users/7309033) ![][flag_PH] | 1 | **5** | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | [#1](https://osu.ppy.sh/community/matches/71779846) |
+| L | **[MioMilo](https://osu.ppy.sh/users/2199427)** ![][flag_PH] | **5** | 1 | ![][flag_MY] [Tzero](https://osu.ppy.sh/users/6088976) | [#1](https://osu.ppy.sh/community/matches/71779753) |
+| E | **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** ![][flag_SG] | **5** | 2 | ![][flag_MY] [not\_aweeb](https://osu.ppy.sh/users/9375317) | [#1](https://osu.ppy.sh/community/matches/71779566) |
+| M | [Rampax](https://osu.ppy.sh/users/3995630) ![][flag_MY] | 2 | **5** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | [#1](https://osu.ppy.sh/community/matches/71779824) |
+| F | [- Seen -](https://osu.ppy.sh/users/5082392) ![][flag_TH] | 1 | **5** | ![][flag_PH] **[KagenoKami](https://osu.ppy.sh/users/7246165)** | [#1](https://osu.ppy.sh/community/matches/71783318) |
+| D | **[megumic](https://osu.ppy.sh/users/7537133)** ![][flag_SG] | **5** | 4 | ![][flag_SG] [Eagle5324](https://osu.ppy.sh/users/11987104) | [#1](https://osu.ppy.sh/community/matches/71785974) |
+| B | **[Sonic-](https://osu.ppy.sh/users/8691555)** ![][flag_MY] | **5** | 4 | ![][flag_ID] [honeymint](https://osu.ppy.sh/users/4796773) | [#1](https://osu.ppy.sh/community/matches/71783048) |
+| D | [heyimcrunchy](https://osu.ppy.sh/users/13067221) ![][flag_MY] | 4 | **5** | ![][flag_MY] **[Auxuelus](https://osu.ppy.sh/users/5414124)** | [#1](https://osu.ppy.sh/community/matches/71783318) |
+| E | **[DVDthe1st](https://osu.ppy.sh/users/2138989)** ![][flag_SG] | **5** | 4 | ![][flag_TH] [Chorus](https://osu.ppy.sh/users/3504692) | [#1](https://osu.ppy.sh/community/matches/71783061) |
+| G | **[Hoaq](https://osu.ppy.sh/users/7696512)** ![][flag_VN] | **5** | 4 | ![][flag_MY] [malaidan](https://osu.ppy.sh/users/14279913) | [#1](https://osu.ppy.sh/community/matches/71783078) |
+| L | **[Tzero](https://osu.ppy.sh/users/6088976)** ![][flag_MY] | **5** | 2 | ![][flag_SG] [m0fum0fu](https://osu.ppy.sh/users/5143605) | [#1](https://osu.ppy.sh/community/matches/71786446) |
+| O | **[konawiki](https://osu.ppy.sh/users/4003979)** ![][flag_PH] | **5** | 2 | ![][flag_PH] [Milkteaism](https://osu.ppy.sh/users/9642774) | [#1](https://osu.ppy.sh/community/matches/71786349) |
+| F | **[Vinno](https://osu.ppy.sh/users/10717635)** ![][flag_ID] | **5** | 3 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/8055861) | [#1](https://osu.ppy.sh/community/matches/71829083) |
+| H | [tiny snek](https://osu.ppy.sh/users/10619389) ![][flag_PH] | 0 | **5** | ![][flag_TH] **[Faken](https://osu.ppy.sh/users/10249166)** | *win by default* |
+| P | **[Demonical](https://osu.ppy.sh/users/5447609)** ![][flag_SG] | **5** | 0 | ![][flag_PH] [Xyloz](https://osu.ppy.sh/users/12040280) | *win by default* |
+| L | **[m0fum0fu](https://osu.ppy.sh/users/5143605)** ![][flag_SG] | **5** | 0 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | *win by default* |
 
 Saturday, 19 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| B | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | **5** | 0 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/71848362) |
-| H | ![][flag_MY] [Agagak](https://osu.ppy.sh/users/3645490) | 2 | **5** | ![][flag_SG] **[woahsia](https://osu.ppy.sh/users/195946)** | [#1](https://osu.ppy.sh/community/matches/71847333) |
-| J | ![][flag_TH] [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) | 0 | **5** | ![][flag_ID] **[Fayn](https://osu.ppy.sh/users/5390495)** | [#1](https://osu.ppy.sh/community/matches/71848086) |
-| N | ![][flag_LA] **[Lessrtrer](https://osu.ppy.sh/users/11038623)** | **5** | 4 | ![][flag_PH] [fixedbyglue](https://osu.ppy.sh/users/8296269) | [#1](https://osu.ppy.sh/community/matches/71850852) |
-| O | ![][flag_PH] [-Graigory-](https://osu.ppy.sh/users/14024170) | 4 | **5** | ![][flag_MY] **[Computer Badger](https://osu.ppy.sh/users/6893361)** | [#1](https://osu.ppy.sh/community/matches/71838335) |
-| K | ![][flag_SG] [SeeL](https://osu.ppy.sh/users/5104320) | 0 | **5** | ![][flag_US] (![][flag_PH]) **[\_Kolin](https://osu.ppy.sh/users/7249644)** | [#1](https://osu.ppy.sh/community/matches/71837577) |
-| N | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **5** | 1 | ![][flag_SG] [Rtzero](https://osu.ppy.sh/users/9262462) | [#1](https://osu.ppy.sh/community/matches/71837512) |
-| K | ![][flag_SG] **[Lunarsol](https://osu.ppy.sh/users/6622650)** | **5** | 3 | ![][flag_PH] [Revillica](https://osu.ppy.sh/users/9806095) | [#1](https://osu.ppy.sh/community/matches/71837416) |
-| D | ![][flag_ID] **[CubeixID200](https://osu.ppy.sh/users/10678919)** | **5** | 1 | ![][flag_PH] [Aryuii](https://osu.ppy.sh/users/11272208) | [#1](https://osu.ppy.sh/community/matches/71840806) |
-| A | ![][flag_MY] **[Chizu-Kun](https://osu.ppy.sh/users/10288461)** | **5** | 1 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/71840786) |
-| I | ![][flag_MY] **[verdas123](https://osu.ppy.sh/users/11148851)** | **5** | 4 | ![][flag_PH] [FrostIce](https://osu.ppy.sh/users/8238365) | [#1](https://osu.ppy.sh/community/matches/71840838) |
-| B | ![][flag_PH] [Senjuro](https://osu.ppy.sh/users/3003839) | 1 | **5** | ![][flag_MY] **[vernonlim](https://osu.ppy.sh/users/10167542)** | [#1](https://osu.ppy.sh/community/matches/71844042) |
-| N | ![][flag_SG] [Hecatia](https://osu.ppy.sh/users/8244635) | 4 | **5** | ![][flag_ID] **[Firia](https://osu.ppy.sh/users/9730262)** | [#1](https://osu.ppy.sh/community/matches/71839128) |
-| J | ![][flag_PH] [xidorn](https://osu.ppy.sh/users/7904667) | 2 | **5** | ![][flag_SG] **[oneplusone](https://osu.ppy.sh/users/1843447)** | [#1](https://osu.ppy.sh/community/matches/71845910) |
-| C | ![][flag_ID] **[Bunan-](https://osu.ppy.sh/users/2763354)** | **5** | 4 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/71845935) |
-| F | ![][flag_MY] **[Ayameru](https://osu.ppy.sh/users/7373182)** | **5** | 3 | ![][flag_MY] [Rawn](https://osu.ppy.sh/users/2621067) | [#1](https://osu.ppy.sh/community/matches/71848034) |
-| N | ![][flag_SG] **[Rtzero](https://osu.ppy.sh/users/9262462)** | **5** | 4 | ![][flag_ID] [Firia](https://osu.ppy.sh/users/9730262) | [#1](https://osu.ppy.sh/community/matches/71840868) |
-| A | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **5** | 1 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/71850882) |
-| K | ![][flag_SG] **[SeeL](https://osu.ppy.sh/users/5104320)** | **5** | 2 | ![][flag_SG] [Lunarsol](https://osu.ppy.sh/users/6622650) | [#1](https://osu.ppy.sh/community/matches/71840661) |
-| E | ![][flag_SG] [yayatutu135](https://osu.ppy.sh/users/8420023) | 3 | **5** | ![][flag_TH] **[Iambosszie](https://osu.ppy.sh/users/7286850)** | [#1](https://osu.ppy.sh/community/matches/71850717) |
-| L | ![][flag_VN] **[sindes19](https://osu.ppy.sh/users/11021073)** | **5** | 2 | ![][flag_PH] [MarvelWizardKH](https://osu.ppy.sh/users/5356586) | [#1](https://osu.ppy.sh/community/matches/71850844) |
-| C | ![][flag_PH] **[Rammu](https://osu.ppy.sh/users/10652837)** | **5** | 3 | ![][flag_MY] [DuoX](https://osu.ppy.sh/users/9560694) | [#1](https://osu.ppy.sh/community/matches/71850702) |
-| H | ![][flag_VN] **[Tuon](https://osu.ppy.sh/users/6673790)** | **5** | 3 | ![][flag_SG] [woahsia](https://osu.ppy.sh/users/195946) | [#1](https://osu.ppy.sh/community/matches/71854343) |
-| C | ![][flag_SG] **[ExImperia](https://osu.ppy.sh/users/5200499)** | **5** | 1 | ![][flag_PH] [Oooodriiin](https://osu.ppy.sh/users/7223737) | [#1](https://osu.ppy.sh/community/matches/71854335) |
-| K | ![][flag_PH] [Revillica](https://osu.ppy.sh/users/9806095) | 1 | **5** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/71856892) |
-| D | ![][flag_SG] **[Eagle5324](https://osu.ppy.sh/users/11987104)** | **5** | 1 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/71856880) |
-| I | ![][flag_ID] [Suikami](https://osu.ppy.sh/users/1929336) | 2 | **5** | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | [#1](https://osu.ppy.sh/community/matches/71856888) |
-| P | ![][flag_PH] [Xyloz](https://osu.ppy.sh/users/12040280) | 0 | **5** | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | *win by default* |
-| O | ![][flag_MY] [Yaro](https://osu.ppy.sh/users/9196013) | 0 | **5** | ![][flag_SG] **[Milk Tee](https://osu.ppy.sh/users/6708955)** | *win by default* |
-| L | ![][flag_PH] **[MarvelWizardKH](https://osu.ppy.sh/users/5356586)** | **5** | 0 | ![][flag_VN] [Llama\_The\_Goat](https://osu.ppy.sh/users/11232450) | *win by default* |
-| E | ![][flag_MY] **[not\_aweeb](https://osu.ppy.sh/users/9375317)** | **5** | 0 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/9375317) | *win by default* |
-| J | ![][flag_MY] **[Flashback9](https://osu.ppy.sh/users/7714136)** | **5** | 0 | ![][flag_VN] [Phoeni\_](https://osu.ppy.sh/users/14953642) | *win by default* |
-| E | ![][flag_TH] [Iambosszie](https://osu.ppy.sh/users/7286850) | 0 | **5** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | *win by default* |
-| M | ![][flag_ID] [Walfrid](https://osu.ppy.sh/users/6600809) | 0 | **5** | ![][flag_BN] **[Daynem W](https://osu.ppy.sh/users/4699134)** | *win by default* |
+| B | **[Fuma](https://osu.ppy.sh/users/1501956)** ![][flag_ID] | **5** | 0 | ![][flag_SG] [moosepi](https://osu.ppy.sh/users/1868745) | [#1](https://osu.ppy.sh/community/matches/71848362) |
+| H | [Agagak](https://osu.ppy.sh/users/3645490) ![][flag_MY] | 2 | **5** | ![][flag_SG] **[woahsia](https://osu.ppy.sh/users/195946)** | [#1](https://osu.ppy.sh/community/matches/71847333) |
+| J | [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) ![][flag_TH] | 0 | **5** | ![][flag_ID] **[Fayn](https://osu.ppy.sh/users/5390495)** | [#1](https://osu.ppy.sh/community/matches/71848086) |
+| N | **[Lessrtrer](https://osu.ppy.sh/users/11038623)** ![][flag_LA] | **5** | 4 | ![][flag_PH] [fixedbyglue](https://osu.ppy.sh/users/8296269) | [#1](https://osu.ppy.sh/community/matches/71850852) |
+| O | [-Graigory-](https://osu.ppy.sh/users/14024170) ![][flag_PH] | 4 | **5** | ![][flag_MY] **[Computer Badger](https://osu.ppy.sh/users/6893361)** | [#1](https://osu.ppy.sh/community/matches/71838335) |
+| K | [SeeL](https://osu.ppy.sh/users/5104320) ![][flag_SG] | 0 | **5** | ![][flag_US] (![][flag_PH]) **[\_Kolin](https://osu.ppy.sh/users/7249644)** | [#1](https://osu.ppy.sh/community/matches/71837577) |
+| N | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **5** | 1 | ![][flag_SG] [Rtzero](https://osu.ppy.sh/users/9262462) | [#1](https://osu.ppy.sh/community/matches/71837512) |
+| K | **[Lunarsol](https://osu.ppy.sh/users/6622650)** ![][flag_SG] | **5** | 3 | ![][flag_PH] [Revillica](https://osu.ppy.sh/users/9806095) | [#1](https://osu.ppy.sh/community/matches/71837416) |
+| D | **[CubeixID200](https://osu.ppy.sh/users/10678919)** ![][flag_ID] | **5** | 1 | ![][flag_PH] [Aryuii](https://osu.ppy.sh/users/11272208) | [#1](https://osu.ppy.sh/community/matches/71840806) |
+| A | **[Chizu-Kun](https://osu.ppy.sh/users/10288461)** ![][flag_MY] | **5** | 1 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/71840786) |
+| I | **[verdas123](https://osu.ppy.sh/users/11148851)** ![][flag_MY] | **5** | 4 | ![][flag_PH] [FrostIce](https://osu.ppy.sh/users/8238365) | [#1](https://osu.ppy.sh/community/matches/71840838) |
+| B | [Senjuro](https://osu.ppy.sh/users/3003839) ![][flag_PH] | 1 | **5** | ![][flag_MY] **[vernonlim](https://osu.ppy.sh/users/10167542)** | [#1](https://osu.ppy.sh/community/matches/71844042) |
+| N | [Hecatia](https://osu.ppy.sh/users/8244635) ![][flag_SG] | 4 | **5** | ![][flag_ID] **[Firia](https://osu.ppy.sh/users/9730262)** | [#1](https://osu.ppy.sh/community/matches/71839128) |
+| J | [xidorn](https://osu.ppy.sh/users/7904667) ![][flag_PH] | 2 | **5** | ![][flag_SG] **[oneplusone](https://osu.ppy.sh/users/1843447)** | [#1](https://osu.ppy.sh/community/matches/71845910) |
+| C | **[Bunan-](https://osu.ppy.sh/users/2763354)** ![][flag_ID] | **5** | 4 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/71845935) |
+| F | **[Ayameru](https://osu.ppy.sh/users/7373182)** ![][flag_MY] | **5** | 3 | ![][flag_MY] [Rawn](https://osu.ppy.sh/users/2621067) | [#1](https://osu.ppy.sh/community/matches/71848034) |
+| N | **[Rtzero](https://osu.ppy.sh/users/9262462)** ![][flag_SG] | **5** | 4 | ![][flag_ID] [Firia](https://osu.ppy.sh/users/9730262) | [#1](https://osu.ppy.sh/community/matches/71840868) |
+| A | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **5** | 1 | ![][flag_PH] [zonelouise](https://osu.ppy.sh/users/1492995) | [#1](https://osu.ppy.sh/community/matches/71850882) |
+| K | **[SeeL](https://osu.ppy.sh/users/5104320)** ![][flag_SG] | **5** | 2 | ![][flag_SG] [Lunarsol](https://osu.ppy.sh/users/6622650) | [#1](https://osu.ppy.sh/community/matches/71840661) |
+| E | [yayatutu135](https://osu.ppy.sh/users/8420023) ![][flag_SG] | 3 | **5** | ![][flag_TH] **[Iambosszie](https://osu.ppy.sh/users/7286850)** | [#1](https://osu.ppy.sh/community/matches/71850717) |
+| L | **[sindes19](https://osu.ppy.sh/users/11021073)** ![][flag_VN] | **5** | 2 | ![][flag_PH] [MarvelWizardKH](https://osu.ppy.sh/users/5356586) | [#1](https://osu.ppy.sh/community/matches/71850844) |
+| C | **[Rammu](https://osu.ppy.sh/users/10652837)** ![][flag_PH] | **5** | 3 | ![][flag_MY] [DuoX](https://osu.ppy.sh/users/9560694) | [#1](https://osu.ppy.sh/community/matches/71850702) |
+| H | **[Tuon](https://osu.ppy.sh/users/6673790)** ![][flag_VN] | **5** | 3 | ![][flag_SG] [woahsia](https://osu.ppy.sh/users/195946) | [#1](https://osu.ppy.sh/community/matches/71854343) |
+| C | **[ExImperia](https://osu.ppy.sh/users/5200499)** ![][flag_SG] | **5** | 1 | ![][flag_PH] [Oooodriiin](https://osu.ppy.sh/users/7223737) | [#1](https://osu.ppy.sh/community/matches/71854335) |
+| K | [Revillica](https://osu.ppy.sh/users/9806095) ![][flag_PH] | 1 | **5** | ![][flag_SG] **[\_gt](https://osu.ppy.sh/users/8301957)** | [#1](https://osu.ppy.sh/community/matches/71856892) |
+| D | **[Eagle5324](https://osu.ppy.sh/users/11987104)** ![][flag_SG] | **5** | 1 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/71856880) |
+| I | [Suikami](https://osu.ppy.sh/users/1929336) ![][flag_ID] | 2 | **5** | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | [#1](https://osu.ppy.sh/community/matches/71856888) |
+| P | [Xyloz](https://osu.ppy.sh/users/12040280) ![][flag_PH] | 0 | **5** | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | *win by default* |
+| O | [Yaro](https://osu.ppy.sh/users/9196013) ![][flag_MY] | 0 | **5** | ![][flag_SG] **[Milk Tee](https://osu.ppy.sh/users/6708955)** | *win by default* |
+| L | **[MarvelWizardKH](https://osu.ppy.sh/users/5356586)** ![][flag_PH] | **5** | 0 | ![][flag_VN] [Llama\_The\_Goat](https://osu.ppy.sh/users/11232450) | *win by default* |
+| E | **[not\_aweeb](https://osu.ppy.sh/users/9375317)** ![][flag_MY] | **5** | 0 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/9375317) | *win by default* |
+| J | **[Flashback9](https://osu.ppy.sh/users/7714136)** ![][flag_MY] | **5** | 0 | ![][flag_VN] [Phoeni\_](https://osu.ppy.sh/users/14953642) | *win by default* |
+| E | [Iambosszie](https://osu.ppy.sh/users/7286850) ![][flag_TH] | 0 | **5** | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | *win by default* |
+| M | [Walfrid](https://osu.ppy.sh/users/6600809) ![][flag_ID] | 0 | **5** | ![][flag_BN] **[Daynem W](https://osu.ppy.sh/users/4699134)** | *win by default* |
 
 Sunday, 20 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| N | ![][flag_SG] **[Hecatia](https://osu.ppy.sh/users/8244635)** | **5** | 4 | ![][flag_LA] [Lessrtrer](https://osu.ppy.sh/users/11038623) | [#1](https://osu.ppy.sh/community/matches/71856901) |
-| P | ![][flag_PH] [ishokuP](https://osu.ppy.sh/users/7309033) | 2 | **5** | ![][flag_PH] **[Kagitingan](https://osu.ppy.sh/users/7407323)** | [#1](https://osu.ppy.sh/community/matches/71901385) |
-| M | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | **5** | 0 | ![][flag_BN] [Daynem W](https://osu.ppy.sh/users/4699134) | [#1](https://osu.ppy.sh/community/matches/71910253) |
-| F | ![][flag_PH] **[Zyxus](https://osu.ppy.sh/users/8055861)** | **5** | 1 | ![][flag_MY] [Ayameru](https://osu.ppy.sh/users/7373182) | [#1](https://osu.ppy.sh/community/matches/71901905) |
-| G | ![][flag_SG] [Deze](https://osu.ppy.sh/users/7638335) | 1 | **5** | ![][flag_ID] **[Venta](https://osu.ppy.sh/users/11320627)** | [#1](https://osu.ppy.sh/community/matches/71905092) |
-| A | ![][flag_SG] **[Moltenfury](https://osu.ppy.sh/users/3395820)** | **5** | 2 | ![][flag_SG] [kirkirs](https://osu.ppy.sh/users/9902622) | [#1](https://osu.ppy.sh/community/matches/71905072) |
-| M | ![][flag_MY] **[decaykets](https://osu.ppy.sh/users/3404543)** | **5** | 2 | ![][flag_SG] [Shleepy](https://osu.ppy.sh/users/8486823) | [#1](https://osu.ppy.sh/community/matches/71905077) |
-| I | ![][flag_MY] [alphaplay](https://osu.ppy.sh/users/9304966) | 4 | **5** | ![][flag_MY] **[verdas123](https://osu.ppy.sh/users/11148851)** | [#1](https://osu.ppy.sh/community/matches/71905118) |
-| F | ![][flag_TH] [- Seen -](https://osu.ppy.sh/users/5082392) | 0 | **5** | ![][flag_ID] **[Vinno](https://osu.ppy.sh/users/10717635)** | [#1](https://osu.ppy.sh/community/matches/71912308) |
-| B | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | **5** | 1 | ![][flag_MY] [Sonic-](https://osu.ppy.sh/users/8691555) | [#1](https://osu.ppy.sh/community/matches/71905077) |
-| M | ![][flag_ID] **[Walfrid](https://osu.ppy.sh/users/6600809)** | **5** | 2 | ![][flag_MY] [decaykets](https://osu.ppy.sh/users/3404543) | [#1](https://osu.ppy.sh/community/matches/71912284) |
-| O | ![][flag_PH] **[Milkteaism](https://osu.ppy.sh/users/9642774)** | **5** | 1 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | [#1](https://osu.ppy.sh/community/matches/71915100) |
-| C | ![][flag_MY] **[DuoX](https://osu.ppy.sh/users/9560694)** | **5** | 1 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/71915387) |
-| A | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | **5** | 1 | ![][flag_MY] [Chizu-Kun](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71914805) |
-| G | ![][flag_SG] [Deze](https://osu.ppy.sh/users/7638335) | 0 | **5** | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | [#1](https://osu.ppy.sh/community/matches/71918346) |
-| B | ![][flag_SG] **[moosepi](https://osu.ppy.sh/users/1868745)** | **5** | 2 | ![][flag_MY] [vernonlim](https://osu.ppy.sh/users/10167542) | [#1](https://osu.ppy.sh/community/matches/71915355) |
-| H | ![][flag_MY] **[Agagak](https://osu.ppy.sh/users/3645490)** | **5** | 1 | ![][flag_TH] [Faken](https://osu.ppy.sh/users/10249166) | [#1](https://osu.ppy.sh/community/matches/71915406) |
-| O | ![][flag_MY] [Yaro](https://osu.ppy.sh/users/9196013) | 2 | **5** | ![][flag_MY] **[Computer Badger](https://osu.ppy.sh/users/6893361)** | [#1](https://osu.ppy.sh/community/matches/71920580) |
-| J | ![][flag_TH] [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) | 4 | **5** | ![][flag_MY] **[Flashback9](https://osu.ppy.sh/users/7714136)** | [#1](https://osu.ppy.sh/community/matches/71973260) |
-| P | ![][flag_PH] **[Kagitingan](https://osu.ppy.sh/users/7407323)** | **5** | 0 | ![][flag_SG] [fausion](https://osu.ppy.sh/users/12261210) | *win by default* |
-| D | ![][flag_MY] **[heyimcrunchy](https://osu.ppy.sh/users/13067221)** | **5** | 0 | ![][flag_ID] [CubeixID200](https://osu.ppy.sh/users/10678919) | *win by default* |
-| J | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | **5** | 0 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | *win by default* |
-| G | ![][flag_MY] [Heya](https://osu.ppy.sh/users/11379332) | 0 | **5** | ![][flag_VN] **[Hoaq](https://osu.ppy.sh/users/7696512)** | *win by default* |
+| N | **[Hecatia](https://osu.ppy.sh/users/8244635)** ![][flag_SG] | **5** | 4 | ![][flag_LA] [Lessrtrer](https://osu.ppy.sh/users/11038623) | [#1](https://osu.ppy.sh/community/matches/71856901) |
+| P | [ishokuP](https://osu.ppy.sh/users/7309033) ![][flag_PH] | 2 | **5** | ![][flag_PH] **[Kagitingan](https://osu.ppy.sh/users/7407323)** | [#1](https://osu.ppy.sh/community/matches/71901385) |
+| M | **[Rampax](https://osu.ppy.sh/users/3995630)** ![][flag_MY] | **5** | 0 | ![][flag_BN] [Daynem W](https://osu.ppy.sh/users/4699134) | [#1](https://osu.ppy.sh/community/matches/71910253) |
+| F | **[Zyxus](https://osu.ppy.sh/users/8055861)** ![][flag_PH] | **5** | 1 | ![][flag_MY] [Ayameru](https://osu.ppy.sh/users/7373182) | [#1](https://osu.ppy.sh/community/matches/71901905) |
+| G | [Deze](https://osu.ppy.sh/users/7638335) ![][flag_SG] | 1 | **5** | ![][flag_ID] **[Venta](https://osu.ppy.sh/users/11320627)** | [#1](https://osu.ppy.sh/community/matches/71905092) |
+| A | **[Moltenfury](https://osu.ppy.sh/users/3395820)** ![][flag_SG] | **5** | 2 | ![][flag_SG] [kirkirs](https://osu.ppy.sh/users/9902622) | [#1](https://osu.ppy.sh/community/matches/71905072) |
+| M | **[decaykets](https://osu.ppy.sh/users/3404543)** ![][flag_MY] | **5** | 2 | ![][flag_SG] [Shleepy](https://osu.ppy.sh/users/8486823) | [#1](https://osu.ppy.sh/community/matches/71905077) |
+| I | [alphaplay](https://osu.ppy.sh/users/9304966) ![][flag_MY] | 4 | **5** | ![][flag_MY] **[verdas123](https://osu.ppy.sh/users/11148851)** | [#1](https://osu.ppy.sh/community/matches/71905118) |
+| F | [- Seen -](https://osu.ppy.sh/users/5082392) ![][flag_TH] | 0 | **5** | ![][flag_ID] **[Vinno](https://osu.ppy.sh/users/10717635)** | [#1](https://osu.ppy.sh/community/matches/71912308) |
+| B | **[Senjuro](https://osu.ppy.sh/users/3003839)** ![][flag_PH] | **5** | 1 | ![][flag_MY] [Sonic-](https://osu.ppy.sh/users/8691555) | [#1](https://osu.ppy.sh/community/matches/71905077) |
+| M | **[Walfrid](https://osu.ppy.sh/users/6600809)** ![][flag_ID] | **5** | 2 | ![][flag_MY] [decaykets](https://osu.ppy.sh/users/3404543) | [#1](https://osu.ppy.sh/community/matches/71912284) |
+| O | **[Milkteaism](https://osu.ppy.sh/users/9642774)** ![][flag_PH] | **5** | 1 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | [#1](https://osu.ppy.sh/community/matches/71915100) |
+| C | **[DuoX](https://osu.ppy.sh/users/9560694)** ![][flag_MY] | **5** | 1 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/71915387) |
+| A | **[zonelouise](https://osu.ppy.sh/users/1492995)** ![][flag_PH] | **5** | 1 | ![][flag_MY] [Chizu-Kun](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71914805) |
+| G | [Deze](https://osu.ppy.sh/users/7638335) ![][flag_SG] | 0 | **5** | ![][flag_ID] **[Rexeez](https://osu.ppy.sh/users/1987591)** | [#1](https://osu.ppy.sh/community/matches/71918346) |
+| B | **[moosepi](https://osu.ppy.sh/users/1868745)** ![][flag_SG] | **5** | 2 | ![][flag_MY] [vernonlim](https://osu.ppy.sh/users/10167542) | [#1](https://osu.ppy.sh/community/matches/71915355) |
+| H | **[Agagak](https://osu.ppy.sh/users/3645490)** ![][flag_MY] | **5** | 1 | ![][flag_TH] [Faken](https://osu.ppy.sh/users/10249166) | [#1](https://osu.ppy.sh/community/matches/71915406) |
+| O | [Yaro](https://osu.ppy.sh/users/9196013) ![][flag_MY] | 2 | **5** | ![][flag_MY] **[Computer Badger](https://osu.ppy.sh/users/6893361)** | [#1](https://osu.ppy.sh/community/matches/71920580) |
+| J | [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) ![][flag_TH] | 4 | **5** | ![][flag_MY] **[Flashback9](https://osu.ppy.sh/users/7714136)** | [#1](https://osu.ppy.sh/community/matches/71973260) |
+| P | **[Kagitingan](https://osu.ppy.sh/users/7407323)** ![][flag_PH] | **5** | 0 | ![][flag_SG] [fausion](https://osu.ppy.sh/users/12261210) | *win by default* |
+| D | **[heyimcrunchy](https://osu.ppy.sh/users/13067221)** ![][flag_MY] | **5** | 0 | ![][flag_ID] [CubeixID200](https://osu.ppy.sh/users/10678919) | *win by default* |
+| J | **[xidorn](https://osu.ppy.sh/users/7904667)** ![][flag_PH] | **5** | 0 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | *win by default* |
+| G | [Heya](https://osu.ppy.sh/users/11379332) ![][flag_MY] | 0 | **5** | ![][flag_VN] **[Hoaq](https://osu.ppy.sh/users/7696512)** | *win by default* |
 
 ### Group Stage week 1
 
@@ -623,79 +647,79 @@ Friday, 11 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| C | ![][flag_MY] [CookieDASH](https://osu.ppy.sh/users/8249895) | 2 | **5** | ![][flag_ID] **[Bunan-](https://osu.ppy.sh/users/2763354)** | [#1](https://osu.ppy.sh/community/matches/71354815) |
-| D | ![][flag_SG] **[Auxuelus](https://osu.ppy.sh/users/5414124)** | **5** | 0 | ![][flag_PH] [Aryuii](https://osu.ppy.sh/users/11272208) | [#1](https://osu.ppy.sh/community/matches/71352781) |
-| H | ![][flag_SG] **[woahsia](https://osu.ppy.sh/users/195946)** | **5** | 4 | ![][flag_TH] [Faken](https://osu.ppy.sh/users/10249166) | [#1](https://osu.ppy.sh/community/matches/71337505) |
-| A | ![][flag_MY] **[Chizu-Kun](https://osu.ppy.sh/users/10288461)** | **5** | 2 | ![][flag_ID] [fnayR](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71345549) |
-| B | ![][flag_MY] **[vernonlim](https://osu.ppy.sh/users/10167542)** | **5** | 0 | ![][flag_ID] [honeymint](https://osu.ppy.sh/users/4796773) | [#1](https://osu.ppy.sh/community/matches/71357848) |
-| G | ![][flag_VN] [Hoaq](https://osu.ppy.sh/users/7696512) | 1 | **5** | ![][flag_SG] **[Deze](https://osu.ppy.sh/users/7638335)** | [#1](https://osu.ppy.sh/community/matches/71357340) |
-| H | ![][flag_VN] **[Tuon](https://osu.ppy.sh/users/6673790)** | **5** | 4 | ![][flag_SG] [woahsia](https://osu.ppy.sh/users/195946) | [#1](https://osu.ppy.sh/community/matches/71357097) |
+| C | [CookieDASH](https://osu.ppy.sh/users/8249895) ![][flag_MY] | 2 | **5** | ![][flag_ID] **[Bunan-](https://osu.ppy.sh/users/2763354)** | [#1](https://osu.ppy.sh/community/matches/71354815) |
+| D | **[Auxuelus](https://osu.ppy.sh/users/5414124)** ![][flag_SG] | **5** | 0 | ![][flag_PH] [Aryuii](https://osu.ppy.sh/users/11272208) | [#1](https://osu.ppy.sh/community/matches/71352781) |
+| H | **[woahsia](https://osu.ppy.sh/users/195946)** ![][flag_SG] | **5** | 4 | ![][flag_TH] [Faken](https://osu.ppy.sh/users/10249166) | [#1](https://osu.ppy.sh/community/matches/71337505) |
+| A | **[Chizu-Kun](https://osu.ppy.sh/users/10288461)** ![][flag_MY] | **5** | 2 | ![][flag_ID] [fnayR](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71345549) |
+| B | **[vernonlim](https://osu.ppy.sh/users/10167542)** ![][flag_MY] | **5** | 0 | ![][flag_ID] [honeymint](https://osu.ppy.sh/users/4796773) | [#1](https://osu.ppy.sh/community/matches/71357848) |
+| G | [Hoaq](https://osu.ppy.sh/users/7696512) ![][flag_VN] | 1 | **5** | ![][flag_SG] **[Deze](https://osu.ppy.sh/users/7638335)** | [#1](https://osu.ppy.sh/community/matches/71357340) |
+| H | **[Tuon](https://osu.ppy.sh/users/6673790)** ![][flag_VN] | **5** | 4 | ![][flag_SG] [woahsia](https://osu.ppy.sh/users/195946) | [#1](https://osu.ppy.sh/community/matches/71357097) |
 
 Saturday, 12 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| N | ![][flag_ID] **[Firia](https://osu.ppy.sh/users/9730262)** | **5** | 0 | ![][flag_PH] [fixedbyglue](https://osu.ppy.sh/users/8296269) | [#1](https://osu.ppy.sh/community/matches/71420032) |
-| J | ![][flag_ID] **[Fayn](https://osu.ppy.sh/users/5390495)** | **5** | 0 | ![][flag_VN] [Phoeni\_](https://osu.ppy.sh/users/14953642) | [#1](https://osu.ppy.sh/community/matches/71423238) |
-| M | ![][flag_MY] [decaykets](https://osu.ppy.sh/users/3404543) | 3 | **5** | ![][flag_BN] **[Daynem W](https://osu.ppy.sh/users/4699134)** | [#1](https://osu.ppy.sh/community/matches/71422481) |
-| L | ![][flag_VN] **[sindes19](https://osu.ppy.sh/users/11021073)** | **5** | 0 | ![][flag_VN] [Llama\_The\_Goat](https://osu.ppy.sh/users/11232450) | [#1](https://osu.ppy.sh/community/matches/71422241) |
-| J | ![][flag_TH] **[\[AmPhyze\]](https://osu.ppy.sh/users/9552188)** | **5** | 3 | ![][flag_MY] [Flashback9](https://osu.ppy.sh/users/7714136) | [#1](https://osu.ppy.sh/community/matches/71364002) |
-| M | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | **5** | 0 | ![][flag_SG] [Shleepy](https://osu.ppy.sh/users/8486823) | [#1](https://osu.ppy.sh/community/matches/71365508) |
-| N | ![][flag_LA] [Lessrtrer](https://osu.ppy.sh/users/11038623) | 2 | **5** | ![][flag_SG] **[Hecatia](https://osu.ppy.sh/users/8244635)** | [#1](https://osu.ppy.sh/community/matches/71407439) |
-| K | ![][flag_SG] **[Lunarsol](https://osu.ppy.sh/users/6622650)** | **5** | 2 | ![][flag_SG] [RePeaTT](https://osu.ppy.sh/users/11132323) | [#1](https://osu.ppy.sh/community/matches/71409744) |
-| E | ![][flag_SG] **[DVDthe1st](https://osu.ppy.sh/users/2138989)** | **5** | 4 | ![][flag_SG] [yayatutu135](https://osu.ppy.sh/users/8420023) | [#1](https://osu.ppy.sh/community/matches/71409625) |
-| P | ![][flag_PH] **[ishokuP](https://osu.ppy.sh/users/7309033)** | **5** | 2 | ![][flag_PH] [Kagitingan](https://osu.ppy.sh/users/7407323) | [#1](https://osu.ppy.sh/community/matches/71411394) |
-| A | ![][flag_SG] **[Moltenfury](https://osu.ppy.sh/users/3395820)** | **5** | 3 | ![][flag_SG] [kirkirs](https://osu.ppy.sh/users/9902622) | [#1](https://osu.ppy.sh/community/matches/71414507) |
-| K | ![][flag_US] (![][flag_PH]) **[\_Kolin](https://osu.ppy.sh/users/3645490)** | **5** | 4 | ![][flag_SG] [\_gt](https://osu.ppy.sh/users/10619389) | [#1](https://osu.ppy.sh/community/matches/8301957) |
-| I | ![][flag_TH] **[Deppyforce](https://osu.ppy.sh/users/5286213)** | **5** | 0 | ![][flag_PH] [FrostIce](https://osu.ppy.sh/users/8238365) | [#1](https://osu.ppy.sh/community/matches/71420053) |
-| C | ![][flag_SG] **[ExImperia](https://osu.ppy.sh/users/5200499)** | **5** | 1 | ![][flag_PH] [Oooodriiin](https://osu.ppy.sh/users/7223737) | [#1](https://osu.ppy.sh/community/matches/71420035) |
-| K | ![][flag_SG] **[SeeL](https://osu.ppy.sh/users/5104320)** | **5** | 0 | ![][flag_SG] [Lunarsol](https://osu.ppy.sh/users/6622650) | [#1](https://osu.ppy.sh/community/matches/71411352) |
-| E | ![][flag_TH] **[Chorus](https://osu.ppy.sh/users/3504692)** | **5** | 0 | ![][flag_TH] [Iambosszie](https://osu.ppy.sh/users/7286850) | [#1](https://osu.ppy.sh/community/matches/71425225) |
-| M | ![][flag_ID] [Walfrid](https://osu.ppy.sh/users/6600809) | 2 | **5** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | [#1](https://osu.ppy.sh/community/matches/71428564) |
-| F | ![][flag_PH] **[Zyxus](https://osu.ppy.sh/users/8055861)** | **5** | 0 | ![][flag_MY] [Rawn](https://osu.ppy.sh/users/2621067) | [#1](https://osu.ppy.sh/community/matches/71428391) |
-| M | ![][flag_MY] **[Rampax](https://osu.ppy.sh/users/3995630)** | **5** | 0 | ![][flag_BN] [Daynem W](https://osu.ppy.sh/users/4699134) | [#1](https://osu.ppy.sh/community/matches/71428288) |
-| G | ![][flag_ID] **[ngonk](https://osu.ppy.sh/users/12030070)** | **5** | 2 | ![][flag_MY] [malaidan](https://osu.ppy.sh/users/14279913) | [#1](https://osu.ppy.sh/community/matches/71424988) |
-| I | ![][flag_MY] [verdas123](https://osu.ppy.sh/users/11148851) | 4 | **5** | ![][flag_MY] **[alphaplay](https://osu.ppy.sh/users/9304966)** | [#1](https://osu.ppy.sh/community/matches/71425280) |
-| D | ![][flag_MY] **[heyimcrunchy](https://osu.ppy.sh/users/13067221)** | **5** | 4 | ![][flag_ID] [CubeixID200](https://osu.ppy.sh/users/10678919) | [#1](https://osu.ppy.sh/community/matches/71428006) |
-| B | ![][flag_PH] **[Senjuro](https://osu.ppy.sh/users/3003839)** | **5** | 2 | ![][flag_MY] [Sonic-](https://osu.ppy.sh/users/8691555) | [#1](https://osu.ppy.sh/community/matches/71429558) |
-| D | ![][flag_SG] **[Eagle5324](https://osu.ppy.sh/users/11987104)** | **5** | 4 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/71431267) |
-| J | ![][flag_PH] **[xidorn](https://osu.ppy.sh/users/7904667)** | **5** | 4 | ![][flag_TH] [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) | [#1](https://osu.ppy.sh/community/matches/71431565) |
-| N | ![][flag_ID] **[Lifeline](https://osu.ppy.sh/users/11367222)** | **5** | 2 | ![][flag_SG] [Hecatia](https://osu.ppy.sh/users/8244635) | [#1](https://osu.ppy.sh/community/matches/71413017) |
-| E | ![][flag_SG] **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** | **5** | 0 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/2138989) | *win by default* |
-| N | ![][flag_SG] **[Rtzero](https://osu.ppy.sh/users/9262462)** | **5** | 0 | ![][flag_ID] [Firia](https://osu.ppy.sh/users/9730262) | *win by default* |
+| N | **[Firia](https://osu.ppy.sh/users/9730262)** ![][flag_ID] | **5** | 0 | ![][flag_PH] [fixedbyglue](https://osu.ppy.sh/users/8296269) | [#1](https://osu.ppy.sh/community/matches/71420032) |
+| J | **[Fayn](https://osu.ppy.sh/users/5390495)** ![][flag_ID] | **5** | 0 | ![][flag_VN] [Phoeni\_](https://osu.ppy.sh/users/14953642) | [#1](https://osu.ppy.sh/community/matches/71423238) |
+| M | [decaykets](https://osu.ppy.sh/users/3404543) ![][flag_MY] | 3 | **5** | ![][flag_BN] **[Daynem W](https://osu.ppy.sh/users/4699134)** | [#1](https://osu.ppy.sh/community/matches/71422481) |
+| L | **[sindes19](https://osu.ppy.sh/users/11021073)** ![][flag_VN] | **5** | 0 | ![][flag_VN] [Llama\_The\_Goat](https://osu.ppy.sh/users/11232450) | [#1](https://osu.ppy.sh/community/matches/71422241) |
+| J | **[\[AmPhyze\]](https://osu.ppy.sh/users/9552188)** ![][flag_TH] | **5** | 3 | ![][flag_MY] [Flashback9](https://osu.ppy.sh/users/7714136) | [#1](https://osu.ppy.sh/community/matches/71364002) |
+| M | **[Chiyuu](https://osu.ppy.sh/users/8226107)** ![][flag_MY] | **5** | 0 | ![][flag_SG] [Shleepy](https://osu.ppy.sh/users/8486823) | [#1](https://osu.ppy.sh/community/matches/71365508) |
+| N | [Lessrtrer](https://osu.ppy.sh/users/11038623) ![][flag_LA] | 2 | **5** | ![][flag_SG] **[Hecatia](https://osu.ppy.sh/users/8244635)** | [#1](https://osu.ppy.sh/community/matches/71407439) |
+| K | **[Lunarsol](https://osu.ppy.sh/users/6622650)** ![][flag_SG] | **5** | 2 | ![][flag_SG] [RePeaTT](https://osu.ppy.sh/users/11132323) | [#1](https://osu.ppy.sh/community/matches/71409744) |
+| E | **[DVDthe1st](https://osu.ppy.sh/users/2138989)** ![][flag_SG] | **5** | 4 | ![][flag_SG] [yayatutu135](https://osu.ppy.sh/users/8420023) | [#1](https://osu.ppy.sh/community/matches/71409625) |
+| P | **[ishokuP](https://osu.ppy.sh/users/7309033)** ![][flag_PH] | **5** | 2 | ![][flag_PH] [Kagitingan](https://osu.ppy.sh/users/7407323) | [#1](https://osu.ppy.sh/community/matches/71411394) |
+| A | **[Moltenfury](https://osu.ppy.sh/users/3395820)** ![][flag_SG] | **5** | 3 | ![][flag_SG] [kirkirs](https://osu.ppy.sh/users/9902622) | [#1](https://osu.ppy.sh/community/matches/71414507) |
+| K | **[\_Kolin](https://osu.ppy.sh/users/3645490)** ![][flag_US] (![][flag_PH]) | **5** | 4 | ![][flag_SG] [\_gt](https://osu.ppy.sh/users/10619389) | [#1](https://osu.ppy.sh/community/matches/8301957) |
+| I | **[Deppyforce](https://osu.ppy.sh/users/5286213)** ![][flag_TH] | **5** | 0 | ![][flag_PH] [FrostIce](https://osu.ppy.sh/users/8238365) | [#1](https://osu.ppy.sh/community/matches/71420053) |
+| C | **[ExImperia](https://osu.ppy.sh/users/5200499)** ![][flag_SG] | **5** | 1 | ![][flag_PH] [Oooodriiin](https://osu.ppy.sh/users/7223737) | [#1](https://osu.ppy.sh/community/matches/71420035) |
+| K | **[SeeL](https://osu.ppy.sh/users/5104320)** ![][flag_SG] | **5** | 0 | ![][flag_SG] [Lunarsol](https://osu.ppy.sh/users/6622650) | [#1](https://osu.ppy.sh/community/matches/71411352) |
+| E | **[Chorus](https://osu.ppy.sh/users/3504692)** ![][flag_TH] | **5** | 0 | ![][flag_TH] [Iambosszie](https://osu.ppy.sh/users/7286850) | [#1](https://osu.ppy.sh/community/matches/71425225) |
+| M | [Walfrid](https://osu.ppy.sh/users/6600809) ![][flag_ID] | 2 | **5** | ![][flag_MY] **[Chiyuu](https://osu.ppy.sh/users/8226107)** | [#1](https://osu.ppy.sh/community/matches/71428564) |
+| F | **[Zyxus](https://osu.ppy.sh/users/8055861)** ![][flag_PH] | **5** | 0 | ![][flag_MY] [Rawn](https://osu.ppy.sh/users/2621067) | [#1](https://osu.ppy.sh/community/matches/71428391) |
+| M | **[Rampax](https://osu.ppy.sh/users/3995630)** ![][flag_MY] | **5** | 0 | ![][flag_BN] [Daynem W](https://osu.ppy.sh/users/4699134) | [#1](https://osu.ppy.sh/community/matches/71428288) |
+| G | **[ngonk](https://osu.ppy.sh/users/12030070)** ![][flag_ID] | **5** | 2 | ![][flag_MY] [malaidan](https://osu.ppy.sh/users/14279913) | [#1](https://osu.ppy.sh/community/matches/71424988) |
+| I | [verdas123](https://osu.ppy.sh/users/11148851) ![][flag_MY] | 4 | **5** | ![][flag_MY] **[alphaplay](https://osu.ppy.sh/users/9304966)** | [#1](https://osu.ppy.sh/community/matches/71425280) |
+| D | **[heyimcrunchy](https://osu.ppy.sh/users/13067221)** ![][flag_MY] | **5** | 4 | ![][flag_ID] [CubeixID200](https://osu.ppy.sh/users/10678919) | [#1](https://osu.ppy.sh/community/matches/71428006) |
+| B | **[Senjuro](https://osu.ppy.sh/users/3003839)** ![][flag_PH] | **5** | 2 | ![][flag_MY] [Sonic-](https://osu.ppy.sh/users/8691555) | [#1](https://osu.ppy.sh/community/matches/71429558) |
+| D | **[Eagle5324](https://osu.ppy.sh/users/11987104)** ![][flag_SG] | **5** | 4 | ![][flag_MY] [Auxuelus](https://osu.ppy.sh/users/5414124) | [#1](https://osu.ppy.sh/community/matches/71431267) |
+| J | **[xidorn](https://osu.ppy.sh/users/7904667)** ![][flag_PH] | **5** | 4 | ![][flag_TH] [\[AmPhyze\]](https://osu.ppy.sh/users/9552188) | [#1](https://osu.ppy.sh/community/matches/71431565) |
+| N | **[Lifeline](https://osu.ppy.sh/users/11367222)** ![][flag_ID] | **5** | 2 | ![][flag_SG] [Hecatia](https://osu.ppy.sh/users/8244635) | [#1](https://osu.ppy.sh/community/matches/71413017) |
+| E | **[\[-Lockon-\]](https://osu.ppy.sh/users/6726331)** ![][flag_SG] | **5** | 0 | ![][flag_SG] [DVDthe1st](https://osu.ppy.sh/users/2138989) | *win by default* |
+| N | **[Rtzero](https://osu.ppy.sh/users/9262462)** ![][flag_SG] | **5** | 0 | ![][flag_ID] [Firia](https://osu.ppy.sh/users/9730262) | *win by default* |
 
 Sunday, 13 December 2020:
 
 | Group | Player 1 |  |  | Player 2 | Match link |
 | :-: | --: | :-: | :-: | :-- | :-- |
-| O | ![][flag_PH] **[Milkteaism](https://osu.ppy.sh/users/9642774)** | **5** | 4 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | [#1](https://osu.ppy.sh/community/matches/71477430) |
-| P | ![][flag_ID] **[Daffy](https://osu.ppy.sh/users/5968633)** | **5** | 0 | ![][flag_SG] [fausion](https://osu.ppy.sh/users/12261210) | [#1](https://osu.ppy.sh/community/matches/71477272) |
-| L | ![][flag_SG] **[m0fum0fu](https://osu.ppy.sh/users/5143605)** | **5** | 0 | ![][flag_PH] [MarvelWizardKH](https://osu.ppy.sh/users/5356586) | [#1](https://osu.ppy.sh/community/matches/71487424) |
-| J | ![][flag_SG] **[oneplusone](https://osu.ppy.sh/users/1843447)** | **5** | 3 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | [#1](https://osu.ppy.sh/community/matches/71470352) |
-| O | ![][flag_PH] [-Graigory-](https://osu.ppy.sh/users/14024170) | 2 | **5** | ![][flag_MY] **[Yaro](https://osu.ppy.sh/users/9196013)** | [#1](https://osu.ppy.sh/community/matches/71472275) |
-| P | ![][flag_SG] **[Demonical](https://osu.ppy.sh/users/5447609)** | **5** | 0 | ![][flag_PH] [ishokuP](https://osu.ppy.sh/users/7309033) | [#1](https://osu.ppy.sh/community/matches/71475877) |
-| F | ![][flag_TH] **[- Seen -](https://osu.ppy.sh/users/5082392)** | **5** | 3 | ![][flag_MY] [Ayameru](https://osu.ppy.sh/users/7373182) | [#1](https://osu.ppy.sh/community/matches/71475873) |
-| A | ![][flag_ID] **[Skydiver](https://osu.ppy.sh/users/4750008)** | **5** | 3 | ![][flag_MY] [Chizu-Kun](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71475866) |
-| H | ![][flag_SG] **[Rtyzen](https://osu.ppy.sh/users/2439822)** | **5** | 3 | ![][flag_MY] [Agagak](https://osu.ppy.sh/users/3645490) | [#1](https://osu.ppy.sh/community/matches/71477403) |
-| K | ![][flag_ID] [cfood](https://osu.ppy.sh/users/8626190) | 3 | **5** | ![][flag_US] (![][flag_PH]) **[\_Kolin](https://osu.ppy.sh/users/7249644)** | [#1](https://osu.ppy.sh/community/matches/71480763) |
-| O | ![][flag_SG] **[Milk Tee](https://osu.ppy.sh/users/6708955)** | **5** | 2 | ![][flag_MY] [Computer Badger](https://osu.ppy.sh/users/6893361) | [#1](https://osu.ppy.sh/community/matches/71467999) |
-| C | ![][flag_MY] **[DuoX](https://osu.ppy.sh/users/9560694)** | **5** | 2 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/71482803) |
-| B | ![][flag_SG] **[moosepi](https://osu.ppy.sh/users/1868745)** | **5** | 4 | ![][flag_MY] [vernonlim](https://osu.ppy.sh/users/10167542) | [#1](https://osu.ppy.sh/community/matches/71482715) |
-| F | ![][flag_ID] [Vinno](https://osu.ppy.sh/users/10717635) | 3 | **5** | ![][flag_TH] **[- Seen -](https://osu.ppy.sh/users/5082392)** | [#1](https://osu.ppy.sh/community/matches/71482814) |
-| I | ![][flag_ID] **[Suikami](https://osu.ppy.sh/users/1929336)** | **5** | 3 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/71483312) |
-| C | ![][flag_PH] **[Rammu](https://osu.ppy.sh/users/10652837)** | **5** | 0 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/71485163) |
-| G | ![][flag_ID] **[Venta](https://osu.ppy.sh/users/11320627)** | **5** | 4 | ![][flag_ID] [ngonk](https://osu.ppy.sh/users/12030070) | [#1](https://osu.ppy.sh/community/matches/71485030) |
-| I | ![][flag_ID] **[k\_1tty](https://osu.ppy.sh/users/11320627)** | **5** | 1 | ![][flag_MY] [alphaplay](https://osu.ppy.sh/users/9304966) | [#1](https://osu.ppy.sh/community/matches/71487526) |
-| P | ![][flag_PH] **[Xyloz](https://osu.ppy.sh/users/12040280)** | **5** | 3 | ![][flag_ID] [Daffy](https://osu.ppy.sh/users/5968633) | [#1](https://osu.ppy.sh/community/matches/71487542) |
-| L | ![][flag_PH] **[MioMilo](https://osu.ppy.sh/users/2199427)** | **5** | 1 | ![][flag_SG] [m0fum0fu](https://osu.ppy.sh/users/5143605) | [#1](https://osu.ppy.sh/community/matches/71490431) |
-| A | ![][flag_PH] **[zonelouise](https://osu.ppy.sh/users/1492995)** | **5** | 1 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/71489692) |
-| O | ![][flag_PH] **[konawiki](https://osu.ppy.sh/users/4003979)** | **5** | 0 | ![][flag_MY] [Yaro](https://osu.ppy.sh/users/9196013) | [#1](https://osu.ppy.sh/community/matches/71490433) |
-| F | ![][flag_PH] **[KagenoKami](https://osu.ppy.sh/users/7246165)** | **5** | 4 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/9196013) | [#1](https://osu.ppy.sh/community/matches/71490425) |
-| D | ![][flag_SG] **[megumic](https://osu.ppy.sh/users/7246165)** | **5** | 0 | ![][flag_MY] [heyimcrunchy](https://osu.ppy.sh/users/13067221) | [#1](https://osu.ppy.sh/community/matches/71490377) |
-| L | ![][flag_MY] **[Tzero](https://osu.ppy.sh/users/6088976)** | **5** | 3 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | [#1](https://osu.ppy.sh/community/matches/71493498) |
-| B | ![][flag_ID] **[Fuma](https://osu.ppy.sh/users/1501956)** | **5** | 1 | ![][flag_PH] [Senjuro](https://osu.ppy.sh/users/3003839) | [#1](https://osu.ppy.sh/community/matches/71487494) |
-| E | ![][flag_MY] **[not\_aweeb](https://osu.ppy.sh/users/9375317)** | **5** | 0 | ![][flag_TH] [Chorus](https://osu.ppy.sh/users/3504692) | *win by default* |
-| G | ![][flag_ID] [Rexeez](https://osu.ppy.sh/users/9375317) | 0 | **5** | ![][flag_SG] **[Deze](https://osu.ppy.sh/users/7638335)** | *win by default* |
+| O | **[Milkteaism](https://osu.ppy.sh/users/9642774)** ![][flag_PH] | **5** | 4 | ![][flag_SG] [Milk Tee](https://osu.ppy.sh/users/6708955) | [#1](https://osu.ppy.sh/community/matches/71477430) |
+| P | **[Daffy](https://osu.ppy.sh/users/5968633)** ![][flag_ID] | **5** | 0 | ![][flag_SG] [fausion](https://osu.ppy.sh/users/12261210) | [#1](https://osu.ppy.sh/community/matches/71477272) |
+| L | **[m0fum0fu](https://osu.ppy.sh/users/5143605)** ![][flag_SG] | **5** | 0 | ![][flag_PH] [MarvelWizardKH](https://osu.ppy.sh/users/5356586) | [#1](https://osu.ppy.sh/community/matches/71487424) |
+| J | **[oneplusone](https://osu.ppy.sh/users/1843447)** ![][flag_SG] | **5** | 3 | ![][flag_ID] [Fayn](https://osu.ppy.sh/users/5390495) | [#1](https://osu.ppy.sh/community/matches/71470352) |
+| O | [-Graigory-](https://osu.ppy.sh/users/14024170) ![][flag_PH] | 2 | **5** | ![][flag_MY] **[Yaro](https://osu.ppy.sh/users/9196013)** | [#1](https://osu.ppy.sh/community/matches/71472275) |
+| P | **[Demonical](https://osu.ppy.sh/users/5447609)** ![][flag_SG] | **5** | 0 | ![][flag_PH] [ishokuP](https://osu.ppy.sh/users/7309033) | [#1](https://osu.ppy.sh/community/matches/71475877) |
+| F | **[- Seen -](https://osu.ppy.sh/users/5082392)** ![][flag_TH] | **5** | 3 | ![][flag_MY] [Ayameru](https://osu.ppy.sh/users/7373182) | [#1](https://osu.ppy.sh/community/matches/71475873) |
+| A | **[Skydiver](https://osu.ppy.sh/users/4750008)** ![][flag_ID] | **5** | 3 | ![][flag_MY] [Chizu-Kun](https://osu.ppy.sh/users/10288461) | [#1](https://osu.ppy.sh/community/matches/71475866) |
+| H | **[Rtyzen](https://osu.ppy.sh/users/2439822)** ![][flag_SG] | **5** | 3 | ![][flag_MY] [Agagak](https://osu.ppy.sh/users/3645490) | [#1](https://osu.ppy.sh/community/matches/71477403) |
+| K | [cfood](https://osu.ppy.sh/users/8626190) ![][flag_ID] | 3 | **5** | ![][flag_US] (![][flag_PH]) **[\_Kolin](https://osu.ppy.sh/users/7249644)** | [#1](https://osu.ppy.sh/community/matches/71480763) |
+| O | **[Milk Tee](https://osu.ppy.sh/users/6708955)** ![][flag_SG] | **5** | 2 | ![][flag_MY] [Computer Badger](https://osu.ppy.sh/users/6893361) | [#1](https://osu.ppy.sh/community/matches/71467999) |
+| C | **[DuoX](https://osu.ppy.sh/users/9560694)** ![][flag_MY] | **5** | 2 | ![][flag_SG] [ExImperia](https://osu.ppy.sh/users/5200499) | [#1](https://osu.ppy.sh/community/matches/71482803) |
+| B | **[moosepi](https://osu.ppy.sh/users/1868745)** ![][flag_SG] | **5** | 4 | ![][flag_MY] [vernonlim](https://osu.ppy.sh/users/10167542) | [#1](https://osu.ppy.sh/community/matches/71482715) |
+| F | [Vinno](https://osu.ppy.sh/users/10717635) ![][flag_ID] | 3 | **5** | ![][flag_TH] **[- Seen -](https://osu.ppy.sh/users/5082392)** | [#1](https://osu.ppy.sh/community/matches/71482814) |
+| I | **[Suikami](https://osu.ppy.sh/users/1929336)** ![][flag_ID] | **5** | 3 | ![][flag_TH] [Deppyforce](https://osu.ppy.sh/users/5286213) | [#1](https://osu.ppy.sh/community/matches/71483312) |
+| C | **[Rammu](https://osu.ppy.sh/users/10652837)** ![][flag_PH] | **5** | 0 | ![][flag_ID] [Bunan-](https://osu.ppy.sh/users/2763354) | [#1](https://osu.ppy.sh/community/matches/71485163) |
+| G | **[Venta](https://osu.ppy.sh/users/11320627)** ![][flag_ID] | **5** | 4 | ![][flag_ID] [ngonk](https://osu.ppy.sh/users/12030070) | [#1](https://osu.ppy.sh/community/matches/71485030) |
+| I | **[k\_1tty](https://osu.ppy.sh/users/11320627)** ![][flag_ID] | **5** | 1 | ![][flag_MY] [alphaplay](https://osu.ppy.sh/users/9304966) | [#1](https://osu.ppy.sh/community/matches/71487526) |
+| P | **[Xyloz](https://osu.ppy.sh/users/12040280)** ![][flag_PH] | **5** | 3 | ![][flag_ID] [Daffy](https://osu.ppy.sh/users/5968633) | [#1](https://osu.ppy.sh/community/matches/71487542) |
+| L | **[MioMilo](https://osu.ppy.sh/users/2199427)** ![][flag_PH] | **5** | 1 | ![][flag_SG] [m0fum0fu](https://osu.ppy.sh/users/5143605) | [#1](https://osu.ppy.sh/community/matches/71490431) |
+| A | **[zonelouise](https://osu.ppy.sh/users/1492995)** ![][flag_PH] | **5** | 1 | ![][flag_SG] [Moltenfury](https://osu.ppy.sh/users/3395820) | [#1](https://osu.ppy.sh/community/matches/71489692) |
+| O | **[konawiki](https://osu.ppy.sh/users/4003979)** ![][flag_PH] | **5** | 0 | ![][flag_MY] [Yaro](https://osu.ppy.sh/users/9196013) | [#1](https://osu.ppy.sh/community/matches/71490433) |
+| F | **[KagenoKami](https://osu.ppy.sh/users/7246165)** ![][flag_PH] | **5** | 4 | ![][flag_PH] [Zyxus](https://osu.ppy.sh/users/9196013) | [#1](https://osu.ppy.sh/community/matches/71490425) |
+| D | **[megumic](https://osu.ppy.sh/users/7246165)** ![][flag_SG] | **5** | 0 | ![][flag_MY] [heyimcrunchy](https://osu.ppy.sh/users/13067221) | [#1](https://osu.ppy.sh/community/matches/71490377) |
+| L | **[Tzero](https://osu.ppy.sh/users/6088976)** ![][flag_MY] | **5** | 3 | ![][flag_VN] [sindes19](https://osu.ppy.sh/users/11021073) | [#1](https://osu.ppy.sh/community/matches/71493498) |
+| B | **[Fuma](https://osu.ppy.sh/users/1501956)** ![][flag_ID] | **5** | 1 | ![][flag_PH] [Senjuro](https://osu.ppy.sh/users/3003839) | [#1](https://osu.ppy.sh/community/matches/71487494) |
+| E | **[not\_aweeb](https://osu.ppy.sh/users/9375317)** ![][flag_MY] | **5** | 0 | ![][flag_TH] [Chorus](https://osu.ppy.sh/users/3504692) | *win by default* |
+| G | [Rexeez](https://osu.ppy.sh/users/9375317) ![][flag_ID] | 0 | **5** | ![][flag_SG] **[Deze](https://osu.ppy.sh/users/7638335)** | *win by default* |
 
 ## Ruleset
 
@@ -778,8 +802,7 @@ Sunday, 13 December 2020:
 2. Each player has to ban **one beatmap** (on Group Stage) and **two beatmaps** (on the Knock-out stages) from the mappool. These beatmaps are not allowed to be picked by any player during the entire match.
    - Each player may not ban two maps from the same modpool in a single match.
    - Banning does not apply in the Qualifier lobbies.
-3. Each player is free to select one warm-up beatmap. Using beatmaps with questionable content is prohibited.
-   - Warm-ups do not apply in the Qualifier lobbies.
+3. **There will be no warm-up beatmaps to be played in the multiplayer lobby.** Players who are looking up to warm themselves up before the match are expected to do so by their own outside the multiplayer lobby.
 4. In a FreeMod pick, each player has to apply at least one mod to play the map with. Allowed mods are EZ, HR, HD, FL, or any possible combinations of the four mods.
    - Playing a FreeMod pick without any mods activated is not allowed.
 5. In case a map ends with a score tie, **the player that doesn't pick the map** gets the point.


### PR DESCRIPTION
final update for the osu! South East Asia Tournament 4 wiki article. aside from amending the final scores/podium to the article i also made some other changes to it such as :

- added clarification regarding the one rule that mentions warm-up maps (the tournament ended up not featuring any warm-up maps at all)
- fixed Player 1's flag positions (i just realized that Player 1's flag should be written after the player's name instead of before, whoops :x)

![image](https://user-images.githubusercontent.com/36564236/106392342-e5fb0b80-6423-11eb-8662-456b5ac3b86d.png)

- added oseat4 to Tournaments listing