### PR TITLE
[ID] Fix wording in "Geki" and "Katu"

### DIFF
--- a/wiki/Geki/id.md
+++ b/wiki/Geki/id.md
@@ -9,7 +9,7 @@ no_native_review: true
 
 *Lihat juga: [Katu](/wiki/Katu)*
 
-**Geki (激)** atau *Elite Beat!* merupakan sebuah indikator dalam [sistem penilaian osu!](/wiki/Score) yang akan muncul setiap kali seorang pemain berhasil menyelesaikan suatu rangkaian combo dengan [akurasi](/wiki/Gameplay/Accuracy) yang sempurna. Apabila seorang pemain berhasil memunculkan Geki, *health bar* yang dimiliki oleh pemain yang bersangkutan akan terisi ulang secara signifikan.
+**Geki (激)** atau *Elite Beat!* merupakan sebuah indikator dalam [sistem penilaian osu!](/wiki/Score) yang akan muncul setiap kali seorang pemain berhasil mengenai seluruh objek yang ada dalam suatu rangkaian combo dengan [akurasi](/wiki/Gameplay/Accuracy) yang sempurna. Apabila seorang pemain berhasil memunculkan Geki, *health bar* yang dimiliki oleh pemain yang bersangkutan akan terisi ulang secara signifikan.
 
 Terminologi Geki sendiri berasal dari permainan [Elite Beat Agents](/wiki/iNiS_games) pada konsol Nintendo DS yang mendasari awal terbentuknya [osu!](/wiki/Game_Mode).
 
@@ -17,9 +17,9 @@ Terminologi Geki sendiri berasal dari permainan [Elite Beat Agents](/wiki/iNiS_g
 
 ![Contoh kenampakan Geki dalam Elite Beat Agents](img/eba-bornlove-300g.jpg "Contoh kenampakan  Geki dalam Elite Beat Agents")
 
-![Contoh kenampakan  Geki dalam Osu! Tatakae! Ouendan! 2](img/oto-sambomaster-300g.jpg "Contoh kenampakan  Geki Osu! Tatakae! Ouendan! 2")
+![Contoh kenampakan Geki dalam Osu! Tatakae! Ouendan! 2](img/oto-sambomaster-300g.jpg "Contoh kenampakan dalam Geki Osu! Tatakae! Ouendan! 2")
 
-![Contoh kenampakan  Geki dalam osu!](img/osu-lonelest-300g.jpg "Contoh kenampakan Geki dalam osu!")
+![Contoh kenampakan Geki dalam osu!](img/osu-lonelest-300g.jpg "Contoh kenampakan Geki dalam osu!")
 
 ## Geki dalam mode-mode permainan lainnya
 
@@ -33,7 +33,7 @@ Geki tidak dipergunakan dalam mode osu!catch.
 
 ### osu!mania
 
-Geki dipergunakan untuk menandakan not-not yang berhasil dikenai dengan sempurna, di mana Geki akan muncul pada layar permainan dalam bentuk `300` yang berwarna pelangi (terkadang disebut juga dengan MAX). Walaupun dalam perhitungannya setiap Geki akan bernilai 320 poin, Geki memiliki bobot akurasi yang serupa dengan 300 normal pada umumnya.
+Geki dipergunakan untuk menandai not-not yang berhasil dikenai dengan sempurna, di mana Geki akan muncul pada layar permainan dalam wujud `300` yang berwarna pelangi (terkadang disebut juga dengan MAX). Walaupun dalam perhitungannya setiap Geki bernilai 320 poin, Geki memiliki bobot akurasi yang serupa dengan 300 normal pada umumnya.
 
 ## Storyboard
 

--- a/wiki/Katu/id.md
+++ b/wiki/Katu/id.md
@@ -11,7 +11,7 @@ no_native_review: true
 
 *”Katu” yang dibahas pada artikel ini memiliki konteks yang berbeda dengan “Katu” yang ada pada mode permainan osu!taiko.*
 
-**Katu (激)**, *Katsu*, atau *Beat!*, merupakan sebuah indikator dalam [sistem penilaian osu!](/wiki/Score) yang akan muncul setiap kali seorang pemain berhasil menyelesaikan suatu rangkaian combo tanpa [akurasi](/wiki/Gameplay/Accuracy) yang sempurna. Meskipun demikian, Katu tidak akan muncul apabila dalam suatu rangkaian combo terdapat 50 atau *miss* dari pemain.
+**Katu (激)**, *Katsu*, atau *Beat!*, merupakan sebuah indikator dalam [sistem penilaian osu!](/wiki/Score) yang akan muncul setiap kali seorang pemain berhasil mengenai seluruh objek yang ada dalam suatu rangkaian combo dengan [akurasi](/wiki/Gameplay/Accuracy) yang baik namun tidak sempurna. Meskipun demikian, Katu tidak akan muncul apabila dalam suatu rangkaian combo terdapat 50 atau *miss* dari pemain.
 
 Terdapat dua jenis Katu yang kemunculannya ditentukan berdasarkan seberapa akurat seorang pemain dalam mengenai objek terakhir yang ada di dalam suatu rangkaian combo. Katu yang disertai dengan 300 pada akhir combo akan mengisi ulang *health bar* dalam jumlah yang lebih signifikan dibanding dengan Katu yang disertai dengan 100 pada akhir combo walaupun dampak keduanya tidak sebesar ketika mendapatkan [Geki](/wiki/Geki).
 

--- a/wiki/Katu/id.md
+++ b/wiki/Katu/id.md
@@ -44,7 +44,7 @@ Katu dipergunakan untuk menghitung jumlah droplet yang gagal untuk ditangkap ole
 
 ### osu!mania
 
-Katu dipergunakan untuk menandakan not-not yang bernilai 200, yang menandakan bahwa *timing* pemain dalam mengenai not-not yang ada tersebut masih kurang akurat.
+Katu dipergunakan untuk menandai not-not yang bernilai 200, di mana kemunculan Katu secara tidak langsung menyiratkan bahwa *timing* pemain dalam mengenai not-not yang ada tersebut masih kurang akurat.
 
 ## Storyboard
 


### PR DESCRIPTION
related to the pr that just got merged yesterday. primarily meant to address the mistake in the image alt text here in where the word `dalam` appears to be removed by mistake before the merge :

![image](https://user-images.githubusercontent.com/36564236/115500735-196b6a80-a29c-11eb-950b-39706aa5480f.png)

also applied a few minor wording changes/improvements on some sentences.
