### PR TITLE
[ID] Add "Ranking Criteria Council"

### DIFF
--- a/wiki/Ranking_Criteria/Ranking_Criteria_Council/en.md
+++ b/wiki/Ranking_Criteria/Ranking_Criteria_Council/en.md
@@ -54,7 +54,7 @@ Members of the Ranking Criteria Council were hand-picked to represent different 
 - ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) (QAT)
 - ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092) (QAT)
 
-The Ranking Criteria Council was ultimately unsuccessful. Only members involved in osu!catch promoted new proposals, while the other game modes did not make progress until the Ranking Criteira Council was disbanded and replaced with the United Beat-Knights of Ranking Criteria.
+The Ranking Criteria Council was ultimately unsuccessful. Only members involved in osu!catch promoted new proposals, while the other game modes did not make progress until the Ranking Criteria Council was disbanded and replaced with the United Beat-Knights of Ranking Criteria.
 
 ## United Beat-Knights of Ranking Criteria
 

--- a/wiki/Ranking_Criteria/Ranking_Criteria_Council/en.md
+++ b/wiki/Ranking_Criteria/Ranking_Criteria_Council/en.md
@@ -12,53 +12,53 @@ Members of the Ranking Criteria Council were hand-picked to represent different 
 
 ### osu! members
 
-- [Charles445](https://osu.ppy.sh/users/85000) (American mappers)
+- ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) (American mappers)
 - *(vacant)* (American players)
-- [Cherry Blossom](https://osu.ppy.sh/users/1156742) (European mappers)
-- [Doomsday](https://osu.ppy.sh/users/18983) (European players)
+- ![][flag_FR] [Cherry Blossom](https://osu.ppy.sh/users/1156742) (European mappers)
+- ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983) (European players)
 - *(vacant)* (Asian mappers)
-- [Frostmourne](https://osu.ppy.sh/users/199669) (Asian players)
-- [Garven](https://osu.ppy.sh/users/244216) (QAT)
-- [Mao](https://osu.ppy.sh/users/2204515) (QAT)
+- ![][flag_TH] [Frostmourne](https://osu.ppy.sh/users/199669) (Asian players)
+- ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) (QAT)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) (QAT)
 
 ### osu!taiko members
 
-- [OzzyOzrock](https://osu.ppy.sh/users/465153) (American mappers)
-- [Shyguy](https://osu.ppy.sh/users/178038) (American players)
-- [Nwolf](https://osu.ppy.sh/users/1910766) (European mappers)
+- ![][flag_US] [OzzyOzrock](https://osu.ppy.sh/users/465153) (American mappers)
+- ![][flag_US] [Shyguy](https://osu.ppy.sh/users/178038) (American players)
+- ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) (European mappers)
 - *(vacant)* (European players)
-- [qoot8123](https://osu.ppy.sh/users/766371) (Asian mappers)
-- [bbj0920](https://osu.ppy.sh/users/87546) (Asian players)
-- [MMzz](https://osu.ppy.sh/users/128993) (QAT)
-- [DakeDekaane](https://osu.ppy.sh/users/1425253) (QAT)
+- ![][flag_TW] [qoot8123](https://osu.ppy.sh/users/766371) (Asian mappers)
+- ![][flag_KR] [bbj0920](https://osu.ppy.sh/users/87546) (Asian players)
+- ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) (QAT)
+- ![][flag_MX] [DakeDekaane](https://osu.ppy.sh/users/1425253) (QAT)
 
 ### osu!catch members
 
-- [ZiRox](https://osu.ppy.sh/users/200768) (American mappers)
-- [Zak](https://osu.ppy.sh/users/1375955) (American players)
-- [JBHyperion](https://osu.ppy.sh/users/4879508) (European mappers)
+- ![][flag_CL] [ZiRoX](https://osu.ppy.sh/users/200768) (American mappers)
+- ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955) (American players)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) (European mappers)
 - *(vacant)* (European players)
-- [Spectator](https://osu.ppy.sh/users/702598) (Asian mappers)
-- [He Ang Erika](https://osu.ppy.sh/users/2451381) (Asian players)
-- [Deif](https://osu.ppy.sh/users/318565) (QAT)
-- [Kurokami](https://osu.ppy.sh/users/260933) (QAT)
+- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) (Asian mappers)
+- ![][flag_SG] [He Ang Erika](https://osu.ppy.sh/users/2451381) (Asian players)
+- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) (QAT)
+- ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) (QAT)
 
 ### osu!mania members
 
-- [Fullerene-](https://osu.ppy.sh/users/2531335) (American mappers)
-- [Halogen-](https://osu.ppy.sh/users/169992) (American players)
-- [-Kamikaze-](https://osu.ppy.sh/users/2124783) (European mappers)
-- [Hayabusa](https://osu.ppy.sh/users/3104108) (European players)
-- [iJinjin](https://osu.ppy.sh/users/2141612) (Asian mappers)
-- [Cryolien](https://osu.ppy.sh/users/1626983) (Asian players)
-- [Starry-](https://osu.ppy.sh/users/2166199) (QAT)
-- [Blocko](https://osu.ppy.sh/users/4075092) (QAT)
+- ![][flag_CA] [Fullerene-](https://osu.ppy.sh/users/2531335) (American mappers)
+- ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992) (American players)
+- ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/users/2124783) (European mappers)
+- ![][flag_GB] [Hayabusa](https://osu.ppy.sh/users/3104108) (European players)
+- ![][flag_US] (![][flag_KR]) [Jinjin](https://osu.ppy.sh/users/3360737) (Asian mappers)
+- ![][flag_MY] [Cryolien](https://osu.ppy.sh/users/1626983) (Asian players)
+- ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) (QAT)
+- ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092) (QAT)
 
-The Ranking Criteria Council was ultimately unsuccessful. Only members involved in osu!catch promoted new proposals, while the other game modes did not make progress until the Ranking Criteira Council was disbanded and replaced with the United Beat-knights of Ranking Criteria.
+The Ranking Criteria Council was ultimately unsuccessful. Only members involved in osu!catch promoted new proposals, while the other game modes did not make progress until the Ranking Criteira Council was disbanded and replaced with the United Beat-Knights of Ranking Criteria.
 
 ## United Beat-Knights of Ranking Criteria
 
-The United Beat-Knights of Ranking Criteria (*UBKRC*) was a new group with similar goals to the Ranking Criteria Council, however it was handled with less strictness. The group chose an intentionally stupid name to appear more friendly than its predecessor. The group was managed by [Okoratu](https://osu.ppy.sh/users/1623405) and [pishifat](https://osu.ppy.sh/users/3178418) until completion.
+The **United Beat-Knights of Ranking Criteria** (*UBKRC*) was a new group with similar goals to the Ranking Criteria Council, however it was handled with less strictness. The group chose an intentionally stupid name to appear more friendly than its predecessor. The group was managed by ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) and ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) until completion.
 
 Within the UBKRC, teams of experts were chosen to handle each area of the general Ranking Criteria and game-mode specific sections. Users could join if they showed an active interest in any group.
 
@@ -66,97 +66,121 @@ Between 2016 and 2018, the UBKRC reformed all sections of the Ranking Criteria t
 
 ### osu! members
 
-- [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
-- [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
-- [Monstrata](https://osu.ppy.sh/users/2706438)
-- [Zexous](https://osu.ppy.sh/users/1715876)
-- [hehe](https://osu.ppy.sh/users/2123087)
-- [Doyak](https://osu.ppy.sh/users/2046893)
-- [Myxo](https://osu.ppy.sh/users/2202645)
-- [Wafu](https://osu.ppy.sh/users/888955)
-- [Mir](https://osu.ppy.sh/users/8688812)
-- [-Mo-](https://osu.ppy.sh/users/2202163)
-- [Naxess](https://osu.ppy.sh/users/8129817)
-- [Plaudible](https://osu.ppy.sh/users/7149815)
-- [Shiirn](https://osu.ppy.sh/users/465126)
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
+- ![][flag_CA] [Monstrata](https://osu.ppy.sh/users/2706438)
+- ![][flag_US] [Zexous](https://osu.ppy.sh/users/1715876)
+- ![][flag_SG] [hehe](https://osu.ppy.sh/users/2123087)
+- ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893)
+- ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812)
+- ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163)
+- ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817)
+- ![][flag_US] [Plaudible](https://osu.ppy.sh/users/7149815)
+- ![][flag_US] [Shiirn](https://osu.ppy.sh/users/465126)
 
 ### osu!taiko members
 
-- [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
-- [Raiden](https://osu.ppy.sh/users/2239480) (Organizer)
-- [Aldwych](https://osu.ppy.sh/users/1416484)
-- [Arrival](https://osu.ppy.sh/users/1694000)
-- [hikikochan](https://osu.ppy.sh/users/6512678)
-- [Nardoxyribonucleic](https://osu.ppy.sh/users/876419)
-- [Nwolf](https://osu.ppy.sh/users/1910766)
-- [qoot8123](https://osu.ppy.sh/users/766371)
-- [OnosakiHito](https://osu.ppy.sh/users/290128)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) (Organizer)
+- ![][flag_FR] [Aldwych](https://osu.ppy.sh/users/1416484)
+- ![][flag_FR] [Arrival](https://osu.ppy.sh/users/1694000)
+- ![][flag_US] [hikikochan](https://osu.ppy.sh/users/6512678)
+- ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419)
+- ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766)
+- ![][flag_TW] [qoot8123](https://osu.ppy.sh/users/766371)
+- ![][flag_DE] [OnosakiHito](https://osu.ppy.sh/users/290128)
 
 ### osu!catch members
 
-- [JBHyperion](https://osu.ppy.sh/users/4879508) (Organizer)
-- [Deif](https://osu.ppy.sh/users/318565) (Organizer)
-- [He Ang CTB](https://osu.ppy.sh/users/2451381)
-- [Kurokami](https://osu.ppy.sh/users/260933)
-- [Zak](https://osu.ppy.sh/users/1375955)
-- [ZiRoX](https://osu.ppy.sh/users/200768)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) (Organizer)
+- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) (Organizer)
+- ![][flag_SG] [He Ang CTB](https://osu.ppy.sh/users/2451381)
+- ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933)
+- ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955)
+- ![][flag_CL] [ZiRoX](https://osu.ppy.sh/users/200768)
 
 ### osu!mania members
 
 *Note: The original osu!mania UBKRC members were unable to complete a Ranking Criteria draft and were replaced by the users below*
 
-- [Feerum](https://osu.ppy.sh/users/4815717) (Organizer)
-- [Maxus](https://osu.ppy.sh/users/4335785) (Organizer)
-- [MEGAtive](https://osu.ppy.sh/users/3094101)
-- [-MysticEyes](https://osu.ppy.sh/users/6253266)
-- [Kawawa](https://osu.ppy.sh/users/4647754)
+- ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717) (Organizer)
+- ![][flag_ID] [Maxus](https://osu.ppy.sh/users/4335785) (Organizer)
+- ![][flag_ID] [MEGAtive](https://osu.ppy.sh/users/3094101)
+- ![][flag_US] [-MysticEyes](https://osu.ppy.sh/users/6253266)
+- ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754)
 
 ### Metadata members
 
-- [IamKwaN](https://osu.ppy.sh/users/1856463) (Organizer)
-- [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
-- [Lanturn](https://osu.ppy.sh/users/1446665)
-- [alacat](https://osu.ppy.sh/users/869782)
-- [Fycho](https://osu.ppy.sh/users/1876867)
-- [neonat](https://osu.ppy.sh/users/1561995)
-- [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) (Organizer)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
+- ![][flag_US] [Lanturn](https://osu.ppy.sh/users/1446665)
+- ![][flag_JP] [alacat](https://osu.ppy.sh/users/869782)
+- ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867)
+- ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
 
 ### Storyboarding members
 
-- [Naxess](https://osu.ppy.sh/users/8129817) (Organizer)
-- [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
-- [Damnae](https://osu.ppy.sh/users/989377)
-- [Sidetail](https://osu.ppy.sh/users/2036217)
-- [Starrodkirby86](https://osu.ppy.sh/users/410)
-- [Wafu](https://osu.ppy.sh/users/888955)
-- [yf_bmp](https://osu.ppy.sh/users/1243669)
+- ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) (Organizer)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
+- ![][flag_DE] [Damnae](https://osu.ppy.sh/users/989377)
+- ![][flag_CA] [Sidetail](https://osu.ppy.sh/users/2036217)
+- ![][flag_US] [Starrodkirby86](https://osu.ppy.sh/users/410)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669)
 
 ### Timing members
 
-- [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
-- [Shiro](https://osu.ppy.sh/users/113005)
-- [Bonsai](https://osu.ppy.sh/users/987334)
-- [JBHyperion](https://osu.ppy.sh/users/4879508)
-- [Okoratu](https://osu.ppy.sh/users/1623405)
-- [Raiden](https://osu.ppy.sh/users/2239480)
-- [frukoyurdakul](https://osu.ppy.sh/users/7612550)
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
+- ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005)
+- ![][flag_AT] [Bonsai](https://osu.ppy.sh/users/987334)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480)
+- ![][flag_TR] [frukoyurdakul](https://osu.ppy.sh/users/7612550)
 
 ### Spread members
 
-- [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
-- [Blocko](https://osu.ppy.sh/users/4075092)
-- [Doyak](https://osu.ppy.sh/users/2046893)
-- [Myxo](https://osu.ppy.sh/users/2202645)
-- [JBHyperion](https://osu.ppy.sh/users/4879508)
-- [Monstrata](https://osu.ppy.sh/users/2706438)
-- [Zexous](https://osu.ppy.sh/users/1715876)
-- [Okoratu](https://osu.ppy.sh/users/1623405)
-- [Raiden](https://osu.ppy.sh/users/2239480)
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Organizer)
+- ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092)
+- ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893)
+- ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508)
+- ![][flag_CA] [Monstrata](https://osu.ppy.sh/users/2706438)
+- ![][flag_US] [Zexous](https://osu.ppy.sh/users/1715876)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480)
 
 ### Skinning members
 
-- [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
-- [Chaoslitz](https://osu.ppy.sh/users/3621552)
-- [Haskorion](https://osu.ppy.sh/users/3252321)
-- [Noffy](https://osu.ppy.sh/users/1541323)
-- [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Organizer)
+- ![][flag_HK] [Chaoslitz](https://osu.ppy.sh/users/3621552)
+- ![][flag_DE] [Haskorion](https://osu.ppy.sh/users/3252321)
+- ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+
+[flag_AT]: /wiki/shared/flag/AT.gif "Austria"
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CN]: /wiki/shared/flag/CN.gif "China"
+[flag_CL]: /wiki/shared/flag/CL.gif "Chile"
+[flag_CZ]: /wiki/shared/flag/CL.gif "Czech Republic"
+[flag_DE]: /wiki/shared/flag/DE.gif "Germany"
+[flag_ES]: /wiki/shared/flag/ES.gif "Spain"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "United Kingdom"
+[flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
+[flag_HU]: /wiki/shared/flag/HU.gif "Hungary"
+[flag_ID]: /wiki/shared/flag/ID.gif "Indonesia"
+[flag_JP]: /wiki/shared/flag/JP.gif "Japan"
+[flag_KR]: /wiki/shared/flag/KR.gif "South Korea"
+[flag_MX]: /wiki/shared/flag/MX.gif "Mexico"
+[flag_MY]: /wiki/shared/flag/MY.gif "Malaysia"
+[flag_PL]: /wiki/shared/flag/PL.gif "Poland"
+[flag_SE]: /wiki/shared/flag/SE.gif "Sweden"
+[flag_SG]: /wiki/shared/flag/SG.gif "Singapore"
+[flag_TH]: /wiki/shared/flag/TH.gif "Thailand"
+[flag_TR]: /wiki/shared/flag/TR.gif "Turkey"
+[flag_TW]: /wiki/shared/flag/TW.gif "Taiwan"
+[flag_US]: /wiki/shared/flag/US.gif "United States"

--- a/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
+++ b/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
@@ -54,7 +54,7 @@ Layaknya [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) terda
 - ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) (perwakilan QAT)
 - ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092) (perwakilan QAT)
 
-Dalam prakteknya, Ranking Criteria Council dinilai gagal dalam melaksanakan tugasnya. Dari empat divisi yang ada, hanya divisi osu!catch yang berhasil merombak Ranking Criteria yang ada. Ranking Criteria Council pun dibubarkan untuk kemudian digantikan oleh United Beat-Knights of Ranking Criteria.
+Dalam prakteknya, Ranking Criteria Council dinilai gagal dalam melaksanakan tugasnya. Dari empat divisi yang ada, hanya divisi osu!catch yang berhasil merombak Ranking Criteria sebagaimana yang diharapkan. Ranking Criteria Council pun dibubarkan untuk kemudian digantikan oleh United Beat-Knights of Ranking Criteria.
 
 ## United Beat-Knights of Ranking Criteria
 

--- a/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
+++ b/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
@@ -54,7 +54,7 @@ Layaknya [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) terda
 - ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) (perwakilan QAT)
 - ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092) (perwakilan QAT)
 
-Dalam prakteknya, Ranking Criteria Council dinilai gagal dalam melaksanakan tugasnya. Dari empat divisi yang ada, hanya divisi osu!catch yang berhasil merombak Ranking Criteria walaupun hasilnya belum maksimal. Ranking Criteria Council pun dibubarkan untuk kemudian digantikan oleh United Beat-Knights of Ranking Criteria.
+Dalam prakteknya, Ranking Criteria Council dinilai gagal dalam melaksanakan tugasnya. Dari empat divisi yang ada, hanya divisi osu!catch yang berhasil merombak Ranking Criteria yang ada. Ranking Criteria Council pun dibubarkan untuk kemudian digantikan oleh United Beat-Knights of Ranking Criteria.
 
 ## United Beat-Knights of Ranking Criteria
 

--- a/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
+++ b/wiki/Ranking_Criteria/Ranking_Criteria_Council/id.md
@@ -1,0 +1,186 @@
+# Ranking Criteria Council
+
+**Ranking Criteria Council** merupakan kelompok pengguna yang secara khusus dibentuk pada tahun 2016 untuk merombak ulang [Ranking Criteria](/wiki/Ranking_Criteria).
+
+Dahulu kala, terdapat banyak hal pada Ranking Criteria yang tidak terperinci dengan jelas. Para anggota [Quality Assurance Team](/wiki/Modding/Quality_Assurance_Team) (*QAT*) sering kali terpaksa menilai sesuatu hanya berdasarkan pengalaman dan sudut pandang mereka masing-masing. Hal ini memicu banyaknya beatmap yang didiskualifikasi atas alasan yang saling tidak konsisten antar satu sama lain, yang pada akhirnya mendorong pembentukan Ranking Criteria Council agar ke depannya osu! dapat memiliki Ranking Criteria yang terikat pada suatu standar yang jelas.
+
+Para anggota Ranking Criteria Council saling berdiskusi pada [sub-forum Ranking Criteria](https://osu.ppy.sh/community/forums/87) secara tertutup. Anggota-anggota komunitas lainnya dapat melihat hal-hal apa saja yang mereka diskusikan namun tidak dapat berpartisipasi di dalamnya.
+
+## Keanggotaan Ranking Criteria Council
+
+Layaknya [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) terdahulu, Ranking Criteria Council tersusun atas nama-nama ahli dari seluruh belahan dunia yang secara khusus ditunjuk untuk dapat mewakili wilayahnya masing-masing.
+
+### Anggota-anggota divisi osu!
+
+- ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) (perwakilan mapper Amerika)
+- *(lowong)* (perwakilan pemain Amerika)
+- ![][flag_FR] [Cherry Blossom](https://osu.ppy.sh/users/1156742) (perwakilan mapper Eropa)
+- ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983) (perwakilan pemain Eropa)
+- *(lowong)* (perwakilan mapper Asia)
+- ![][flag_TH] [Frostmourne](https://osu.ppy.sh/users/199669) (perwakilan pemain Asia)
+- ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) (perwakilan QAT)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) (perwakilan QAT)
+
+### Anggota-anggota divisi osu!taiko
+
+- ![][flag_US] [OzzyOzrock](https://osu.ppy.sh/users/465153) (perwakilan mapper Amerika)
+- ![][flag_US] [Shyguy](https://osu.ppy.sh/users/178038) (perwakilan pemain Amerika)
+- ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) (perwakilan mapper Eropa)
+- *(lowong)* (perwakilan pemain Eropa)
+- ![][flag_TW] [qoot8123](https://osu.ppy.sh/users/766371) (perwakilan mapper Asia)
+- ![][flag_KR] [bbj0920](https://osu.ppy.sh/users/87546) (perwakilan pemain Asia)
+- ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993) (perwakilan QAT)
+- ![][flag_MX] [DakeDekaane](https://osu.ppy.sh/users/1425253) (perwakilan QAT)
+
+### Anggota-anggota divisi osu!catch
+
+- ![][flag_CL] [ZiRoX](https://osu.ppy.sh/users/200768) (perwakilan mapper Amerika)
+- ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955) (perwakilan pemain Amerika)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) (perwakilan mapper Eropa)
+- *(lowong)* (perwakilan pemain Eropa)
+- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) (perwakilan mapper Asia)
+- ![][flag_SG] [He Ang Erika](https://osu.ppy.sh/users/2451381) (perwakilan pemain Asia)
+- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) (perwakilan QAT)
+- ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) (perwakilan QAT)
+
+### Anggota-anggota divisi osu!mania
+
+- ![][flag_CA] [Fullerene-](https://osu.ppy.sh/users/2531335) (perwakilan mapper Amerika)
+- ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992) (perwakilan pemain Amerika)
+- ![][flag_PL] [-Kamikaze-](https://osu.ppy.sh/users/2124783) (perwakilan mapper Eropa)
+- ![][flag_GB] [Hayabusa](https://osu.ppy.sh/users/3104108) (perwakilan pemain Eropa)
+- ![][flag_US] (![][flag_KR]) [Jinjin](https://osu.ppy.sh/users/3360737) (perwakilan mapper Asia)
+- ![][flag_MY] [Cryolien](https://osu.ppy.sh/users/1626983) (perwakilan pemain Asia)
+- ![][flag_GB] [Starry-](https://osu.ppy.sh/users/2166199) (perwakilan QAT)
+- ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092) (perwakilan QAT)
+
+Dalam prakteknya, Ranking Criteria Council dinilai gagal dalam melaksanakan tugasnya. Dari empat divisi yang ada, hanya divisi osu!catch yang berhasil merombak Ranking Criteria walaupun hasilnya belum maksimal. Ranking Criteria Council pun dibubarkan untuk kemudian digantikan oleh United Beat-Knights of Ranking Criteria.
+
+## United Beat-Knights of Ranking Criteria
+
+**United Beat-Knights of Ranking Criteria** (*UBKRC*) merupakan kelompok pengguna yang dibentuk dengan tujuan yang sama dengan Ranking Criteria Council, namun dengan sistem pengelolaan yang lebih terbuka. Agar tidak terkesan kaku seperti halnya Ranking Criteria Council terdahulu, nama UBKRC sengaja dipilih sedemikian rupa karena nama tersebut terkesan konyol dan mengada-ada. Kelompok ini sendiri diketuai oleh ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) dan ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418).
+
+UBKRC tersusun atas nama-nama ahli pada bidangnya masing-masing yang ditugaskan untuk merombak segala aspek yang dicakup oleh Ranking Criteria baik yang bersifat umum ataupun spesifik. Anggota-anggota komunitas lainnya yang tertarik untuk ikut berkontribusi dapat bergabung ke dalam UBKRC sewaktu-waktu apabila dibutuhkan.
+
+Setelah melewati proses kajian selama kurang lebih dua tahun, pada tahun 2018 UBKRC akhirnya berhasil menyusun Ranking Criteria baru yang sesuai dengan kebutuhan beatmap-beatmap modern. UBKRC pun lantas dibubarkan dan sub-forum Ranking Criteria kembali dibuka untuk umum setelahnya.
+
+### Anggota-anggota divisi osu!
+
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Koordinator)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Koordinator)
+- ![][flag_CA] [Monstrata](https://osu.ppy.sh/users/2706438)
+- ![][flag_US] [Zexous](https://osu.ppy.sh/users/1715876)
+- ![][flag_SG] [hehe](https://osu.ppy.sh/users/2123087)
+- ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893)
+- ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_DE] [Mir](https://osu.ppy.sh/users/8688812)
+- ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163)
+- ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817)
+- ![][flag_US] [Plaudible](https://osu.ppy.sh/users/7149815)
+- ![][flag_US] [Shiirn](https://osu.ppy.sh/users/465126)
+
+### Anggota-anggota divisi osu!taiko
+
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Koordinator)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480) (Koordinator)
+- ![][flag_FR] [Aldwych](https://osu.ppy.sh/users/1416484)
+- ![][flag_FR] [Arrival](https://osu.ppy.sh/users/1694000)
+- ![][flag_US] [hikikochan](https://osu.ppy.sh/users/6512678)
+- ![][flag_HK] [Nardoxyribonucleic](https://osu.ppy.sh/users/876419)
+- ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766)
+- ![][flag_TW] [qoot8123](https://osu.ppy.sh/users/766371)
+- ![][flag_DE] [OnosakiHito](https://osu.ppy.sh/users/290128)
+
+### Anggota-anggota divisi osu!catch
+
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) (Koordinator)
+- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) (Koordinator)
+- ![][flag_SG] [He Ang CTB](https://osu.ppy.sh/users/2451381)
+- ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933)
+- ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955)
+- ![][flag_CL] [ZiRoX](https://osu.ppy.sh/users/200768)
+
+### Anggota-anggota divisi osu!mania
+
+*Catatan: Divisi osu!mania UBKRC telah beberapa kali berganti personil seiring waktu. Nama-nama yang tertera di bawah ini adalah nama-nama yang berhasil menyelesaikan perombakan Ranking Criteria osu!mania pada akhir masa bakti UBKRC.*
+
+- ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717) (Koordinator)
+- ![][flag_ID] [Maxus](https://osu.ppy.sh/users/4335785) (Koordinator)
+- ![][flag_ID] [MEGAtive](https://osu.ppy.sh/users/3094101)
+- ![][flag_US] [-MysticEyes](https://osu.ppy.sh/users/6253266)
+- ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754)
+
+### Anggota-anggota divisi Metadata
+
+- ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) (Koordinator)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Koordinator)
+- ![][flag_US] [Lanturn](https://osu.ppy.sh/users/1446665)
+- ![][flag_JP] [alacat](https://osu.ppy.sh/users/869782)
+- ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867)
+- ![][flag_SG] [neonat](https://osu.ppy.sh/users/1561995)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+
+### Anggota-anggota divisi Storyboarding
+
+- ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) (Koordinator)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Koordinator)
+- ![][flag_DE] [Damnae](https://osu.ppy.sh/users/989377)
+- ![][flag_CA] [Sidetail](https://osu.ppy.sh/users/2036217)
+- ![][flag_US] [Starrodkirby86](https://osu.ppy.sh/users/410)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+- ![][flag_CN] [yf_bmp](https://osu.ppy.sh/users/1243669)
+
+### Anggota-anggota divisi Timing
+
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Koordinator)
+- ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005)
+- ![][flag_AT] [Bonsai](https://osu.ppy.sh/users/987334)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480)
+- ![][flag_TR] [frukoyurdakul](https://osu.ppy.sh/users/7612550)
+
+### Anggota-anggota divisi Beatmap Spread
+
+- ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) (Koordinator)
+- ![][flag_US] [Blocko](https://osu.ppy.sh/users/4075092)
+- ![][flag_KR] [Doyak](https://osu.ppy.sh/users/2046893)
+- ![][flag_DE] [Myxo](https://osu.ppy.sh/users/2202645)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508)
+- ![][flag_CA] [Monstrata](https://osu.ppy.sh/users/2706438)
+- ![][flag_US] [Zexous](https://osu.ppy.sh/users/1715876)
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405)
+- ![][flag_ES] [Raiden](https://osu.ppy.sh/users/2239480)
+
+### Anggota-anggota divisi Skinning
+
+- ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) (Koordinator)
+- ![][flag_HK] [Chaoslitz](https://osu.ppy.sh/users/3621552)
+- ![][flag_DE] [Haskorion](https://osu.ppy.sh/users/3252321)
+- ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
+- ![][flag_CZ] [Wafu](https://osu.ppy.sh/users/888955)
+
+[flag_AT]: /wiki/shared/flag/AT.gif "Austria"
+[flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
+[flag_CN]: /wiki/shared/flag/CN.gif "Tiongkok"
+[flag_CL]: /wiki/shared/flag/CL.gif "Cili"
+[flag_CZ]: /wiki/shared/flag/CL.gif "Republik Ceska"
+[flag_DE]: /wiki/shared/flag/DE.gif "Jerman"
+[flag_ES]: /wiki/shared/flag/ES.gif "Spanyol"
+[flag_FR]: /wiki/shared/flag/FR.gif "Prancis"
+[flag_GB]: /wiki/shared/flag/GB.gif "Britania Raya"
+[flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
+[flag_HU]: /wiki/shared/flag/HU.gif "Hungaria"
+[flag_ID]: /wiki/shared/flag/ID.gif "Indonesia"
+[flag_JP]: /wiki/shared/flag/JP.gif "Jepang"
+[flag_KR]: /wiki/shared/flag/KR.gif "Korea Selatan"
+[flag_MX]: /wiki/shared/flag/MX.gif "Meksiko"
+[flag_MY]: /wiki/shared/flag/MY.gif "Malaysia"
+[flag_PL]: /wiki/shared/flag/PL.gif "Polandia"
+[flag_SE]: /wiki/shared/flag/SE.gif "Swedia"
+[flag_SG]: /wiki/shared/flag/SG.gif "Singapura"
+[flag_TH]: /wiki/shared/flag/TH.gif "Thailand"
+[flag_TR]: /wiki/shared/flag/TR.gif "Turki"
+[flag_TW]: /wiki/shared/flag/TW.gif "Taiwan"
+[flag_US]: /wiki/shared/flag/US.gif "Amerika Serikat"


### PR DESCRIPTION
Indonesian translation for the Ranking Criteria Council (http://osu.ppy.sh/wiki/en/Ranking_Criteria/Ranking_Criteria_Council) wiki article.

plus i made a few changes/fixes to the original English article as well as follows :

- added corresponding flags
- fixed link to Jinjin's userpage (as it stands the article wrongly links to [stupud man](http://osu.ppy.sh/users/2141612) in Jinjin's place; although stupud man has briefly used the username "iJinjin" before, he's not the Jinjin that was involved in the Ranking Criteria Council back then. the Jinjin that we're looking for is [this Jinjin instead](http://osu.ppy.sh/users/3360737))
- fixed typo in ZiRoX's name