### PR TITLE
Update links in osu!catch

### DIFF
--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -58,7 +58,7 @@ Collecting the hyperfruit will make the catcher's dash upgraded to *hyperdash* (
 
 ## Play Styles
 
-*Refer to [Play Styles page under osu!catch](/wiki/Play_Style#-osu!catch).*
+*Refer to [Play Style page under osu!catch](/wiki/Play_style#-osu!catch).*
 
 ## Controls
 

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -58,7 +58,7 @@ Collecting the hyperfruit will make the catcher's dash upgraded to *hyperdash* (
 
 ## Play Styles
 
-*Refer to [Play Styles page under osu!catch](/wiki/Play_Styles).*
+*Refer to [Play Styles page under osu!catch](/wiki/Play_Style#-osu!catch).*
 
 ## Controls
 
@@ -74,7 +74,7 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 
 ## Scoring
 
-*Scoring Values can be found in [Score under osu!catch Scoring Values section](/wiki/Score#osu-catch).*
+*Scoring Values can be found in [Score under osu!catch Scoring Values section](/wiki/Score#osu!catch).*
 
 Scoring section details all the intricacies of scoring, including mathematical formula.
 


### PR DESCRIPTION
The "Play Styles page under osu!catch" link didn't redirect to the osu!catch part of the wiki article.
Same for the "Score under osu!catch Scoring Values section" link.

This commit/PR should fix that!