### PR TITLE
Rewrite all instances of "osu!standard" as "osu!" in the Article Styling Criteria

### DIFF
--- a/wiki/Article_styling_criteria/Writing/en.md
+++ b/wiki/Article_styling_criteria/Writing/en.md
@@ -182,7 +182,7 @@ Game modes must be written as follows:
 - `osu!catch`
 - `osu!mania`
 
-Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name. Do note however that citing the osu! game mode as `osu!standard` is *not* recommended — unless necesary, `osu!` should be used instead.
+Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name. Do note however that citing the osu! game mode as `osu!standard` is *not* recommended.
 
 ## osu!
 

--- a/wiki/Article_styling_criteria/Writing/en.md
+++ b/wiki/Article_styling_criteria/Writing/en.md
@@ -83,7 +83,7 @@ When writing out game modifiers for tournament articles, they must instead use u
 Gameplay elements must not be capitalised, unless they act as a title for a link that points to the article. The following is an example:
 
 ```markdown
-In osu!, beatmaps are composed of three different gameplay elements: hit circles, sliders, and spinners.
+In the osu! game mode, beatmaps are composed of three different gameplay elements: hit circles, sliders, and spinners.
 ```
 
 ### Language names

--- a/wiki/Article_styling_criteria/Writing/en.md
+++ b/wiki/Article_styling_criteria/Writing/en.md
@@ -83,7 +83,7 @@ When writing out game modifiers for tournament articles, they must instead use u
 Gameplay elements must not be capitalised, unless they act as a title for a link that points to the article. The following is an example:
 
 ```markdown
-In osu!standard, beatmaps are composed of three different gameplay elements: hit circles, sliders, and spinners.
+In osu!, beatmaps are composed of three different gameplay elements: hit circles, sliders, and spinners.
 ```
 
 ### Language names
@@ -177,16 +177,12 @@ October 25, 2016 (11:45 UTC)
 
 Game modes must be written as follows:
 
-- `osu!standard` (unofficial, but used to prevent ambiguity)
+- `osu!`
 - `osu!taiko`
 - `osu!catch`
 - `osu!mania`
 
-*Notice: `osu!standard` is used to maintain consistency when referring to the game mode. Folder names, however, must use `osu!` even if it is referring to the game mode.*
-
-Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name.
-
-Articles such as the [Ranking Criteria](/wiki/Ranking_Criteria) may use `osu!` instead of `osu!standard`.
+Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name. Do note however that citing the osu! game mode as `osu!standard` is *not* recommended — unless necesary, `osu!` should be used instead.
 
 ## osu!
 

--- a/wiki/Article_styling_criteria/Writing/en.md
+++ b/wiki/Article_styling_criteria/Writing/en.md
@@ -182,7 +182,7 @@ Game modes must be written as follows:
 - `osu!catch`
 - `osu!mania`
 
-Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name. Do note however that citing the osu! game mode as `osu!standard` is *not* recommended.
+Referring to the old game mode names (i.e. `Catch the Beat`, `Taiko`, and `Mania`) may be done if discussing said game mode's previous name.
 
 ## osu!
 

--- a/wiki/Article_styling_criteria/Writing/es.md
+++ b/wiki/Article_styling_criteria/Writing/es.md
@@ -1,4 +1,5 @@
 ---
+outdated: true
 no_native_review: true
 ---
 

--- a/wiki/Article_styling_criteria/Writing/ru.md
+++ b/wiki/Article_styling_criteria/Writing/ru.md
@@ -1,3 +1,7 @@
+---
+outdated: true
+---
+
 # Содержание статей
 
 *См. также: [Оформление статей](/wiki/Article_style_criteria/Formatting)*


### PR DESCRIPTION
this was discussed earlier in one of the comments in my other open pr : http://github.com/ppy/osu-wiki/pull/5245#pullrequestreview-633145435

in short the Article Styling Criteria as it stands is still promoting the use of `osu!standard` despite the fact that `osu!` has been the much preferred term for a long while, as confirmed by @peppy himself :

![image](https://user-images.githubusercontent.com/36564236/114389649-7772c080-9bbf-11eb-8b0d-463799bbb0bb.png)

![image](https://user-images.githubusercontent.com/36564236/114389741-93766200-9bbf-11eb-8c1d-038f6e38751a.png)

this pr makes changes to the Article Styling Criteria so that `osu!` can formally be considered as the proper way of referring the game mode in question going forward.
