### PR TITLE
[FR] Add "Contributor Code of Conduct"

### DIFF
--- a/wiki/Contributor_Code_of_Conduct/fr.md
+++ b/wiki/Contributor_Code_of_Conduct/fr.md
@@ -1,0 +1,90 @@
+# Code de conduite Contributor Covenant
+
+## Notre engagement
+
+En tant que membres, contributeur·trice·s et dirigeant·e·s, nous nous engageons à faire de la participation à notre communauté une expérience sans harcèlement, quel que soit l'âge, la taille corporelle, le handicap visible ou invisible, l’appartenance ethnique, les caractéristiques sexuelles, l’identité et l’expression de genre, le niveau d’expérience, l'éducation, le statut socio-économique, la nationalité, l’apparence personnelle, la race, la religion, ou l’identité et l’orientation sexuelle.
+
+Nous nous engageons à agir et interagir de manière à contribuer à une communauté ouverte, accueillante, diversifiée, inclusive et saine.
+
+## Nos critères
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+- Faire preuve d’empathie et de bienveillance envers les autres
+- Être respectueux des opinions, points de vue et expériences divergents
+- Donner et recevoir avec grâce les critiques constructives
+- Assumer ses responsabilités et s’excuser auprès des personnes affectées par nos erreurs et apprendre de ces expériences
+- Se concentrer sur ce qui est le meilleur non pas uniquement pour nous en tant qu’individu, mais aussi pour l’ensemble de la communauté
+
+Exemples de comportements inacceptables :
+
+- L’utilisation de langage ou d’images sexualisés et d’attentions ou d’avances sexuelles de toute nature
+- Le trolling, les commentaires insultants ou désobligeants et les attaques personnelles ou d’ordre politique
+- Le harcèlement en public ou en privé
+- La publication d’informations privées d’autrui, telle qu’une adresse postale ou une adresse électronique, sans leur autorisation explicite
+- Toute autre conduite qui pourrait raisonnablement être considérée comme inappropriée dans un cadre professionnel
+
+## Responsabilités d’application
+
+Les dirigeant·e·s de la communauté sont chargé·e·s de clarifier et de faire respecter nos normes de comportements acceptables et prendront des mesures correctives appropriées et équitables en réponse à tout comportement qu’ils ou elles jugent inapproprié, menaçant, offensant ou nuisible.
+
+Les dirigeant·e·s de la communauté ont le droit et la responsabilité de supprimer, modifier ou rejeter les commentaires, les contributions, le code, les modifications de wikis, les rapports d’incidents ou de bogues et autres contributions qui ne sont pas alignés sur ce code de conduite, et communiqueront les raisons des décisions de modération le cas échéant.
+
+## Portée d’application
+
+Ce code de conduite s’applique à la fois au sein des espaces du projet ainsi que dans les espaces publics lorsqu’un individu représente officiellement le projet ou sa communauté. Font parties des exemples de représentation d’un projet ou d’une communauté l’utilisation d’une adresse électronique officielle, la publication sur les réseaux sociaux à l’aide d’un compte officiel ou le fait d’agir en tant que représentant·e désigné·e lors d’un événement en ligne ou hors-ligne.
+
+## Application
+
+Les cas de comportements abusifs, harcelants ou tout autre comportement inacceptables peuvent être signalés aux dirigeant·e·s de la communauté responsables de l’application du code de conduite à [abuse@ppy.sh](mailto:abuse@ppy.sh).
+
+Les responsables communautaires qui ont accès à cette boîte de réception sont les suivants :
+
+- [peppy](https://osu.ppy.sh/users/2) ([pe@ppy.sh](mailto:pe@ppy.sh))
+- [Ephemeral](https://osu.ppy.sh/users/102335) ([ephemeral@ppy.sh](mailto:ephemeral@ppy.sh))
+
+Toutes les plaintes seront examinées et feront l’objet d’une enquête rapide et équitable.
+
+Tou·te·s les dirigeant·e·s de la communauté sont tenu·e·s de respecter la vie privée et la sécurité des personnes ayant signalé un incident.
+
+## Directives d’application
+
+Les dirigeant·e·s de communauté suivront ces directives d’application sur l’impact communautaire afin de déterminer les conséquences de toute action qu’ils jugent contraire au présent code de conduite :
+
+### 1. Correction
+
+**Impact communautaire** : Utilisation d’un langage inapproprié ou tout autre comportement jugé non professionnel ou indésirable dans la communauté.
+
+**Conséquence** : Un avertissement écrit et privé de la part des dirigeant·e·s de la communauté, clarifiant la nature du non-respect et expliquant pourquoi le comportement était inapproprié. Des excuses publiques peuvent être demandées.
+
+### 2. Avertissement
+
+**Impact communautaire** : Un non-respect par un seul incident ou une série d’actions.
+
+**Conséquence** : Un avertissement avec des conséquences dû à la poursuite du comportement. Aucune interaction avec les personnes concernées, y compris l’interaction non sollicitée avec celles et ceux qui sont chargé·e·s de l’application de ce code de conduite, pendant une période déterminée. Cela comprend le fait d'éviter les interactions dans les espaces communautaires ainsi que sur les canaux externes comme les médias sociaux. Le non-respect de ces conditions peut entraîner un bannissement temporaire ou permanent.
+
+### 3. Bannissement temporaire
+
+**Impact communautaire** : Un non-respect grave des normes communautaires, notamment un comportement inapproprié soutenu.
+
+**Conséquence** : Un bannissement temporaire de toutes formes d’interactions ou de communications avec la communauté pendant une période déterminée. Aucune interaction publique ou privée avec les personnes concernées, y compris les interactions non sollicitées avec celles et ceux qui appliquent ce code de conduite, n’est autorisée pendant cette période. Le non-respect de ces conditions peut entraîner un bannissement permanent.
+
+### 4. Bannissement permanent
+
+**Impact communautaire** : Démontrer un schéma récurrent de non-respect des normes de la communauté y compris un comportement inapproprié soutenu, le harcèlement d’un individu ainsi que l’agression ou le dénigrement de catégories d’individus.
+
+**Conséquence** : Un bannissement permanent de toutes formes d’interactions publiques au sein de la communauté.
+
+## Attributions
+
+Ce code de conduite est adapté du [Contributor Covenant][homepage], disponible à [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Les Directives d’application ont été inspirées par le [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+Pour obtenir des réponses aux questions courantes sur ce code de conduite, consultez la FAQ à [https://www.contributor-covenant.org/faq][FAQ]. Les traductions sont disponibles sur [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Proposal for the French translation of the wiki page `Contributor Code of Conduct`.

Translation made with the [Contributor Covenant](https://www.contributor-covenant.org/fr/version/2/0/code_of_conduct/) website