### PR TITLE
BN rules update: specify when activity is checked

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
@@ -18,7 +18,7 @@ Sustained behaviour in conflict with these expectations is grounds for dismissal
 
 ## Activity
 
-- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked on the first of each month and during regular BN evaluations, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
+- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked on the first day of each month and during regular BN evaluations, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
 - **When warned for activity, minimum activity requirements for your respective gamemode(s) must be met over the course of one month.** Failing to meet the required minimum when being warned for it prior may result in removal from the Beatmap Nominators.
 
 ### Requirements

--- a/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
@@ -18,7 +18,7 @@ Sustained behaviour in conflict with these expectations is grounds for dismissal
 
 ## Activity
 
-- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked monthly, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
+- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked on the first of each month, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
 - **When warned for activity, minimum activity requirements for your respective gamemode(s) must be met over the course of one month.** Failing to meet the required minimum when being warned for it prior may result in removal from the Beatmap Nominators.
 
 ### Requirements

--- a/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Rules/en.md
@@ -18,7 +18,7 @@ Sustained behaviour in conflict with these expectations is grounds for dismissal
 
 ## Activity
 
-- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked on the first of each month, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
+- **Activity requirements for your respective gamemode(s) must be met.** Average activity over the last 3 months will be checked on the first of each month and during regular BN evaluations, taking into account any leave of absence communicated. Any BN who falls below their mode's required average will get an activity warning.
 - **When warned for activity, minimum activity requirements for your respective gamemode(s) must be met over the course of one month.** Failing to meet the required minimum when being warned for it prior may result in removal from the Beatmap Nominators.
 
 ### Requirements


### PR DESCRIPTION
"Checked monthly" was not specific enough and led to misunderstandings, so this specifies when activity gets checked a bit more.