### PR TITLE
Add recommended length of pause-loop and applause

### DIFF
--- a/wiki/Skinning/Sounds/en.md
+++ b/wiki/Skinning/Sounds/en.md
@@ -542,6 +542,7 @@ Notes:
 
 - On the ranking screen after clearing a map.
 - Should be formatted as `.mp3` or `.ogg` in beatmaps aiming for rank.
+- Using a long audio track will impact the game client’s performance. It isn’t supposed to be bigger than a few kilobytes.
 
 ---
 
@@ -552,6 +553,7 @@ Notes:
 - Plays when the game is paused.
 - This sound is looped.
 - Fades out when the client loses focus.
+- Using a long audio track will impact the game client’s performance. It isn’t supposed to be bigger than a few kilobytes.
 
 ### Hitsounds
 


### PR DESCRIPTION
Solves #2758 

> Not intended to last longer than [...] (about 5 seconds).
This really shouldn't be relevant for other elements, since they should have nothing to overlap with.

> Using a long audio track will impact the game client’s performance, as it is loaded each time you play a beatmap, even if you never fail. It isn’t supposed to be bigger than a few kilobytes.
This only really needs to be added to failsound, applause and pause-loop since these are basically the only sounds that tend to be this long.

For the reasons listed above I have only added a note to applause and pause-loop, would just need to useless clutter otherwise. 
An alternative would be to add this note in the beginning of the article, but then people would probably forget about it, so its better to add it to the elements where its important.