### PR TITLE
Add old site's forum ranks to User titles wiki article

### DIFF
--- a/wiki/User_title/en.md
+++ b/wiki/User_title/en.md
@@ -30,15 +30,15 @@ On the forum sections of the [old osu! website](https://old.ppy.sh)<!-- TODO: wi
 
 | Forum title | Total post count |
 | :-: | :-- |
-| Rhythm Rookie | 0-4 |
-| Tempo Trainee | 5-14 |
-| Whistle Blower | 15-29 |
-| Cymbal Sounder | 30-49 |
-| Beat Clicker | 50-79 |
-| Slider Savant | 80-119 |
-| Spinner Sage | 120-179 |
-| Star Shooter | 180-259 |
-| Combo Commander | 260-499 |
+| Rhythm Rookie | 0–4 |
+| Tempo Trainee | 5–14 |
+| Whistle Blower | 15–29 |
+| Cymbal Sounder | 30–49 |
+| Beat Clicker | 50–79 |
+| Slider Savant | 80–119 |
+| Spinner Sage | 120–179 |
+| Star Shooter | 180–259 |
+| Combo Commander | 260–499 |
 | Rhythm Incarnate | 500+ |
 
 These titles were only visible on the sidebars of forum posts (not on the users' profiles) and were not shown if another custom title was already set prior.

--- a/wiki/User_title/en.md
+++ b/wiki/User_title/en.md
@@ -10,6 +10,8 @@ tags:
 
 # User title
 
+*For the list of people who have attained special user titles, see [Users with unique titles](/wiki/People/Users_with_unique_titles).*
+
 ![Screenshot of Tom94's profile information](img/dev.png "The \"osu!dev\" title can be seen near the top of Tom94's profile.")
 
 A **user title** is a short label on a user's profile page set by the [osu!team](/wiki/People/The_Team). Most titles indicate membership of a [user group](/wiki/People/The_Team#user-groups), but some users have earned [more unique titles](/wiki/People/Users_with_unique_titles) for specific achievements or contributions.
@@ -24,9 +26,22 @@ The colour of a user title is the same as the user's colour, which is also usual
 
 <!-- the bottom post on https://web.archive.org/web/20131107133826/https://osu.ppy.sh/forum/t/141240 -->
 
-On the forum sections of the [old osu! website](https://old.ppy.sh)<!-- TODO: wiki page -->, users could obtain titles by reaching certain post count milestones. These were only shown on the sidebars of forum posts, not the users' profiles, and were not shown if a custom title was already set.
+On the forum sections of the [old osu! website](https://old.ppy.sh)<!-- TODO: wiki page -->, users could obtain titles by reaching certain post count milestones as follows: <!-- https://osu.ppy.sh/community/forums/posts/2306316 -->
 
-<!-- TODO: list all of the titles and their requirements -->
+| Forum title | Total post count |
+| :-: | :-- |
+| Rhythm Rookie | 0-4 |
+| Tempo Trainee | 5-14 |
+| Whistle Blower | 15-29 |
+| Cymbal Sounder | 30-49 |
+| Beat Clicker | 50-79 |
+| Slider Savant | 80-119 |
+| Spinner Sage | 120-179 |
+| Star Shooter | 180-259 |
+| Combo Commander | 260-499 |
+| Rhythm Incarnate | 500+ |
+
+These titles were only visible on the sidebars of forum posts (not on the users' profiles) and were not shown if another custom title was already set prior.
 
 ## Trivia
 

--- a/wiki/User_title/id.md
+++ b/wiki/User_title/id.md
@@ -8,7 +8,9 @@ tags:
 
 # Gelar pengguna
 
-![Cuplikan laman profil Tom94](img/dev.png "Gelar \“osu!dev\” sebagaimana yang tersemat pada laman profil Tom94.")
+*Untuk melihat daftar nama-nama pengguna yang memiliki gelar khusus, harap kunjungi laman [Pengguna dengan gelar khusus](/wiki/People/Users_with_unique_titles).*
+
+![Cuplikan laman profil Tom94](img/dev.png "Gelar \"osu!dev\" sebagaimana yang tersemat pada laman profil Tom94.")
 
 **Gelar pengguna** merupakan label atau tajuk khusus yang tersemat pada laman profil pengguna. Suatu gelar pengguna pada umumnya disematkan oleh [osu!team](/wiki/People/The_Team) untuk menandakan status keanggotaan seseorang di dalam [gugus pengguna (*user group*)](/wiki/People/The_Team#user-groups) tertentu. Meskipun demikian, terdapat beberapa gelar yang [diberikan secara khusus](/wiki/People/Users_with_unique_titles) kepada pengguna-pengguna tertentu sebagai bentuk apresiasi atas pencapaian yang telah mereka raih dalam bidangnya masing-masing.
 
@@ -18,14 +20,27 @@ Gelar-gelar yang disematkan pada pengguna pada umumnya akan terpajang dengan war
 
 ### Gelar-gelar yang terkait dengan jumlah postingan forum
 
-![Cuplikan tampilan profil Damnae pada forum osu! terdahulu](img/star-shooter.png "Gelar \“Star Shooter\” sebagaimana yang tersemat di atas jumlah postingan forum Damnae.
+![Cuplikan tampilan profil Damnae pada forum osu! terdahulu](img/star-shooter.png "Gelar \"Star Shooter\" sebagaimana yang tersemat di atas jumlah postingan forum Damnae.
 ")
 
 <!-- the bottom post on https://web.archive.org/web/20131107133826/https://osu.ppy.sh/forum/t/141240 -->
 
-Pada [situs web osu! yang lama](https://old.ppy.sh), terdapat beberapa gelar yang akan secara otomatis disematkan kepada para pengguna yang telah menulis postingan forum dalam jumlah tertentu. Gelar-gelar ini hanya dapat dilihat pada laman forum dan tidak akan muncul pada laman profil masing-masing pengguna.
+Pada [situs web osu! yang lama](https://old.ppy.sh), terdapat beberapa gelar yang akan secara otomatis disematkan kepada para pengguna yang telah menulis postingan forum dalam jumlah tertentu sebagai berikut:
 
-<!-- TODO: list all of the titles and their requirements -->
+| Gelar forum | Total postingan forum |
+| :-: | :-- |
+| Rhythm Rookie | 0-4 |
+| Tempo Trainee | 5-14 |
+| Whistle Blower | 15-29 |
+| Cymbal Sounder | 30-49 |
+| Beat Clicker | 50-79 |
+| Slider Savant | 80-119 |
+| Spinner Sage | 120-179 |
+| Star Shooter | 180-259 |
+| Combo Commander | 260-499 |
+| Rhythm Incarnate | 500+ |
+
+Adapun gelar-gelar di atas hanya dapat dilihat pada laman forum dan tidak akan muncul pada laman profil masing-masing pengguna.
 
 ## Trivia
 

--- a/wiki/User_title/id.md
+++ b/wiki/User_title/id.md
@@ -29,15 +29,15 @@ Pada [situs web osu! yang lama](https://old.ppy.sh), terdapat beberapa gelar yan
 
 | Gelar forum | Total postingan forum |
 | :-: | :-- |
-| Rhythm Rookie | 0-4 |
-| Tempo Trainee | 5-14 |
-| Whistle Blower | 15-29 |
-| Cymbal Sounder | 30-49 |
-| Beat Clicker | 50-79 |
-| Slider Savant | 80-119 |
-| Spinner Sage | 120-179 |
-| Star Shooter | 180-259 |
-| Combo Commander | 260-499 |
+| Rhythm Rookie | 0–4 |
+| Tempo Trainee | 5–14 |
+| Whistle Blower | 15–29 |
+| Cymbal Sounder | 30–49 |
+| Beat Clicker | 50–79 |
+| Slider Savant | 80–119 |
+| Spinner Sage | 120–179 |
+| Star Shooter | 180–259 |
+| Combo Commander | 260–499 |
 | Rhythm Incarnate | 500+ |
 
 Adapun gelar-gelar di atas hanya dapat dilihat pada laman forum dan tidak akan muncul pada laman profil masing-masing pengguna.

--- a/wiki/User_title/id.md
+++ b/wiki/User_title/id.md
@@ -25,7 +25,7 @@ Gelar-gelar yang disematkan pada pengguna pada umumnya akan terpajang dengan war
 
 <!-- the bottom post on https://web.archive.org/web/20131107133826/https://osu.ppy.sh/forum/t/141240 -->
 
-Pada [situs web osu! yang lama](https://old.ppy.sh), terdapat beberapa gelar yang akan secara otomatis disematkan kepada para pengguna yang telah menulis postingan forum dalam jumlah tertentu sebagai berikut:
+Pada [situs web osu! yang lama](https://old.ppy.sh), terdapat beberapa gelar yang akan secara otomatis disematkan kepada para pengguna yang telah menulis postingan forum dalam jumlah tertentu sebagai berikut: <!-- https://osu.ppy.sh/community/forums/posts/2306316 -->
 
 | Gelar forum | Total postingan forum |
 | :-: | :-- |

--- a/wiki/User_title/zh.md
+++ b/wiki/User_title/zh.md
@@ -11,6 +11,7 @@ tags:
   - titles
   - user color # these can be removed if a dedicated page for "user colour" is added
   - user colour
+outdated: true
 ---
 
 # 用户头衔


### PR DESCRIPTION
when i was working on [#5167](http://github.com/ppy/osu-wiki/pull/5167) i noticed that the article had a ``<!-- TODO: list all of the titles and their requirements -->`` when it comes to the sentence that was describing the old site's forum ranks, so... yeah i decided to do some research on this and wrote down what's been missing in the article ;~;