### PR TITLE
[FR] Add "Project Loved Team"

### DIFF
--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -1,0 +1,143 @@
+---
+tags:
+  - captain
+  - captains
+  - capitaine
+  - capitaines
+---
+
+# Project Loved Team
+
+Le **Project Loved Team** est composée de membres de la communauté d'osu! qui gèrent le [Project Loved](/wiki/Project_Loved), la plateforme de vote qui promeut les [beatmaps](/wiki/Beatmap) dans la catégorie [loved](/wiki/Beatmap/Category#loved).
+
+## Capitaines
+
+Le Project Loved Team se compose principalement de *capitaines* pour chaque [mode de jeu](/wiki/Game_mode). Les capitaines sont responsables de la nomination des beatmaps dans la catégorie loved et agissent en tant que représentants de la communauté en ayant une bonne idée des beatmaps à choisir. Ils rédigent également de courtes descriptions des beatmaps nominées afin d'aider les lecteurs à se faire une idée de chaque beatmap s'ils ne les ont pas vues ou jouées auparavant.
+
+### osu!
+
+- ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
+- ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
+- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
+
+### osu!taiko
+
+- ![][flag_CL] [-Kazu-](https://osu.ppy.sh/users/920861)
+- ![][flag_JP] [KuroKuroKuro](https://osu.ppy.sh/users/11931563)
+- ![][flag_KR] [POCARI SWEAT](https://osu.ppy.sh/users/5082685)
+- ![][flag_RU] [Remus](https://osu.ppy.sh/users/6850949)
+- ![][flag_TW] [X a v y](https://osu.ppy.sh/users/3738344)
+
+### osu!catch
+
+- ![][flag_NL] [Sartan](https://osu.ppy.sh/users/4100941)
+- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
+- ![][flag_DE] [Tenshichan](https://osu.ppy.sh/users/1101600)
+- ![][flag_NL] [Wesley](https://osu.ppy.sh/users/2407265)
+
+### osu!mania
+
+- ![][flag_US] [-mint-](https://osu.ppy.sh/users/8976576)
+- ![][flag_SG] [Abraxos](https://osu.ppy.sh/users/5025064)
+- ![][flag_US] [Alter-](https://osu.ppy.sh/users/4980256)
+- ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754)
+- ![][flag_US] [Penguinosity](https://osu.ppy.sh/users/10235296)
+- ![][flag_GB] [Pope Gadget](https://osu.ppy.sh/users/2288341)
+
+## Coordinateurs
+
+Les coordinateurs sont principalement chargés de veiller à ce que tous les capitaines travaillent ensemble pour assurer le bon déroulement du projet. Ils écrivent les nouvelles et les messages du forum, maintiennent les outils et aident à modérer les discussions sur la catégorie loved.
+
+- ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350)
+- ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237)
+
+## Vérificateurs des métadonnées d'une beatmap
+
+Les vérificateurs des métadonnées vérifient chaque beatmap qui sera soumis au vote, et travaillent avec les mappeurs pour corriger les éventuelles erreurs avant que les beatmaps ne soient potentiellement déplacées vers la catégorie loved.
+
+- ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350)
+- ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
+- ![][flag_ES] [kadoen](https://osu.ppy.sh/users/12780575)
+- ![][flag_ES] [Komirin](https://osu.ppy.sh/users/4725379)
+- ![][flag_ES] [Nikolayio](https://osu.ppy.sh/users/11279465)
+- ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
+- ![][flag_ES] [RandomeLoL](https://osu.ppy.sh/users/7080063)
+
+## Alumni
+
+### Capitaines osu!
+
+- ![][flag_US] [BTMC](https://osu.ppy.sh/users/3171691)
+- ![][flag_PL] [fartownik](https://osu.ppy.sh/users/56917)
+- ![][flag_CA] [Kaifin](https://osu.ppy.sh/users/2596942)
+- ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689)
+- ![][flag_GB] [Ventus](https://osu.ppy.sh/users/1986262)
+- ![][flag_LV] [waywern2012](https://osu.ppy.sh/users/5870453)
+
+### Capitaines osu!taiko
+
+- ![][flag_JP] [\_yu68](https://osu.ppy.sh/users/6170507)
+- ![][flag_TW] [-\[ ix Ishida xi \]-](https://osu.ppy.sh/users/242910)
+- ![][flag_US] [Backfire](https://osu.ppy.sh/users/263110)
+- ![][flag_IT] [D3kuu](https://osu.ppy.sh/users/7807444)
+- ![][flag_JP] [iceOC](https://osu.ppy.sh/users/5482401)
+- ![][flag_US] [jyake](https://osu.ppy.sh/users/9099822)
+- ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766)
+- ![][flag_JP] [nyanmi-1828](https://osu.ppy.sh/users/6866480)
+- ![][flag_SE] [Raphalge](https://osu.ppy.sh/users/3918650)
+- ![][flag_JP] [tasuke912](https://osu.ppy.sh/users/2774767)
+- ![][flag_JP] [TKS](https://osu.ppy.sh/users/940878)
+- ![][flag_CL] [Ulqui](https://osu.ppy.sh/users/1263669)
+- ![][flag_FR] [Yuzeyun](https://osu.ppy.sh/users/481582)
+
+### Capitaines osu!catch
+
+- ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883)
+- ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565)
+- ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508)
+- ![][flag_CN] [Yumeno Himiko](https://osu.ppy.sh/users/1806962)
+- ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955)
+
+### Capitaines osu!mania
+
+- ![][flag_PL] [\_underjoy](https://osu.ppy.sh/users/2235750)
+- ![][flag_ES] [aitor98](https://osu.ppy.sh/users/3154852)
+- ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992)
+- ![][flag_PL] [Kamikaze](https://osu.ppy.sh/users/2124783)
+- ![][flag_PH] [lenpai](https://osu.ppy.sh/users/5314573)
+- ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707)
+- ![][flag_US] [stupud man](https://osu.ppy.sh/users/2141612)
+- ![][flag_US] [Toaph Daddy](https://osu.ppy.sh/users/7616811)
+
+### Éditeurs vidéo
+
+- ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
+- ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
+
+## Le saviez-vous ?
+
+- ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) a créé l'équipe originale de capitaines en septembre 2017 ainsi que le système [Captain's Pick](/wiki/Beatmap/History_of_Loved#captain's-pick-and-project-loved-(sep-2017---present)) qui a ensuite été renommé Project Loved. Jusqu'à fin 2019, il a supervisé et géré l'ensemble du projet.
+- Il y a un groupe d'utilisateurs Project Loved sur le site web avec l'ID de groupe 31, mais la liste n'est pas publique. Il est utilisé pour les autorisations de modérer le [forum Project Loved](https://osu.ppy.sh/community/forums/120) et de promouvoir les beatmaps dans la catégorie Loved.
+  - Jusqu'au 16 avril 2021, les seules personnes qui avaient fait partie du groupe étaient ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350), ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), et ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689). Maintenant, toute les personnes du Project Loved Team appartient au groupe.
+
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CL]: /wiki/shared/flag/CL.gif "Chili"
+[flag_CN]: /wiki/shared/flag/CN.gif "Chine"
+[flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
+[flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"
+[flag_HU]: /wiki/shared/flag/HU.gif "Hongrie"
+[flag_IT]: /wiki/shared/flag/IT.gif "Italie"
+[flag_JP]: /wiki/shared/flag/JP.gif "Japon"
+[flag_KR]: /wiki/shared/flag/KR.gif "Corée du Sud"
+[flag_LT]: /wiki/shared/flag/LT.gif "Lituanie"
+[flag_LV]: /wiki/shared/flag/LV.gif "Lettonie"
+[flag_NL]: /wiki/shared/flag/NL.gif "Pays-Bas"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
+[flag_PL]: /wiki/shared/flag/PL.gif "Pologne"
+[flag_RU]: /wiki/shared/flag/RU.gif "Fédération de Russie"
+[flag_SE]: /wiki/shared/flag/SE.gif "Suède"
+[flag_SG]: /wiki/shared/flag/SG.gif "Singapour"
+[flag_TW]: /wiki/shared/flag/TW.gif "Taiwan"
+[flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -12,7 +12,7 @@ La **Project Loved Team** est composée de membres de la communauté d'osu! qui 
 
 ## Capitaines
 
-La Project Loved Team se compose principalement de *capitaines* pour chaque [mode de jeu](/wiki/Game_mode). Les capitaines sont responsables de la nomination des beatmaps dans la catégorie loved et agissent en tant que représentants de la communauté en ayant une bonne idée des beatmaps à choisir. Ils rédigent également de courtes descriptions des beatmaps nominées afin d'aider les lecteurs à se faire une idée de chaque beatmap s'ils ne les ont pas vues ou jouées auparavant.
+La Project Loved Team se compose principalement de *capitaines* pour chaque [mode de jeu](/wiki/Game_mode). Les capitaines sont responsables de la nomination des beatmaps dans la catégorie loved et agissent en tant que représentants de la communauté en ayant une bonne idée des beatmaps à choisir. Ils rédigent également de courtes descriptions des beatmaps nominées afin d'aider les lecteurs à se faire une idée de chaque beatmap s'ils ne les ont pas vu ou joué auparavant.
 
 ### osu!
 

--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -8,11 +8,11 @@ tags:
 
 # Project Loved Team
 
-Le **Project Loved Team** est composée de membres de la communauté d'osu! qui gèrent le [Project Loved](/wiki/Project_Loved), la plateforme de vote qui promeut les [beatmaps](/wiki/Beatmap) dans la catégorie [loved](/wiki/Beatmap/Category#loved).
+La **Project Loved Team** est composée de membres de la communauté d'osu! qui gèrent le [Project Loved](/wiki/Project_Loved), la plateforme de vote qui promeut les [beatmaps](/wiki/Beatmap) dans la catégorie [loved](/wiki/Beatmap/Category#loved).
 
 ## Capitaines
 
-Le Project Loved Team se compose principalement de *capitaines* pour chaque [mode de jeu](/wiki/Game_mode). Les capitaines sont responsables de la nomination des beatmaps dans la catégorie loved et agissent en tant que représentants de la communauté en ayant une bonne idée des beatmaps à choisir. Ils rédigent également de courtes descriptions des beatmaps nominées afin d'aider les lecteurs à se faire une idée de chaque beatmap s'ils ne les ont pas vues ou jouées auparavant.
+La Project Loved Team se compose principalement de *capitaines* pour chaque [mode de jeu](/wiki/Game_mode). Les capitaines sont responsables de la nomination des beatmaps dans la catégorie loved et agissent en tant que représentants de la communauté en ayant une bonne idée des beatmaps à choisir. Ils rédigent également de courtes descriptions des beatmaps nominées afin d'aider les lecteurs à se faire une idée de chaque beatmap s'ils ne les ont pas vues ou jouées auparavant.
 
 ### osu!
 
@@ -53,7 +53,7 @@ Les coordinateurs sont principalement chargés de veiller à ce que tous les cap
 
 ## Vérificateurs des métadonnées d'une beatmap
 
-Les vérificateurs des métadonnées vérifient chaque beatmap qui sera soumis au vote, et travaillent avec les mappeurs pour corriger les éventuelles erreurs avant que les beatmaps ne soient potentiellement déplacées vers la catégorie loved.
+Les vérificateurs des métadonnées vérifient chaque beatmap qui sera soumise au vote, et travaillent avec les mappeurs pour corriger les éventuelles erreurs avant que les beatmaps ne soient potentiellement déplacées vers la catégorie loved.
 
 - ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350)
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
@@ -116,9 +116,9 @@ Les vérificateurs des métadonnées vérifient chaque beatmap qui sera soumis a
 
 ## Le saviez-vous ?
 
-- ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) a créé l'équipe originale de capitaines en septembre 2017 ainsi que le système [Captain's Pick](/wiki/Beatmap/History_of_Loved#captain's-pick-and-project-loved-(sep-2017---present)) qui a ensuite été renommé Project Loved. Jusqu'à fin 2019, il a supervisé et géré l'ensemble du projet.
-- Il y a un groupe d'utilisateurs Project Loved sur le site web avec l'ID de groupe 31, mais la liste n'est pas publique. Il est utilisé pour les autorisations de modérer le [forum Project Loved](https://osu.ppy.sh/community/forums/120) et de promouvoir les beatmaps dans la catégorie Loved.
-  - Jusqu'au 16 avril 2021, les seules personnes qui avaient fait partie du groupe étaient ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350), ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), et ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689). Maintenant, toute les personnes du Project Loved Team appartient au groupe.
+- ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) a créé l'équipe originelle de capitaines en septembre 2017 ainsi que le système [Captain's Pick](/wiki/Beatmap/History_of_Loved#captain's-pick-and-project-loved-(sep-2017---present)) qui a ensuite été renommé Project Loved. Jusqu'à fin 2019, il a supervisé et géré l'ensemble du projet.
+- Il y a un groupe d'utilisateurs Project Loved sur le site web avec l'ID de groupe 31, mais la liste n'est pas publique. Il est utilisé pour leur donner l'autorisation de modérer le [forum Project Loved](https://osu.ppy.sh/community/forums/120) et de promouvoir les beatmaps dans la catégorie Loved.
+  - Jusqu'au 16 avril 2021, les seules personnes qui faisaient partie du groupe étaient ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350), ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), et ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689). Maintenant, tous les utilisateurs faisant partie de la Project Loved Team appartiennent au groupe.
 
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chili"


### PR DESCRIPTION
Proposal for the French translation of the wiki page `Project Loved Team`.

I re-translated the article, despite #4991 because the PR author could not update the file, which had been updated during the review. As he gave his permission to redo a PR for this article, I did so.