### PR TITLE
[FR] Add `Banana`, `Fruit`, `Hyperfruit`, update `Juice stream`

### DIFF
--- a/wiki/Hit_object/Banana/fr.md
+++ b/wiki/Hit_object/Banana/fr.md
@@ -1,0 +1,9 @@
+---
+stub: true
+---
+
+# Banane
+
+Les **bananes** sont des [objet](/wiki/Hit_object) bonus présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Les bananes sont générées lorsqu'un [spinner](/wiki/Hit_object/Spinner) est placé dans l'éditeur. Par rapport à un spinner, elles n'ont pas besoin d'être effacées car chaque banane est optionnelle pour être attrapée.
+
+Réussir à attraper une banane augmentera le [score](/wiki/Score) de 1100 points sans tenir compte du [combo](/wiki/Glossary/Combo_(score_multiplier)), et elles donnent également un coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar).

--- a/wiki/Hit_object/Banana/fr.md
+++ b/wiki/Hit_object/Banana/fr.md
@@ -4,6 +4,6 @@ stub: true
 
 # Banane
 
-Les **bananes** sont des [objet](/wiki/Hit_object) bonus présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Les bananes sont générées lorsqu'un [spinner](/wiki/Hit_object/Spinner) est placé dans l'éditeur. Par rapport à un spinner, elles n'ont pas besoin d'être effacées car chaque banane est optionnelle pour être attrapée.
+Les **bananes** sont des [objets](/wiki/Hit_object) bonus présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Les bananes sont générées lorsqu'un [spinner](/wiki/Hit_object/Spinner) est placé dans l'éditeur. Contrairement à un spinner, les bananes n'ont pas besoin d'être attrapées puisque ce sont des objets optionnels.
 
 Réussir à attraper une banane augmentera le [score](/wiki/Score) de 1100 points sans tenir compte du [combo](/wiki/Glossary/Combo_(score_multiplier)), et elles donnent également un coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar).

--- a/wiki/Hit_object/Fruit/fr.md
+++ b/wiki/Hit_object/Fruit/fr.md
@@ -1,0 +1,9 @@
+---
+stub: true
+---
+
+# Fruits
+
+Les **fruits** sont de gros [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un fruit une fois que le fruit suivant ou le [drop](/wiki/Hit_object/Juice_stream#drop) est impossible à attraper par un dash normale.
+
+Si le joueur réussit à attraper un fruit, il gagne un [score](/wiki/Score), augmente le [combo]( /wiki/Glossary/Combo_(score_multiplier)) de 1, donne un coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et est traité comme un 300 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un fruit, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).

--- a/wiki/Hit_object/Fruit/fr.md
+++ b/wiki/Hit_object/Fruit/fr.md
@@ -4,6 +4,6 @@ stub: true
 
 # Fruits
 
-Les **fruits** sont de gros [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un fruit une fois que le fruit suivant ou le [drop](/wiki/Hit_object/Juice_stream#drop) est impossible à attraper par un dash normale.
+Les **fruits** sont de gros [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un fruit une fois que le fruit suivant ou le [drop](/wiki/Hit_object/Juice_stream#drop) est impossible à attraper avec un dash normal.
 
-Si le joueur réussit à attraper un fruit, il gagne un [score](/wiki/Score), augmente le [combo]( /wiki/Glossary/Combo_(score_multiplier)) de 1, donne un coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et est traité comme un 300 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un fruit, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
+Si le joueur réussit à attraper un fruit, il gagne du [score](/wiki/Score), augmente le [combo]( /wiki/Glossary/Combo_(score_multiplier)) de 1, donne un coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et est traité comme un 300 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un fruit, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).

--- a/wiki/Hit_object/Hyperfruit/fr.md
+++ b/wiki/Hit_object/Hyperfruit/fr.md
@@ -1,0 +1,9 @@
+---
+stub: true
+---
+
+# Hyperfruit
+
+Un **hyperfruit** est un effet qui peut être généré sur un [fruit](/wiki/Hit_object/Fruit) ou un [drop](/wiki/Hit_object/Juice_stream#drop). Cet effet sera généré lorsque le prochain fruit ou le prochain drop ne peut pas être attrapé avec un dash normal. Le mouvement créé pour attraper l'hyperfruit est appelé un hyperdash. Cet effet est également généré lorsque la dernière [banane](/wiki/Hit_object/Banana) d'un [spinner](/wiki/Hit_object/Spinner) ne peut pas être attrapée avec un dash.
+
+Pendant le jeu, cet effet se caractérise par un contour coloré sur l'hyperfruit.

--- a/wiki/Hit_object/Hyperfruit/fr.md
+++ b/wiki/Hit_object/Hyperfruit/fr.md
@@ -4,6 +4,6 @@ stub: true
 
 # Hyperfruit
 
-Un **hyperfruit** est un effet qui peut être généré sur un [fruit](/wiki/Hit_object/Fruit) ou un [drop](/wiki/Hit_object/Juice_stream#drop). Cet effet sera généré lorsque le prochain fruit ou le prochain drop ne peut pas être attrapé avec un dash normal. Le mouvement créé pour attraper l'hyperfruit est appelé un hyperdash. Cet effet est également généré lorsque la dernière [banane](/wiki/Hit_object/Banana) d'un [spinner](/wiki/Hit_object/Spinner) ne peut pas être attrapée avec un dash.
+Un **hyperfruit** est un effet qui peut être généré sur un [fruit](/wiki/Hit_object/Fruit) ou un [drop](/wiki/Hit_object/Juice_stream#drop). Cet effet sera généré lorsque le prochain fruit ou le prochain drop ne peut pas être attrapé avec un dash normal. Le mouvement créé après avoir attrapé l'hyperfruit est appelé un hyperdash. Cet effet est également généré lorsque la dernière [banane](/wiki/Hit_object/Banana) d'un [spinner](/wiki/Hit_object/Spinner) ne peut pas être attrapée avec un dash.
 
-Pendant le jeu, cet effet se caractérise par un contour coloré sur l'hyperfruit.
+Durant la partie, cet effet se caractérise par un contour coloré sur l'hyperfruit.

--- a/wiki/Hit_object/Juice_stream/fr.md
+++ b/wiki/Hit_object/Juice_stream/fr.md
@@ -18,4 +18,4 @@ Si le joueur réussit à attraper un drop, il obtiendra un [score](/wiki/Score) 
 
 Les **droplets** sont de petits [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). 
 
-Si vous réussissez à attraper un droplet, vous obtiendrez un [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé]( /wiki/Glossary/ Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper une gouttelette, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).
+Si vous réussissez à attraper un droplet, vous obtiendrez un [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé](/wiki/Glossary/Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper une gouttelette, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).

--- a/wiki/Hit_object/Juice_stream/fr.md
+++ b/wiki/Hit_object/Juice_stream/fr.md
@@ -10,12 +10,12 @@ Les **juice streams** sont un élément du mode [osu!catch](/wiki/Game_Modes/osu
 
 ## Drop
 
-Les **drop** sont des [objets](/wiki/Hit_object) de taille moyenne colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch) . Les drop sont équivalentes aux sliders ticks dans le mode [osu!](/wiki/Game_Modes/osu!). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un drop une fois que le [fruit](/wiki/Hit_object/Fruit) ou le drop suivant est impossible à attraper par un dash normal.
+Les **drop** sont des [objets](/wiki/Hit_object) de taille moyenne colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch) . Les drop sont équivalents aux sliders ticks dans le mode [osu!](/wiki/Game_Modes/osu!). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un drop une fois que le [fruit](/wiki/Hit_object/Fruit) ou le drop suivant est impossible à attraper par un dash normal.
 
-Si le joueur réussit à attraper un drop, il obtiendra un [score](/wiki/Score) de 100, augmentera le [combo](/wiki/Glossary/Combo_(score_multiplier)) de 1, donnera un petit coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et sera traité comme un 100 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un drop, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
+Si le joueur réussit à attraper un drop, il obtiendra du [score](/wiki/Score) de 100, augmentera le [combo](/wiki/Glossary/Combo_(score_multiplier)) de 1, donnera un petit coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et sera traité comme un 100 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un drop, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
 
 ## Droplet
 
 Les **droplets** sont de petits [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). 
 
-Si vous réussissez à attraper un droplet, vous obtiendrez un [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé](/wiki/Glossary/Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper une gouttelette, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).
+Si vous réussissez à attraper un droplet, vous obtiendrez du [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé](/wiki/Glossary/Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper un droplet, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).

--- a/wiki/Hit_object/Juice_stream/fr.md
+++ b/wiki/Hit_object/Juice_stream/fr.md
@@ -6,6 +6,16 @@ stub: true
 
 *Voir aussi : [Score](/wiki/Score)*
 
-Les **juice streams** sont un élément du mode [osu!catch](/wiki/Game_Modes/osu!catch) qui comprend à la fois des drops et des droplets. Les drops donnent un score de 100, équivalent aux slider ticks dans [osu!](/wiki/Game_Modes/osu!), tandis que les droplets donnent un score de 10, équivalent au slider tick dans osu!.
+Les **juice streams** sont un élément du mode [osu!catch](/wiki/Game_Modes/osu!catch) qui comprend à la fois des drop et des droplets. Les juice streams sont générés lorsqu'un [slider](/wiki/Hit_object/Slider) est placé dans l'éditeur.
 
-<!-- TODO: Add links -->
+## Drop
+
+Les **drop** sont des [objets](/wiki/Hit_object) de taille moyenne colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch) . Les drop sont équivalentes aux sliders ticks dans le mode [osu!](/wiki/Game_Modes/osu!). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un drop une fois que le [fruit](/wiki/Hit_object/Fruit) ou le drop suivant est impossible à attraper par un dash normal.
+
+Si le joueur réussit à attraper un drop, il obtiendra un [score](/wiki/Score) de 100, augmentera le [combo](/wiki/Glossary/Combo_(score_multiplier)) de 1, donnera un petit coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et sera traité comme un 100 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un drop, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
+
+## Droplet
+
+Les **droplets** sont de petits [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). 
+
+Si vous réussissez à attraper un droplet, vous obtiendrez un [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé]( /wiki/Glossary/ Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper une gouttelette, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).

--- a/wiki/Hit_object/Juice_stream/fr.md
+++ b/wiki/Hit_object/Juice_stream/fr.md
@@ -12,10 +12,10 @@ Les **juice streams** sont un élément du mode [osu!catch](/wiki/Game_Modes/osu
 
 Les **drop** sont des [objets](/wiki/Hit_object) de taille moyenne colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch) . Les drop sont équivalents aux sliders ticks dans le mode [osu!](/wiki/Game_Modes/osu!). Un [hyperfruit](/wiki/Hit_object/Hyperfruit) sera généré sur un drop une fois que le [fruit](/wiki/Hit_object/Fruit) ou le drop suivant est impossible à attraper par un dash normal.
 
-Si le joueur réussit à attraper un drop, il obtiendra du [score](/wiki/Score) de 100, augmentera le [combo](/wiki/Glossary/Combo_(score_multiplier)) de 1, donnera un petit coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et sera traité comme un 100 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un drop, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
+Si le joueur réussit à attraper un drop, il obtiendra 100 points de [score](/wiki/Score), augmentera le [combo](/wiki/Glossary/Combo_(score_multiplier)) de 1, donnera un petit coup de pouce à la [barre de santé](/wiki/Glossary/Health_bar), et sera traité comme un 100 dans l'écran des résultats. Si le joueur ne réussit pas à attraper un drop, cela entraînera un [combobreak](/wiki/Glossary/Combobreak) et une perte de [santé](/wiki/Beatmapping/Health).
 
 ## Droplet
 
 Les **droplets** sont de petits [objets](/wiki/Hit_object) colorés présents dans les [beatmaps](/wiki/Beatmap) du mode [osu!catch](/wiki/Game_mode/osu!catch). 
 
-Si vous réussissez à attraper un droplet, vous obtiendrez du [score](/wiki/Score) de 10, une petite augmentation de la [barre de santé](/wiki/Glossary/Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper un droplet, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).
+Si vous réussissez à attraper un droplet, vous obtiendrez 10 points de score [score](/wiki/Score), une petite augmentation de la [barre de santé](/wiki/Glossary/Health_bar) et un score de 50 dans l'écran des résultats. Si le joueur ne parvient pas à attraper un droplet, il perd de la [santé](/wiki/Beatmapping/Santé) et conserve son [combo](/wiki/Glossary/Combo_(score_multiplier)).


### PR DESCRIPTION
Translation of the following wiki pages:

- `Hit_object/Banana`
- `Hit_object/Fruit`
- `Hit_object/Hyperfruit`

Proposal to update the French translation of the wiki page `Juice stream`.