### PR TITLE
Remove Xinely from Users with unique titles

### DIFF
--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -92,7 +92,6 @@ Since 2020, [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators)' and 
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Aspire mapping contest winners
 
@@ -337,7 +336,6 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -91,7 +91,6 @@ Depuis 2020, la contribution des [Beatmap Nominators](/wiki/People/The_Team/Beat
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Gagnants de compétitions de mapping Aspire
 
@@ -337,7 +336,6 @@ Ces joueurs ont gagnés leurs titres à travers des prouesses exceptionnelles, o
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -92,7 +92,6 @@ Sejak 2020, dalam mendukung sistem pemeringkatan terhadap aktivitas anggota [Bea
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Pemenang kontes mapping Aspire
 
@@ -337,7 +336,6 @@ Para pemain ini mendapatkan gelar mereka melalui pencapaian tergila dalam game i
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/pl.md
+++ b/wiki/People/Users_with_unique_titles/pl.md
@@ -96,7 +96,6 @@ Od 2020 roku wkład [nominatorów beatmap](/wiki/People/The_Team/Beatmap_Nominat
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Zwycięzcy konkursów w tworzeniu beatmap „Aspire”
 
@@ -335,7 +334,6 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/pt-br.md
+++ b/wiki/People/Users_with_unique_titles/pt-br.md
@@ -92,7 +92,6 @@ Desde 2020, atividade de membros dos [Nomeadores de Beatmap](/wiki/People/The_Te
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Vencedores de competição de mapping Aspire
 
@@ -337,7 +336,6 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/th.md
+++ b/wiki/People/Users_with_unique_titles/th.md
@@ -92,7 +92,6 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### ผู้ชนะการแข่ง Aspire mapping
 
@@ -331,7 +330,6 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/tr.md
+++ b/wiki/People/Users_with_unique_titles/tr.md
@@ -92,7 +92,6 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Aspire mapping yarışması kazananları
 
@@ -336,7 +335,6 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -97,7 +97,6 @@ outdated_since: decbc8e68d8ba4ae641a7476833fa5986f9785d9
 - ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994)
 - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
 - ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872)
-- ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445)
 
 ### Aspire 作图大赛获奖者
 
@@ -334,7 +333,6 @@ osu!team 为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421) | Elite Mapper |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | Elite Mapper |
 | ![][flag_ID] [xiemon](https://osu.ppy.sh/users/5203667) | osu!artist |
-| ![][flag_ID] [Xinely](https://osu.ppy.sh/users/1521445) | Elite Nominator |
 | ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669) | Elite Storyboarder |
 | ![][flag_HM] [Zallius](https://osu.ppy.sh/users/55) | Boats |
 | ![][flag_DE] [Zetera](https://osu.ppy.sh/users/587737) | Medal Hunter |


### PR DESCRIPTION
similar to [#5171](https://github.com/ppy/osu-wiki/pull/5171) -- [Xinely](http://osu.ppy.sh/users/1521445) got removed from BN a few hours ago and her "Elite Nominator" title has so been revoked accordingly by now.

![image](https://user-images.githubusercontent.com/36564236/114497461-68861f80-9c4c-11eb-9057-7332010658dc.png)