### PR TITLE
Extend the main page with new links and details

### DIFF
--- a/wiki/Main_Page/cs.md
+++ b/wiki/Main_Page/cs.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/de.md
+++ b/wiki/Main_Page/de.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -5,7 +5,7 @@ layout: main_page
 <!-- Do not add any empty lines inside this div. -->
 
 <div class="wiki-main-page__blurb">
-Welcome to the osu! wiki, the open-source knowledge base of osu!, a free-to-win rhythm game.
+Welcome to the osu! wiki, the open-source knowledge base containing a wide range of information related to osu!, a free-to-win rhythm game.
 </div>
 
 <div class="wiki-main-page__panels">
@@ -13,7 +13,7 @@ Welcome to the osu! wiki, the open-source knowledge base of osu!, a free-to-win 
 
 # Getting started
 
-Important articles and guides that help dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Help forum](https://osu.ppy.sh/forum/5), which is always open.
+Important articles and guides which will help you dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Help forum](https://osu.ppy.sh/forum/5).
 
 [Rules](/wiki/Rules) • [Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre)
 
@@ -24,7 +24,7 @@ Important articles and guides that help dive into osu!. In case anything goes wr
 
 # Game client
 
-Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to present. Get to know it better, from miscellaneous settings and customization possibilities to technical details and file formats it uses and understands.
+Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to present. Get to know it better, from various settings, through customization capabilities, to technical details and file formats the game uses.
 
 [Interface](/wiki/Interface) • [Options](/wiki/Options) • [Visual settings](/wiki/Visual_Settings) • [Shortcut key reference](/wiki/Shortcut_key_reference) • [Configuration file](/wiki/osu!_Program_Files/User_Configuration_File) • [Program files](/wiki/osu!_Program_Files)
 
@@ -35,7 +35,7 @@ Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to pr
 
 # Gameplay
 
-Anything about clicking circles, striking drums, catching fruits, or touching the synthesizer: key elements, concepts, mechanics, and competitive play.
+Everything about clicking circles, striking drums, catching fruits, and playing the synthesizer: key elements, concepts, mechanics, and competitive play.
 
 [Game modes](/wiki/Game_mode): [osu!](/wiki/Game_mode/osu!) • [osu!taiko](/wiki/Game_mode/osu!taiko) • [osu!catch](/wiki/Game_mode/osu!catch) • [osu!mania](/wiki/Game_mode/osu!mania)
 
@@ -85,9 +85,9 @@ Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelin
 
 Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour online.
 
-[Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Help forum](https://osu.ppy.sh/forum/5)
+[Help centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Help forum](https://osu.ppy.sh/forum/5)
 
-Profile: [Silence](/wiki/Silence) • [Account restrictions](/wiki/Help_Centre/Account_Restrictions)
+Profile restrictions: [Silence](/wiki/Silence) • [Account restrictions](/wiki/Help_Centre/Account_Restrictions)
 
 Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report bad behaviour](/wiki/Reporting_Bad_Behaviour) • [Report abuse](/wiki/Reporting_Bad_Behaviour/Abuse) • [Report cheating](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play)
 
@@ -96,7 +96,7 @@ Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report b
 
 # Community and projects
 
-Social interaction is one of main things that fuel osu! players around the world. Explore the activities and contests, get in touch with others, or organize the next big event!
+Social interaction is one of main things that fuel osu! players all around the world. Explore the activities and contests, get in touch with others, or organize the next big event!
 
 [Tournaments](/wiki/Tournaments) • [Featured Artists](/wiki/Featured_Artists) • [Beatmap Spotlights](/wiki/Beatmap_Spotlights) • [Contests](/wiki/Contests) • [Community mentorship program](wiki/Community_Mentorship_Program)
 
@@ -129,7 +129,7 @@ Interact with osu! via other applications and media, or help it grow further.
 
 # Wiki and meta pages
 
-Just as almost everything out here, the osu! wiki is written and maintained by volunteers like you. Suggest an improvement, report an issue, or even write your own article at the [osu-wiki GitHub repository](https://github.com/ppy/osu-wiki "osu! wiki at GitHub").
+Just as almost everything out here, the osu! wiki is written and maintained by volunteers. Suggest an improvement, report an issue, or even write your own article at the [osu-wiki GitHub repository](https://github.com/ppy/osu-wiki "osu! wiki at GitHub").
 
 [History of osu!](/wiki/History_of_osu!) • [History of osu! wiki](/wiki/History_of_osu!/osu!_wiki) • [Mapping and modding timeline](/wiki/Mapping_and_Modding_Timeline) • [April Fools](wiki/History_of_osu!/April_Fools)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -13,7 +13,7 @@ Welcome to the osu! wiki, the open-source knowledge base containing a wide range
 
 # Getting started
 
-Important articles and guides which will help you dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Help forum](https://osu.ppy.sh/forum/5).
+Important articles and guides that will help you dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Help forum](https://osu.ppy.sh/forum/5).
 
 [Rules](/wiki/Rules) • [Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre)
 
@@ -24,7 +24,7 @@ Important articles and guides which will help you dive into osu!. In case anythi
 
 # Game client
 
-Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to present. Get to know it better, from various settings, through customization capabilities, to technical details and file formats the game uses.
+Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to present. Get to know the game better from its various settings and customisation capabilities to technical details and file formats it uses.
 
 [Interface](/wiki/Interface) • [Options](/wiki/Options) • [Visual settings](/wiki/Visual_Settings) • [Shortcut key reference](/wiki/Shortcut_key_reference) • [Configuration file](/wiki/osu!_Program_Files/User_Configuration_File) • [Program files](/wiki/osu!_Program_Files)
 
@@ -46,7 +46,7 @@ Everything about clicking circles, striking drums, catching fruits, and playing 
 
 # [Beatmap editor](/wiki/Beatmap_Editor)
 
-All osu! beatmaps are created by its vibrant and dynamic community, blooming with ideas. Always wanted to share your favourite music with others, but never knew how? Familiarize yourself with the built-in editor and the opportunities it has to offer.
+All osu! beatmaps are created by the blooming imagination of its dynamic community. Always wanted to share your favourite music with others, but never knew how? Familiarize yourself with the built-in editor and the opportunities it has to offer.
 
 Sections: [Compose](/wiki/Beatmap_Editor/Compose) • [Design](/wiki/Beatmap_Editor/Design) • [Timing](/wiki/Beatmap_Editor/Timing) • [Song setup](/wiki/Beatmap_Editor/Song_Setup)
 
@@ -59,7 +59,7 @@ Activities: [Beatmapping](/wiki/Beatmapping) • [Mapping techniques](/wiki/Mapp
 
 # Beatmap submission and ranking
 
-Ranking is the process of obtaining a scoreboard for a beatmap, which makes it more popular and well-recognized. Discover what it takes to walk this path, and how to increase your chance to succeed: beatmap reviews, quality control, and procedures that help streamline ranking.
+Ranking is the process of obtaining a leaderboard for a beatmap, which makes it more popular and well-recognized. Discover what it takes to walk this path, and how to increase your chance to succeed: beatmap reviews, quality control, and procedures that help streamline ranking.
 
 [Submission](/wiki/Submission) • [Modding](/wiki/Modding) • [Ranking procedure](/wiki/Beatmap_ranking_procedure) • [Mappers' Guild](/wiki/Mappers_Guild) • [Project Loved](/wiki/Project_Loved)
 
@@ -76,7 +76,7 @@ Read about procedures and regulations that keep osu! and its community safe, fro
 
 Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelines) • [Explicit content](/wiki/Rules/Explicit_Content) • [Song content rules](/wiki/Rules/Song_Content_Rules) • [Visual content considerations](/wiki/Rules/Visual_Content_Considerations)
 
-[Legal pages](/wiki/Legal): [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing) • [Privacy](/wiki/Legal/Privacy) • [Terms of Service](/wiki/Legal/Terms)
+[Legal pages](/wiki/Legal): [Terms of Service](/wiki/Legal/Terms) • [Privacy](/wiki/Legal/Privacy) • [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing)
 
 </div>
 <div class="wiki-main-page-panel">
@@ -96,18 +96,18 @@ Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report b
 
 # Community and projects
 
-Social interaction is one of main things that fuel osu! players all around the world. Explore the activities and contests, get in touch with others, or organize the next big event!
+Social interaction is one of main things that fuel osu! players all around the world. Explore the activities and contests, get in touch with others, or help organize the next big event!
 
-[Tournaments](/wiki/Tournaments) • [Featured Artists](/wiki/Featured_Artists) • [Beatmap Spotlights](/wiki/Beatmap_Spotlights) • [Contests](/wiki/Contests) • [Community mentorship program](wiki/Community_Mentorship_Program)
+[Tournaments](/wiki/Tournaments) • [Beatmap Spotlights](/wiki/Beatmap_Spotlights) • [Contests](/wiki/Contests) • [Community mentorship program](wiki/Community_Mentorship_Program)
 
-[Projects](/wiki/Projects): [osu!academy](/wiki/osu!academy) • [osu!mapping](/wiki/osu!mapping) • [osu!talk](/wiki/osu!talk)
+[Projects](/wiki/Projects): [Featured Artists](/wiki/Featured_Artists) • [osu!academy](/wiki/osu!academy) • [osu!mapping](/wiki/osu!mapping) • [osu!talk](/wiki/osu!talk)
 
 </div>
 <div class="wiki-main-page-panel">
 
 # People
 
-osu! wouldn't have been possible without many users helping with development, maintenance and community management: their efforts, time, and dedication make the game live and prosper.
+osu! wouldn't have been possible without many users helping with development, maintenance, and community management: their efforts, time, and dedication make the game live and prosper.
 
 [The Team](/wiki/People/The_Team): [Developers](/wiki/People/The_Team/Developers) • [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) • [Support Team](/wiki/People/The_Team/Support_Team) • [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) • [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) • [osu! Alumni](/wiki/People/The_Team/osu!_Alumni) • [Project Loved Team](/wiki/People/The_Team/Project_Loved_Team)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -39,7 +39,7 @@ Anything about clicking circles, striking drums, catching fruits, or touching th
 
 [Game modes](/wiki/Game_mode): [osu!](/wiki/Game_mode/osu!) • [osu!taiko](/wiki/Game_mode/osu!taiko) • [osu!catch](/wiki/Game_mode/osu!catch) • [osu!mania](/wiki/Game_mode/osu!mania)
 
-[Beatmap](/wiki/Beatmap) • [Difficulty](/wiki/Beatmap/Difficulty) • [Hit object](/wiki/Hit_object) • [Mods](/wiki/Game_modifier) • [Score](/wiki/Score) • [Replay](/wiki/Replay) • [Medals](/wiki/Medals] • [Multi](/wiki/Multi)
+[Beatmap](/wiki/Beatmap) • [Difficulty](/wiki/Beatmap/Difficulty) • [Hit object](/wiki/Hit_object) • [Mods](/wiki/Game_modifier) • [Score](/wiki/Score) • [Replay](/wiki/Replay) • [Medals](/wiki/Medals) • [Multi](/wiki/Multi)
 
 </div>
 <div class="wiki-main-page-panel">

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -72,18 +72,18 @@ Ranking is the process of obtaining a scoreboard for a beatmap, which makes it m
 
 Read about procedures and regulations that keep osu! and its community safe, from music licensing and media guidelines to chat and forum rules.
 
-[Legal pages](/wiki/Legal): [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing) • [Privacy](/wiki/Legal/Privacy) • [Terms of Service](/wiki/Legal/Terms)
+[Rules](/wiki/Rules) • [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) • [Code of Conduct for modding and mapping](wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping)
 
 Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelines) • [Explicit content](/wiki/Rules/Explicit_Content) • [Song content rules](/wiki/Rules/Song_Content_Rules) • [Visual content considerations](/wiki/Rules/Visual_Content_Considerations)
 
-[Rules](/wiki/Rules) • [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) • [Code of Conduct for modding and mapping](wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping)
+[Legal pages](/wiki/Legal): [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing) • [Privacy](/wiki/Legal/Privacy) • [Terms of Service](/wiki/Legal/Terms)
 
 </div>
 <div class="wiki-main-page-panel">
 
 # Help
 
-Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour online.
+Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour in the community.
 
 [Help centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Help forum](https://osu.ppy.sh/forum/5)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -13,7 +13,9 @@ Welcome to the osu! wiki, a project containing a wide range of osu! related info
 
 # Getting started
 
-[Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre) • [FAQ](/wiki/FAQ)
+[Rules](/wiki/Rules) • [Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre)
+
+[Chat console](/wiki/Chat_Console) • [BanchoBot](/wiki/BanchoBot) • [FAQ](/wiki/FAQ) • [Guides](/wiki/Guides) • [Glossary](/wiki/Glossary)
 
 </div>
 <div class="wiki-main-page-panel">
@@ -31,7 +33,7 @@ Welcome to the osu! wiki, a project containing a wide range of osu! related info
 
 [Game modes](/wiki/Game_mode): [osu!](/wiki/Game_mode/osu!) • [osu!taiko](/wiki/Game_mode/osu!taiko) • [osu!catch](/wiki/Game_mode/osu!catch) • [osu!mania](/wiki/Game_mode/osu!mania)
 
-[Beatmap](/wiki/Beatmap) • [Hit object](/wiki/Hit_object) • [Mods](/wiki/Game_modifier) • [Score](/wiki/Score) • [Replay](/wiki/Replay) • [Multi](/wiki/Multi)
+[Beatmap](/wiki/Beatmap) • [Difficulty](/wiki/Beatmap/Difficulty) • [Hit object](/wiki/Hit_object) • [Mods](/wiki/Game_modifier) • [Score](/wiki/Score) • [Replay](/wiki/Replay) • [Medals](/wiki/Medals] • [Multi](/wiki/Multi)
 
 </div>
 <div class="wiki-main-page-panel">
@@ -42,7 +44,7 @@ Sections: [Compose](/wiki/Beatmap_Editor/Compose) • [Design](/wiki/Beatmap_Edi
 
 Components: [AiMod](/wiki/Beatmap_Editor/AiMod) • [Beat snap divisor](/wiki/Beatmap_Editor/Beat_Snap_Divisor) • [Distance snap](/wiki/Beatmap_Editor/Distance_Snap) • [Menu](/wiki/Beatmap_Editor/Menu) • [SB load](/wiki/Beatmap_Editor/SB_Load) • [Timelines](/wiki/Beatmap_Editor/Timelines)
 
-[Beatmapping](/wiki/Beatmapping) • [Difficulty](/wiki/Beatmap/Difficulty) • [Mapping techniques](/wiki/Mapping_Techniques) • [Storyboarding](/wiki/Storyboarding)
+[Beatmapping](/wiki/Beatmapping) • [Mapping techniques](/wiki/Mapping_Techniques) • [Storyboarding](/wiki/Storyboarding) • [Skinning](/wiki/Skinning)
 
 </div>
 <div class="wiki-main-page-panel">
@@ -56,9 +58,31 @@ Components: [AiMod](/wiki/Beatmap_Editor/AiMod) • [Beat snap divisor](/wiki/Be
 </div>
 <div class="wiki-main-page-panel">
 
-# Community
+# Rules and legalese
 
-[Tournaments](/wiki/Tournaments) • [Skinning](/wiki/Skinning) • [Projects](/wiki/Projects) • [Guides](/wiki/Guides) • [osu!dev Discord server](/wiki/osu!dev_Discord_server) • [How you can help](/wiki/How_You_Can_Help!) • [Glossary](/wiki/Glossary)
+[Legal pages](/wiki/Legal): [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing) • [Privacy](/wiki/Legal/Privacy) • [Terms of Service](/wiki/Legal/Terms)
+
+Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelines) • [Explicit content](/wiki/Rules/Explicit_Content) • [Song content rules](/wiki/Rules/Song_Content_Rules) • [Visual content considerations](/wiki/Rules/Visual_Content_Considerations)
+
+[Rules](/wiki/Rules) • [Contributor Code of Conduct](/wiki/Contributor_Code_of_Conduct) • [Code of Conduct for modding and mapping](wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping)
+
+</div>
+<div class="wiki-main-page-panel">
+
+# Help
+
+[Technical help](https://osu.ppy.sh/forum/5) • [Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team)
+
+Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report bad behaviour](/wiki/Reporting_Bad_Behaviour) • [Report abuse](/wiki/Reporting_Bad_Behaviour/Abuse) • [Report cheating](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play)
+
+</div>
+<div class="wiki-main-page-panel">
+
+# Community and projects
+
+[Tournaments](/wiki/Tournaments) • [Featured Artists](/wiki/Featured_Artists) • [Beatmap Spotlights](/wiki/Beatmap_Spotlights) • [Contests](/wiki/Contests) • [Community mentorship program](wiki/Community_Mentorship_Program)
+
+[Projects](/wiki/Projects): [osu!academy](/wiki/osu!academy) • [osu!mapping](/wiki/osu!mapping) • [osu!talk](/wiki/osu!talk)
 
 </div>
 <div class="wiki-main-page-panel">
@@ -76,12 +100,14 @@ Organisations: [osu! UCI](/wiki/Organisations/osu!_UCI)
 
 # For developers
 
-[API](/wiki/osu!api) • [Bot account](/wiki/Bot_account) • [Brand identity guidelines](/wiki/Brand_identity_guidelines)
+[API](/wiki/osu!api) • [Bot account](/wiki/Bot_account) • [Brand identity guidelines](/wiki/Brand_identity_guidelines) • [osu!dev Discord server](/wiki/osu!dev_Discord_server)
 
 </div>
 <div class="wiki-main-page-panel">
 
-# About the wiki
+# Meta
+
+[History of osu!](/wiki/History_of_osu!) • [History of osu! wiki](/wiki/History_of_osu!/osu!_wiki) • [Mapping and modding timeline](/wiki/Mapping_and_Modding_Timeline) • [April Fools](wiki/History_of_osu!/April_Fools)
 
 [Sitemap](/wiki/Sitemap) • [Contribution guide](/wiki/osu!_wiki_Contribution_Guide) • [Article styling criteria](/wiki/Article_Styling_Criteria) • [News styling criteria](/wiki/News_Styling_Criteria)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -59,7 +59,7 @@ Activities: [Beatmapping](/wiki/Beatmapping) • [Mapping techniques](/wiki/Mapp
 
 # Beatmap submission and ranking
 
-Ranking is the process of obtaining a leaderboard for a beatmap, which makes it more popular and well-recognized. Discover what it takes to walk this path, and how to increase your chance to succeed: beatmap reviews, quality control, and procedures that help streamline ranking.
+Ranking is the process of obtaining a leaderboard for a beatmap, which makes it more popular and well-recognized. Discover what it takes to walk this path and how to increase your chances to succeed through beatmap reviews, as well as the procedures for quality control and the ranking process.
 
 [Submission](/wiki/Submission) • [Modding](/wiki/Modding) • [Ranking procedure](/wiki/Beatmap_ranking_procedure) • [Mappers' Guild](/wiki/Mappers_Guild) • [Project Loved](/wiki/Project_Loved)
 
@@ -83,7 +83,7 @@ Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelin
 
 # Help
 
-Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour in the community.
+Answers to frequent questions and solutions to common issues live here.
 
 [Help centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Help forum](https://osu.ppy.sh/forum/5)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -5,13 +5,15 @@ layout: main_page
 <!-- Do not add any empty lines inside this div. -->
 
 <div class="wiki-main-page__blurb">
-Welcome to the osu! wiki, a project containing a wide range of osu! related information.
+Welcome to the osu! wiki, the open-source knowledge base of osu!, a free-to-win rhythm game.
 </div>
 
 <div class="wiki-main-page__panels">
 <div class="wiki-main-page-panel wiki-main-page-panel--full">
 
 # Getting started
+
+Important articles and guides that help dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Technical help](https://osu.ppy.sh/forum/5) forum, which is always open.
 
 [Rules](/wiki/Rules) • [Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre)
 
@@ -22,6 +24,8 @@ Welcome to the osu! wiki, a project containing a wide range of osu! related info
 
 # Game client
 
+Being the guide to the world of rhythm, beats, and flashes, osu! has a lot to present. Get to know it better, from miscellaneous settings and customization possibilities to technical details and file formats it uses and understands.
+
 [Interface](/wiki/Interface) • [Options](/wiki/Options) • [Visual settings](/wiki/Visual_Settings) • [Shortcut key reference](/wiki/Shortcut_key_reference) • [Configuration file](/wiki/osu!_Program_Files/User_Configuration_File) • [Program files](/wiki/osu!_Program_Files)
 
 [File formats](/wiki/osu!_File_Formats): [.osz](/wiki/osu!_File_Formats/Osz_(file_format)) • [.osk](/wiki/osu!_File_Formats/Osk_(file_format)) • [.osr](/wiki/osu!_File_Formats/Osr_(file_format)) • [.osu](/wiki/osu!_File_Formats/Osu_(file_format)) • [.osb](/wiki/osu!_File_Formats/Osb_(file_format)) • [.db](/wiki/osu!_File_Formats/Db_(file_format))
@@ -30,6 +34,8 @@ Welcome to the osu! wiki, a project containing a wide range of osu! related info
 <div class="wiki-main-page-panel">
 
 # Gameplay
+
+Anything about clicking circles, striking drums, catching fruits, or touching the synthesizer: key elements, concepts, mechanics, and competitive play.
 
 [Game modes](/wiki/Game_mode): [osu!](/wiki/Game_mode/osu!) • [osu!taiko](/wiki/Game_mode/osu!taiko) • [osu!catch](/wiki/Game_mode/osu!catch) • [osu!mania](/wiki/Game_mode/osu!mania)
 
@@ -40,16 +46,20 @@ Welcome to the osu! wiki, a project containing a wide range of osu! related info
 
 # [Beatmap editor](/wiki/Beatmap_Editor)
 
+All osu! beatmaps are created by its vibrant and dynamic community, blooming with ideas. Always wanted to share your favourite music with others, but never knew how? Familiarize yourself with the built-in editor and the opportunities it has to offer.
+
 Sections: [Compose](/wiki/Beatmap_Editor/Compose) • [Design](/wiki/Beatmap_Editor/Design) • [Timing](/wiki/Beatmap_Editor/Timing) • [Song setup](/wiki/Beatmap_Editor/Song_Setup)
 
 Components: [AiMod](/wiki/Beatmap_Editor/AiMod) • [Beat snap divisor](/wiki/Beatmap_Editor/Beat_Snap_Divisor) • [Distance snap](/wiki/Beatmap_Editor/Distance_Snap) • [Menu](/wiki/Beatmap_Editor/Menu) • [SB load](/wiki/Beatmap_Editor/SB_Load) • [Timelines](/wiki/Beatmap_Editor/Timelines)
 
-[Beatmapping](/wiki/Beatmapping) • [Mapping techniques](/wiki/Mapping_Techniques) • [Storyboarding](/wiki/Storyboarding) • [Skinning](/wiki/Skinning)
+Activities: [Beatmapping](/wiki/Beatmapping) • [Mapping techniques](/wiki/Mapping_Techniques) • [Storyboarding](/wiki/Storyboarding) • [Skinning](/wiki/Skinning)
 
 </div>
 <div class="wiki-main-page-panel">
 
 # Beatmap submission and ranking
+
+Ranking is the process of obtaining a scoreboard for a beatmap, which makes it more popular and well-recognized. Discover what it takes to walk this path, and how to increase your chance to succeed: beatmap reviews, quality control, and procedures that help streamline ranking.
 
 [Submission](/wiki/Submission) • [Modding](/wiki/Modding) • [Ranking procedure](/wiki/Beatmap_ranking_procedure) • [Mappers' Guild](/wiki/Mappers_Guild) • [Project Loved](/wiki/Project_Loved)
 
@@ -59,6 +69,8 @@ Components: [AiMod](/wiki/Beatmap_Editor/AiMod) • [Beat snap divisor](/wiki/Be
 <div class="wiki-main-page-panel">
 
 # Rules and legalese
+
+Read about procedures and regulations that keep osu! and its community safe, from music licensing and media guidelines to chat and forum rules.
 
 [Legal pages](/wiki/Legal): [Copyright (DMCA)](/wiki/Legal/Copyright) • [Music licensing](/wiki/Legal/Music_Licensing) • [Privacy](/wiki/Legal/Privacy) • [Terms of Service](/wiki/Legal/Terms)
 
@@ -71,7 +83,11 @@ Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelin
 
 # Help
 
-[Technical help](https://osu.ppy.sh/forum/5) • [Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team)
+Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour online.
+
+[Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Technical help](https://osu.ppy.sh/forum/5)
+
+Profile: [Silence](/wiki/Silence) • [Account restrictions](/wiki/Help_Centre/Account_Restrictions)
 
 Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report bad behaviour](/wiki/Reporting_Bad_Behaviour) • [Report abuse](/wiki/Reporting_Bad_Behaviour/Abuse) • [Report cheating](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play)
 
@@ -79,6 +95,8 @@ Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report b
 <div class="wiki-main-page-panel">
 
 # Community and projects
+
+Social interaction is one of main things that fuel osu! players around the world. Explore the activities and contests, get in touch with others, or organize the next big event!
 
 [Tournaments](/wiki/Tournaments) • [Featured Artists](/wiki/Featured_Artists) • [Beatmap Spotlights](/wiki/Beatmap_Spotlights) • [Contests](/wiki/Contests) • [Community mentorship program](wiki/Community_Mentorship_Program)
 
@@ -88,6 +106,8 @@ Do your part: [How and what to help with](/wiki/How_you_can_help!) • [Report b
 <div class="wiki-main-page-panel">
 
 # People
+
+osu! wouldn't have been possible without many users helping with development, maintenance and community management: their efforts, time, and dedication make the game live and prosper.
 
 [The Team](/wiki/People/The_Team): [Developers](/wiki/People/The_Team/Developers) • [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) • [Support Team](/wiki/People/The_Team/Support_Team) • [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) • [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) • [osu! Alumni](/wiki/People/The_Team/osu!_Alumni) • [Project Loved Team](/wiki/People/The_Team/Project_Loved_Team)
 
@@ -100,12 +120,16 @@ Organisations: [osu! UCI](/wiki/Organisations/osu!_UCI)
 
 # For developers
 
+Interact with osu! via other applications and media, or help it grow further.
+
 [API](/wiki/osu!api) • [Bot account](/wiki/Bot_account) • [Brand identity guidelines](/wiki/Brand_identity_guidelines) • [osu!dev Discord server](/wiki/osu!dev_Discord_server)
 
 </div>
 <div class="wiki-main-page-panel">
 
-# Meta
+# Wiki and meta pages
+
+Just as almost everything out here, the osu! wiki is written and maintained by volunteers like you. Suggest an improvement, report an issue, or even write your own article at the [osu-wiki GitHub repository](https://github.com/ppy/osu-wiki "osu! wiki at GitHub").
 
 [History of osu!](/wiki/History_of_osu!) • [History of osu! wiki](/wiki/History_of_osu!/osu!_wiki) • [Mapping and modding timeline](/wiki/Mapping_and_Modding_Timeline) • [April Fools](wiki/History_of_osu!/April_Fools)
 

--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -13,7 +13,7 @@ Welcome to the osu! wiki, the open-source knowledge base of osu!, a free-to-win 
 
 # Getting started
 
-Important articles and guides that help dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Technical help](https://osu.ppy.sh/forum/5) forum, which is always open.
+Important articles and guides that help dive into osu!. In case anything goes wrong or appears uncertain, make sure to visit the [Help forum](https://osu.ppy.sh/forum/5), which is always open.
 
 [Rules](/wiki/Rules) • [Welcome](/wiki/Welcome) • [Installation](/wiki/Installation) • [Registration](/wiki/Registration) • [Help Centre](/wiki/Help_Centre)
 
@@ -85,7 +85,7 @@ Media regulations: [Content usage guidelines](/wiki/Rules/Content_Usage_Guidelin
 
 Answers to frequent questions and solutions to common issues live here. Learn how to deal with network issues, or combat bad behaviour online.
 
-[Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Technical help](https://osu.ppy.sh/forum/5)
+[Help Centre](/wiki/Help_Centre) • [Performance troubleshooting](/wiki/Performance_Troubleshooting) • [Account support team](wiki/People/The_Team/Account_support_team) • [Help forum](https://osu.ppy.sh/forum/5)
 
 Profile: [Silence](/wiki/Silence) • [Account restrictions](/wiki/Help_Centre/Account_Restrictions)
 

--- a/wiki/Main_Page/es.md
+++ b/wiki/Main_Page/es.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <!-- Translated to Latin American Spanish, there it might be some differences with Castilian. Most possibly, it seems more like Chilean Spanish. -->

--- a/wiki/Main_Page/fr.md
+++ b/wiki/Main_Page/fr.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/id.md
+++ b/wiki/Main_Page/id.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/ja.md
+++ b/wiki/Main_Page/ja.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/ko.md
+++ b/wiki/Main_Page/ko.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/pl.md
+++ b/wiki/Main_Page/pl.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/pt-br.md
+++ b/wiki/Main_Page/pt-br.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/ro.md
+++ b/wiki/Main_Page/ro.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/ru.md
+++ b/wiki/Main_Page/ru.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/th.md
+++ b/wiki/Main_Page/th.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/tr.md
+++ b/wiki/Main_Page/tr.md
@@ -1,6 +1,8 @@
 ---
 layout: main_page
 no_native_review: true
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/uk.md
+++ b/wiki/Main_Page/uk.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">

--- a/wiki/Main_Page/zh-tw.md
+++ b/wiki/Main_Page/zh-tw.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <!-- Do not add any empty lines inside this div. -->

--- a/wiki/Main_Page/zh.md
+++ b/wiki/Main_Page/zh.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated: true
+outdated_since: 1f00c369d836e214e9e2b5a3dc8ea21ff3392217
 ---
 
 <div class="wiki-main-page__blurb">


### PR DESCRIPTION
part of #2606. summary:
- two new main page sections, `Rules and legalese` and `Help`
- short free-form summaries that aim to give each section of the main page a 1,000 ft. overview
- ~~the Welcome article is removed and `/wiki/Welcome` is redirected to `/wiki/Main_Page~~ will be done in a separate PR

I considered putting the overview of osu! somewhere on the main page as well, but I honestly have no idea how to do that without alienating it.

Preview of the first two sections: [118862270-cf4ac880-b8dd-11eb-9730-75ad82bd359e.png](https://user-images.githubusercontent.com/4686101/118862270-cf4ac880-b8dd-11eb-9730-75ad82bd359e.png)
