### PR TITLE
Make Boolean Matching Case-Insensitive For Manually-Triggered Actions

### DIFF
--- a/.github/workflows/manual-sync.yml
+++ b/.github/workflows/manual-sync.yml
@@ -51,8 +51,8 @@ jobs:
          # https://stackoverflow.com/questions/14700579/bash-converting-string-to-boolean-variable
          function boolean () {
             case $1 in
-              true) echo true ;;
-              false) echo false ;;
+              [Tt][Rr][Uu][Ee]) echo true ;;
+              [Ff][Aa][Ll][Ss][Ee]) echo false ;;
               *) echo "Unknown operand \"$1\"" 1>&2; exit 1 ;;
             esac
          }

--- a/wiki/osu!_wiki_Contribution_Guide/Common_Issues/en.md
+++ b/wiki/osu!_wiki_Contribution_Guide/Common_Issues/en.md
@@ -50,8 +50,6 @@ Fortunately, there are a few ways to resolve this problem depending on which bra
 
 #### Using GitHub
 
-**Warning: This tool is experimental. While it was tested on most common cases, it may still break. If you encounter issues, please report it to the [osu-wiki issues board](https://github.com/ppy/osu-wiki/issues).**
-
 You'll need to run a GitHub workflow written by osu! wiki contributors.
 
 1. Open **your fork** and go to the `Actions` tab.


### PR DESCRIPTION
This will make boolean matching case-insensitive in the manual actions script. This also removes the disclaimer in the OWCG guide as this script is mostly considered production-ready by most cases.