### PR TITLE
Add missing escape characters in Project Loved Team wiki article

### DIFF
--- a/wiki/People/The_Team/Project_Loved_Team/en.md
+++ b/wiki/People/The_Team/Project_Loved_Team/en.md
@@ -75,7 +75,7 @@ Metadata reviewers check through every beatmap that will be put up for voting, a
 ### osu!taiko captains
 
 - ![][flag_JP] [\_yu68](https://osu.ppy.sh/users/6170507)
-- ![][flag_TW] [-[ ix Ishida xi ]-](https://osu.ppy.sh/users/242910)
+- ![][flag_TW] [-\[ ix Ishida xi \]-](https://osu.ppy.sh/users/242910)
 - ![][flag_US] [Backfire](https://osu.ppy.sh/users/263110)
 - ![][flag_IT] [D3kuu](https://osu.ppy.sh/users/7807444)
 - ![][flag_JP] [iceOC](https://osu.ppy.sh/users/5482401)

--- a/wiki/People/The_Team/Project_Loved_Team/tr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/tr.md
@@ -77,7 +77,7 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 ### osu!taiko kaptanları
 
 - ![][flag_JP] [\_yu68](https://osu.ppy.sh/users/6170507)
-- ![][flag_TW] [-[ ix Ishida xi ]-](https://osu.ppy.sh/users/242910)
+- ![][flag_TW] [-\[ ix Ishida xi \]-](https://osu.ppy.sh/users/242910)
 - ![][flag_US] [Backfire](https://osu.ppy.sh/users/263110)
 - ![][flag_IT] [D3kuu](https://osu.ppy.sh/users/7807444)
 - ![][flag_JP] [iceOC](https://osu.ppy.sh/users/5482401)


### PR DESCRIPTION
when i was reviewing [#5295](http://github.com/ppy/osu-wiki/pull/5295) earlier i noticed that the link to -[ ix Ishida xi ]-'s profile was not working as intended (as it was missing the appropriate escape `\[` and `\]` characters) so yeah