### PR TITLE
Correct Tasha user link in Staff log 2013

### DIFF
--- a/wiki/Staff_Log/2013/en.md
+++ b/wiki/Staff_Log/2013/en.md
@@ -131,7 +131,7 @@
 
 ## August
 
-- Added [karterfreak](https://osu.ppy.sh/users/1031958) to osu!taiko Beatmap Appreciation Team (2013-08-01) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
+- Added [Tasha](https://osu.ppy.sh/users/1031958) to osu!taiko Beatmap Appreciation Team (2013-08-01) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
 - Added [OnosakiHito](https://osu.ppy.sh/users/290128) to osu!taiko Beatmap Appreciation Team (2013-08-01)
 - Moved [Armin](https://osu.ppy.sh/users/105902) from Beatmap Appreciation Team to osu! Alumni (2013-08-02) <!-- https://osu.ppy.sh/community/forums/posts/2474589 -->
 - Moved [abalee](https://osu.ppy.sh/users/13103) from Beatmap Appreciation Team to osu! Alumni (2013-08-02)

--- a/wiki/Staff_Log/2013/en.md
+++ b/wiki/Staff_Log/2013/en.md
@@ -131,7 +131,7 @@
 
 ## August
 
-- Added [Tasha](https://osu.ppy.sh/users/17909541) to osu!taiko Beatmap Appreciation Team (2013-08-01) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
+- Added [karterfreak](https://osu.ppy.sh/users/1031958) to osu!taiko Beatmap Appreciation Team (2013-08-01) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
 - Added [OnosakiHito](https://osu.ppy.sh/users/290128) to osu!taiko Beatmap Appreciation Team (2013-08-01)
 - Moved [Armin](https://osu.ppy.sh/users/105902) from Beatmap Appreciation Team to osu! Alumni (2013-08-02) <!-- https://osu.ppy.sh/community/forums/posts/2474589 -->
 - Moved [abalee](https://osu.ppy.sh/users/13103) from Beatmap Appreciation Team to osu! Alumni (2013-08-02)


### PR DESCRIPTION
In the list August it states _"-Added Tasha to osu!taiko Beatmap Appreciation Team"_ but the user that is being linked is [incorrect](https://osu.ppy.sh/users/17909541). The correct user is [karterfreak](https://osu.ppy.sh/users/1031958).  This was [explained and clarified](https://imgur.com/myZSrUM) by OnosakiHito who was a founding member of the osu!Taiko BAT alongside karterfreak. 