### PR TITLE
Add catch Hit Objects stubs

### DIFF
--- a/wiki/Hit_object/Banana/en.md
+++ b/wiki/Hit_object/Banana/en.md
@@ -4,8 +4,8 @@ stub: true
 
 # Banana
 
-*Bananas* are bonus [hit objects](/wiki/Hit_object) in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Bananas are equivalent to the [spinner](/wiki/Hit_object/Spinner) in [osu!](/wiki/Game_Modes/osu!), the difference being that you will always pass the bananas even when all bananas are missed.
+*Bananas* are bonus [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Bananas get generated when a [spinner](/wiki/Hit_object/Spinner) is placed in the editor. Compared to a spinner they don't have to be cleared as each banana is optional to catch.
 
-Successfully catching a banana will result in an increase of [score](/wiki/Score) of 1100 points without taking [combo](/wiki/Beatmapping/Combo) into account.
+Successfully catching a banana will increase the [score](/wiki/Score) with 1100 points without taking [combo](/wiki/Beatmapping/Combo) into account, and they also provide a boost to the [health bar](/wiki/Glossary/Health_bar).
 
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Banana/en.md
+++ b/wiki/Hit_object/Banana/en.md
@@ -6,6 +6,6 @@ stub: true
 
 *Bananas* are bonus [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Bananas get generated when a [spinner](/wiki/Hit_object/Spinner) is placed in the editor. Compared to a spinner they don't have to be cleared as each banana is optional to catch.
 
-Successfully catching a banana will increase the [score](/wiki/Score) with 1100 points without taking [combo](/wiki/Beatmapping/Combo) into account, and they also provide a boost to the [health bar](/wiki/Glossary/Health_bar).
+Successfully catching a banana will increase the [score](/wiki/Score) with 1100 points without taking [combo](/wiki/Glossary/Combo_(score_multiplier)) into account, and they also provide a boost to the [health bar](/wiki/Glossary/Health_bar).
 
-<!-- TODO: Add links and images-->
+<!-- TODO: Add images -->

--- a/wiki/Hit_object/Banana/en.md
+++ b/wiki/Hit_object/Banana/en.md
@@ -1,0 +1,11 @@
+---
+stub: true
+---
+
+# Banana
+
+*Bananas* are bonus [hit objects](/wiki/Hit_object) in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Bananas are equivalent to the [spinner](/wiki/Hit_object/Spinner) in [osu!](/wiki/Game_Modes/osu!), the difference being that you will always pass the bananas even when all bananas are missed.
+
+Successfully catching a banana will result in an increase of [score](/wiki/Score) of 1100 points without taking [combo](/wiki/Beatmapping/Combo) into account.
+
+<!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Fruit/en.md
+++ b/wiki/Hit_object/Fruit/en.md
@@ -6,6 +6,6 @@ stub: true
 
 *Fruits* are large coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a fruit once the next fruit or [drop](/wiki/Hit_object/Juice_stream#drop) is uncatchable by normal dashing.
 
-Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
+Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Glossary/Combo_(score_multiplier)) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
 
-<!-- TODO: Add links and images-->
+<!-- TODO: Add images -->

--- a/wiki/Hit_object/Fruit/en.md
+++ b/wiki/Hit_object/Fruit/en.md
@@ -4,6 +4,8 @@ stub: true
 
 # Fruit
 
-*Fruits* are large coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Successfully collecting a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in result screen. If the player fails to catch a fruit it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
+*Fruits* are large coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). A hyperdash will be generated on a fruit once the next fruit or [drop](/wiki/Hit_object/Juice_stream#drop) is uncatchable by normal dashing.
+
+Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
 
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Fruit/en.md
+++ b/wiki/Hit_object/Fruit/en.md
@@ -1,0 +1,9 @@
+---
+stub: true
+---
+
+# Fruit
+
+*Fruits* are large coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Successfully collecting a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in result screen. If the player fails to catch a fruit it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
+
+<!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Fruit/en.md
+++ b/wiki/Hit_object/Fruit/en.md
@@ -6,6 +6,6 @@ stub: true
 
 *Fruits* are large coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a fruit once the next fruit or [drop](/wiki/Hit_object/Juice_stream#drop) is uncatchable by normal dashing.
 
-Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
+Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
 
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Fruit/en.md
+++ b/wiki/Hit_object/Fruit/en.md
@@ -4,7 +4,7 @@ stub: true
 
 # Fruit
 
-*Fruits* are large coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). A hyperdash will be generated on a fruit once the next fruit or [drop](/wiki/Hit_object/Juice_stream#drop) is uncatchable by normal dashing.
+*Fruits* are large coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a fruit once the next fruit or [drop](/wiki/Hit_object/Juice_stream#drop) is uncatchable by normal dashing.
 
 Successfully catching a fruit will earn the player [score](/wiki/Score), increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 300 in the result screen. If the player fails to catch a fruit it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
 

--- a/wiki/Hit_object/Hyperfruit/en.md
+++ b/wiki/Hit_object/Hyperfruit/en.md
@@ -1,0 +1,15 @@
+---
+stub: true
+---
+
+# Hyperfruit
+
+A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/Fruit) or [drop](/wiki/Hit_object/Juice_stream#drop). This effect will be generated when the next fruit or drop can't be catched with normal dashing. This effect will also generate when the last [banana](/wiki/Hit_object/Banana) of a spinner can't be caught with a dash. 
+
+During play, this is characterized by a coloured outline on the first object.
+
+## Hyperdash
+
+A *hyperdash* is the term used for the movement between a hyperfruit, and the following active object.
+
+<!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Hyperfruit/en.md
+++ b/wiki/Hit_object/Hyperfruit/en.md
@@ -4,8 +4,8 @@ stub: true
 
 # Hyperfruit
 
-A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/Fruit) or [drop](/wiki/Hit_object/Juice_stream#drop). This effect will be generated when the next fruit or drop can't be catched with normal dashing. This effect will also generate when the last [banana](/wiki/Hit_object/Banana) of a spinner can't be caught with a dash. 
+A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/Fruit) or [drop](/wiki/Hit_object/Juice_stream#drop). This effect will be generated when the next fruit or drop can't be caught with normal dashing. This effect will also generate when the last [banana](/wiki/Hit_object/Banana) of a [spinner](/wiki/Hit_object/Spinner) can't be caught with a dash.
 
-During play, this is characterized by a coloured outline on the first object.
+During play, this effect is characterized by a coloured outline on the hyperfruit.
 
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Hyperfruit/en.md
+++ b/wiki/Hit_object/Hyperfruit/en.md
@@ -4,8 +4,8 @@ stub: true
 
 # Hyperfruit
 
-A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/Fruit) or [drop](/wiki/Hit_object/Juice_stream#drop). This effect will be generated when the next fruit or drop can't be caught with normal dashing. This effect will also generate when the last [banana](/wiki/Hit_object/Banana) of a [spinner](/wiki/Hit_object/Spinner) can't be caught with a dash.
+A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/Fruit) or [drop](/wiki/Hit_object/Juice_stream#drop). This effect will be generated when the next fruit or drop can't be caught with normal dashing. The movement that is created when catching the hyperfruit is called a hyperdash. This effect will also generate when the last [banana](/wiki/Hit_object/Banana) of a [spinner](/wiki/Hit_object/Spinner) can't be caught with a dash.
 
 During play, this effect is characterized by a coloured outline on the hyperfruit.
 
-<!-- TODO: Add links and images-->
+<!-- TODO: Add images -->

--- a/wiki/Hit_object/Hyperfruit/en.md
+++ b/wiki/Hit_object/Hyperfruit/en.md
@@ -8,8 +8,4 @@ A *hyperfruit* is an effect that can be generated on a [fruit](/wiki/Hit_object/
 
 During play, this is characterized by a coloured outline on the first object.
 
-## Hyperdash
-
-A *hyperdash* is the term used for the movement between a hyperfruit, and the following active object.
-
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Juice_stream/en.md
+++ b/wiki/Hit_object/Juice_stream/en.md
@@ -12,7 +12,7 @@ stub: true
 
 *Drops* are medium-sized coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Drops are equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a drop once the next [fruit](/wiki/Hit_object/Fruit) or drop is uncatchable by normal dashing.
 
-Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
+Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
 
 ## Droplet
 

--- a/wiki/Hit_object/Juice_stream/en.md
+++ b/wiki/Hit_object/Juice_stream/en.md
@@ -6,6 +6,19 @@ stub: true
 
 *See also: [Score](/wiki/Score)*
 
-**Juice streams** are an element in [osu!catch](/wiki/Game_Modes/osu!catch) which include both drops and droplets. Drops give a score of 100, equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!), while droplets give a score of 10, equivalent to the slider tick in osu!.
+**Juice streams** are an element in [osu!catch](/wiki/Game_Modes/osu!catch) which include both drops and droplets. Juice streams are equivalent to [sliders](/wiki/Hit_object/Slider) in [osu!](/wiki/Game_Modes/osu!).
 
-<!-- TODO: Add links -->
+## Drop
+
+*Drops* are medium-sized coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Drops are equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!). A hyperdash will be generated on a drop once the next [fruit](/wiki/Hit_object/Fruit) or drop is uncatchable by normal dashing.
+
+Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
+
+## Droplet
+
+*Droplets* are small coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). 
+
+Successfully catching a droplet will earn the player a [score](/wiki/Score) of 10, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 50 in the result screen. If the player fails to catch a droplet it will result in a loss in [health](/wiki/Beatmapping/Health).
+
+<!-- TODO: explain how droplets get generated -->
+<!-- TODO: Add links and images-->

--- a/wiki/Hit_object/Juice_stream/en.md
+++ b/wiki/Hit_object/Juice_stream/en.md
@@ -12,14 +12,14 @@ stub: true
 
 *Drops* are medium-sized coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Drops are equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a drop once the next [fruit](/wiki/Hit_object/Fruit) or drop is uncatchable by normal dashing.
 
-Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
+Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Glossary/Combo_(score_multiplier)) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combobreak](/wiki/Glossary/Combobreak) and a loss in [health](/wiki/Beatmapping/Health).
 
 ## Droplet
 
 *Droplets* are small coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). 
 
-Successfully catching a droplet will earn the player a [score](/wiki/Score) of 10, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 50 in the result screen. If the player fails to catch a droplet it will result in a loss in [health](/wiki/Beatmapping/Health).
+Successfully catching a droplet will earn the player a [score](/wiki/Score) of 10, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 50 in the result screen. If the player fails to catch a droplet it will result in a loss in [health](/wiki/Beatmapping/Health) and you will maintain your [combo](/wiki/Glossary/Combo_(score_multiplier)).
 
-<!-- TODO: explain how droplets get generated -->
+<!-- TODO: Explain how droplets get generated -->
 
-<!-- TODO: Add links and images-->
+<!-- TODO: Add images -->

--- a/wiki/Hit_object/Juice_stream/en.md
+++ b/wiki/Hit_object/Juice_stream/en.md
@@ -6,19 +6,20 @@ stub: true
 
 *See also: [Score](/wiki/Score)*
 
-**Juice streams** are an element in [osu!catch](/wiki/Game_Modes/osu!catch) which include both drops and droplets. Juice streams are equivalent to [sliders](/wiki/Hit_object/Slider) in [osu!](/wiki/Game_Modes/osu!).
+**Juice streams** are an element in [osu!catch](/wiki/Game_Modes/osu!catch) which include both drops and droplets. Juice streams get generated when a [slider](/wiki/Hit_object/Slider) is placed in the editor.
 
 ## Drop
 
-*Drops* are medium-sized coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Drops are equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!). A hyperdash will be generated on a drop once the next [fruit](/wiki/Hit_object/Fruit) or drop is uncatchable by normal dashing.
+*Drops* are medium-sized coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). Drops are equivalent to slider ticks in [osu!](/wiki/Game_Modes/osu!). A [hyperfruit](/wiki/Hit_object/Hyperfruit) will be generated on a drop once the next [fruit](/wiki/Hit_object/Fruit) or drop is uncatchable by normal dashing.
 
 Successfully catching a drop will earn the player a [score](/wiki/Score) of 100, increase the [combo](/wiki/Beatmapping/Combo) by 1, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 100 in the result screen. If the player fails to catch a drop it will result in a [combo](/wiki/Beatmapping/Combo) break and a loss in [health](/wiki/Beatmapping/Health).
 
 ## Droplet
 
-*Droplets* are small coloured [hit objects](/wiki/Hit_object) present in a [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). 
+*Droplets* are small coloured [hit objects](/wiki/Hit_object) present in [osu!catch](/wiki/Game_mode/osu!catch) [beatmaps](/wiki/Beatmap). 
 
 Successfully catching a droplet will earn the player a [score](/wiki/Score) of 10, provide a small boost to the [health bar](/wiki/Glossary/Health_bar), and is treated as 50 in the result screen. If the player fails to catch a droplet it will result in a loss in [health](/wiki/Beatmapping/Health).
 
 <!-- TODO: explain how droplets get generated -->
+
 <!-- TODO: Add links and images-->

--- a/wiki/Hit_object/en.md
+++ b/wiki/Hit_object/en.md
@@ -13,7 +13,7 @@ tags:
 
 | osu! | osu!taiko | osu!catch | osu!mania |
 | :-: | :-: | :-: | :-: |
-| [hit circles](/wiki/Hit_object/Hit_circle) | hit circles | fruits | notes |
+| [hit circles](/wiki/Hit_object/Hit_circle) | hit circles | [fruits](/wiki/Hit_object/Fruit) | notes |
 | [sliders](/wiki/Hit_object/Slider) | drumrolls | fruit trails | hold notes |
 | [spinners](/wiki/Hit_object/Spinner) | dendens | bananas | x |
 | x | x | hyperfruits | x |

--- a/wiki/Hit_object/en.md
+++ b/wiki/Hit_object/en.md
@@ -15,7 +15,7 @@ tags:
 | :-: | :-: | :-: | :-: |
 | [hit circles](/wiki/Hit_object/Hit_circle) | hit circles | [fruits](/wiki/Hit_object/Fruit) | notes |
 | [sliders](/wiki/Hit_object/Slider) | drumrolls | [juice stream](/wiki/Hit_object/Juice_stream) | hold notes |
-| [spinners](/wiki/Hit_object/Spinner) | dendens | bananas | x |
+| [spinners](/wiki/Hit_object/Spinner) | dendens | [bananas](/wiki/Hit_object/Banana) | x |
 | x | x | hyperfruits | x |
 
 From a programming standpoint, hold notes in osu!mania aren't equivalent to sliders in osu!, though they've been grouped together for simplification in this table. Other elements which aren't interacted with during gameplay, such as the health bar or kiai stars, are considered either gameplay enhancing or part of the user interface.

--- a/wiki/Hit_object/en.md
+++ b/wiki/Hit_object/en.md
@@ -14,7 +14,7 @@ tags:
 | osu! | osu!taiko | osu!catch | osu!mania |
 | :-: | :-: | :-: | :-: |
 | [hit circles](/wiki/Hit_object/Hit_circle) | hit circles | [fruits](/wiki/Hit_object/Fruit) | notes |
-| [sliders](/wiki/Hit_object/Slider) | drumrolls | fruit trails | hold notes |
+| [sliders](/wiki/Hit_object/Slider) | drumrolls | [juice stream](/wiki/Hit_object/Juice_stream) | hold notes |
 | [spinners](/wiki/Hit_object/Spinner) | dendens | bananas | x |
 | x | x | hyperfruits | x |
 

--- a/wiki/Hit_object/en.md
+++ b/wiki/Hit_object/en.md
@@ -16,7 +16,7 @@ tags:
 | [hit circles](/wiki/Hit_object/Hit_circle) | hit circles | [fruits](/wiki/Hit_object/Fruit) | notes |
 | [sliders](/wiki/Hit_object/Slider) | drumrolls | [juice stream](/wiki/Hit_object/Juice_stream) | hold notes |
 | [spinners](/wiki/Hit_object/Spinner) | dendens | [bananas](/wiki/Hit_object/Banana) | x |
-| x | x | hyperfruits | x |
+| x | x | [hyperfruits](/wiki/Hit_object/Hyperfruit) | x |
 
 From a programming standpoint, hold notes in osu!mania aren't equivalent to sliders in osu!, though they've been grouped together for simplification in this table. Other elements which aren't interacted with during gameplay, such as the health bar or kiai stars, are considered either gameplay enhancing or part of the user interface.
 


### PR DESCRIPTION
TicClick asked me if I could help out so here it is. Added stubs for catch hit objects, issue #3152

The issue also mentions 'Edge Dash' although this is a term that is used for a far dash and is not a hit object by itself

A PR with catch glossary and implementing this in the catch RC will follow once this is merged