### PR TITLE
Fix email for account deletion requests on "Help Centre"; remove the GDPR note from the account support team article

### DIFF
--- a/wiki/Help_Centre/en.md
+++ b/wiki/Help_Centre/en.md
@@ -195,7 +195,7 @@ This doesn't mean you can make a new account to do the same thing, either! Havin
 
 *Caution: Account deletion is permanent, and therefore cannot be undone!*
 
-Yes, any user can request for their account to be deleted by sending an email to [accounts@ppy.sh](mailto:accounts@ppy.sh). Keep in mind that deleting your account is **final**, meaning that it cannot be reversed or undone. Deleting your account does not mean you can create a new account, as having multiple accounts is against the [rules](/wiki/Rules#community-rules). This means you will no longer be able to use any of osu!'s online features.
+Yes, any user can request for their account to be deleted by sending an email to [privacy@ppy.sh](mailto:privacy@ppy.sh). Keep in mind that deleting your account is **final**, meaning that it cannot be reversed or undone. Deleting your account does not mean you can create a new account, as having multiple accounts is against the [rules](/wiki/Rules#community-rules). This means you will no longer be able to use any of osu!'s online features.
 
 #### Can I play on a computer that another osu! user has used before?
 

--- a/wiki/People/The_Team/Account_support_team/en.md
+++ b/wiki/People/The_Team/Account_support_team/en.md
@@ -42,4 +42,4 @@ You should contact this team regarding account-related topics that are out of yo
 ### [privacy@ppy.sh](mailto:privacy@ppy.sh)
 
 - [Data requests](/wiki/Legal/Privacy#data-controller) and privacy concerns.
-- **Permanent** [account deletion requests](/wiki/Legal/Privacy#your-rights-and-control) for EU residents ([GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation "Wikipedia") coverage).
+- **Permanent** [account deletion requests](/wiki/Legal/Privacy#your-rights-and-control).

--- a/wiki/People/The_Team/Account_support_team/fr.md
+++ b/wiki/People/The_Team/Account_support_team/fr.md
@@ -42,4 +42,4 @@ Vous devriez contacter cette équipe pour les sujets concernant votre compte qui
 ### [privacy@ppy.sh](mailto:privacy@ppy.sh)
 
 - [Demandes de données](/wiki/Legal/Privacy#data-controller) et problèmes de confidentialité.
-- [Requêtes de suppression de compte](/wiki/Legal/Privacy#your-rights-and-control) **permanente** pour les utilisateurs résidant dans l'Union Européenne ([RGPD](https://fr.wikipedia.org/wiki/Règlement_général_sur_la_protection_des_données "Wikipédia")).
+- [Requêtes de suppression de compte](/wiki/Legal/Privacy#your-rights-and-control) **permanente**.

--- a/wiki/People/The_Team/Account_support_team/id.md
+++ b/wiki/People/The_Team/Account_support_team/id.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 234321c76b4fe27bcd7d21524603a9d975701ecb
+---
+
 # Account support team
 
 *Untuk tim yang memoderasi subforum tertentu, kunjungi: [Support Team](/wiki/People/The_Team/Support_Team)*

--- a/wiki/People/The_Team/Account_support_team/tr.md
+++ b/wiki/People/The_Team/Account_support_team/tr.md
@@ -42,4 +42,4 @@ Erişiminizin ötesindeki hesap ile ilişkili konular hakkında bu ekiple irtiba
 ### [privacy@ppy.sh](mailto:privacy@ppy.sh)
 
 - [Veri talepleri](/wiki/Legal/Privacy#data-controller) veya gizlilik endişeleri.
-- AB vatandaşları için ([GDPR](https://tr.wikipedia.org/wiki/Genel_Veri_Koruma_Y%C3%B6netmeli%C4%9Fi "Vikipedi") kapsamında) **kalıcı** [hesap kaldırma talepleri](/wiki/Legal/Privacy#your-rights-and-control).
+- **Kalıcı** [hesap kaldırma talepleri](/wiki/Legal/Privacy#your-rights-and-control).

--- a/wiki/People/The_Team/Account_support_team/tr.md
+++ b/wiki/People/The_Team/Account_support_team/tr.md
@@ -21,10 +21,10 @@ Erişiminizin ötesindeki hesap ile ilişkili konular hakkında bu ekiple irtiba
 ### [accounts@ppy.sh](mailto:accounts@ppy.sh)
 
 - [Hesabınıza uygulanan kısıtlamalara karşı itirazlar](/wiki/Help_Centre/Account_Restrictions). Bu kısıtlamalara aşağıdakiler de dahildir:
-    - susturmalar;
-    - profil içeriğinin kaldırılması;
-    - beatmapin kaldırılması;
-    - forum gönderisinin ve yorumun kaldırılması.
+  - susturmalar;
+  - profil içeriğinin kaldırılması;
+  - beatmapin kaldırılması;
+  - forum gönderisinin ve yorumun kaldırılması.
 - [İtiraf etmek istediğiniz](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play#what-can-i-do-if-i've-broken-the-rules?) olumsuz davranışlar.
 - osu! hesabınızla ilişkili [e-postanıza olan erişimi kaybetmeniz](/wiki/Help_Centre#sign-in), veya hesabınızın çalınması.
 - Kullanıcı adı [geri çevirme veya ufak yazım düzeltmeleri](/wiki/Help_Centre#name-changes).


### PR DESCRIPTION
Fix account deletion email from Help Centre and remove GDPR clause from Account Restriction Team page