### PR TITLE
Fix Spoilerbox not being treated as a tag in BBCode

### DIFF
--- a/wiki/BBCode/en.md
+++ b/wiki/BBCode/en.md
@@ -119,7 +119,7 @@ The tag is most commonly used to hide large walls of text and images that may bl
 
 Toolbar button: ![Box button](img/spoilerbox.png "Box")
 
-#### Spoilerbox
+### Spoilerbox
 
 ```
 [spoilerbox]text[/spoilerbox]

--- a/wiki/BBCode/es.md
+++ b/wiki/BBCode/es.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![La caja de edición en los foros](img/editor.jpg)

--- a/wiki/BBCode/fr.md
+++ b/wiki/BBCode/fr.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![L'éditeur de sujet du forum avec ces boutons](img/editor.jpg "la boite à outil d'édition du forum")

--- a/wiki/BBCode/id.md
+++ b/wiki/BBCode/id.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![forum post dengan tombol-tombolnya](img/editor.jpg "tempat edit di forum")

--- a/wiki/BBCode/ko.md
+++ b/wiki/BBCode/ko.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![포럼에서의 글쓰기 화면.](img/editor.jpg "포럼에서의 글쓰기 화면.")

--- a/wiki/BBCode/pl.md
+++ b/wiki/BBCode/pl.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![Edytor postów na forum](img/editor.jpg "Pole edycji postów na forum")

--- a/wiki/BBCode/pt-br.md
+++ b/wiki/BBCode/pt-br.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![A caixa de edição nos fóruns](img/editor.jpg "A caixa de edição nos fóruns")

--- a/wiki/BBCode/zh.md
+++ b/wiki/BBCode/zh.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # BBCode
 
 ![论坛中的编辑器与按钮](img/editor.jpg "论坛中的编辑器")


### PR DESCRIPTION
Currently, https://osu.ppy.sh/wiki/en/BBCode#spoilerbox (link that can be found under both "Spoiler" and "Box") does not redirect to the Spoilerbox part of the article.
Furthermore, Spoilerbox doesn't show up in the table of contents on the left side of the screen.
I believe this commit/PR should fix this!

Below is a screenshot of the current table of contents, you can see that Spoilerbox is not featured in it.

![Screenshot_2021-03-15 BBCode · knowledge base osu ](https://user-images.githubusercontent.com/67872932/111190493-6b431580-85b7-11eb-9de5-552728f64aa8.png)
