### PR TITLE
Update History of osu! 2014

### DIFF
--- a/wiki/History_of_osu!/2014/en.md
+++ b/wiki/History_of_osu!/2014/en.md
@@ -1,25 +1,44 @@
 # History of osu! 2014
 
+## January
+
+The entire [performance points (pp)](/wiki/Performance_points) system was completely disabled for maintenance on 20 January 2014 due to miscalculations that had occurred over the previous few months \[1\]. This disabling was then followed by an announcement on 26 January 2014 that detailed a complete, from-the-ground-up redesign of the pp system that was set live the next day \[2,3\]. The new system was designed and implemented by [Tom94](https://osu.ppy.sh/users/1857058) and had aimed to base pp scores off of a new "difficulty value" (separate from [star rating](/wiki/Beatmapping/Star_rating)) that was determined for every [beatmap](/wiki/Beatmap) and [mod](/wiki/Game_modifier) combination in the game \[1\]. As a result of this, the old pp system was renamed to "ppv1" and the new system was named "ppv2".
+
 ## March
 
-As skinning elements expanded, the element, `playfield.jpg` was removed in it's line of duty and replaced with a new generic one that is unskinnable. `playfield.jpg` was an element that allowed you to use any image as the default background of a beatmap, if one isn't supplied.
+On 1 March 2014 the performance points system redesign by Tom94 in months prior was ready to be set live for [osu!taiko](/wiki/Game_mode/osu!taiko), [osu!catch](/wiki/Game_mode/osu!catch), and [osu!mania](/wiki/Game_mode/osu!mania) as the official ranking system for those modes, along with a reminder that the current system was not yet 100% finished, and further feedback from players was still needed \[4\].
 
-![](img/2014-03_01.jpg "playfield.jpg was no more")
+As [skinning](/wiki/Skinning) elements expanded, the element, `playfield.jpg` was deprecated and replaced with a new generic one that is not modifiable. `playfield.jpg` was an element that allowed skinners to use any image as the default background of a beatmap if one was not supplied. This functionality was later brought in the form of `menu-background.jpg`, which changed both the main screen and default playfield backgrounds \[5,6\]. <!--date needed-->
 
-## July
+![](img/2014-03_01.jpg "Default background for beatmaps without specified backgrounds")
 
-peppy removes download restrictions\*!
+## April
 
-Links:
+The first ever "osu! Monthly Fanart Contest" was announced on 3 April 2014. The contest was an informal contest run by [LuigiHann](https://osu.ppy.sh/users/1079) that would run monthly and award two winners one year of [osu!supporter](https://osu.ppy.sh/home/support) (one picked by public and the other by osu! staff) \[7\]. The first contest was concluded in a [newspost](https://osu.ppy.sh/home/news/2014-05-21-first-official-osu-fanart-contest-results) on 21 May 2014 with players [kunny](https://osu.ppy.sh/users/3931585) and [DumplingYumYum](https://osu.ppy.sh/users/1715930) winning first and second place respectively \[8\].
 
-- [Download restrictions removed](https://osu.ppy.sh/home/news/2014-06-18-download-restrictions-removed)
+## June
+
+On 18 June 2014, [peppy](https://osu.ppy.sh/users/2) announced that the download limitations would be removed for all users; however, there was still a, quote, "sanity limit" that would prevent bots from downloading an inhuman amount of beatmaps \[9\].
+
+## August
+
+On 21 August 2014, a [newspost](https://osu.ppy.sh/home/news/2014-08-21-restructuring-of-the-bat) was released announcing a new restructuring of the [Beatmap Appreciation Team (BAT)](/wiki//Modding/Beatmap_Appreciation_Team), which detailed the separation of the original team into the Beatmap Appreciation Team and the [Quality Assurance Team (QAT)](/wiki//Modding/Quality_Assurance_Team) \[10\].
 
 ## October
 
-As always, many new things were added to osu!. One being the new sign-in screen. Another being the new system for scrolling in [osu!mania](/wiki/Game_mode/osu!mania). It was to be based off of the beatmap's bpm rather than a fixed scroll! New intro and outro sequence and an awesome theme song were added into osu!, rather than a random beatmap's music to be played. And many discovered that osu! was pronounced as \\oss!\\, not \\osU!\\.
+October brought a handful of new additions to the base game, including a new sign in screen and new system for scrolling in [osu!mania](/wiki/Game_mode/osu!mania) based off of beatmap BPM, new intro and outro sequences, and a custom theme song that was to be played on startup (as opposed to a random beatmap). <!--citation needed-->
 
-Lastly, leading to peppy making a tough decision to release *osu!test.exe* (now *osu!cuttingedge*) for **anyone**. This was to allow non-osu!supporters to *debug* osu! where the newest (or latest) builds of osu! would be updated to any client. That was, if they're wanting to use it's unstable/experimental features. Every function was given in osu!cuttingedge **except** for multiplayer (osu!supporter was required).
+Additionally, [peppy](https://osu.ppy.sh/users/2) also released the "osu!test" build (now known as "Cutting Edge) to all players, as opposed to just [osu!supporters](https://osu.ppy.sh/home/support) in an attempt to help debugging efforts. <!--citation needed-->
 
-## December
+## References
 
-"Merry Christmas" as peppy wrote with an update that had snow (current game mode icon) falling in the main screen!
+1. [osu! newspost [peppy] (20 January 2014) - "Performance Ranking Maintenance"](https://osu.ppy.sh/home/news/2014-01-20-performance-ranking-maintenance)
+2. [osu! newspost [Tom94] (20 January 2014) - "Performance Ranking Maintenance"](https://osu.ppy.sh/home/news/2014-01-20-performance-ranking-maintenance)
+3. [osu! wiki article - "Performance points"](/wiki/Performance_points)
+4. [osu! newspost [Tom94] (1 March 2014) - "Performance ranking for all gamemodes"](https://osu.ppy.sh/home/news/2014-03-01-performance-ranking-for-all-gamemodes)
+5. [osu! forum comment (Resolved Issues) [Pawsu] - "[resolved] How to change all beatmap backgrounds")](https://osu.ppy.sh/community/forums/topics/397827?start=4749640)
+6. [osu! wiki article - "Skinning history"](/wiki/Skinning/History)
+7. [osu! newspost [LuigiHann] (3 April 2014) - "osu! Monthly Fanart Contest #1 - Ends this week!"](https://osu.ppy.sh/home/news/2014-04-03-osu-monthly-fanart-contest-1-ends-this-week)
+8. [osu! newspost [LuigiHann] (21 May 2014) - "First Official osu! Fanart Contest Results!"](https://osu.ppy.sh/home/news/2014-05-21-first-official-osu-fanart-contest-results)
+9. [osu! newspost [peppy] (18 June 2014) - "Download restrictions removed"](https://osu.ppy.sh/home/news/2014-06-18-download-restrictions-removed)
+10. [osu! newspost [Ephemeral] (21 August 2014) - "Restructuring of the BAT"](https://osu.ppy.sh/home/news/2014-08-21-restructuring-of-the-bat)

--- a/wiki/History_of_osu!/2014/en.md
+++ b/wiki/History_of_osu!/2014/en.md
@@ -28,12 +28,12 @@ On 21 August 2014, a [newspost](https://osu.ppy.sh/home/news/2014-08-21-restruct
 
 October brought a handful of new additions to the base game, including a new sign in screen and new system for scrolling in [osu!mania](/wiki/Game_mode/osu!mania) based off of beatmap BPM, new intro and outro sequences, and a custom theme song that was to be played on startup (as opposed to a random beatmap). <!--citation needed-->
 
-Additionally, [peppy](https://osu.ppy.sh/users/2) also released the "osu!test" build (now known as "Cutting Edge) to all players, as opposed to just [osu!supporters](https://osu.ppy.sh/home/support) in an attempt to help debugging efforts. <!--citation needed-->
+Additionally, [peppy](https://osu.ppy.sh/users/2) also released the "osu!test" build (now known as "Cutting Edge") to all players, as opposed to just [osu!supporters](https://osu.ppy.sh/home/support) in an attempt to help debugging efforts. <!--citation needed-->
 
 ## References
 
 1. [osu! newspost [peppy] (20 January 2014) - "Performance Ranking Maintenance"](https://osu.ppy.sh/home/news/2014-01-20-performance-ranking-maintenance)
-2. [osu! newspost [Tom94] (20 January 2014) - "Performance Ranking Maintenance"](https://osu.ppy.sh/home/news/2014-01-20-performance-ranking-maintenance)
+2. [osu! newspost [Tom94] (26 January 2014) - "New Performance Ranking"](https://osu.ppy.sh/home/news/2014-01-26-new-performance-ranking)
 3. [osu! wiki article - "Performance points"](/wiki/Performance_points)
 4. [osu! newspost [Tom94] (1 March 2014) - "Performance ranking for all gamemodes"](https://osu.ppy.sh/home/news/2014-03-01-performance-ranking-for-all-gamemodes)
 5. [osu! forum comment (Resolved Issues) [Pawsu] - "[resolved] How to change all beatmap backgrounds")](https://osu.ppy.sh/community/forums/topics/397827?start=4749640)

--- a/wiki/History_of_osu!/2014/id.md
+++ b/wiki/History_of_osu!/2014/id.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # 2014
 
 ## Maret


### PR DESCRIPTION
Cleans up and updates the original article with more information on different months throughout 2014. I only used information detailed in that year's newsposts, so some information regarding gameplay updates may have been left out. I made a point to ignore any "Monthly ____ Contests" aside from firsts for obvious reasons.

Part of efforts detailed in #4871; **follows citation conventions detailed in #4911**

*I think it might be better to reorganize the articles to detail events chronologically, but separated in sections by topic rather than by month, but i kept it as is just to make cleanup and updates and easier for the time being*