### PR TITLE
Correct the Half Time mod description for osu!catch

### DIFF
--- a/wiki/Game_modifier/Half_Time/en.md
+++ b/wiki/Game_modifier/Half_Time/en.md
@@ -38,7 +38,7 @@ As a result, using the Half Time mod will lead to an increase in maximum possibl
 
 ### osu!catch
 
-In [osu!catch](/wiki/Game_mode/osu!catch), the BPM and the speed of the catcher is lowered by the same factor as in other modes. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
+In [osu!catch](/wiki/Game_mode/osu!catch), the BPM and the speed of the catcher are lowered by the same factor as in other modes. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
 
 ## Trivia
 

--- a/wiki/Game_modifier/Half_Time/en.md
+++ b/wiki/Game_modifier/Half_Time/en.md
@@ -38,9 +38,7 @@ As a result, using the Half Time mod will lead to an increase in maximum possibl
 
 ### osu!catch
 
-In [osu!catch](/wiki/Game_mode/osu!catch), the BPM is lowered by the same factor as in other modes. Though it *also* decreases the player character's speed so normal fruits without any mods *may* turn into hyperdash fruits.
-
-In addition to this, the leniency for hyperdashes is increased, which makes it much more difficult to stop underneath the next fruit when performing a hyperdash.
+In [osu!catch](/wiki/Game_mode/osu!catch), the BPM is lowered by the same factor as in other modes. However, the speed of the catcher is also decreased. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
 
 ## Trivia
 

--- a/wiki/Game_modifier/Half_Time/en.md
+++ b/wiki/Game_modifier/Half_Time/en.md
@@ -38,7 +38,7 @@ As a result, using the Half Time mod will lead to an increase in maximum possibl
 
 ### osu!catch
 
-In [osu!catch](/wiki/Game_mode/osu!catch), the BPM is lowered by the same factor as in other modes. Additionally, the speed of the catcher is also decreased. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
+In [osu!catch](/wiki/Game_mode/osu!catch), the BPM and the speed of the catcher is lowered by the same factor as in other modes. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
 
 ## Trivia
 

--- a/wiki/Game_modifier/Half_Time/en.md
+++ b/wiki/Game_modifier/Half_Time/en.md
@@ -38,7 +38,7 @@ As a result, using the Half Time mod will lead to an increase in maximum possibl
 
 ### osu!catch
 
-In [osu!catch](/wiki/Game_mode/osu!catch), the BPM is lowered by the same factor as in other modes. However, the speed of the catcher is also decreased. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
+In [osu!catch](/wiki/Game_mode/osu!catch), the BPM is lowered by the same factor as in other modes. Additionally, the speed of the catcher is also decreased. All the [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) and [bananas](/wiki/Hit_object/Banana) stay untouched.
 
 ## Trivia
 

--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -1,5 +1,7 @@
 ---
 stub: true
+outdated: true
+outdated_since: d70ed2a1ee643d5908b44860b9158f00c3de626f
 tags:
   - half time
   - mod

--- a/wiki/Game_modifier/Half_Time/id.md
+++ b/wiki/Game_modifier/Half_Time/id.md
@@ -1,5 +1,7 @@
 ---
 stub: true
+outdated: true
+outdated_since: d70ed2a1ee643d5908b44860b9158f00c3de626f
 tags:
   - half time
   - mod


### PR DESCRIPTION
The description of the halftime mod for osu!catch isn't correct as it only reduces the speed of the beatmap and the catcher.