### PR TITLE
[ID] Add `Beatmap ranking procedure/Ranking queue`

### DIFF
--- a/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
+++ b/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
@@ -1,0 +1,16 @@
+---
+tags:
+  - qualified queue
+  - ranked queue
+  - ranking ETA
+  - antrian peringkat
+  - tahap kualifikasi
+---
+
+# Antrian peringkat beatmap
+
+**Antrian peringkat** (*Ranking queue*) mengatur pemindahan [beatmap-beatmap](/wiki/Beatmap) dari [Qualified](/wiki/Beatmap/Category#qualified) ke [Ranked](/wiki/Beatmap/Category#ranked). Setiap hari, 10 beatmap dari masing-masing [mode permainan](/wiki/Game_mode) dipindahkan dari Qualified ke Ranked, jika beatmap-beatmap tersebut sudah berada di kategori Qualified setidaknya selama 7 hari. Waktu di mana beatmap-beatmap tersebut menjadi ranked adalah acak.
+
+## Diskualifikasi dan re-kualifikasi
+
+Saat sebuah beatmap terkena [diskualifikasi](/wiki/Beatmap_ranking_procedure#pengulangan-nominasi), waktu yang sudah berjalan saat berada di kategori Qualified akan tetap tersimpan. Jika beatmap tersebut telah dikualifikasi lagi, beatmap tersebut akan masuk ke antrian peringkat dan melanjutkan sisa waktu yang sebelumnya sudah ditempuh. Kemampuan untuk "melewati" waktu yang telah dihabiskan dalam batas antrian pada 6 hari adalah untuk memastikan bahwa beatmap-beatmap tersebut selalu berada di kategori Qualified setidaknya selama satu hari penuh.


### PR DESCRIPTION
Add Indonesian translation for [Beatmap ranking queue](https://osu.ppy.sh/wiki/en/Beatmap_ranking_procedure/Ranking_queue) and update outdated Indonesian translation for [Beatmap ranking procedure](https://osu.ppy.sh/wiki/en/Beatmap_ranking_procedure).