### PR TITLE
Fix syntax errors on osu!weekly #95–#99, 103

### DIFF
--- a/news/2017-03-09-osuweekly-95.md
+++ b/news/2017-03-09-osuweekly-95.md
@@ -10,6 +10,7 @@ tumblr_url: http://osunews.tumblr.com/post/158194347743/osuweekly-95
 <!-- more -->
 
 ![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-03-02-osuweekly-94">Previous</a></td>
 <td align="right"><a href="https://osu.ppy.sh/home/news/2017-03-17-osuweekly-96">Next</a></td>
 </tr></table>

--- a/news/2017-03-09-osuweekly-95.md
+++ b/news/2017-03-09-osuweekly-95.md
@@ -22,7 +22,7 @@ tumblr_url: http://osunews.tumblr.com/post/158194347743/osuweekly-95
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news">Weekly news</h2>
+<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
 
 **2017 has already seen its fair share of tournaments, contests and other miscellaneous events and now we've announced our newest featured artist, [Lukhash](https://osu.ppy.sh/home/news/2017-03-03-new-featured-artist-lukhash).** With his arrival comes over 60 tracks all timed and ready to go. With such a huge range of songs now freely available, you're sure to find something in here to suit your tastes.
 
@@ -30,7 +30,7 @@ tumblr_url: http://osunews.tumblr.com/post/158194347743/osuweekly-95
 
 **Year in and year out, we see a lot of tournaments hosted, but not much love is given for the smaller guys.** So if you are one of the smaller guys who wants to join in the tournament fun, [Xeious](https://osu.ppy.sh/users/5357146) has you covered. He recently opened up his [first tournament](https://osu.ppy.sh/community/forums/topics/564411) which will be single elementation, 1v1 matches for players ranked 30k-60k. Registrations will be open until the end of March, or until all 32 slots are filled. So if you're planning to enter, best decide soon as spots are limited.
 
-<h2 name="score" id="score">Scorewatch: March week 2 (With Scorewatch Patrol)</h2>
+<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 2 (With Scorewatch Patrol)</h2>
 
 Before we get into this week's impressive plays, our fellow friends from the Scorewatch Patrol created a [discord server](https://discord.gg/aFubwd4), where you can give your suggestions about scores that are noteworthy.  Feel free to drop by and help their team out or just have a casual osu!-oriented talk. With that said,
 
@@ -62,7 +62,7 @@ NOTABLE MENTIONS:
 
 [applerss](https://osu.ppy.sh/users/983349) tried to outshine \_yu68 on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmaps/1203661?m=1) with an impressive 95.34% HDDT FC, unfortunately getting 2nd on the map but earning 643pp.
 
-<h2 name="twc" id="twc">TWC 2017 Week 0 Summary: Live Drawing Renewal - with magnomizer</h2>
+<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 0 Summary: Live Drawing Renewal - with magnomizer</h2>
 
 As the spring season begins to roll in, we are greeted with the familiar sound of drums. It's that time of year again – TWC has returned for its 7th installment!
 

--- a/news/2017-03-09-osuweekly-95.md
+++ b/news/2017-03-09-osuweekly-95.md
@@ -23,7 +23,7 @@ tumblr_url: http://osunews.tumblr.com/post/158194347743/osuweekly-95
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
+## <a id="news"></a>Weekly news
 
 **2017 has already seen its fair share of tournaments, contests and other miscellaneous events and now we've announced our newest featured artist, [Lukhash](https://osu.ppy.sh/home/news/2017-03-03-new-featured-artist-lukhash).** With his arrival comes over 60 tracks all timed and ready to go. With such a huge range of songs now freely available, you're sure to find something in here to suit your tastes.
 
@@ -31,7 +31,7 @@ tumblr_url: http://osunews.tumblr.com/post/158194347743/osuweekly-95
 
 **Year in and year out, we see a lot of tournaments hosted, but not much love is given for the smaller guys.** So if you are one of the smaller guys who wants to join in the tournament fun, [Xeious](https://osu.ppy.sh/users/5357146) has you covered. He recently opened up his [first tournament](https://osu.ppy.sh/community/forums/topics/564411) which will be single elementation, 1v1 matches for players ranked 30k-60k. Registrations will be open until the end of March, or until all 32 slots are filled. So if you're planning to enter, best decide soon as spots are limited.
 
-<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 2 (With Scorewatch Patrol)</h2>
+## <a id="score"></a>Scorewatch: March week 2 (With Scorewatch Patrol)
 
 Before we get into this week's impressive plays, our fellow friends from the Scorewatch Patrol created a [discord server](https://discord.gg/aFubwd4), where you can give your suggestions about scores that are noteworthy.  Feel free to drop by and help their team out or just have a casual osu!-oriented talk. With that said,
 
@@ -63,7 +63,7 @@ NOTABLE MENTIONS:
 
 [applerss](https://osu.ppy.sh/users/983349) tried to outshine \_yu68 on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmaps/1203661?m=1) with an impressive 95.34% HDDT FC, unfortunately getting 2nd on the map but earning 643pp.
 
-<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 0 Summary: Live Drawing Renewal - with magnomizer</h2>
+## <a id="twc"></a>TWC 2017 Week 0 Summary: Live Drawing Renewal - with magnomizer
 
 As the spring season begins to roll in, we are greeted with the familiar sound of drums. It's that time of year again – TWC has returned for its 7th installment!
 

--- a/news/2017-03-17-osuweekly-96.md
+++ b/news/2017-03-17-osuweekly-96.md
@@ -23,7 +23,7 @@ A new weekly, a slightly modified format! We have kind of already started rollin
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
+## <a id="news"></a>Weekly news
 
 **The aspiration of daring mappers burn with the intensity of a thousand suns in the latest Aspire Mapping Contest!** For those of you who didn't know already, the Aspire mapping contest is a chance for mappers to relieve the burdens of the ranking criteria and let loose their creative demons. With the entrants revealed and our wonderful judges already giving us their take on them, it is nigh time for your to also tell us what you think by [voting for your favorites](https://osu.ppy.sh/community/contests/43)!
 
@@ -31,7 +31,7 @@ A new weekly, a slightly modified format! We have kind of already started rollin
 
 **The osu!weekly will be trialing a new format starting... right now!** With the incorporation of a more navigable weekly, we will be looking to aggressively promote content from everywhere around a community. We will also be trialing a new **tournament feature program**, where just about any moderately sized tournament can get a similar, albeit smaller, block on every weekly detailing the progress of their brackets and matches. If your tournament doesn't quite meet the size requirement, don't worry! Your data can be later used towards building a wiki page for your competition, so we'll keep it around! Interested in participating? Hit us up at [news@ppy.sh](mailto:news@ppy.sh) with your interest as well as the tournament you're hosting, and we'll get back to you shortly with more details.
 
-<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
+## <a id="com"></a>Around the community
 
 **This is one of the new blocks we'll be testing out in the coming weeks, and will be something like a community sub box.** The videos posted here contain the opinions of the creators and do not reflect the opinion of osu!, the osu!staff, or necessarily the osu!weekly, but we do think the videos and the people behind it are *pretty darn cool*. If you have videos that you think are "cool enough" to show up here, drop us a message at [news@ppy.sh](mailto:news@ppy.sh)!
 
@@ -45,13 +45,13 @@ A new weekly, a slightly modified format! We have kind of already started rollin
 
 **[Eternity](https://www.youtube.com/channel/UCw3nEFKQxcyPuMLF0m9w4aA) is a new music based channel that showcases neat songs and their corresponding maps in the game**. This channel proves to be a good way to discover great listens while letting you know the fact that someone has already mapped it for your circle clicking enjoyment.
 
-<h2 name="tournament" id="tournament" class="osu-md__header osu-md__header--2">Tournament Corner</h2>
+## <a id="tournament"></a>Tournament Corner
 
 **An interesting new ["sightreading" tournament](https://osu.ppy.sh/community/forums/topics/562991/start=0) has popped up courtesy of our friend [neonat!](https://osu.ppy.sh/users/neonat).** Unfortunately for players, it seems like player registration is limited to Singaporeans only. However, since the format for this tournament is quite special, they will be looking for mappers to help fill in their map pool over the course of the next few weeks! If you're interested in helping out, neonat has provided us with a link to [his discord](https://discord.gg/MSzxQjw) so you can drop right in to say hello!
 
-<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 3 (With Scorewatch Patrol)</h2>
+## <a id="score"></a>Scorewatch: March week 3 (With Scorewatch Patrol)
 
-[Ekoro](https://osu.ppy.sh/users/284905), currently participating in TWC 2017, is not just capable of whacking those drums. He pulled off a mindblowing EZFL 98.50% FC on [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmapsets/482090) on The Eclipse difficulty, giving him 385pp. Ekoro has been super capable in playing FL, and this score is nothing short of breathtaking.
+[Ekoro](https://osu.ppy.sh/users/284905), currently participating in TWC 2017, is not just capable of whacking those drums. He pulled off a mindblowing EZFL 98.50% FC on [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmapsets/482090#osu/1028733) on The Eclipse difficulty, giving him 385pp. Ekoro has been super capable in playing FL, and this score is nothing short of breathtaking.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/p3KjGz5puaM" frameborder="0" allowfullscreen></iframe>
 
@@ -79,7 +79,7 @@ NOTABLE MENTIONS:
 
 [stu00608](https://osu.ppy.sh/users/1977606) went super crazy on [SENTIVE - The end of a century](https://osu.ppy.sh/beatmaps/202965?m=1) as he slapped HD, SD, DT and FL on to get a 99.15% FC worth 537pp.
 
-<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 1 Summary:Group Stage- with magnomizer</h2>
+## <a id="twc"></a>TWC 2017 Week 1 Summary: Group Stage - with magnomizer
 
 ![](http://nyquill.s-ul.eu/uQu8qlCt)
 

--- a/news/2017-03-17-osuweekly-96.md
+++ b/news/2017-03-17-osuweekly-96.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/158496610533/osuweekly-96
 A new weekly, a slightly modified format! We have kind of already started rolling this out, but in the coming weeks we will be starting a new version of the standard osu!weekly formula. Looking out for cool new stories? Read on to get your fill!
 
 ![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-03-09-osuweekly-95">Previous</a></td>
 <td align="right">Next</td>
 </tr></table>
@@ -50,7 +51,7 @@ A new weekly, a slightly modified format! We have kind of already started rollin
 
 <h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 3 (With Scorewatch Patrol)</h2>
 
-[Ekoro](https://osu.ppy.sh/users/284905), currently participating in TWC 2017, is not just capable of whacking those drums. He pulled off a mindblowing EZFL 98.50% FC on [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmaps/1028733) on The Eclipse difficulty, giving him 385pp. Ekoro has been super capable in playing FL, and this score is nothing short of breathtaking.
+[Ekoro](https://osu.ppy.sh/users/284905), currently participating in TWC 2017, is not just capable of whacking those drums. He pulled off a mindblowing EZFL 98.50% FC on [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmapsets/482090) on The Eclipse difficulty, giving him 385pp. Ekoro has been super capable in playing FL, and this score is nothing short of breathtaking.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/p3KjGz5puaM" frameborder="0" allowfullscreen></iframe>
 

--- a/news/2017-03-17-osuweekly-96.md
+++ b/news/2017-03-17-osuweekly-96.md
@@ -22,7 +22,7 @@ A new weekly, a slightly modified format! We have kind of already started rollin
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news">Weekly news</h2>
+<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
 
 **The aspiration of daring mappers burn with the intensity of a thousand suns in the latest Aspire Mapping Contest!** For those of you who didn't know already, the Aspire mapping contest is a chance for mappers to relieve the burdens of the ranking criteria and let loose their creative demons. With the entrants revealed and our wonderful judges already giving us their take on them, it is nigh time for your to also tell us what you think by [voting for your favorites](https://osu.ppy.sh/community/contests/43)!
 
@@ -30,7 +30,7 @@ A new weekly, a slightly modified format! We have kind of already started rollin
 
 **The osu!weekly will be trialing a new format starting... right now!** With the incorporation of a more navigable weekly, we will be looking to aggressively promote content from everywhere around a community. We will also be trialing a new **tournament feature program**, where just about any moderately sized tournament can get a similar, albeit smaller, block on every weekly detailing the progress of their brackets and matches. If your tournament doesn't quite meet the size requirement, don't worry! Your data can be later used towards building a wiki page for your competition, so we'll keep it around! Interested in participating? Hit us up at [news@ppy.sh](mailto:news@ppy.sh) with your interest as well as the tournament you're hosting, and we'll get back to you shortly with more details.
 
-<h2 name="com" id="com">Around the community</h2>
+<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
 
 **This is one of the new blocks we'll be testing out in the coming weeks, and will be something like a community sub box.** The videos posted here contain the opinions of the creators and do not reflect the opinion of osu!, the osu!staff, or necessarily the osu!weekly, but we do think the videos and the people behind it are *pretty darn cool*. If you have videos that you think are "cool enough" to show up here, drop us a message at [news@ppy.sh](mailto:news@ppy.sh)!
 
@@ -44,11 +44,11 @@ A new weekly, a slightly modified format! We have kind of already started rollin
 
 **[Eternity](https://www.youtube.com/channel/UCw3nEFKQxcyPuMLF0m9w4aA) is a new music based channel that showcases neat songs and their corresponding maps in the game**. This channel proves to be a good way to discover great listens while letting you know the fact that someone has already mapped it for your circle clicking enjoyment.
 
-<h2 name="tournament" id="tournament">Tournament Corner</h2>
+<h2 name="tournament" id="tournament" class="osu-md__header osu-md__header--2">Tournament Corner</h2>
 
 **An interesting new ["sightreading" tournament](https://osu.ppy.sh/community/forums/topics/562991/start=0) has popped up courtesy of our friend [neonat!](https://osu.ppy.sh/users/neonat).** Unfortunately for players, it seems like player registration is limited to Singaporeans only. However, since the format for this tournament is quite special, they will be looking for mappers to help fill in their map pool over the course of the next few weeks! If you're interested in helping out, neonat has provided us with a link to [his discord](https://discord.gg/MSzxQjw) so you can drop right in to say hello!
 
-<h2 name="score" id="score">Scorewatch: March week 3 (With Scorewatch Patrol)</h2>
+<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 3 (With Scorewatch Patrol)</h2>
 
 [Ekoro](https://osu.ppy.sh/users/284905), currently participating in TWC 2017, is not just capable of whacking those drums. He pulled off a mindblowing EZFL 98.50% FC on [9mm Parabellum Bullet - Inferno](https://osu.ppy.sh/beatmaps/1028733) on The Eclipse difficulty, giving him 385pp. Ekoro has been super capable in playing FL, and this score is nothing short of breathtaking.
 
@@ -78,7 +78,7 @@ NOTABLE MENTIONS:
 
 [stu00608](https://osu.ppy.sh/users/1977606) went super crazy on [SENTIVE - The end of a century](https://osu.ppy.sh/beatmaps/202965?m=1) as he slapped HD, SD, DT and FL on to get a 99.15% FC worth 537pp.
 
-<h2 name="twc" id="twc">TWC 2017 Week 1 Summary:Group Stage- with magnomizer</h2>
+<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 1 Summary:Group Stage- with magnomizer</h2>
 
 ![](http://nyquill.s-ul.eu/uQu8qlCt)
 

--- a/news/2017-03-23-osuweekly-97.md
+++ b/news/2017-03-23-osuweekly-97.md
@@ -22,13 +22,13 @@ As we delve further into March madness, we edge closer and closer to the very se
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news">Weekly news</h2>
+<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
 
 **New season, new [fan art contest](https://osu.ppy.sh/home/news/2017-03-21-fanart-contest-9-spring), this time celebrating the wonderful season of Spring.** The contest will run for approximately 3 weeks ending on the 11th of April. In this time, you'll be tasked with designing a main menu background similar to the [Christmas fan art contest](https://osu.ppy.sh/home/news/2016-11-28-fanart-contest-8-christmas),, just instead of snow and Christmas presents, we'll be (hopefully) seeing sakura blossoms and picnic baskets. Or whatever else happens in Spring wherever you live!
 
 **The [Aspire 2017 contest voting](https://osu.ppy.sh/home/news/2017-03-13-aspire-2017-voting-now-open) is in it's final moments, as voting closes very soon!** Not long left now, so if you haven't voted yet, or seen the amazing entries that this contest has birthed, we highly recommend taking some time to go [have a look](https://osu.ppy.sh/community/contests/43) at the creativity of some of the communities finest mappers!
 
-<h2 name="com" id="com">Around the community</h2>
+<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
 
 **On the topic of Aspire 2017, [pishifat](https://osu.ppy.sh/users/3178418) recently released a [video](https://www.youtube.com/watch?v=f1xj0P9XOow) talking a bit about the history of the beatmapping contest.** The video goes over how the Aspire contests started and how they evolved throughout each rendition. The video touches over some rather interesting points both good and bad and also has a look at what's to come. Definitely worth a watch if you want some valuable perspective and history on what's behind all the Aspire hype!
 
@@ -42,11 +42,11 @@ As we delve further into March madness, we edge closer and closer to the very se
 
 **The Ranking Charts have been around for a very long time, longer than most of you can remember.** Over the years, the system has changed extensively as the game and community have developed.This month though marks the next big step in the the future of the program - Spotlights.This new feature looks to bring in a lot more substance and interest for both mappers and players to the program, with brand new prizes, medals and much much more. While some parts of the new system aren't ready to be announced, you can read the initial changes over on the [announcement page.](https://osu.ppy.sh/home/news/2017-03-18-introducing-to-you-spotlights)
 
-<h2 name="tournament" id="tournament">Tournament Corner</h2>
+<h2 name="tournament" id="tournament" class="osu-md__header osu-md__header--2">Tournament Corner</h2>
 
 **[Doomsday's](https://osu.ppy.sh/users/18983) Corgi Cup tournament is back for it's 3rd edition**. This friendly tournament is an inhouse tournament for Doomsday's twitch subscribers (and a few close friends). The tournament will span over 7 weeks with the Qualifiers starting this weekend. The tournament will be streamed over on [Doomsday twitch channel](https://www.twitch.tv/doomsday) and will feature players from a wide range of skill levels. You can learn more about the Corgi Cup [here](https://docs.google.com/spreadsheets/d/1WgCjEliR1Jg0mFox6cS5TkJbOd6UZWsoV3euLkXDkpc/edit#gid=1354042911) or just head over to Twitch for an 8pm UTC start on Saturday.
 
-<h2 name="score" id="score">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
+<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
 
 **[Cookiezi](https://osu.ppy.sh/users/124493) still proves his absolute dominance in the osu! Standard scene by pulling off a crazy HDHR 97.07% FC on [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmaps/890911&m=0) on Vert's Extreme, giving him 423pp and the only HDHR FC and only FC without score reducing mods.** Simply mindblowing, then again, he is Cookiezi.
 
@@ -76,7 +76,7 @@ NOTABLE MENTIONS:
 
 [Rohulk](https://osu.ppy.sh/users/3219026) boasts his incredible consistency with an amazing HDHR SS on [Kano - Kimiiro Hanabi -album version-](https://osu.ppy.sh/beatmaps/1093352) to give him 436pp.
 
-<h2 name="twc" id="twc">TWC 2017 Week 2 Summary: Separation of the Brackets - with magnomizer</h2>
+<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 2 Summary: Separation of the Brackets - with magnomizer</h2>
 
 This week in the Round of 16, we were treated to 8 splendid matches between the 16 countries that remain in the tournament. While it was a shame that none of the matches were close enough for tiebreaker, the whole experience was intense nonetheless. Don't worry if you've missed out though, as you can always watch the VODs [here](https://www.twitch.tv/osulive/videos/all), or settle for a brief recap below:
 

--- a/news/2017-03-23-osuweekly-97.md
+++ b/news/2017-03-23-osuweekly-97.md
@@ -23,13 +23,13 @@ As we delve further into March madness, we edge closer and closer to the very se
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
+## <a id="news"></a>Weekly news
 
 **New season, new [fan art contest](https://osu.ppy.sh/home/news/2017-03-21-fanart-contest-9-spring), this time celebrating the wonderful season of Spring.** The contest will run for approximately 3 weeks ending on the 11th of April. In this time, you'll be tasked with designing a main menu background similar to the [Christmas fan art contest](https://osu.ppy.sh/home/news/2016-11-28-fanart-contest-8-christmas),, just instead of snow and Christmas presents, we'll be (hopefully) seeing sakura blossoms and picnic baskets. Or whatever else happens in Spring wherever you live!
 
 **The [Aspire 2017 contest voting](https://osu.ppy.sh/home/news/2017-03-13-aspire-2017-voting-now-open) is in it's final moments, as voting closes very soon!** Not long left now, so if you haven't voted yet, or seen the amazing entries that this contest has birthed, we highly recommend taking some time to go [have a look](https://osu.ppy.sh/community/contests/43) at the creativity of some of the communities finest mappers!
 
-<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
+## <a id="com"></a>Around the community
 
 **On the topic of Aspire 2017, [pishifat](https://osu.ppy.sh/users/3178418) recently released a [video](https://www.youtube.com/watch?v=f1xj0P9XOow) talking a bit about the history of the beatmapping contest.** The video goes over how the Aspire contests started and how they evolved throughout each rendition. The video touches over some rather interesting points both good and bad and also has a look at what's to come. Definitely worth a watch if you want some valuable perspective and history on what's behind all the Aspire hype!
 
@@ -43,11 +43,11 @@ As we delve further into March madness, we edge closer and closer to the very se
 
 **The Ranking Charts have been around for a very long time, longer than most of you can remember.** Over the years, the system has changed extensively as the game and community have developed.This month though marks the next big step in the the future of the program - Spotlights.This new feature looks to bring in a lot more substance and interest for both mappers and players to the program, with brand new prizes, medals and much much more. While some parts of the new system aren't ready to be announced, you can read the initial changes over on the [announcement page.](https://osu.ppy.sh/home/news/2017-03-18-introducing-to-you-spotlights)
 
-<h2 name="tournament" id="tournament" class="osu-md__header osu-md__header--2">Tournament Corner</h2>
+## <a id="tournament"></a>Tournament Corner
 
 **[Doomsday's](https://osu.ppy.sh/users/18983) Corgi Cup tournament is back for it's 3rd edition**. This friendly tournament is an inhouse tournament for Doomsday's twitch subscribers (and a few close friends). The tournament will span over 7 weeks with the Qualifiers starting this weekend. The tournament will be streamed over on [Doomsday twitch channel](https://www.twitch.tv/doomsday) and will feature players from a wide range of skill levels. You can learn more about the Corgi Cup [here](https://docs.google.com/spreadsheets/d/1WgCjEliR1Jg0mFox6cS5TkJbOd6UZWsoV3euLkXDkpc/edit#gid=1354042911) or just head over to Twitch for an 8pm UTC start on Saturday.
 
-<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
+## <a id="score"></a>Scorewatch: March week 4 (With Scorewatch Patrol)
 
 **[Cookiezi](https://osu.ppy.sh/users/124493) still proves his absolute dominance in the osu! Standard scene by pulling off a crazy HDHR 97.07% FC on [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmaps/890911&m=0) on Vert's Extreme, giving him 423pp and the only HDHR FC and only FC without score reducing mods.** Simply mindblowing, then again, he is Cookiezi.
 
@@ -77,7 +77,7 @@ NOTABLE MENTIONS:
 
 [Rohulk](https://osu.ppy.sh/users/3219026) boasts his incredible consistency with an amazing HDHR SS on [Kano - Kimiiro Hanabi -album version-](https://osu.ppy.sh/beatmapsets/514772#osu/1093352) to give him 436pp.
 
-<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 2 Summary: Separation of the Brackets - with magnomizer</h2>
+## <a id="twc"></a>TWC 2017 Week 2 Summary: Separation of the Brackets - with magnomizer
 
 This week in the Round of 16, we were treated to 8 splendid matches between the 16 countries that remain in the tournament. While it was a shame that none of the matches were close enough for tiebreaker, the whole experience was intense nonetheless. Don't worry if you've missed out though, as you can always watch the VODs [here](https://www.twitch.tv/osulive/videos/all), or settle for a brief recap below:
 

--- a/news/2017-03-23-osuweekly-97.md
+++ b/news/2017-03-23-osuweekly-97.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/158736955798/osuweekly-97
 As we delve further into March madness, we edge closer and closer to the very serious month of April. What will we see in the final week of March, and what looms over the horizon in April?
 
 ![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-03-17-osuweekly-96">Previous</a></td>
 <td align="right">Next</td>
 </tr></table>
@@ -56,25 +57,25 @@ As we delve further into March madness, we edge closer and closer to the very se
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Z5LF2VZaQfs" frameborder="0" allowfullscreen></iframe>
 
-**[-GN](https://osu.ppy.sh/users/895581) definitely came out top this week with his amazing 5 miss HD score on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmaps/1114721) mapped by rrtyui. His score sits comfortably at 2nd and also gave him 231pp.** Check it out!
+**[-GN](https://osu.ppy.sh/users/895581) definitely came out top this week with his amazing 5 miss HD score on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmapsets/517474#osu/1114721) mapped by rrtyui. His score sits comfortably at 2nd and also gave him 231pp.** Check it out!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/iQuehNLVSCQ" frameborder="0" allowfullscreen></iframe>
 
-**[ExGon](https://osu.ppy.sh/users/214187) decided to take a swing at [Fleshgod Apocalypse - The Deceit / The Violation](https://osu.ppy.sh/beatmaps/974018&m=2) and set a 99.91% 5 miss score, hitting a peak combo of 3892.** Step aside Hypwer27 and Kyptoric, the 3rd no mod pass on this difficulty beats out both scores combined, with ExGon going past 600,000,000. Let's hope this shocking score won't bore you to death with 10 minutes of metal.
+**[ExGon](https://osu.ppy.sh/users/214187) decided to take a swing at [Fleshgod Apocalypse - The Deceit / The Violation](https://osu.ppy.sh/beatmapsets/367631#fruits/974018) and set a 99.91% 5 miss score, hitting a peak combo of 3892.** Step aside Hypwer27 and Kyptoric, the 3rd no mod pass on this difficulty beats out both scores combined, with ExGon going past 600,000,000. Let's hope this shocking score won't bore you to death with 10 minutes of metal.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/K0o_yEzYOBU" frameborder="0" allowfullscreen></iframe>
 
-**[Deceitful](https://osu.ppy.sh/users/1396447) became the 2nd osu!catch player to get an HDHR SS on [Halozy - Genryuu Kaiko](https://osu.ppy.sh/beatmaps/582801?m=2) (the 1st being ExGon), gaining a massive 898pp and the 2nd spot on the map.** The No. 1 Indonesian and Southeast Asian osu!catch player moved to 7th place with that score. Incredible stuff.
+**[Deceitful](https://osu.ppy.sh/users/1396447) became the 2nd osu!catch player to get an HDHR SS on [Halozy - Genryuu Kaiko](https://osu.ppy.sh/beatmapsets/253969#fruits/582801) (the 1st being ExGon), gaining a massive 898pp and the 2nd spot on the map.** The No. 1 Indonesian and Southeast Asian osu!catch player moved to 7th place with that score. Incredible stuff.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/nGB3Cnfg844" frameborder="0" allowfullscreen></iframe>
 
 NOTABLE MENTIONS:
 
-[Azer](https://osu.ppy.sh/users/2155578) passed this test with flying colors as he pulled off an impressive 99.85% HD FC on [Hatsune Miku - Kouon Chu Oniki Test](https://osu.ppy.sh/beatmaps/342074) on captin1's difficulty.
+[Azer](https://osu.ppy.sh/users/2155578) passed this test with flying colors as he pulled off an impressive 99.85% HD FC on [Hatsune Miku - Kouon Chu Oniki Test](https://osu.ppy.sh/beatmapsets/124997#osu/342074) on captin1's difficulty.
 
-[Musty](https://osu.ppy.sh/users/251683) has happily taken the 2nd place spot on [ke-ji feat. Nanahira - Ange du Blanc Pur](https://osu.ppy.sh/beatmaps/1192807) with an impressive 99.80% FC.
+[Musty](https://osu.ppy.sh/users/251683) has happily taken the 2nd place spot on [ke-ji feat. Nanahira - Ange du Blanc Pur](https://osu.ppy.sh/beatmapsets/564165#osu/1192807) with an impressive 99.80% FC.
 
-[Rohulk](https://osu.ppy.sh/users/3219026) boasts his incredible consistency with an amazing HDHR SS on [Kano - Kimiiro Hanabi -album version-](https://osu.ppy.sh/beatmaps/1093352) to give him 436pp.
+[Rohulk](https://osu.ppy.sh/users/3219026) boasts his incredible consistency with an amazing HDHR SS on [Kano - Kimiiro Hanabi -album version-](https://osu.ppy.sh/beatmapsets/514772#osu/1093352) to give him 436pp.
 
 <h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 2 Summary: Separation of the Brackets - with magnomizer</h2>
 

--- a/news/2017-03-30-osuweekly-98.md
+++ b/news/2017-03-30-osuweekly-98.md
@@ -22,7 +22,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news">Weekly news</h2>
+<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
 
 **Granted, you could have already figured this out by yourself, but [new.ppy.sh](https://osu.ppy.sh/home) has a [brand new look!](https://github.com/ppy/osu-web/pull/1054)** For those of you who are severely behind on the times, the work in progress of our new net platform is available for public testing. With the site inching steadily towards a release, there's not much time left to get your own name on a piece of osu! contribution history! If you have the technical know-how, you can head on over to the repository where you can contribute to the development of both the [osu-web](https://github.com/ppy/osu-web) and the [lazer](https://github.com/ppy/osu) projects.
 
@@ -32,7 +32,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 **It seems that [Ephemeral](https://osu.ppy.sh/users/Ephemeral) has hit a rather stiff hitch in his work, but is now nearing a complete recovery!** This means that popular events that I know you all have been *direly* needing news of will finally see the light of day sometime soon. Hopefully, we'll also finally have the new scheduled dev meeting for everyone to gloss over as well!
 
-<h2 name="com" id="com">Around the community</h2>
+<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
 
 **Our top spot regular [pishifat](https://osu.ppy.sh/users/pishifat) continues to deliver, this week giving us a little bit of his take on how we choose songs to be mapped!** This topic should be no stranger to a lot of those who already are well and beyond the gates of the ranked category. For those of us who are not yet so experienced, perhaps now is a good time to do yourself a favor and watch some of the videos that this man puts out. While I can't say watching a lot of videos in one go is very healthy, you'll find yourself well on your way to becoming a mapping champion a lot faster here!
 
@@ -40,7 +40,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ZQRfwRFgZW8" frameborder="0" allowfullscreen></iframe>
 
-<h2 name="score" id="score">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
+<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
 
 [Angelsim](https://osu.ppy.sh/users/1777162) took accuracy to the next league as he managed to pull off a stunning 99.74% FC on [LeaF - Paraclete](https://osu.ppy.sh/beatmapsets/455109), gaining 486pp. This play becomes the only play on the leaderboards to have a single digit 100 count. Almost flawless.
 
@@ -68,7 +68,7 @@ NOTABLE MENTIONS:
 
 [jakads](https://osu.ppy.sh/users/259972) pulled off an impressive 97.92% S rank score on [xi - PEACE BREAKER](https://osu.ppy.sh/beatmapsets/382682) on the 1.2x difficulty, only getting 38 misses throughout.
 
-<h2 name="twc" id="twc">TWC 2017 Week 3 Summary: Quarter Finals - with magnomizer</h2>
+<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 3 Summary: Quarter Finals - with magnomizer</h2>
 
 ![](http://nyquill.s-ul.eu/uQu8qlCt)
 

--- a/news/2017-03-30-osuweekly-98.md
+++ b/news/2017-03-30-osuweekly-98.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/158993380768/osuweekly-98
 This is the osu!weekly, coming to you straight from the new homepage! What new homepage, you may ask? Unless you're already the appropriate target for the first statement, you're going to have to read on to find out!
 
 ![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-03-23-osuweekly-97">Previous</a></td>
 <td align="right">Next</td>
 </tr></table>
@@ -26,7 +27,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 **Granted, you could have already figured this out by yourself, but [new.ppy.sh](https://osu.ppy.sh/home) has a [brand new look!](https://github.com/ppy/osu-web/pull/1054)** For those of you who are severely behind on the times, the work in progress of our new net platform is available for public testing. With the site inching steadily towards a release, there's not much time left to get your own name on a piece of osu! contribution history! If you have the technical know-how, you can head on over to the repository where you can contribute to the development of both the [osu-web](https://github.com/ppy/osu-web) and the [lazer](https://github.com/ppy/osu) projects.
 
-**The osu!weekly is currently trying to get more tournaments into our wiki!** If you are currently approved for a badge already from our lovely staff, send us an e-mail at news@ppy.sh to find out how you can participate in our community promotion program.
+**The osu!weekly is currently trying to get more tournaments into our wiki!** If you are currently approved for a badge already from our lovely staff, send us an e-mail at <news@ppy.sh> to find out how you can participate in our community promotion program.
 
 **While we wait for the new platform to take shape, [Loctav](https://osu.ppy.sh/users/71366) has sounded the [call to arms](https://osu.ppy.sh/community/forums/topics/573004/start=0) for mappers to start digging away at our featured artists!** That said, if you have a map of a song that is taken directly from our [featured artist listing](https://osu.ppy.sh/beatmaps/artists), drop your map in the thread and we'll see where we can take it together.
 
@@ -46,11 +47,11 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qs7cXPzDnHQ" frameborder="0" allowfullscreen></iframe>
 
-Care to play a 22 minute 7* map? Sure, said [ThePooN](https://osu.ppy.sh/users/718454), who went on to break the 1 billion score barrier and set a 6 miss 99.75% score on [Renard - Because Maybe! pt. 2](https://osu.ppy.sh/beatmaps/369349) that gave him 529pp. Sit down, relax, and listen to some Renard with some insane skill from this French player.
+Care to play a 22 minute 7* map? Sure, said [ThePooN](https://osu.ppy.sh/users/718454), who went on to break the 1 billion score barrier and set a 6 miss 99.75% score on [Renard - Because Maybe! pt. 2](https://osu.ppy.sh/beatmapsets/149471#osu/369349) that gave him 529pp. Sit down, relax, and listen to some Renard with some insane skill from this French player.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x0Nss79R0Js" frameborder="0" allowfullscreen></iframe>
 
-[WubWoofWolf](https://osu.ppy.sh/users/39828) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmaps/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
+[WubWoofWolf](https://osu.ppy.sh/beatmapsets/405167#osu/941254) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmaps/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Dr-3OlFqDcA" frameborder="0" allowfullscreen></iframe>
 

--- a/news/2017-03-30-osuweekly-98.md
+++ b/news/2017-03-30-osuweekly-98.md
@@ -18,12 +18,11 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 <ul>
   <li><a href="#news">Weekly News</a></li>
   <li><a href="#com">Around the community</a></li>
-  <li><a href="#tournament">Tournament Corner</a></li>
   <li><a href="#score">Score Watch</a></li>
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly news</h2>
+## <a id="news"></a>Weekly news
 
 **Granted, you could have already figured this out by yourself, but [new.ppy.sh](https://osu.ppy.sh/home) has a [brand new look!](https://github.com/ppy/osu-web/pull/1054)** For those of you who are severely behind on the times, the work in progress of our new net platform is available for public testing. With the site inching steadily towards a release, there's not much time left to get your own name on a piece of osu! contribution history! If you have the technical know-how, you can head on over to the repository where you can contribute to the development of both the [osu-web](https://github.com/ppy/osu-web) and the [lazer](https://github.com/ppy/osu) projects.
 
@@ -33,7 +32,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 **It seems that [Ephemeral](https://osu.ppy.sh/users/Ephemeral) has hit a rather stiff hitch in his work, but is now nearing a complete recovery!** This means that popular events that I know you all have been *direly* needing news of will finally see the light of day sometime soon. Hopefully, we'll also finally have the new scheduled dev meeting for everyone to gloss over as well!
 
-<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
+## <a id="com"></a>Around the community
 
 **Our top spot regular [pishifat](https://osu.ppy.sh/users/pishifat) continues to deliver, this week giving us a little bit of his take on how we choose songs to be mapped!** This topic should be no stranger to a lot of those who already are well and beyond the gates of the ranked category. For those of us who are not yet so experienced, perhaps now is a good time to do yourself a favor and watch some of the videos that this man puts out. While I can't say watching a lot of videos in one go is very healthy, you'll find yourself well on your way to becoming a mapping champion a lot faster here!
 
@@ -41,7 +40,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ZQRfwRFgZW8" frameborder="0" allowfullscreen></iframe>
 
-<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: March week 4 (With Scorewatch Patrol)</h2>
+## <a id="score"></a>Scorewatch: March week 4 (With Scorewatch Patrol)
 
 [Angelsim](https://osu.ppy.sh/users/1777162) took accuracy to the next league as he managed to pull off a stunning 99.74% FC on [LeaF - Paraclete](https://osu.ppy.sh/beatmapsets/455109), gaining 486pp. This play becomes the only play on the leaderboards to have a single digit 100 count. Almost flawless.
 
@@ -51,7 +50,7 @@ Care to play a 22 minute 7* map? Sure, said [ThePooN](https://osu.ppy.sh/users/7
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x0Nss79R0Js" frameborder="0" allowfullscreen></iframe>
 
-[WubWoofWolf](https://osu.ppy.sh/beatmapsets/405167#osu/941254) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmapsets/405167#osu/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
+[WubWoofWolf](https://osu.ppy.sh/users/39828) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmapsets/405167#osu/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Dr-3OlFqDcA" frameborder="0" allowfullscreen></iframe>
 
@@ -69,7 +68,7 @@ NOTABLE MENTIONS:
 
 [jakads](https://osu.ppy.sh/users/259972) pulled off an impressive 97.92% S rank score on [xi - PEACE BREAKER](https://osu.ppy.sh/beatmapsets/382682) on the 1.2x difficulty, only getting 38 misses throughout.
 
-<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 3 Summary: Quarter Finals - with magnomizer</h2>
+## <a id="twc"></a>TWC 2017 Week 3 Summary: Quarter Finals - with magnomizer
 
 ![](http://nyquill.s-ul.eu/uQu8qlCt)
 

--- a/news/2017-03-30-osuweekly-98.md
+++ b/news/2017-03-30-osuweekly-98.md
@@ -27,7 +27,7 @@ This is the osu!weekly, coming to you straight from the new homepage! What new h
 
 **Granted, you could have already figured this out by yourself, but [new.ppy.sh](https://osu.ppy.sh/home) has a [brand new look!](https://github.com/ppy/osu-web/pull/1054)** For those of you who are severely behind on the times, the work in progress of our new net platform is available for public testing. With the site inching steadily towards a release, there's not much time left to get your own name on a piece of osu! contribution history! If you have the technical know-how, you can head on over to the repository where you can contribute to the development of both the [osu-web](https://github.com/ppy/osu-web) and the [lazer](https://github.com/ppy/osu) projects.
 
-**The osu!weekly is currently trying to get more tournaments into our wiki!** If you are currently approved for a badge already from our lovely staff, send us an e-mail at <news@ppy.sh> to find out how you can participate in our community promotion program.
+**The osu!weekly is currently trying to get more tournaments into our wiki!** If you are currently approved for a badge already from our lovely staff, send us an e-mail at [news@ppy.sh](mailto:news@ppy.sh) to find out how you can participate in our community promotion program.
 
 **While we wait for the new platform to take shape, [Loctav](https://osu.ppy.sh/users/71366) has sounded the [call to arms](https://osu.ppy.sh/community/forums/topics/573004/start=0) for mappers to start digging away at our featured artists!** That said, if you have a map of a song that is taken directly from our [featured artist listing](https://osu.ppy.sh/beatmaps/artists), drop your map in the thread and we'll see where we can take it together.
 
@@ -51,7 +51,7 @@ Care to play a 22 minute 7* map? Sure, said [ThePooN](https://osu.ppy.sh/users/7
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x0Nss79R0Js" frameborder="0" allowfullscreen></iframe>
 
-[WubWoofWolf](https://osu.ppy.sh/beatmapsets/405167#osu/941254) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmaps/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
+[WubWoofWolf](https://osu.ppy.sh/beatmapsets/405167#osu/941254) makes the SS rank feel like a joke to him as he pulled that out of [Kuroneko Dungeon - Ryoushi no Umi no Lindwurm](https://osu.ppy.sh/beatmapsets/405167#osu/941254) on yf & Crystal's Extra with HDHR to gain 312pp. No one in the leaderboards are remotely close to him. See this flawless play for yourself!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Dr-3OlFqDcA" frameborder="0" allowfullscreen></iframe>
 

--- a/news/2017-04-06-osuweekly-99.md
+++ b/news/2017-04-06-osuweekly-99.md
@@ -22,7 +22,7 @@ April is off to a strong start. We're not even a week in and we have results for
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly News</h2>
+## <a id="news"></a>Weekly News
 
 **The first stage of Aspire 2017 finally concluded, and a winner was declared.** Dominating the conversation surrounding the contest from the start, [ProfessionalBox](https://osu.ppy.sh/users/3250792) (aka Somber Ibis) won explosively with top scores from all of the Honorable Mentions judges, as well as a massive, dominating lead in the overall public voting. [MinG3012](https://osu.ppy.sh/users/1583218) (as Versatile Mallard) and [Emilia](https://osu.ppy.sh/users/2003326) (as Tranquil Chipmunk) trailed further behind, just barely scraping past Sonnyc (as Forlorn Thrasher) to nab an Honorable Mention. Read more about it and find links to the ranked/loved maps [here](https://osu.ppy.sh/home/news/2017-04-03-aspire-2017-stage-one-concludes)! Otherwise, take a look at the winning entry below:
 
@@ -38,7 +38,7 @@ April is off to a strong start. We're not even a week in and we have results for
 
 **We've also hit a brand new milestone reaching 6 billion ranked plays!** A true testament to the community's growth over the years, this not-at-all-small milestone represents a **colossal** amount of time spent playing osu!. Assuming an average beatmap duration of 150s, that's over 900 BILLION seconds spent playing osu!, or 15bil minutes, or 250mil hours, which is nearly 29000~ collective years. Purely of osu!. Astonishing. 10 million users isn't far away, either!
 
-<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
+## <a id="com"></a>Around the community
 
 **Last week, we got some insight by [pishifat](https://osu.ppy.sh/users/3178418) about how to pick the right song to map, but then what?** You now have your very own map, but how do you get it noticed? How do you get people to take the time to look at your map and provide feedback. Well, pishifat's [newest video](https://www.youtube.com/watch?v=tCydtxk8yKA) covers different ways to get your map noticed and then looks at the pros and cons of each method.
 
@@ -48,7 +48,7 @@ April is off to a strong start. We're not even a week in and we have results for
 
 **[Raveille](https://osu.ppy.sh/users/1388767) has started up a new [beatmap project](https://osu.ppy.sh/community/forums/topics/576357) for this compendium of favorites looking to try create a massive multimode mapset.** The beatmap project will be a first come first server with the aim to have anywhere between 4-12 mappers taking part per gamemode. So if you'd like to take a crack at mapping any of these infamous songs, now might just be as good a time as any.
 
-<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: April Week 1 (With Scorewatch Patrol)</h2>
+## <a id="score"></a>Scorewatch: April Week 1 (With Scorewatch Patrol)
 
 **Once upon a time, long long ago, 800pp couldn't have even been thought of.** Now, one man stands with 2 such scores in his hands. Yes, you heard it right, [Cookiezi](https://osu.ppy.sh/users/124493) has set the 2nd 800pp osu!std play and the highest osu!std play of all time, with a 99.55% HDDT FC on [kradness&Reol - Remote Control](https://osu.ppy.sh/beatmaps/774965?m=0) to earn himself 817pp.
 
@@ -86,7 +86,7 @@ Not content with dab sliders alone, [Emilia](https://osu.ppy.sh/users/2003326) s
 
 Next week, for the 100th osu!weekly edition, we got something neat in store for the Scorewatch section. Make sure to return next week!
 
-<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 4 Summary: Onwards toward Finals glory</h2>
+## <a id="twc"></a>TWC 2017 Week 4 Summary: Onwards toward Finals glory
 
 The Semi Finals saw 12 amazing teams take up arms with a ticket to the finals on the line. While some of the teams started to really struggle with the ever increasing difficulty of each new mappool, other teams breezed right through it.  If you missed any of the action, you can always watch the VOD's [here](https://www.twitch.tv/osulive/videos/all), or settle of the brief recap below.
 

--- a/news/2017-04-06-osuweekly-99.md
+++ b/news/2017-04-06-osuweekly-99.md
@@ -21,7 +21,7 @@ April is off to a strong start. We're not even a week in and we have results for
   <li><a href="#twc">Taiko World Cup</a></li>
 </ul>
 
-<h2 name="news" id="news">Weekly News</h2>
+<h2 name="news" id="news" class="osu-md__header osu-md__header--2">Weekly News</h2>
 
 **The first stage of Aspire 2017 finally concluded, and a winner was declared.** Dominating the conversation surrounding the contest from the start, [ProfessionalBox](https://osu.ppy.sh/users/3250792) (aka Somber Ibis) won explosively with top scores from all of the Honorable Mentions judges, as well as a massive, dominating lead in the overall public voting. [MinG3012](https://osu.ppy.sh/users/1583218) (as Versatile Mallard) and [Emilia](https://osu.ppy.sh/users/2003326) (as Tranquil Chipmunk) trailed further behind, just barely scraping past Sonnyc (as Forlorn Thrasher) to nab an Honorable Mention. Read more about it and find links to the ranked/loved maps [here](https://osu.ppy.sh/home/news/2017-04-03-aspire-2017-stage-one-concludes)! Otherwise, take a look at the winning entry below:
 
@@ -37,7 +37,7 @@ April is off to a strong start. We're not even a week in and we have results for
 
 **We've also hit a brand new milestone reaching 6 billion ranked plays!** A true testament to the community's growth over the years, this not-at-all-small milestone represents a **colossal** amount of time spent playing osu!. Assuming an average beatmap duration of 150s, that's over 900 BILLION seconds spent playing osu!, or 15bil minutes, or 250mil hours, which is nearly 29000~ collective years. Purely of osu!. Astonishing. 10 million users isn't far away, either!
 
-<h2 name="com" id="com">Around the community</h2>
+<h2 name="com" id="com" class="osu-md__header osu-md__header--2">Around the community</h2>
 
 **Last week, we got some insight by [pishifat](https://osu.ppy.sh/users/3178418) about how to pick the right song to map, but then what?** You now have your very own map, but how do you get it noticed? How do you get people to take the time to look at your map and provide feedback. Well, pishifat's [newest video](https://www.youtube.com/watch?v=tCydtxk8yKA) covers different ways to get your map noticed and then looks at the pros and cons of each method.
 
@@ -47,7 +47,7 @@ April is off to a strong start. We're not even a week in and we have results for
 
 **[Raveille](https://osu.ppy.sh/users/1388767) has started up a new [beatmap project](https://osu.ppy.sh/community/forums/topics/576357) for this compendium of favorites looking to try create a massive multimode mapset.** The beatmap project will be a first come first server with the aim to have anywhere between 4-12 mappers taking part per gamemode. So if you'd like to take a crack at mapping any of these infamous songs, now might just be as good a time as any.
 
-<h2 name="score" id="score">Scorewatch: April Week 1 (With Scorewatch Patrol)</h2>
+<h2 name="score" id="score" class="osu-md__header osu-md__header--2">Scorewatch: April Week 1 (With Scorewatch Patrol)</h2>
 
 **Once upon a time, long long ago, 800pp couldn't have even been thought of.** Now, one man stands with 2 such scores in his hands. Yes, you heard it right, [Cookiezi](https://osu.ppy.sh/users/124493) has set the 2nd 800pp osu!std play and the highest osu!std play of all time, with a 99.55% HDDT FC on [kradness&Reol - Remote Control](https://osu.ppy.sh/beatmaps/774965?m=0) to earn himself 817pp.
 
@@ -85,7 +85,7 @@ Not content with dab sliders alone, [Emilia](https://osu.ppy.sh/users/2003326) s
 
 Next week, for the 100th osu!weekly edition, we got something neat in store for the Scorewatch section. Make sure to return next week!
 
-<h2 name="twc" id="twc">TWC 2017 Week 4 Summary: Onwards toward Finals glory</h2>
+<h2 name="twc" id="twc" class="osu-md__header osu-md__header--2">TWC 2017 Week 4 Summary: Onwards toward Finals glory</h2>
 
 The Semi Finals saw 12 amazing teams take up arms with a ticket to the finals on the line. While some of the teams started to really struggle with the ever increasing difficulty of each new mappool, other teams breezed right through it.  If you missed any of the action, you can always watch the VOD's [here](https://www.twitch.tv/osulive/videos/all), or settle of the brief recap below.
 

--- a/news/2017-04-06-osuweekly-99.md
+++ b/news/2017-04-06-osuweekly-99.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/159271999848/osuweekly-99
 April is off to a strong start. We're not even a week in and we have results for both Aspire and MBC \#15, not to mention new loved maps, a public dev meeting and some early information about a osu!taiko Aspire contest?
 
 ![](https://puu.sh/nqIAS/05e726ece8.jpg)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-03-30-osuweekly-98">Previous</a></td>
 <td align="right">Next</td>
 </tr></table>
@@ -65,19 +66,19 @@ April is off to a strong start. We're not even a week in and we have results for
 
 <iframe width="750" height="315" src="https://www.youtube.com/embed/IgEsw4GuAyI" frameborder="0" allowfullscreen></iframe>
 
-**[\_yu68](https://osu.ppy.sh/users/6170507) didn't make a fool out of himself on April Fools as he pulled off an amazing 99.82% DT FC on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmaps/1203661) to earn himself 704pp.** He'd be glad the score actually submitted.
+**[\_yu68](https://osu.ppy.sh/users/6170507) didn't make a fool out of himself on April Fools as he pulled off an amazing 99.82% DT FC on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmapsets/567916#taiko/1203661) to earn himself 704pp.** He'd be glad the score actually submitted.
 
 <iframe width="750" height="315" src="https://www.youtube.com/embed/HvQMFuonFk0" frameborder="0" allowfullscreen></iframe>
 
-**[Pope Gadget](https://osu.ppy.sh/users/2288341) pulled off a fascinating 99.58% 4 miss play on [sun3 - Morgenglut 2012](https://osu.ppy.sh/beatmaps/993347), a very fast and dense LN oriented map.** This is really something amazing coming from one of the best European players in osu!mania. Give it a watch!
+**[Pope Gadget](https://osu.ppy.sh/users/2288341) pulled off a fascinating 99.58% 4 miss play on [sun3 - Morgenglut 2012](https://osu.ppy.sh/beatmapsets/463897#mania/993347), a very fast and dense LN oriented map.** This is really something amazing coming from one of the best European players in osu!mania. Give it a watch!
 
 <iframe width="750" height="315" src="https://www.youtube.com/embed/6RlEyex9zTc" frameborder="0" allowfullscreen></iframe>
 
 NOTABLE MENTIONS:
 
-Not content with dab sliders alone, [Emilia](https://osu.ppy.sh/users/2003326) soared into the top 20 like a bullet as he pulled off a 98.05% HDDT FC on [Kanae Asaba - Endless Starlight ~Inochi no Kirameki~ (OP ver.)](https://osu.ppy.sh/beatmaps/1102144) to earn himself 639pp.
+Not content with dab sliders alone, [Emilia](https://osu.ppy.sh/users/2003326) soared into the top 20 like a bullet as he pulled off a 98.05% HDDT FC on [Kanae Asaba - Endless Starlight ~Inochi no Kirameki~ (OP ver.)](https://osu.ppy.sh/beatmapsets/518737#osu/1102144) to earn himself 639pp.
 
-[Vaxei](https://osu.ppy.sh/users/4787150) gladly took the No. 2 spot on [Ito Kanako - Skyclad no Kansokusha](https://osu.ppy.sh/beatmaps/907850) with a casual 99.34% HDDT FC, giving him 673pp.
+[Vaxei](https://osu.ppy.sh/users/4787150) gladly took the No. 2 spot on [Ito Kanako - Skyclad no Kansokusha](https://osu.ppy.sh/beatmapsets/416129#osu/907850) with a casual 99.34% HDDT FC, giving him 673pp.
 
 [SillyFangirl](https://osu.ppy.sh/users/2288363) got the co-co-co-co-combo breaker breaking as he broke his way through a 94.70% DT score on [Blitz Lunar - Mathsma Attack](https://osu.ppy.sh/beatmaps/703073&m=3) mapped by Shoegazer.
 

--- a/news/2017-05-11-osuweekly-103.md
+++ b/news/2017-05-11-osuweekly-103.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/160532947128/osuweekly-103
 Over 100 issues of the osu!weekly, 10 million users, and 10 years of unforgettable memories. A slew of new information this week made it one of the most memorable of our decade long history yet! Our story is only just beginning, so read on to find out what's been going on.
 
 ![](https://puu.sh/vMd30/5388c3131e.png)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-05-02-osuweekly-102">Previous</a></td>
 <td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-18-osuweekly-104">Next</a></td>
 </tr></table>
@@ -66,7 +67,7 @@ How on EARTH are you supposed to read this? [_Rise](https://osu.ppy.sh/users/521
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Mu7iI3A8pl4" frameborder="0" allowfullscreen></iframe>
 
-"We await the first FC on the SV difficulty of [Camellia - Shun no Shifudo o Ikashita Kare Fumi Paeria](https://osu.ppy.sh/beatmaps/977744)", that was what I wrote back in osu!weekly \#84, but it seems like the dream has came true, all thanks to [jakads](https://osu.ppy.sh/users/259972) who pulled off an outstanding 99.96% SD FC on the SV difficulty. This is one mania score you have got to watch!
+"We await the first FC on the SV difficulty of [Camellia - Shun no Shifudo o Ikashita Kare Fumi Paeria](https://osu.ppy.sh/beatmapsets/453985#mania/977744)", that was what I wrote back in osu!weekly \#84, but it seems like the dream has came true, all thanks to [jakads](https://osu.ppy.sh/users/259972) who pulled off an outstanding 99.96% SD FC on the SV difficulty. This is one mania score you have got to watch!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XA83qwZbUxM" frameborder="0" allowfullscreen></iframe>
 
@@ -78,7 +79,7 @@ How on EARTH are you supposed to read this? [_Rise](https://osu.ppy.sh/users/521
 
 [ExGon](https://osu.ppy.sh/users/214187) took 74 hours to complete [MillhioreF - Waltz o' the Irish](https://osu.ppy.sh/beatmaps/326585&m=0). Yes. 74 hours. He streamed this amazing slow slider score on twitch to complete an amazing 1 note SS score.
 
-[DanyL](https://osu.ppy.sh/users/3069354) and [Vaxei](https://osu.ppy.sh/users/4787150) blew Cookiezi's score into a pile of dust as they took [TrySail - High Free Spirits -TV.Ver-](https://osu.ppy.sh/beatmaps/980431) (Skystar's Extra) and smashed it with 96.79% and 98.82% HDDT FCs, giving them 692pp and 746pp respectively.
+[DanyL](https://osu.ppy.sh/users/3069354) and [Vaxei](https://osu.ppy.sh/users/4787150) blew Cookiezi's score into a pile of dust as they took [TrySail - High Free Spirits -TV.Ver-](https://osu.ppy.sh/beatmapsets/440706#osu/980431) (Skystar's Extra) and smashed it with 96.79% and 98.82% HDDT FCs, giving them 692pp and 746pp respectively.
 
 [Musty](https://osu.ppy.sh/users/251683) followed in Vaxei's footsteps and, within 2 weeks, secured a breathtaking 98.86% HR FC on [DragonForce - Symphony of the Night](https://osu.ppy.sh/beatmaps/985141?m=0) to earn himself 620pp.
 

--- a/news/2017-05-11-osuweekly-103.md
+++ b/news/2017-05-11-osuweekly-103.md
@@ -18,7 +18,7 @@ Over 100 issues of the osu!weekly, 10 million users, and 10 years of unforgettab
   <li><a href="#news">Weekly News</a></li>
   <li><a href="#com">Around the community</a></li>
   <li><a href="#score">Score Watch</a></li>
-<ul>
+</ul>
 
 <h2 name="news" id="news"><img src="http://nyquill.s-ul.eu/a0GJK4pB"/></h2>
 

--- a/news/2017-05-11-osuweekly-103.md
+++ b/news/2017-05-11-osuweekly-103.md
@@ -63,7 +63,7 @@ People wondered if [filsdelama](https://osu.ppy.sh/users/2831793) would follow u
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/uApdUofyhFI" frameborder="0" allowfullscreen></iframe>
 
-How on EARTH are you supposed to read this? [_Rise](https://osu.ppy.sh/users/5217107) pulled off the first ever HDHR FC on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmaps/1203661), scoring 527pp with his 99.10% score. Incredible.
+How on EARTH are you supposed to read this? [_Rise](https://osu.ppy.sh/users/5217107) pulled off the first ever HDHR FC on [Camellia - Exit This Earth's Atomosphere](https://osu.ppy.sh/beatmapsets/567916#taiko/1203661), scoring 527pp with his 99.10% score. Incredible.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Mu7iI3A8pl4" frameborder="0" allowfullscreen></iframe>
 


### PR DESCRIPTION
Fixes the header syntax errors as described in [this message (Discord)](https://discord.com/channels/188630481301012481/218677502141399041/837767574161850378) as well as a forgotten forward slash on osu!weekly #103

Apologies in advance if I messed anything up, I'm not extremely well versed in HTML or CSS