### PR TITLE
Correct the date for publicly available online rankings in `History of osu! 2007` article

### DIFF
--- a/wiki/History_of_osu!/2007/en.md
+++ b/wiki/History_of_osu!/2007/en.md
@@ -62,7 +62,7 @@ Quickly after the public release, the first play [mods](/wiki/Game_modifier), [E
 
 ## October
 
-October 1, 2007 was the day when online rankings were made publicly available. This also saw the launch of the `.osz` packaging method, and an online beatmap database with an early web-based submission system. Online rankings were added to the in-game interface and were also displayed on the website.
+October 6, 2007 was the day when online rankings were made publicly available. This also saw the launch of the `.osz` packaging method, and an online beatmap database with an early web-based submission system. Online rankings were added to the in-game interface and were also displayed on the website.
 
 ![](img/2007-10_01.jpg)
 

--- a/wiki/History_of_osu!/2007/es.md
+++ b/wiki/History_of_osu!/2007/es.md
@@ -67,7 +67,7 @@ Rápidamente después del lanzamiento público, los primeros mods, [Easy](/wiki/
 
 ## Octubre
 
-2007-10-01 fue el día en que las clasificaciones en línea se pusieron a disposición públicamente. Esto también vio el lanzamiento del método de empaquetado `.osz`, y la base de datos de beatmaps en línea con un sistema de envío temprano basado en la web. Las clasificaciones en línea fueron añadidas a la interfaz dentro del juego y también mostradas en la página.
+2007-10-06 fue el día en que las clasificaciones en línea se pusieron a disposición públicamente. Esto también vio el lanzamiento del método de empaquetado `.osz`, y la base de datos de beatmaps en línea con un sistema de envío temprano basado en la web. Las clasificaciones en línea fueron añadidas a la interfaz dentro del juego y también mostradas en la página.
 
 ![](img/2007-10_01.jpg)
 

--- a/wiki/History_of_osu!/2007/id.md
+++ b/wiki/History_of_osu!/2007/id.md
@@ -66,7 +66,7 @@ Beberapa saat setelah rilis secara publik, mod bermain pertama, [Easy](/wiki/EZ)
 
 ## Oktober
 
-2007-10-01 adalah hari ketika peringkat online dibuat tersedia untuk publik. Selain peringkat online, peluncuran metode pengemasan `.osz` juga diluncurkan pada hari itu bersamaan dengan database beatmap online dengan sistem pengajuan berbasis web tahap awal. Peringkat online ditambahkan ke antarmuka dalam game dan juga ditampilkan di situs web.
+2007-10-06 adalah hari ketika peringkat online dibuat tersedia untuk publik. Selain peringkat online, peluncuran metode pengemasan `.osz` juga diluncurkan pada hari itu bersamaan dengan database beatmap online dengan sistem pengajuan berbasis web tahap awal. Peringkat online ditambahkan ke antarmuka dalam game dan juga ditampilkan di situs web.
 
 ![](img/2007-10_01.jpg)
 

--- a/wiki/History_of_osu!/2007/nl.md
+++ b/wiki/History_of_osu!/2007/nl.md
@@ -66,7 +66,7 @@ Een korte tijd na de publieke release werden de eerste mods, [Easy](/wiki/EZ) en
 
 ## Oktober
 
-2007-10-01 was de dag waarop de online ranglijsten openbaar werden gemaakt. Ook de lancering van de .osz-zipmethode en de online beatmap-database met een vroeg webgebaseerd inzendingssysteem werd op die dag uitgevoerd. Online rankings werden toegevoegd aan de in-game interface en werden ook getoond op de website.
+2007-10-06 was de dag waarop de online ranglijsten openbaar werden gemaakt. Ook de lancering van de .osz-zipmethode en de online beatmap-database met een vroeg webgebaseerd inzendingssysteem werd op die dag uitgevoerd. Online rankings werden toegevoegd aan de in-game interface en werden ook getoond op de website.
 
 ![](img/2007-10_01.jpg)
 


### PR DESCRIPTION
While finalising tables for #4720, we noticed that peppy added public online rankings on October 6, 2007, and not October 1, 2007, as we previously assumed from this article and the [Official Development Changelog](https://osu.ppy.sh/community/forums/topics/15?start=966).

While parts of the system were available between October 1, 2007, and October 6, 2007, anything else was limited to testers. As far as we can tell, the online portion of the public online rankings was made functional on [October 6, 2007](https://osu.ppy.sh/community/forums/topics/15?start=966) with the first ranked maps being [DISCO PRINCE](https://osu.ppy.sh/beatmapsets/1#osu/75) and [1,2,3,4, 007[Wipeout Series]](https://osu.ppy.sh/beatmapsets/3#osu/54).

I've only changed the date in all the articles, but I am assuming that the article will be rewritten at some point, so I haven't changed anything else.