### PR TITLE
Add o!BWC2021 Registrations Open newspost & update wiki article

### DIFF
--- a/news/2021-05-02-osu-beatmapping-world-championship-2021-registrations-open.md
+++ b/news/2021-05-02-osu-beatmapping-world-championship-2021-registrations-open.md
@@ -1,0 +1,75 @@
+---
+layout: post
+title: "osu! Beatmapping World Championship 2021: Registrations Open"
+date: 2021-05-02 12:00:00 +0000
+---
+
+Attention to all mappers! osu! Beatmapping World Championship 2021 is on the horizon!
+
+![](/wiki/shared/news/banners/obwc2021.png)
+
+People say the third time is the charm, and here we are announcing the third iteration of osu! Beatmapping World Championship. We've got to make this one count, everyone!
+
+Having all the judges, participants and guests enjoy the spirit of the contest is the primary goal we've set to achieve. Therefore, we have taken your feedback by heart and applied certain changes to get us closer to this very objective. Without further adieu, let's have a look at what has changed!
+
+## Team Formation
+
+Similar to the last year's edition, teams will be formed based on the country they represent. However, this year, multiple teams can be formed to represent a particular country. If multiple teams are created within a single country, only the team with the highest score amongst them will proceed with the contest upon the first round.
+
+These teams may consist of 3-6 members, where all the members must come from the same country per their osu! profile. Each team can only be created and named by its *Team Captain*, who will act as the primary point of contact between the team and the contest staff. For Captains to form their teams, all participants must be logged in to our website beforehand. Otherwise, they will not be displayed on the *Team Creation* page.
+
+Once their Team Captain selects team members, each member will need to accept the invitation to join that team. Contest staff will later finalize the team creation once everyone accepts their invitation and the team name is approved. Before that, Captains are free to change members and the team name.
+
+## Contest Format
+
+The contest has four rounds. Unlike last year, we will be hosting an **accumulative leaderboard** to grant participating teams more chances to prove themselves.
+
+As mentioned above, only the highest-scoring team of a particular country will participate in the second round. Therefore, we will announce the results of the first round. However, the rest results will be kept confidential and will only be announced after the conclusion of the final round, during our livestream. There will be no eliminations after the first round.
+
+Each round, teams will be awarded a certain amount of points by the judges evaluating their entries. Obviously, these hard-earned points will not go to waste! Behind the scenes, these points will be added up to one another in the leaderboard, and the grand total will determine the final placement of the respective team.
+
+### Judges
+
+If you'd recall, we were looking for judges, details of which can be found in [this newspost](https://osu.ppy.sh/home/news/2021-04-11-osu-beatmapping-world-championship-2021-call-for-judges). We have received dozens of applicants over the span of a few weeks, and for that, we would like to thank you for your interest! Unfortunately, we have closed the osu! mode judge applications for this edition as of today, so if you're a latecomer, try to make it earlier next year! For multi-mode judges (osu!taiko, osu!catch and osu!mania), applications are still open! If you're interested, fill out the [application form](https://forms.gle/Yu2M2ZiwhapJYc7K7 "Google Forms") right away!
+
+## Schedule
+
+Keep in mind that schedules are subject to change if necessary.
+
+| Event | Timestamp |
+| --: | :-- |
+| Registration Phase | 2021-05-02/2021-05-16 |
+| First Round - Mapping phase | 2021-05-17/2021-05-31 |
+| First Round - Judging phase | 2021-06-01/2021-06-15 |
+| Second Round - Mapping phase | 2021-06-16/2021-06-30 |
+| Second Round - Judging phase | 2021-07-01/2021-07-15 |
+| Third Round - Mapping phase | 2021-07-16/2021-07-30 |
+| Third Round - Judging phase | 2021-07-31/2021-08-14 |
+| Fourth Round - Mapping phase | 2021-08-15/2021-08-29 |
+| Fourth Round - Judging phase | 2021-08-30/2021-09-13 |
+| Results Announcement & Livestream | 2021-09-15 |
+
+## Prizes
+
+We couldn't announce it as a contest if there were no prizes, could we? Well, here they are everyone! The prizes are as follows:
+
+| Placing | Prize(s) |
+| :-: | :-- |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 8 months of osu!supporter tag, unique profile badge, entries fast-tracked over to the qualified section |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 6 months of osu!supporter tag, unique profile badge |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 4 months of osu!supporter tag, unique profile badge |
+| **Players' Pick Winner** | 2 months of osu!supporter tag, unique profile badge |
+
+Note that Players' Pick and top 3 prizes can be added together if a team wins both prizes!
+
+## Registration
+
+Done reading and looking for where to register? You're at the right place! If you want to take part as a contestant, all you need to do is to login our website!
+
+For those wishing to form their teams as Team Captains, [**click here to create your team**](https://obwc.net/teams/create "o!BWC Team Creation")!
+
+---
+
+Everything related to the contest and beyond can be found on the [forum thread](https://osu.ppy.sh/community/forums/topics/1312490), [wiki article](/wiki/Contests/oBWC/3) and [the official website](https://obwc.net "o!BWC"). To keep yourself up-to-date, feel free to [follow us on Twitter](https://twitter.com/osubwc "Twitter") and [join our Discord server](https://discord.gg/CZp4bNx "Discord")!
+
+—Chaos, Imakuri, Mafumafu, Milan-, Nozhomi, Pachiru and Zeus-

--- a/wiki/Contests/oBWC/3/en.md
+++ b/wiki/Contests/oBWC/3/en.md
@@ -61,6 +61,7 @@ The osu! Beatmapping World Championship is run by various community members.
 - [Twitter](https://twitter.com/osubwc)
 - [Livestream](https://www.twitch.tv/osubwc)
 - [Official website](https://obwc.net/)
+- [Official documentation](https://gist.github.com/zeusminus/5b7cac0cbd6bcec422776dac5085f25f)
 
 ## Ruleset
 

--- a/wiki/Contests/oBWC/3/en.md
+++ b/wiki/Contests/oBWC/3/en.md
@@ -34,10 +34,12 @@ All deadlines start at 00:00 UTC and end at 23:59 UTC.
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | *To be announced* |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | *To be announced* |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | *To be announced* |
-| **Players' Pick Winner** | *To be announced* |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 8 months of osu!supporter tag, unique profile badge, entries fast-tracked over to the qualified section |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 6 months of osu!supporter tag, unique profile badge |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 4 months of osu!supporter tag, unique profile badge |
+| **Players' Pick Winner** | 2 months of osu!supporter tag, unique profile badge¹ |
+
+¹ Profile badge is pending approval
 
 ## Organisation
 
@@ -46,10 +48,10 @@ The osu! Beatmapping World Championship is run by various community members.
 | Position | Member(s) |
 | :-- | :-- |
 | Host | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870), ![][flag_FR] [Imakuri](https://osu.ppy.sh/users/6100837), ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909), ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994), ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981), ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983), ![][flag_TR] [Zeus-](https://osu.ppy.sh/users/5464437) |
-| Web manager | ![][flag_FR] [Imakuri](https://osu.ppy.sh/users/6100837), ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994) |
+| Web manager | ![][flag_CL] [Milan-](https://osu.ppy.sh/users/1052994), ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983) |
 | Mapper judge | *To be announced* |
 | Player judge | *To be announced* |
-| Designer | ![][flag_FR] [Imakuri](https://osu.ppy.sh/users/6100837), ![][flag_CA] [Kaetwo](https://osu.ppy.sh/users/1997719) |
+| Designer | ![][flag_CA] [Kaetwo](https://osu.ppy.sh/users/1997719) |
 | Statistician | ![][flag_CN] [Mafumafu](https://osu.ppy.sh/users/3076909), ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981) |
 | Wiki editor | ![][flag_TR] [Zeus-](https://osu.ppy.sh/users/5464437) |
 
@@ -58,6 +60,7 @@ The osu! Beatmapping World Championship is run by various community members.
 - [Discord server](https://discord.gg/CZp4bNx)
 - [Twitter](https://twitter.com/osubwc)
 - [Livestream](https://www.twitch.tv/osubwc)
+- [Official website](https://obwc.net/)
 
 ## Ruleset
 
@@ -76,11 +79,27 @@ The osu! Beatmapping World Championship is run by various community members.
 13. **Teams must consist of users from a single country only.** Merging or combining countries does not allow people to represent their individual country to the fullest. You can only join the team that belongs to the country displayed on your osu! profile.
 14. **Keep the organizers in touch with team updates past the preparation phase.** If a contestant has to drop out from the contest for any reason, please let the staff know about it as soon as possible. No replacements will be allowed and no rewards will be attributed to the user if the team achieves the top 3 or is nominated for the Players' Pick award. Users that quit the contest are not able to rejoin. If the number of participants drops below the required minimum, the team will be disqualified.
 
+## Judging criteria
+
+### Mapper panel
+
+- **Cohesion (30%)**: This criterion will focus on how consistent the map is. All elements of the map has to remain coherent with the rhythm and the music. For instance, if the entry represents the music well and the sections from different members are integrated seamlessly without weird transitions and abrupt spikes, that entry deserves to be praised.
+- **Expertise (30%)**: Our judges are also expected to focus on the advanced skills or expertise of mapping. A map with high expertise shows excellent management over note patterns, flows, movements, and even hitsounds. Those maps are outstanding compared with their peers in this contest and mark themselves as top-tier in the state-of-the-art mapping community.
+- **Creativity (30%)**: As with everything, beatmaps and mapping techniques are subject to change over time. Moreover, the history of osu!mapping is always shaped by creative maps, showing an avant-garde or even ahead-of-time understanding of mapping. Creative yet solid maps are the art of osu! and thus definitely promoted in this contest.
+- **Judge's Impression (10%)**: Judges can use this for extra scores or penalties for their specific comments or remarks on something in the entry.
+
+### Player panel
+
+- **Sophistication (30%)**: This criterion will focus on how comfortable it is to play the beatmap, according to its difficulty level. As much as they can be considered pieces of art, beatmaps are defined as in-game levels made for users to enjoy them. Therefore, for them to gain players' attraction, they need to be player-friendly first.
+- **Profundity (30%)**: Players are supposed to rate the quality of the beatmap by looking at nothing but its structure. Playing a super-simple jump/stream map might be fun, but we are here to have a competition here after all! Establishing complex mapping structures can take vast amounts of time and effort. Thus players are supposed to take the profundities of the beatmaps into account during their evaluation.
+- **Uniqueness (30%)**: Throughout the history of osu!, we can see that beatmaps displaying unique patterns usually be the centre of community attention and sometimes even become era-defining masterpieces. With that in mind, we would like to draw players' attention to the artistic aspects of mapping and see where their opinions revolve.
+- **Player's Impression (10%)**: Players are asked to note down their personal thoughts and subjective opinions regarding the beatmap and rate it accordingly.
+
 ## FAQ
 
 1. **What is this contest?**
 
-The osu! Beatmapping World Championship is a standard mode contest where several countries compete against each other to show off their country's mapping ability. Each team member will be handpicked by a Team Captain, composed of 3 to 6 members, including the Team Captain.
+The osu! Beatmapping World Championship is an osu! mode mapping contest where several countries compete against each other to show off their country's mapping ability. Each team member will be handpicked by a Team Captain, composed of 3 to 6 members, including the Team Captain.
 
 2. **How does this contest work?**
 

--- a/wiki/Contests/oBWC/en.md
+++ b/wiki/Contests/oBWC/en.md
@@ -6,3 +6,4 @@ Index page for all of the osu! Beatmapping World Championship series.
 
 - [osu! Mapping World Cup #1](1)
 - [osu! Beatmapping World Championship 2020](2)
+- [osu! Beatmapping World Championship 2021](3)


### PR DESCRIPTION
*The third time is the charm!* 🗺️ 

- Add osu! Beatmapping World Championship 2021 Registrations Open newspost
- Update prizes, staff listing on the wiki
- Add judging criteria and a link to the official website to the wiki