### PR TITLE
[EN/FR] Fix a typo in the `Combo fire` article

### DIFF
--- a/wiki/Glossary/Combo_fire/en.md
+++ b/wiki/Glossary/Combo_fire/en.md
@@ -8,7 +8,7 @@ tags:
 
 ![Ancient screenshot of the combo fire](/wiki/shared/combo-fire.jpg "R.I.P. combo fire")
 
-**Combo fire** was a background gameplay element that originated from the [osu! Tatake! Ouendan!](https://en.wikipedia.org/wiki/Osu!_Tatakae!_Ouendan "Wikipedia") DS Game that eventually got integrated into osu!. This would display a burning, yellow flame after obtaining a [combo milestone](/wiki/Glossary/Combo_milestone). If the player obtained a [combo](/wiki/Glossary/Combo_(score_multiplier)) of 500x, the combo fire would change colour from yellow to blue. The fire would extinguish if the combo was broken, but would be reobtainable if combo was regained.
+**Combo fire** was a background gameplay element that originated from the [osu! Tatakae! Ouendan!](https://en.wikipedia.org/wiki/Osu!_Tatakae!_Ouendan "Wikipedia") DS Game that eventually got integrated into osu!. This would display a burning, yellow flame after obtaining a [combo milestone](/wiki/Glossary/Combo_milestone). If the player obtained a [combo](/wiki/Glossary/Combo_(score_multiplier)) of 500x, the combo fire would change colour from yellow to blue. The fire would extinguish if the combo was broken, but would be reobtainable if combo was regained.
 
 Combo fire was disabled on March 5, 2013 due to performance concerns.
 

--- a/wiki/Glossary/Combo_fire/fr.md
+++ b/wiki/Glossary/Combo_fire/fr.md
@@ -8,7 +8,7 @@ tags:
 
 ![Capture d'écran ancienne du combo fire](/wiki/shared/combo-fire.jpg "R.I.P. combo fire")
 
-Le **combo fire** était un élément de gameplay qui provient du jeu DS [osu! Tatake! Ouendan!](https://fr.wikipedia.org/wiki/Osu!_Tatakae!_%C5%8Cendan "Wikipédia") et qui a été intégré dans osu!. Une flamme jaune s'affichait après l'obtention d'un [combo milestone](/wiki/Glossary/Combo_milestone). Si le joueur obtenait un [combo](/wiki/Glossary/Combo_(score_multiplier)) de 500x, le combo fire passait du jaune au bleu. Le feu s'étégnait si le combo était perdu, mais pouvait être récupéré si le combo était retrouvé.
+Le **combo fire** était un élément de gameplay qui provient du jeu DS [osu! Tatakae! Ouendan!](https://fr.wikipedia.org/wiki/Osu!_Tatakae!_%C5%8Cendan "Wikipédia") et qui a été intégré dans osu!. Une flamme jaune s'affichait après l'obtention d'un [combo milestone](/wiki/Glossary/Combo_milestone). Si le joueur obtenait un [combo](/wiki/Glossary/Combo_(score_multiplier)) de 500x, le combo fire passait du jaune au bleu. Le feu s'étégnait si le combo était perdu, mais pouvait être récupéré si le combo était retrouvé.
 
 Le combo fire a été désactivé le 5 mars 2013 en raison de problèmes de performance.
 


### PR DESCRIPTION
- EN and FR, fixed typo on line `osu! Tatake! Ouendan!` **/wiki/Glossary/[Combo fire](https://osu.ppy.sh/wiki/en/Glossary/Combo_fire)**