### PR TITLE
[FR] Add `Mapping and Modding Timeline`, fix links in other file

### DIFF
--- a/wiki/Mapping_and_Modding_Timeline/en.md
+++ b/wiki/Mapping_and_Modding_Timeline/en.md
@@ -275,7 +275,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 ### September
 
 - **2016-09-30:** The [Community Mentorship Program](/wiki/Community_Mentorship_Program) re-launched after a long hiatus.
-  - Its new structure was centered around [Discord](https://discord.com/brand-new) communication and seasonal cycles.
+  - Its new structure was centered around [Discord](https://discord.com/) communication and seasonal cycles.
   - The program was led by ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) and ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923) <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### October

--- a/wiki/Mapping_and_Modding_Timeline/en.md
+++ b/wiki/Mapping_and_Modding_Timeline/en.md
@@ -275,7 +275,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 ### September
 
 - **2016-09-30:** The [Community Mentorship Program](/wiki/Community_Mentorship_Program) re-launched after a long hiatus.
-  - Its new structure was centered around [Discord](https://discord.com/) communication and seasonal cycles.
+  - Its new structure was centered around [Discord](https://discord.com) communication and seasonal cycles.
   - The program was led by ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) and ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923) <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### October

--- a/wiki/Mapping_and_Modding_Timeline/en.md
+++ b/wiki/Mapping_and_Modding_Timeline/en.md
@@ -88,9 +88,6 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 - **2010-10-03:** MAT were granted permission to nominate beatmaps for ranking with normal `bubble` (![bubble icon](/wiki/shared/icon/bubble.gif)) icons, as opposed to proto-bubbles.
   - Proto-bubbles were ignored by most BAT members, so the MAT had no purpose without this change.
   - This gave MAT considerably more influence in the ranking process.<!-- https://osu.ppy.sh/community/forums/topics/38403 -->
-- **2011-10-10:** MAT members were no longer allowed to nominate or vote on new additions to their team.
-  - Having gained bubbling permissions, it was assumed that the MAT would vote for personal gain, so this was prevented before damage could be done.
-  - The BAT gained full responsibility for MAT additions.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 ### December
 
@@ -113,6 +110,9 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 
 - **2011-10-08:** [Ranking Criteria subforum](https://osu.ppy.sh/community/forums/87) opened for public discussion on [Ranking Criteria](/wiki/Ranking_Criteria) proposals.
   - These discussions were previously held by BAT members in a private subforum. <!-- date is not exact. the earliest thread in the subforum was posted on 2011-10-08 -->
+- **2011-10-10:** MAT members were no longer allowed to nominate or vote on new additions to their team.
+  - Having gained bubbling permissions, it was assumed that the MAT would vote for personal gain, so this was prevented before damage could be done.
+  - The BAT gained full responsibility for MAT additions.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 **1368 beatmaps** were ranked in 2011. This was the first decline after 4 years of consecutive growth.
 
@@ -146,7 +146,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 
 ### May
 
-- **2013-05-15:** The [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) was formed. <!-- https://osu.ppy.sh/community/forums/topics/132665 -->
+- **2013-05-15:** The [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) was formed. <!-- https://osu.ppy.sh/community/forums/topics/132665 -->
   - The role of BAT manager was split between 3 users from different regions in an attempt to promote equal input among mapping subgroups. ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) represented North America, ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) represented Asia, and ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) represented Europe.
   - Prior to this, Asian subgroups were often neglected because they communicated mainly outside of osu!'s IRC/forums.<!-- https://osu.ppy.sh/community/forums/topics/117187 -->
   - When the 3 members did not agree on a decision, it needed to be decided by a higher-up (most often ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335)).
@@ -162,7 +162,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 
 - **2013-12-12:** Beatmaps with two nominations began being promoted to the [Qualified](/wiki/Beatmap/Category#qualified) category instead of Ranked.
   - Qualified beatmaps could be disqualified within 1 week, replacing the option of unranking a beatmap within 1 week. <!-- https://osu.ppy.sh/community/forums/topics/171257 -->
-- **2013-12-22:** The [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) cycled its regional leaders to avoid burnout.
+- **2013-12-22:** The [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) cycled its regional leaders to avoid burnout.
   - ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) represented North America, ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) represented Asia, and ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) represented Europe. <!-- https://osu.ppy.sh/community/forums/topics/172289 -->
 
 **1327 beatmaps** were ranked in 2013.
@@ -243,7 +243,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 
 - **2016-02-13:** [Ranking Criteria Council](/wiki/Ranking_Criteria/Ranking_Criteria_Council) was created to reform the [Ranking Criteria](/wiki/Ranking_Criteria).
   - Public proposals on the Ranking Criteria subforum were no longer considered.
-  - Taking a stance similar to the [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate), the Ranking Criteria Council involved members to represent major mapping subgroups by region. Each game mode had 1 mapper and 1 player from the Americas, Europe, and Asia, along with 2 members of the QAT.
+  - Taking a stance similar to the [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate), the Ranking Criteria Council involved members to represent major mapping subgroups by region. Each game mode had 1 mapper and 1 player from the Americas, Europe, and Asia, along with 2 members of the QAT.
   - Each game mode's goal was to create a general/difficulty-specific Ranking Criteria for their respective mode. osu!catch was the only game mode that achieved this goal under this system.
   - The collective goal of this group was to rewrite all sections of the general Ranking Criteria. <!-- https://osu.ppy.sh/community/forums/topics/420229 -->
 - **2016-02-24:** Mapset and spread restructure was introduced to limit the number of difficulties in each difficulty tier per beatmap.
@@ -275,7 +275,7 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 ### September
 
 - **2016-09-30:** The [Community Mentorship Program](/wiki/Community_Mentorship_Program) re-launched after a long hiatus.
-  - Its new structure was centered around [Discord](https://discord.com/new) communication and seasonal cycles.
+  - Its new structure was centered around [Discord](https://discord.com/brand-new) communication and seasonal cycles.
   - The program was led by ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) and ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923) <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### October

--- a/wiki/Mapping_and_Modding_Timeline/en.md
+++ b/wiki/Mapping_and_Modding_Timeline/en.md
@@ -88,6 +88,9 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 - **2010-10-03:** MAT were granted permission to nominate beatmaps for ranking with normal `bubble` (![bubble icon](/wiki/shared/icon/bubble.gif)) icons, as opposed to proto-bubbles.
   - Proto-bubbles were ignored by most BAT members, so the MAT had no purpose without this change.
   - This gave MAT considerably more influence in the ranking process.<!-- https://osu.ppy.sh/community/forums/topics/38403 -->
+- **2010-10-10:** MAT members were no longer allowed to nominate or vote on new additions to their team.
+  - Having gained bubbling permissions, it was assumed that the MAT would vote for personal gain, so this was prevented before damage could be done.
+  - The BAT gained full responsibility for MAT additions.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 ### December
 
@@ -110,9 +113,6 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
 
 - **2011-10-08:** [Ranking Criteria subforum](https://osu.ppy.sh/community/forums/87) opened for public discussion on [Ranking Criteria](/wiki/Ranking_Criteria) proposals.
   - These discussions were previously held by BAT members in a private subforum. <!-- date is not exact. the earliest thread in the subforum was posted on 2011-10-08 -->
-- **2011-10-10:** MAT members were no longer allowed to nominate or vote on new additions to their team.
-  - Having gained bubbling permissions, it was assumed that the MAT would vote for personal gain, so this was prevented before damage could be done.
-  - The BAT gained full responsibility for MAT additions.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 **1368 beatmaps** were ranked in 2011. This was the first decline after 4 years of consecutive growth.
 

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -10,14 +10,14 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 ### Octobre
 
-- **21/09/2007 :** Les [critères de classement](/wiki/Ranking_Criteria) lancé. 
+- **21/09/2007 :** Les [Critères de Classement](/wiki/Ranking_Criteria) sortent. 
 - **29/07/2007 :**: Les icônes des fils de discussion du forum ont été normalisées pour le processus de classement.
   - Une icône `star` (![l'icône star](/wiki/shared/icon/star.gif)) marquait les bonnes beatmaps qui nécessitent plus de travail.
-  - Une icône `bubble` (![l'icône bubble](/wiki/shared/icon/bubble.gif)) marquait les beatmaps pris en compte pour le classement.
-  - Une icône `heart` (![l'icône heart](/wiki/shared/icon/heart.gif)) marquait les beatmaps classées. Ces icônes ne pouvaient être placées qu'après qu'un beatmap ait été mis en bulle, assurant ainsi deux nominations par beatmap.
-  - Une icône `nuke` (![Icône nuke](/wiki/shared/icon/nuke.gif)) marquait les beatmaps qui ne pouvaient en aucun cas être classés. 
+  - Une icône `bubble` (![l'icône bubble](/wiki/shared/icon/bubble.gif)) marquait les beatmaps prises en compte pour le classement.
+  - Une icône `heart` (![l'icône heart](/wiki/shared/icon/heart.gif)) marquait les beatmaps classées. Ces icônes ne pouvaient être placées qu'après qu'une beatmap ait été mis en bulle, assurant ainsi deux nominations par beatmap.
+  - Une icône `nuke` (![Icône nuke](/wiki/shared/icon/nuke.gif)) marquait les beatmaps qui ne pouvaient en aucun cas être classées. 
 
-**200 beatmaps** ont été classés en 2007.
+**200 beatmaps** ont été classées en 2007.
 
 <!-- missing formation of the BAT -->
 
@@ -30,9 +30,9 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 ### Juillet
 
-- **31/07/2008 :** La catégorie [Approuvé](/wiki/Beatmap/Category#approved) a été mise en place pour fournir des classements aux beatmaps inappropriés pour le classement.
+- **31/07/2008 :** La catégorie [Approuvée](/wiki/Beatmap/Category#approved) a été mise en place pour fournir des classements aux beatmaps inappropriées pour le classement.
   - Les raisons courantes d'approbation comprenaient initialement une durée supérieure à 5 minutes et des scores supérieurs à 20 millions, qui n'étaient pas autorisés pour le contenu classé. 
-  - Une icône `flame` (![l'icône flame](/wiki/shared/icon/flame.gif)) marquait les beatmaps approuvés après deux bulles.
+  - Une icône `flame` (![l'icône flame](/wiki/shared/icon/flame.gif)) marquait les beatmaps approuvées après deux bulles.
 
 ### Décembre
 
@@ -40,7 +40,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - Les membres ont été sélectionnés sur la base des critères décrits dans le [message du forum de l'annonce](https://osu.ppy.sh/community/forums/topics/8416).
   - Les membres BAT avaient un titre rouge sur les forums.
 
-**690 beatmaps** ont été classés en 2008.
+**690 beatmaps** ont été classées en 2008.
 
 ## 2009
 
@@ -68,7 +68,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - Le MAT s'appelait initialement "équipe de modding intermédiaire" et était composé de moddeurs établis qui n'étaient pas encore prêts à entrer dans le BAT.
   - Les objectifs du MAT étaient de réduire la charge de travail des BAT, d'identifier les maps qui passaient entre les mailles du filet du cycle de classement et d'améliorer le contrôle de la qualité, deux problèmes urgents à l'époque. Rétrospectivement, aucun de ses objectifs n'a été pleinement réalisé.
 
-**1400 beatmaps** ont été classés en 2009.
+**1400 beatmaps** ont été classées en 2009.
 
 ## 2010
 
@@ -94,15 +94,15 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 - **31/12/2010 :** ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) a été nommé chef des BAT après la démission de ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345).
   - Comme ses prédécesseurs, il a continué à s'occuper de la promotion des nouveaux BAT et à maintenir les BAT actuelles.
 
-**1864 beatmaps** ont été classés en 2010.
+**1864 beatmaps** ont été classées en 2010.
 
 ## 2011
 
 ### Mars
 
 - **09/03/2011 :** Les membres du MAT ont reçu l'autorisation de mettre des bubbles sur des beatmaps de la catégorie [approuvée](/wiki/Beatmap/Category#approuvée).
-  - Seule une des deux bubble d'une carte approuvée pouvait être placée par un membre du MAT.
-  - Ce changement a été mis en œuvre parce que les beatmaps approuvés devenaient plus courants.
+  - Seule une des deux bubble d'une beatmap approuvée pouvait être placée par un membre du MAT.
+  - Ce changement a été mis en œuvre parce que les beatmaps approuvées devenaient plus courantes.
 - **23/08/2011 :** La "Beatmap Approval Team" a été renommé en "Beatmap Appreciation Team".
   - Le but de ce nouveau nom était d'unir les utilisateurs impliqués dans l'approbation des beatmaps et les utilisateurs impliqués dans la modération générale (essentiellement la [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team)) sous le même nom, que "Beatmap Approval Team" ne représentait pas efficacement.
 
@@ -112,9 +112,9 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - Ces discussions étaient auparavant tenues par les membres du BAT dans un sous-forum privé.
 - **10/10/2011 :** Les membres du MAT n'étaient plus autorisés à nommer ou à voter pour les nouveaux membres de leur équipe.
   - Ayant obtenu des autorisations pour placer des bubbles, il a été supposé que le MAT voterait pour son propre intérêt, ce qui a été empêché avant que des dommages ne soient causés.
-  - Les BAT a acquis l'entière responsabilité des ajouts des MAT.
+  - Les BAT ont acquis l'entière responsabilité des ajouts des MAT.
 
-**1368 beatmaps** ont été classés en 2011. Il s'agit de la première baisse après 4 années de croissance consécutives.
+**1368 beatmaps** ont été classées en 2011. Il s'agit de la première baisse après 4 années de croissance consécutives.
 
 ## 2012
 
@@ -124,10 +124,10 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 ### Août
 
-- **21/08/2012 :** Les beatmaps de la catégorie [approuvée](/wiki/Beatmap/Category#approved) ont commencé à récompenser le score classé.
-  - Le score classé n'est plus utilisé comme principale mesure de score, de sorte que les beatmaps approuvés ne peuvent plus être utilisés abusivement pour le classement des joueurs.
+- **21/08/2012 :** Les beatmaps de la catégorie [approuvée](/wiki/Beatmap/Category#approved) ont commencé à faire gagner du score classé.
+  - Le score classé n'est plus utilisé comme principale mesure de score, de sorte que les beatmaps approuvées ne peuvent plus être utilisées abusivement pour le classement des joueurs.
 
-**1460 beatmaps** ont été classés en 2012.
+**1460 beatmaps** ont été classées en 2012.
 
 ## 2013
 
@@ -139,10 +139,10 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 ### Avril
 
-- **23/04/2013 :** Le MAT a été démantelé.
+- **23/04/2013 :** La MAT a été démantelée.
   - Tous les membres de la MAT ont été ajoutés aux BAT.
   - Ce changement a été effectué parce que la frontière entre les MAT et les BAT était devenue trop mince. Un membre de la MAT était en fait un membre de la BAT qui ne pouvait pas classer les beatmaps, ce qui ne correspondait pas aux objectifs initiaux des MAT en tant que nouveau groupe d'utilisateurs.
-  - Les BAT était également assez inactive à cette époque, un afflux important de nouveaux membres a donc permis de résoudre ce problème.
+  - Les BAT étaient également assez inactifs à cette époque, un afflux important de nouveaux membres a donc permis de résoudre ce problème.
 
 ### Mai
 
@@ -155,17 +155,17 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 - **01/08/2013 :** La politique de déclassement des beatmaps a été mise en place, permettant aux membres du BAT de déclasser un beatmap dans la semaine suivant son classement. 
   - Ce changement était un test pour la catégorie [qualifiée](/wiki/Beatmap/Category#qualifiée) qui a été implémentée plus tard.
-- **02/08/2013 :** Les premier BAT du mode osu!taiko ont été ajoutées, ce qui signifie une séparation des autorisations de mode de jeu dans le groupe.
+- **02/08/2013 :** Les premiers BAT du mode osu!taiko ont été ajoutées, ce qui signifie une séparation des autorisations de mode de jeu dans le groupe.
   - Avant cette date, n'importe quel BAT pouvait théoriquement proposer des beatmaps de n'importe quel mode, mais la croissance des différents modes de jeu a rendu cette distinction nécessaire.
 
 ### Décembre
 
-- **12/12/2013 :** Les beatmaps avec deux nominations ont commencé à être promus dans la catégorie [qualifiée](/wiki/Beatmap/Category#qualifiée) au lieu de la catégorie classée.
-  - Les beatmaps qualifiés pourraient être disqualifiés dans un délai d'une semaine, remplaçant ainsi la possibilité de déclasser un beatmap dans un délai d'une semaine. 
+- **12/12/2013 :** Les beatmaps avec deux nominations ont commencées à être promues dans la catégorie [qualifiée](/wiki/Beatmap/Category#qualifiée) au lieu de la catégorie classée.
+  - Les beatmaps qualifiées pourraient être disqualifiées dans un délai d'une semaine, remplaçant ainsi la possibilité de déclasser une beatmap dans un délai d'une semaine. 
 - **22/12/2013 :** Le [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) fait tourner ses dirigeants régionaux pour éviter l'épuisement.
   - ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) représentait l'Amérique du Nord, ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) l'Asie, et ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) l'Europe.
 
-**1327 beatmaps** ont été classés en 2013.
+**1327 beatmaps** ont été classées en 2013.
 
 ## 2014
 
@@ -177,32 +177,32 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 ### Août
 
-- **21/08/2014 :** La [Quality Assurance Team](/wiki/Modding/Quality_Assurance_Team) (*QAT*) se sépare des BAT actuelle.
-  - Les BAT (souvent appelé newBAT à cette époque) désigne les beatmaps pour le classement.
-  - Les QAT s'assure que les beatmaps qualifiés étaient de qualité suffisante. Les beatmaps qui ne répondaient pas aux normes de qualité étaient disqualifiés.
+- **21/08/2014 :** La [Quality Assurance Team](/wiki/Modding/Quality_Assurance_Team) (*QAT*) se sépare des BAT actuels.
+  - Les BAT (souvent appelé newBAT à cette époque) désigne les beatmaps à classer.
+  - Les QAT s'assure que les beatmaps qualifiés étaient de qualité suffisante. Les beatmaps qui ne répondaient pas aux normes de qualité étaient disqualifiées.
   - Cela a essentiellement inversé la fusion des BAT et des MAT l'année dernière.
   - La division a été mise en œuvre dans le cadre d'un essai manuel pour le [modding v2](/wiki/Beatmap_Discussion) qui tente d'automatiser la promotion et la retraite des BAT.
-  - Malgré les tentatives de présenter les disqualifications comme un changement positif pour la qualité des maps, la communauté les a perçues de manière négative. Cela était particulièrement évident dans le cas de beatmaps controversés comme [disqualification on *Halozy - Genryuu Kaiko*](https://osu.ppy.sh/community/forums/posts/3591479)
+  - Malgré les tentatives de présenter les disqualifications comme un changement positif pour la qualité des maps, la communauté les a perçues de manière négative. Cela était particulièrement évident dans le cas de beatmaps controversées comme [disqualification on *Halozy - Genryuu Kaiko*](https://osu.ppy.sh/community/forums/posts/3591479)
 
 ### Octobre
 
 - **15/10/2014 :** Le sous forum [Beatmap Management](https://osu.ppy.sh/community/forums/115) a remplacé Trello.
-  - L'accessibilité du public aux BAT a augmenté, ce qui était l'objectif du modding v2.
-  - Les questions relatives aux beatmaps nominés/qualifiés ont été postées ici, ainsi que toute annonce relative aux systèmes de mapping/modding.
+  - L'accessibilité du public aux BAT a augmentée, ce qui était l'objectif du modding v2.
+  - Les questions relatives aux beatmaps nominées/qualifiées ont été postées ici, ainsi que toute annonce relative aux systèmes de mapping/modding.
 
 ### Novembre
 
 - **14/11/2014 :** La promotion des nouveaux BAT s'est faite par le biais de votes publics parmi les BAT/QAT actuels.
-  - Les utilisateurs ayant obtenu au moins 15 votes et dont l'activité de modding est calculée automatiquement seront promus au groupe par intermittence.
+  - Les utilisateurs ayant obtenu au moins 15 votes et dont l'activité de modding est calculée automatiquement seraient promus au groupe par intermittence.
   - Cela a été géré sur Trello dans le passé.
 
-**1381 beatmaps** ont été classés en 2014.
+**1381 beatmaps** ont été classées en 2014.
 
 ## 2015
 
 ### Février
 
-- **01/02/2015 :** Les noms d'utilisateurs rouges ont été supprimés des BAT et les BAT a été renommé en [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) (*BN*).
+- **01/02/2015 :** Les noms d'utilisateurs rouges ont été supprimés des BAT et les BAT ont été renommés en [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) (*BN*).
   - Ces changements avaient pour but de rendre les BN plus proche de l'utilisateur moyen, ce qui était l'objectif de la conception communautaire du modding v2.
   - L'équipe a été initialement renommée Beatmap Appreciators, mais elle a rapidement été renommée Beatmap Nominators à la suite d'une suggestion de la communauté.
   - Les Beatmap Nominators n'étaient généralement pas d'accord avec ce changement et l'ont fortement contesté dans le cadre de l'enquête sur [ce fil du forum](https://osu.ppy.sh/community/forums/topics/292443).

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -1,0 +1,492 @@
+# Calendrier de mapping et de modding
+
+Les systèmes de mapping et de modding sont en constante amélioration. Le **calendrier de mapping et de modding** vise à documenter les plus grands changements apportés au système et à servir d'outil de référence lorsque les utilisateurs intègrent de nouvelles modifications.
+
+## 2007
+
+### Septembre
+
+- **17/09/2007 :** osu! a été rendu public.
+
+### Octobre
+
+- **21/09/2007 :** Les [critères de classement](/wiki/Ranking_Criteria) lancé. 
+- **29/07/2007 :**: Les icônes des fils de discussion du forum ont été normalisées pour le processus de classement.
+  - Une icône `star` (![l'icône star](/wiki/shared/icon/star.gif)) marquait les bonnes beatmaps qui nécessitent plus de travail.
+  - Une icône `bubble` (![l'icône bubble](/wiki/shared/icon/bubble.gif)) marquait les beatmaps pris en compte pour le classement.
+  - Une icône `heart` (![l'icône heart](/wiki/shared/icon/heart.gif)) marquait les beatmaps classées. Ces icônes ne pouvaient être placées qu'après qu'un beatmap ait été mis en bulle, assurant ainsi deux nominations par beatmap.
+  - Une icône `nuke` (![Icône nuke](/wiki/shared/icon/nuke.gif)) marquait les beatmaps qui ne pouvaient en aucun cas être classés. 
+
+**200 beatmaps** ont été classés en 2007.
+
+<!-- missing formation of the BAT -->
+
+## 2008
+
+### Mars
+
+- **11/03/2008 :** La catégorie [Graveyard](/wiki/Beatmap/Category#graveyard) a été mise en place pour accueillir les beatmaps inactives.
+  - La communauté s'attendait à ce que chaque map en attente soit classée, mais les maps étaient fréquemment abandonnées et devaient être séparées.
+
+### Juillet
+
+- **31/07/2008 :** La catégorie [Approuvé](/wiki/Beatmap/Category#approved) a été mise en place pour fournir des classements aux beatmaps inappropriés pour le classement.
+  - Les raisons courantes d'approbation comprenaient initialement une durée supérieure à 5 minutes et des scores supérieurs à 20 millions, qui n'étaient pas autorisés pour le contenu classé. 
+  - Une icône `flame` (![l'icône flame](/wiki/shared/icon/flame.gif)) marquait les beatmaps approuvés après deux bulles.
+
+### Décembre
+
+- **20/12/2008 :** Les conditions pour rejoindre la [Beatmap Approval Team](/wiki/Modding/Beatmap_Appreciation_Team) (*BAT*) ont été publiées.
+  - Les membres ont été sélectionnés sur la base des critères décrits dans le [message du forum de l'annonce](https://osu.ppy.sh/community/forums/topics/8416).
+  - Les membres BAT avaient un titre rouge sur les forums.
+
+**690 beatmaps** ont été classés en 2008.
+
+## 2009
+
+### Février
+
+- **04/02/2009 :** ![][flag_US] [Ivalset](https://osu.ppy.sh/users/827) a été promu premier [BAT manager](/wiki/Modding/Bat_Managers). 
+  - Son rôle principal était d'organiser la promotion de nouvelles BAT et d'améliorer l'activité/la compétence des BAT actuelles. 
+
+### Mars
+
+- **04/03/2009 :** ![] [flag_US] [Ivalset](https://osu.ppy.sh/users/827) a lancé la première [Délégation des pouvoirs de décision en matière d'approbation des beatmap ; escouade de soumission](/wiki/Modding/Delegation_of_the_Beatmap_Approval_Deciding_Authorities_Submission_Squad) (*BADASS*). 
+  - Ce changement a été lancé parce que les BAT précédentes ont été ajoutées sur la base d'un vote informel du canal `#bat` sur l'[IRC](/wiki/Internet_Relay_Chat) d'osu! qui n'était pas visible par suffisamment d'utilisateurs.
+
+### Novembre
+
+- **10/11/2009 :** ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345) a été nommé responsable des BAT après le départ de ![][flag_US] [Ivalset](https://osu.ppy.sh/users/827).
+  - Il a continué à promouvoir de nouveaux BAT et à maintenir les BATS actuelles.
+
+### Décembre
+
+- **27/12/2009 :** L'équipe [Mapping Assistance Team](/wiki/Modding/Mapping_Assistance_Team) (*MAT*) est lancée.
+  - Les membres du MAT pouvaient marquer les beatmaps avec des [proto-bulles](/wiki/Modding/Proto-bulle) qui indiquaient les beatmaps de qualité que les membres du BAT devraient examiner. 
+  - ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) a été le premier [Leader MAT](/wiki/Modding/MAT_Leaders) du groupe. 
+  - Les membres de la MAT avaient un titre violet sur les forums.
+  - Le MAT s'appelait initialement "équipe de modding intermédiaire" et était composé de moddeurs établis qui n'étaient pas encore prêts à entrer dans le BAT.
+  - Les objectifs du MAT étaient de réduire la charge de travail des BAT, d'identifier les maps qui passaient entre les mailles du filet du cycle de classement et d'améliorer le contrôle de la qualité, deux problèmes urgents à l'époque. Rétrospectivement, aucun de ses objectifs n'a été pleinement réalisé.
+
+**1400 beatmaps** ont été classés en 2009.
+
+## 2010
+
+### Juillet
+
+- **24/07/2010 :** La première itération du [Community Mentorship Program](/wiki/Community_Mentorship_Programs#programmes-de-mentorship-antérieurs) a été lancée.
+  - Les utilisateurs peuvent s'inscrire pour apprendre à mapper et à modder directement auprès des membres bénévoles de MAT et BAT.
+  - Le programme a été interrompu en 2013.
+
+### Août
+
+- **27/08/2010 :** ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) a été nommé chef du MAT après le départ de ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335).
+  - Le leadership est passé provisoirement entre les deux utilisateurs jusqu'à ce que ztrot prenne le contrôle en février 2011.
+
+### Octobre
+
+- **03/10/2010 :** Les MAT ont été autorisés à proposer des beatmaps pour le classement avec des icônes "bubble" normales (![icône bubble](/wiki/shared/icon/bubble.gif)), par opposition aux proto-bulles.
+  - Les proto-bulles étaient ignorées par la plupart des membres du BAT, et le MAT n'avait donc aucune utilité sans ce changement.
+  - Cela a donné aux MAT beaucoup plus d'influence dans le processus de classement.
+
+### December
+
+- **31/12/2010 :** ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) a été nommé chef des BAT après la démission de ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345).
+  - Comme ses prédécesseurs, il a continué à s'occuper de la promotion des nouveaux BAT et à maintenir les BAT actuelles.
+
+**1864 beatmaps** ont été classés en 2010.
+
+## 2011
+
+### Mars
+
+- **09/03/2011 :** Les membres du MAT ont reçu l'autorisation de mettre des bubbles sur des beatmaps de la catégorie [approuvée](/wiki/Beatmap/Category#approuvée).
+  - Seule une des deux bubble d'une carte approuvée pouvait être placée par un membre du MAT.
+  - Ce changement a été mis en œuvre parce que les beatmaps approuvés devenaient plus courants.
+- **23/08/2011 :** La "Beatmap Approval Team" a été renommé en "Beatmap Appreciation Team".
+  - Le but de ce nouveau nom était d'unir les utilisateurs impliqués dans l'approbation des beatmaps et les utilisateurs impliqués dans la modération générale (essentiellement la [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team)) sous le même nom, que "Beatmap Approval Team" ne représentait pas efficacement.
+
+### Octobre
+
+- **08/10/2011 :** Le sous-forum [Ranking Criteria](https://osu.ppy.sh/community/forums/87) est ouvert à la discussion publique sur les propositions des [critères de classement](/wiki/Ranking_Criteria).
+  - Ces discussions étaient auparavant tenues par les membres du BAT dans un sous-forum privé.
+- **10/10/2011 :** Les membres du MAT n'étaient plus autorisés à nommer ou à voter pour les nouveaux membres de leur équipe.
+  - Ayant obtenu des autorisations pour placer des bubbles, il a été supposé que le MAT voterait pour son propre intérêt, ce qui a été empêché avant que des dommages ne soient causés.
+  - Les BAT a acquis l'entière responsabilité des ajouts des MAT.
+
+**1368 beatmaps** ont été classés en 2011. Il s'agit de la première baisse après 4 années de croissance consécutives.
+
+## 2012
+
+### Juillet
+
+- **22/07/2012 :** La première itération des [points de performance](/wiki/Performance_Points) connue sous le nom de [ppv1](/wiki/Performance_Points/ppv1) a été mise en place, remplaçant les classements par score total classé.
+
+### Août
+
+- **21/08/2012 :** Les beatmaps de la catégorie [approuvée](/wiki/Beatmap/Category#approved) ont commencé à récompenser le score classé.
+  - Le score classé n'est plus utilisé comme principale mesure de score, de sorte que les beatmaps approuvés ne peuvent plus être utilisés abusivement pour le classement des joueurs.
+
+**1460 beatmaps** ont été classés en 2012.
+
+## 2013
+
+### Mars
+
+- **20/03/2013 :** Les BAT ont été divisés en BAT et en membre de la [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) (*GMT*).
+  - De nombreux membres de la BAT étaient présent uniquement pour les fonctions de modération, ce qui a permis de clarifier les rôles de modding et de membres modérateurs.
+  - Les membres du nouveau GMT étaient auparavant connus sous le nom de "Green BAT".
+
+### Avril
+
+- **23/04/2013 :** Le MAT a été démantelé.
+  - Tous les membres de la MAT ont été ajoutés aux BAT.
+  - Ce changement a été effectué parce que la frontière entre les MAT et les BAT était devenue trop mince. Un membre de la MAT était en fait un membre de la BAT qui ne pouvait pas classer les beatmaps, ce qui ne correspondait pas aux objectifs initiaux des MAT en tant que nouveau groupe d'utilisateurs.
+  - Les BAT était également assez inactive à cette époque, un afflux important de nouveaux membres a donc permis de résoudre ce problème.
+
+### Mai
+
+- **15/05/2013 :** Le [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) a été formé.
+  - Le rôle de gestionnaire de la BAT a été partagé entre 3 utilisateurs de différentes régions afin de promouvoir une contribution égale entre les sous-groupes de mapping. ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) représentait l'Amérique du Nord, ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) l'Asie, et ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) l'Europe.
+  - Avant cela, les sous-groupes asiatiques étaient souvent négligés car ils communiquaient principalement en dehors de l'IRC/des forums d'osu!
+  - Lorsque les 3 membres n'étaient pas d'accord sur une décision, celle-ci devait être décidée par un supérieur (le plus souvent ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335)).
+
+### Août
+
+- **01/08/2013 :** La politique de déclassement des beatmaps a été mise en place, permettant aux membres du BAT de déclasser un beatmap dans la semaine suivant son classement. 
+  - Ce changement était un test pour la catégorie [qualifiée](/wiki/Beatmap/Category#qualifiée) qui a été implémentée plus tard.
+- **02/08/2013 :** Les premier BAT du mode osu!taiko ont été ajoutées, ce qui signifie une séparation des autorisations de mode de jeu dans le groupe.
+  - Avant cette date, n'importe quel BAT pouvait théoriquement proposer des beatmaps de n'importe quel mode, mais la croissance des différents modes de jeu a rendu cette distinction nécessaire.
+
+### Décembre
+
+- **12/12/2013 :** Les beatmaps avec deux nominations ont commencé à être promus dans la catégorie [qualifiée](/wiki/Beatmap/Category#qualifiée) au lieu de la catégorie classée.
+  - Les beatmaps qualifiés pourraient être disqualifiés dans un délai d'une semaine, remplaçant ainsi la possibilité de déclasser un beatmap dans un délai d'une semaine. 
+- **22/12/2013 :** Le [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) fait tourner ses dirigeants régionaux pour éviter l'épuisement.
+  - ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) représentait l'Amérique du Nord, ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) l'Asie, et ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) l'Europe.
+
+**1327 beatmaps** ont été classés en 2013.
+
+## 2014
+
+### Février
+
+- **10/02/2014 :** Pour améliorer l'organisation, le système de modding et de mapping, la gestion interne est passée des forums à Trello.
+- **18/02/2014 :** La catégorie [approuvée](/wiki/Beatmap/Category#approuvée) a été retirée.
+  - Les beatmaps marathon ont été promus dans la catégorie classée avec 3 nominations BAT (2 icônes `bubble` (![icône bubble](/wiki/shared/icon/bubble.gif)) + 1 icône `flame` (![icône flame](/wiki/shared/icon/flame.gif))).
+
+### Août
+
+- **21/08/2014 :** La [Quality Assurance Team](/wiki/Modding/Quality_Assurance_Team) (*QAT*) se sépare des BAT actuelle.
+  - Les BAT (souvent appelé newBAT à cette époque) désigne les beatmaps pour le classement.
+  - Les QAT s'assure que les beatmaps qualifiés étaient de qualité suffisante. Les beatmaps qui ne répondaient pas aux normes de qualité étaient disqualifiés.
+  - Cela a essentiellement inversé la fusion des BAT et des MAT l'année dernière.
+  - La division a été mise en œuvre dans le cadre d'un essai manuel pour le [modding v2](/wiki/Beatmap_Discussion) qui tente d'automatiser la promotion et la retraite des BAT.
+  - Malgré les tentatives de présenter les disqualifications comme un changement positif pour la qualité des maps, la communauté les a perçues de manière négative. Cela était particulièrement évident dans le cas de beatmaps controversés comme [disqualification on *Halozy - Genryuu Kaiko*](https://osu.ppy.sh/community/forums/posts/3591479)
+
+### Octobre
+
+- **15/10/2014 :** Le sous forum [Beatmap Management](https://osu.ppy.sh/community/forums/115) a remplacé Trello.
+  - L'accessibilité du public aux BAT a augmenté, ce qui était l'objectif du modding v2.
+  - Les questions relatives aux beatmaps nominés/qualifiés ont été postées ici, ainsi que toute annonce relative aux systèmes de mapping/modding.
+
+### Novembre
+
+- **14/11/2014 :** La promotion des nouveaux BAT s'est faite par le biais de votes publics parmi les BAT/QAT actuels.
+  - Les utilisateurs ayant obtenu au moins 15 votes et dont l'activité de modding est calculée automatiquement seront promus au groupe par intermittence.
+  - Cela a été géré sur Trello dans le passé.
+
+**1381 beatmaps** ont été classés en 2014.
+
+## 2015
+
+### Février
+
+- **01/02/2015 :** Les noms d'utilisateurs rouges ont été supprimés des BAT et les BAT a été renommé en [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) (*BN*).
+  - Ces changements avaient pour but de rendre les BN plus proche de l'utilisateur moyen, ce qui était l'objectif de la conception communautaire du modding v2.
+  - L'équipe a été initialement renommée Beatmap Appreciators, mais elle a rapidement été renommée Beatmap Nominators à la suite d'une suggestion de la communauté.
+  - Les Beatmap Nominators n'étaient généralement pas d'accord avec ce changement et l'ont fortement contesté dans le cadre de l'enquête sur [ce fil du forum](https://osu.ppy.sh/community/forums/topics/292443).
+- **24/02/2015 :** De nouvelles applications des BN remplacent le vote des BN.
+  - Cela a été fait pour promouvoir la conception communautaire du modding v2 et pour éviter le népotisme qu'impliquait le vote public.
+  - Le seul critère était l'activité de modding du candidat, calculée automatiquement.
+
+### Juin
+
+- **04/06/2015 :** Le classement en temps réel des Beatmap Nominator a été introduit pour évaluer automatiquement la qualité/activité des nominations des BN.
+  - Le système a été abandonné peu après son annonce en raison de problèmes de mise en œuvre par les développeurs d'osu!
+- **06/06/2015 :** Les disqualifications des QAT ont été rendues anonymes sur les forums.
+  - Tous les messages ont été écrits sous un utilisateur nommé "[Quality Assurance Team](https://osu.ppy.sh/users/6616586)".
+  - Elle a été mise en place en réponse aux fréquentes attaques contre les disqualifications des QAT, souvent liées à la suppression des scores de points de performance élevés (par exemple, la [disqualification de *Dragonforce - The Last Journey Home*](https://osu.ppy.sh/community/forums/posts/4009572)) ou liées à des opinions forcées (par exemple, la [disqualification de *Reol - Asymmetry*](https://osu.ppy.sh/community/forums/posts/4206479)).
+  - La communauté a appelé le compte anonyme des QAT le "bot des QAT".
+  - Ce changement a encouragé l'opinion croissante selon laquelle les QAT essayait de se cacher des conséquences de ses actions, ce qui a nui à la réputation des disqualifications et des QAT en général.
+
+### Août
+
+- **25/08/2015 :** Les beatmaps qualifiés ne récompensent plus les joueurs avec des [points de performance](/wiki/Performance_Points).
+  - Cette mesure a été prise en réponse aux nombreuses plaintes concernant la perte de points de performance sur les beatmaps qualifiées.
+  - La tension entre les joueurs et les QAT a été soulagée après ce changement.
+- **26/08/2015 :** Les disqualifications anonymes des QAT ont été supprimées.
+  - La tension entre les joueurs et les QAT étant moindre, l'anonymisation a été jugée inutile.
+
+### Décembre
+
+- **27/12/2015 :** Les [tests BN](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) ont été mis en place pour les applications des BN.
+  - Ces tests demandaient aux utilisateurs de répondre à un formulaire à choix multiple et de modder un beatmap rempli de problèmes.
+
+**1934 beatmaps** ont été classés en 2015. Il s'agissait de la première année de croissance après 4 années consécutives de stagnation.
+
+## 2016
+
+### Février
+
+- **13/02/2016 :** Le [Conseil des critères de classement](/wiki/Ranking_Criteria/Ranking_Criteria_Council) a été créé pour réformer les [critères de classement](/wiki/Ranking_Criteria).
+  - Les propositions publiques sur le sous-forum "Critères de classement" ne sont plus prises en compte.
+  - Adoptant une position similaire à celle du [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate), le conseil des critères de classement comprenait des membres représentant les principaux sous-groupes de mappeurs par région. Chaque mode de jeu comptait 1 mappeur et 1 joueur des Amériques, d'Europe et d'Asie, ainsi que 2 membres des QAT.
+  - L'objectif de chaque mode de jeu était de créer un critère de classement général/difficile pour leur mode respectif. osu!catch est le seul mode de jeu qui a atteint cet objectif avec ce système.
+  - L'objectif collectif de ce groupe était de réécrire toutes les sections des critères généraux de classement.
+- **24/02/2016 :** Une restructuration des mapsets et des spreads a été introduite pour limiter le nombre de difficultés dans chaque niveau de difficulté par beatmap.
+  - L'accueil négatif du public a entraîné son annulation immédiate et son [fil de discussion](https://osu.ppy.sh/community/forums/topics/420223) a accumulé 614 réponses en 24 heures, ce qui en fait le fil de discussion le plus rapide d'osu!
+  - Cette tentative de changement antidémocratique a immédiatement valu au conseil des critères de classement une réputation négative.
+
+### Avril
+
+- **25/04/2016 :** Le QAT a commencé à vérifier les maps qualifiées pour les problèmes *réactifs* plutôt que proactifs.
+  - Les utilisateurs ont signalé des beatmaps qualifiés au QAT pour disqualification. Les QAT a confirmé ou infirmé les problèmes signalés dans les fils de discussion respectifs des beatmaps.
+  - Ce changement a été effectué en réponse à la vision constamment négative des disqualifications par les QAT. Les QAT ont pris leurs distances par rapport aux tâches liées à l'assurance qualité à ce moment-là.
+  - Les contrôles des métadonnées étaient toujours effectués de manière proactive par les QAT, dirigée par ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463).
+
+### Juillet
+
+- **20/07/2016 :** Le [United Beat-Knights of Ranking Criteria](/wiki/Ranking_Criteria/Ranking_Criteria_Council#united-beat-knights-of-ranking-criteria) (*UBKRC*) a été créé pour remplacer le conseil des critères de classement.
+  - Les objectifs de l'UBKRC étaient les mêmes que ceux du conseil des critères de classement, mais il a été plus largement accepté car il était ouvert à l'influence de la communauté.
+  - Des équipes d'experts ont été choisies pour chaque sous-section des critères de classement (par exemple, une équipe d'experts en storyboarding, une autre équipe d'experts en skinning, etc.)
+  - Le groupe était géré par ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418).
+  - Le nom de l'UBKRC a été choisi parce qu'il était ridiculement stupide. Son but était de paraître moins autoritaire que le conseil des critères de classement.
+
+### Août
+
+- **05/08/2016 :** Le [blog Quality Assurance Team](/wiki/Quality_Assurance_Team_Blog) a été créé.
+  - Les QAT était critiquée pour être trop fermée au reste de la communauté de mapping. Ce blog a donc été créé pour accroître la transparence des décisions des QAT et des activités de la communauté.
+- **26/08/2016 :** Le [Code de conduite] (/wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping) a été mis en place pour définir les attentes en matière de comportement des moddeurs.
+  - Jusqu'à présent, ces règles et directives étaient considérées comme relevant du bon sens. En les documentant, la modération pourrait être rendue plus cohérente.
+
+### Septembre
+
+- **30/09/2016 :** Le [Community Mentorship Program] (/wiki/Community_Mentorship_Program) a été relancé après une longue interruption.
+  - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com/brand-new) et les cycles saisonniers.
+  - Le programme était dirigé par ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923)
+
+### Octobre
+
+- **17/01/2016 :** La catégorie [Loved](/wiki/Beatmap/Category#loved) a été créée.
+  - Cette catégorie fournissait des classements pour les maps populaires qui ne pouvaient pas être classées pour diverses raisons.
+  - *Voir [History of Loved](/wiki/Beatmap/History_of_Loved) pour une chronologie détaillée des changements du système Loved.*
+
+### Novembre
+
+- **01/11/2016 :** Le système [Beatmap Veto](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Veto) a été mis en place.
+  - Les Beatmap Nominators pouvaient arrêter une beatmap dans le processus de classement pour des raisons subjectives en réinitialisant une nomination. Ceci était fait avec une icône `bubble pop` (![icône bubble pop](/wiki/shared/icon/bubble-pop.gif)).
+  - Les vétos pourraient être écrasés par les nominations des Beatmap Nominators qui n'ont pas été impliqués dans la beatmap.
+  - Afin de laisser suffisamment de temps pour opposer son veto, les nominations consécutives ne pouvaient pas être fixées à moins de 24 heures d'intervalle.
+  - Les vetos non concluants ont fait l'objet d'une médiation par les QAT peu après la mise en œuvre de ce système.
+- **02/11/2016 :** Les fichiers des Beatmap Nominator ont été créés pour garder un œil sur tous les membres individuels des BN.
+  - Ces dossiers comprenaient les activités de modding/nomination, les disqualifications et les problèmes de comportement.
+  - Les membres du BN ayant 3 "strikes" ou plus enregistrées dans ces fichiers seraient retirés du groupe.
+
+**1720 beatmaps** ont été classés en 2016.
+
+## 2017
+
+### Avril
+
+- **06/04/2017 :** Les [Beatmap Nominator Tiers](/wiki/Modding/Beatmap_Nominator_Tiers) ont été implémentés, divisant les BN en deux sous-groupes appelés "tiers".
+  - Comme le QAT ne jouait plus son rôle de contrôle de la qualité, ce système a été mis en place pour améliorer la qualité des beatmaps entrant dans la catégorie classée.
+  - Ce système a imité le stade ultérieur de la [Mapping Assistance Team](/wiki/Modding/Mapping_Assistance_Team).
+    - Les nominateurs de niveau 1 pourraient mettre des bubbles sur les maps.
+    - Les nominateurs de niveau 2 pourraient mettre des bubbles et qualifier les maps..
+  - Les niveaux ont été déterminés par un test BN conçu pour identifier les problèmes généraux des beatmaps. Les résultats du test ont été terribles, révélant que la conception du test était défectueuse.
+  - Contrairement à ses objectifs, ce système a réduit la motivation de tous les nominateurs de niveau 1 et surchargé les quelques nominateurs de niveau 2 motivés. Les mappeurs disposaient de moins de ressources BN et le nombre total de maps classées pendant la période des niveaux a diminué.
+  - Aucun Beatmap Nominators n'a été ajouté au 2e niveau pendant les 5 mois où ce système était actif, ce qui a considérablement ralenti la vitesse de classement.
+
+### Mai
+
+- **22/05/2017 :** Le serveur Discord Beatmap Nominator a été créé pour les sous-divisions des BN.
+  - Les sous-divisions ont été conçues comme des groupes de discussion composés de nominateurs sélectionnés au hasard dans les deux niveaux, dirigés par un membre de la QAT.
+  - La plupart des responsables des QAT sont passés à ce serveur malgré la résistance des hauts responsables d'osu!
+- **23/05/2017 :** Le bot Discord [Aiess](/wiki/Projets#miscellaneous) a été créé par ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817).
+  - Il s'agit d'un flux d'événements liés aux mapping sur les serveurs Discord d'osu! en commençant par les flux de nomination et de disqualification.
+
+### Juin
+
+- **02/06/2017 :** Les beatmaps marathons ont commencé à exiger 2 nominations au lieu de 3.
+  - Auparavant, il fallait 3 nominations car on s'attendait à ce que les marathons aient plus de contenu à vérifier qu'une beatmap normal, mais ce n'est plus vrai.
+  - L'icône "flame" (![icône flame](/wiki/shared/icon/flame.gif)) n'est plus utilisée.
+
+### Septembre
+
+- **10/09/2017 :** Le "[QAT Upheaval](https://osu.ppy.sh/community/forums/topics/635507)" a été mis en place. Il s'agissait d'une série de changements en réponse au mécontentement de la communauté de mapping sous la direction de l'[osu!team](/wiki/People/The_Team). Suite à ce changement, les QAT a commencé à s'autogérer sans l'intervention de ses supérieurs.
+  - Les [BN Tiers](/wiki/Modding/Beatmap_Nominator_Tiers) ont été remplacés par les [Probationary Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators#probationary-beatmap-nominators). Deux membres des BN en probation ne pouvaient pas nommer la même beatmap et les utilisateurs ne pouvaient pas être en probation pendant plus de deux mois à la fois.
+  - Beatmap Nominators were given purple titles on the forums.
+  - ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) ont été nommés [responsables des QAT](/wiki/Modding/QAT_Leaders) par un vote des membres du BN/QAT. Leur responsabilité était de travailler avec l'équipe d'osu! pour maintenir les communautés de mapping et de modding.
+  - Des badges de profil Beatmap Nominator et Quality Assurance Team ont été créés. Cette récompense et d'autres récompenses pour les Beatmap Nominator ont été prévues pour remotiver l'équipe actuellement insatisfaite.
+  - Avec une direction moins autoritaire et plus d'utilisateurs capables de nommer des beatmaps après ces changements, les normes de mapping ont cessé d'être strictement contrôlées. Des beatmaps controversés qui n'auraient probablement pas été classés sous l'ancien système (par exemple *[FELT - Rendezvous](https://osu.ppy.sh/beatmapsets/725171#osu/1541573)*) ont atteint un statut classé.
+
+### Octobre
+
+- **01/10/2017 :** Les [BN tests](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) ont été remplacés par l'examen du QAT des mods anonymes de chaque candidat BN.
+  - Ce changement a été effectué parce que la tricherie aux BN test était devenue impossible à éviter.
+
+### Décembre
+
+- **17/12/2017 :** ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) a cessé de s'impliquer dans l'équipe d'osu!, notamment en participant activement au QAT.
+
+**1847 beatmaps** ont été classés en 2017.
+
+## 2018
+
+### Février
+
+- **08/02/2018 :** La [Mappers' Guild](/wiki/Mappers_Guild) a été ouverte aux candidatures publiques pour la création généralisée de beatmaps des [Artistes Associés](/wiki/Featured_Artists).
+
+### Mars
+
+- **01/03/2018 :** Les QAT  a séparé ses tâches en branches : évaluation des BE, disqualifications, métadonnées, spotlights, blog, critères de classement et direction générale.
+  - Les membres des QAT peuvent être impliqués dans plusieurs branches.
+  - L'objectif était de donner une raison d'être à certains membres du QAT qui estimaient ne pas avoir de rôle spécifique dans la communauté du mapping/modding. Ce sentiment s'explique en grande partie par le fait que la QAT n'est plus guère impliquée dans l'assurance qualité.
+- **03/03/2018 :** Le canal `#modding` a été créé sur le [serveur Discord osu!dev](/wiki/osu!dev_Discord_server).
+  - Alors que son objectif était de déplacer les discussions sur le mapping hors du serveur Discord des BN, ce centre de discussion était rarement utilisé en dehors des réunions programmées du QAT.
+- **24/03/2018 :** Le sous-forum Critères de classement a été rouvert pour les discussions publiques sur les propositions et l'UBKRC a été supprimé.
+  - L'UBKRC a été interrompu à ce moment-là parce que toutes les sous-sections des critères de classement généraux et par mode de jeu ont été finalisées.
+
+### Avril
+
+- **01/04/2018 :** La QAT a commencé à évaluer les demandes des BN en examinant les mods non anonymes, par opposition aux mods précédemment anonymes.
+  - Cette modification a été apportée car la QAT estimait que les mods anonymes hors contexte ne pouvaient pas déterminer efficacement les capacités d'un moddeur.
+  - Grâce à ce changement, la QAT a déterminé que la partialité ne pouvait être évitée lors de l'évaluation des Beatmap Nominators.
+- **22/04/2018 :** La QAT a tenu sa première réunion sur le serveur osu!dev dans le but d'accroître la transparence des affaires de la QAT et d'éloigner les discussions internes du serveur Discord des BN.
+  - Malgré cette tentative, la plupart des discussions internes étaient toujours traitées sur le serveur Discord des BN.
+
+### Mai
+
+- **22/05/2018 :** ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) devient un [responsable QAT](/wiki/Modding/QAT_Leaders) après que ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) s'est retiré.
+  - Comme son prédécesseur, il a continué à travailler avec l'équipe d'osu! pour gérer les scènes de mapping/modding.
+
+### Juin
+
+- **21/06/2018 :** L'initiative [Quality Assurance Helper](/wiki/People/The_Team/Beatmap_Nominators/General_Information#quality-assurance-helpers) a été créée.
+  - Cette mesure visait à garantir que tous les beatmaps qualifiés étaient examinés par au moins deux membres du BN ou de la QAT avant d'être classés.
+  - Le programme a été géré via Trello et automatisé par ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) via Aiess.
+  - Ce changement a été l'une des principales raisons pour lesquelles le QAT a été renommé par la suite.
+
+### Juillet
+
+- **09/07/2018 :** De nouvelles règles d'étalement des maps ont été mises en place, ce qui a complètement modifié la façon dont les difficultés sont créées dans les mapsets classés à l'avenir.
+  - Avant ce changement, toute carte dont le drain time était inférieur à 5 minutes nécessitait un écart de difficulté complet. Après ce changement, les exigences en matière d'écart de difficulté étaient plus souples pour les beatmaps plus longs dont le drain time était inférieur à 5 minutes.
+  - *Pour plus de détails sur ce changement, lisez son [fil de discussion](https://osu.ppy.sh/community/forums/topics/726474).*
+
+### Décembbre
+
+- **12/12/2018 :** L'équipe d'osu! a pris une [position négative sur les commissions des beatmap](https://osu.ppy.sh/community/forums/topics/840838).
+  - L'équipe reconnaît que des commissions se produiront, mais s'engage à ne prendre aucune mesure à moins que des membres du BN ou de la QAT soient impliqués.
+- **17/12/2018 :** ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) devient un [responsable QAT](/wiki/Modding/QAT_Leaders) après que ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) s'est retiré.
+  - Comme son prédécesseur, il a continué à travailler avec l'équipe d'osu! pour gérer les scènes de mapping/modding.
+- **17/12/2018 :** La QA a été déclarée sans avenir dans son état actuel et les idées de réforme ont été encouragées.
+  - Cette décision a été prise parce que la QAT n'avait pas été impliqué dans quoi que ce soit lié à l'assurance qualité depuis des années, mais un système devait exister pour maintenir les Beatmap Nominators et la communauté de mapping en général.
+  - À l'époque, la QAT suscitait certaines inquiétudes :
+    - Peu d'engagement de la QAT dans les cartes controversées.
+    - Accessibilité limitée pour l'entrée de nouveaux utilisateurs dans l'équipe, ce qui entraîne une stagnation.
+    - Le rôle de la QAT dans la communauté de mapping n'était pas clair.
+
+**2749 beatmaps** ont été classés en 2018. La croissance impressionnante de cette année peut être largement attribuée à l'abandon du rôle d'assurance qualité de la QAT et à une plus grande initiative des Beatmap Nominators.
+
+## 2019
+
+### Janvier
+
+- **29/01/2019 :** Une proposition de réforme de la QAT a été créée à partir d'un conglomérat de propositions d'autres utilisateurs.
+  - La [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (*NAT*) a été introduite par cette proposition, et a été mise en œuvre plus tard cette année.
+
+### Mars
+
+- **01/03/2019 :** La [Mappers' Guild](/wiki/Mappers_Guild) est passée d'une inscription sur dossier à une inscription automatique pour toute personne ayant 3 maps classées.
+  - Les beatmaps des [Artistes associés](/wiki/Featured_Artists) ont été créées et classées plus fréquemment.
+  - Le canal `#mappers-guild` a été créé dans le [serveur Discord osu!dev](/wiki/osu!dev_Discord_server).
+- **13/03/2019 :** La règle exigeant que les nominations consécutives soient espacées d'au moins 24 heures a été supprimée.
+  - Cette règle a fait l'objet d'une plainte majeure de la part des mappeurs et des Beatmap Nominators, car elle donnait l'impression de faire perdre inutilement du temps à tout le monde. Si un problème était découvert après la première nomination, le deuxième nominateur évitait souvent de le signaler pour éviter une attente supplémentaire de 24 heures.
+  - Parallèlement à ce changement, les Beatmap Nominators peuvent opposer leur veto aux beatmaps qualifiés. Cette règle existait à l'origine parce que les Beatmap Nominators avaient besoin de 24 heures pour appliquer potentiellement des vetos aux maps avec une nomination.
+
+### Mai
+
+- **05/05/2019 :** La restructuration des BN/QAT a été finalisée.
+  - La Quality Assurance Team a été renommée en [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team).
+  - Les Beatmap Nominators sont devenus responsables des disqualifications et de la médiation du veto. La médiation du veto a été traitée par un vote à l'aveugle plutôt que par une discussion.
+  - Le site des [Beatmap Nominator](https://bn.mappersguild.com/) a été publié pour automatiser de nombreuses tâches des BN/NAT.
+    - Grâce au site web, les utilisateurs pouvaient poser leur candidature à la BN à tout moment, contrairement au système précédent, basé sur des cycles. De ce fait, les Beatmap Nominators ont été ajoutés à des moments irréguliers plutôt que par grandes vagues.
+    - Les signalements de beatmaps inappropriés et de comportements répréhensibles des BN/NAT sont passés d'un formulaire Google au site web des BN.
+    - Les statistiques et les évaluations de l'activité et de la compétence du modding et des nominateurs des BN sont passées de Google Spreadsheets, douloureusement inefficaces, au site web des BN, ce qui a considérablement augmenté la productivité de la gestion des Beatmap Nominator.
+
+### Août
+
+- **05/08/2019 :** ![] [flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) a publié l'outil [Mapset Verifier](/wiki/Projects#modding), qui automatise une partie importante des processus de vérification des beatmaps pour les Beatmap Nominators.
+- **06/08/2019 :** Les Beatmap Nominators ont pu participer à l'évaluation des demandes des BN.
+  - Les contributions des BN sont visibles pour les NAT lorsqu'il s'agit de parvenir à un consensus, bien qu'elles soient rarement utilisées pour influencer un vote.
+  - La NAT utilise souvent la contribution des BN pour aider à déterminer les futurs membres du NAT.
+
+### Octobre
+
+- **22/10/2019 :** ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) est devenu un leader du NAT après que ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) se soit retiré.
+  - Les dirigeants des NAT ayant souvent été passifs face aux décisions négatives, Ascendance a joué un rôle de contrôle actif et a annoncé les mauvaises nouvelles concernant les suppressions des NAT. <!-- source is discord logs -->
+
+**3217 beatmaps** ont été classés en 2019.
+
+## 2020
+
+### Février
+
+- **07/02/2020 :** Les premiers badges de profil Elite Nominator ont été attribués pour récompenser les performances exceptionnelles continues des membres de l'équipe des BN.
+  - Elles avaient été prévues à l'origine lors du bouleversement de la QAT deux ans auparavant.
+- **21/02/2020 :**  La direction de la NAT en tant que concept a été abandonnée lorsque ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) a quitté la direction du NAT.
+  - Les tâches spécifiques aux leaders de la NAT ont été déléguées à l'ensemble de l'équipe.
+- **24/02/2020 :** Le système [Quality Assurance Helper](/wiki/People/The_Team/Beatmap_Nominators/General_Information#quality-assurance-helpers) a été transféré de Trello au [Beatmap Nominator website](https://bn.mappersguild.com/).
+  - Ce changement a été effectué pour tenir compte de l'activité d'assurance qualité dans les évaluations des Beatmap Nominator.
+
+### Avril
+
+- **11/04/2020 :** Le Mappers' Report, dirigé par ![][flag_DE] [Feerum](https://osu.ppy.sh/users/4815717), a été créé pour résumer les événements de la communauté de mapping par le biais d'articles en première page.
+
+### Octobre
+
+- **02/10/2020 :** Les [Beatmap Nominator Expectations](/wiki/People/The_Team/Beatmap_Nominators/Expectations) ont été établies pour combattre les problèmes de comportement au sein du groupe.
+  - Les préoccupations concernaient notamment le manque d'accessibilité, les actions inciviles dans les milieux communautaires et les normes de qualité douteuses en matière de classement.
+  - Cela a entraîné le retrait immédiat de 5 Beatmap Nominators.
+- **29/10/2020 :** La compétence du mode de jeu d'un Beatmap Nominator est devenue visible sur le site d'osu!.
+
+### Novembre
+
+- **30/11/2020 :** Les beatmaps hybrides ont été retravaillés pour nécessiter 2 nominations par mode de jeu.
+  - Les nominateurs compétents dans plusieurs modes de jeu peuvent sélectionner un ou plusieurs modes de jeu à nommer sur les mapsets applicables.
+
+### Décembre
+
+- **17/12/2020 :** La soumission et l'évaluation de l'examen du contenu inapproprié sont passées des discussions sur Discord aux votes à l'aveugle via le site web des [Beatmap Nominator](https://bn.mappersguild.com/).
+
+**3580 beatmaps** ont été classées en 2020.
+
+## 2021
+
+### Janvier
+
+- **05/01/2021 :** L'étiquette `Explicit` pour les beatmaps a été implémentée pour nettoyer le contenu inapproprié des anciens classements et autoriser le contenu de chansons auparavant inacceptables.
+  - Cette modification ne s'applique pas au contenu visuel des maps en attente. Ceux-ci continuent de suivre les [Considérations relatives au contenu visuel](/wiki/Rules/Visual_Content_Considerations).
+- **30/01/2021 :** Le canal de discussion en jeu `#modhelp` a été remplacé par `#mapping` car le canal original était principalement utilisé pour les discussions sur le mapping.
+
+[flag_AR]: /wiki/shared/flag/AR.gif "Argentine"
+[flag_AU]: /wiki/shared/flag/AU.gif "Australie"
+[flag_CN]: /wiki/shared/flag/CN.gif "Chine"
+[flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"
+[flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
+[flag_SE]: /wiki/shared/flag/SE.gif "Suède"
+[flag_SG]: /wiki/shared/flag/SG.gif "Singapour"
+[flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -218,11 +218,11 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - Tous les messages ont été écrits sous un utilisateur nommé "[Quality Assurance Team](https://osu.ppy.sh/users/6616586)".
   - Elle a été mise en place en réponse aux fréquentes attaques contre les disqualifications des QAT, souvent liées à la suppression des scores de points de performance élevés (par exemple, la [disqualification de *Dragonforce - The Last Journey Home*](https://osu.ppy.sh/community/forums/posts/4009572)) ou liées à des opinions forcées (par exemple, la [disqualification de *Reol - Asymmetry*](https://osu.ppy.sh/community/forums/posts/4206479)).
   - La communauté a appelé le compte anonyme des QAT le "bot des QAT".
-  - Ce changement a encouragé l'opinion croissante selon laquelle les QAT essayait de se cacher des conséquences de ses actions, ce qui a nui à la réputation des disqualifications et des QAT en général.
+  - Ce changement a encouragé l'opinion croissante selon laquelle les QAT essayait de se cacher des conséquences de leurs actions, ce qui a nui à la réputation des disqualifications et des QAT en général.
 
 ### Août
 
-- **25/08/2015 :** Les beatmaps qualifiés ne récompensent plus les joueurs avec des [points de performance](/wiki/Performance_Points).
+- **25/08/2015 :** Les beatmaps qualifiées ne récompensent plus les joueurs avec des [points de performance](/wiki/Performance_Points).
   - Cette mesure a été prise en réponse aux nombreuses plaintes concernant la perte de points de performance sur les beatmaps qualifiées.
   - La tension entre les joueurs et les QAT a été soulagée après ce changement.
 - **26/08/2015 :** Les disqualifications anonymes des QAT ont été supprimées.
@@ -231,9 +231,9 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Décembre
 
 - **27/12/2015 :** Les [tests BN](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) ont été mis en place pour les applications des BN.
-  - Ces tests demandaient aux utilisateurs de répondre à un formulaire à choix multiple et de modder un beatmap rempli de problèmes.
+  - Ces tests demandaient aux utilisateurs de répondre à un formulaire à choix multiple et de modder une beatmap remplie de problèmes.
 
-**1934 beatmaps** ont été classés en 2015. Il s'agissait de la première année de croissance après 4 années consécutives de stagnation.
+**1934 beatmaps** ont été classées en 2015. Il s'agissait de la première année de croissance après 4 années consécutives de stagnation.
 
 ## 2016
 
@@ -251,7 +251,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Avril
 
 - **25/04/2016 :** Le QAT a commencé à vérifier les maps qualifiées pour les problèmes *réactifs* plutôt que proactifs.
-  - Les utilisateurs ont signalé des beatmaps qualifiés au QAT pour disqualification. Les QAT a confirmé ou infirmé les problèmes signalés dans les fils de discussion respectifs des beatmaps.
+  - Les utilisateurs ont signalés des beatmaps qualifiées au QAT pour disqualification. Les QAT ont confirmés ou infirmés les problèmes signalés dans les fils de discussion respectifs des beatmaps.
   - Ce changement a été effectué en réponse à la vision constamment négative des disqualifications par les QAT. Les QAT ont pris leurs distances par rapport aux tâches liées à l'assurance qualité à ce moment-là.
   - Les contrôles des métadonnées étaient toujours effectués de manière proactive par les QAT, dirigée par ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463).
 
@@ -266,7 +266,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Août
 
 - **05/08/2016 :** Le [blog Quality Assurance Team](/wiki/Quality_Assurance_Team_Blog) a été créé.
-  - Les QAT était critiquée pour être trop fermée au reste de la communauté de mapping. Ce blog a donc été créé pour accroître la transparence des décisions des QAT et des activités de la communauté.
+  - Les QAT était critiqués pour être trop fermés au reste de la communauté de mapping. Ce blog a donc été créé pour accroître la transparence des décisions des QAT et des activités de la communauté.
 - **26/08/2016 :** Le [Code de conduite](/wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping) a été mis en place pour définir les attentes en matière de comportement des moddeurs.
   - Jusqu'à présent, ces règles et directives étaient considérées comme relevant du bon sens. En les documentant, la modération pourrait être rendue plus cohérente.
 
@@ -286,14 +286,14 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 - **01/11/2016 :** Le système [Beatmap Veto](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Veto) a été mis en place.
   - Les Beatmap Nominators pouvaient arrêter une beatmap dans le processus de classement pour des raisons subjectives en réinitialisant une nomination. Ceci était fait avec une icône `bubble pop` (![icône bubble pop](/wiki/shared/icon/bubble-pop.gif)).
-  - Les vétos pourraient être écrasés par les nominations des Beatmap Nominators qui n'ont pas été impliqués dans la beatmap.
+  - Les vétos pouvaient être écrasés par les nominations des Beatmap Nominators qui n'ont pas été impliqués dans la beatmap.
   - Afin de laisser suffisamment de temps pour opposer son veto, les nominations consécutives ne pouvaient pas être fixées à moins de 24 heures d'intervalle.
   - Les vetos non concluants ont fait l'objet d'une médiation par les QAT peu après la mise en œuvre de ce système.
 - **02/11/2016 :** Les fichiers des Beatmap Nominator ont été créés pour garder un œil sur tous les membres individuels des BN.
   - Ces dossiers comprenaient les activités de modding/nomination, les disqualifications et les problèmes de comportement.
   - Les membres du BN ayant 3 "strikes" ou plus enregistrées dans ces fichiers seraient retirés du groupe.
 
-**1720 beatmaps** ont été classés en 2016.
+**1720 beatmaps** ont été classées en 2016.
 
 ## 2017
 
@@ -302,8 +302,8 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 - **06/04/2017 :** Les [Beatmap Nominator Tiers](/wiki/Modding/Beatmap_Nominator_Tiers) ont été implémentés, divisant les BN en deux sous-groupes appelés "tiers".
   - Comme le QAT ne jouait plus son rôle de contrôle de la qualité, ce système a été mis en place pour améliorer la qualité des beatmaps entrant dans la catégorie classée.
   - Ce système a imité le stade ultérieur de la [Mapping Assistance Team](/wiki/Modding/Mapping_Assistance_Team).
-    - Les nominateurs de niveau 1 pourraient mettre des bubbles sur les maps.
-    - Les nominateurs de niveau 2 pourraient mettre des bubbles et qualifier les maps..
+    - Les nominateurs de niveau 1 pouvaient mettre des bubbles sur les maps.
+    - Les nominateurs de niveau 2 pouvaient mettre des bubbles et qualifier les maps..
   - Les niveaux ont été déterminés par un test BN conçu pour identifier les problèmes généraux des beatmaps. Les résultats du test ont été terribles, révélant que la conception du test était défectueuse.
   - Contrairement à ses objectifs, ce système a réduit la motivation de tous les nominateurs de niveau 1 et surchargé les quelques nominateurs de niveau 2 motivés. Les mappeurs disposaient de moins de ressources BN et le nombre total de maps classées pendant la période des niveaux a diminué.
   - Aucun Beatmap Nominators n'a été ajouté au 2e niveau pendant les 5 mois où ce système était actif, ce qui a considérablement ralenti la vitesse de classement.
@@ -319,28 +319,28 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Juin
 
 - **02/06/2017 :** Les beatmaps marathons ont commencé à exiger 2 nominations au lieu de 3.
-  - Auparavant, il fallait 3 nominations car on s'attendait à ce que les marathons aient plus de contenu à vérifier qu'une beatmap normal, mais ce n'est plus vrai.
+  - Auparavant, il fallait 3 nominations car on s'attendait à ce que les marathons aient plus de contenu à vérifier qu'une beatmap normale, mais ce n'est plus vrai.
   - L'icône "flame" (![icône flame](/wiki/shared/icon/flame.gif)) n'est plus utilisée.
 
 ### Septembre
 
-- **10/09/2017 :** Le "[QAT Upheaval](https://osu.ppy.sh/community/forums/topics/635507)" a été mis en place. Il s'agissait d'une série de changements en réponse au mécontentement de la communauté de mapping sous la direction de l'[osu!team](/wiki/People/The_Team). Suite à ce changement, les QAT a commencé à s'autogérer sans l'intervention de ses supérieurs.
+- **10/09/2017 :** Le "[QAT Upheaval](https://osu.ppy.sh/community/forums/topics/635507)" a été mis en place. Il s'agissait d'une série de changements en réponse au mécontentement de la communauté de mapping sous la direction de l'[osu!team](/wiki/People/The_Team). Suite à ce changement, les QAT ont commencés à s'autogérer sans l'intervention de leurs supérieurs.
   - Les [BN Tiers](/wiki/Modding/Beatmap_Nominator_Tiers) ont été remplacés par les [Probationary Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators#probationary-beatmap-nominators). Deux membres des BN en probation ne pouvaient pas nommer la même beatmap et les utilisateurs ne pouvaient pas être en probation pendant plus de deux mois à la fois.
-  - Beatmap Nominators were given purple titles on the forums.
+  - Des titres violets ont été donnés aux Beatmap Nominators sur les forums.
   - ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) ont été nommés [responsables des QAT](/wiki/Modding/QAT_Leaders) par un vote des membres du BN/QAT. Leur responsabilité était de travailler avec l'équipe d'osu! pour maintenir les communautés de mapping et de modding.
-  - Des badges de profil Beatmap Nominator et Quality Assurance Team ont été créés. Cette récompense et d'autres récompenses pour les Beatmap Nominator ont été prévues pour remotiver l'équipe actuellement insatisfaite.
-  - Avec une direction moins autoritaire et plus d'utilisateurs capables de nommer des beatmaps après ces changements, les normes de mapping ont cessé d'être strictement contrôlées. Des beatmaps controversés qui n'auraient probablement pas été classés sous l'ancien système (par exemple *[FELT - Rendezvous](https://osu.ppy.sh/beatmapsets/725171#osu/1541573)*) ont atteint un statut classé.
+  - Des badges de profil Beatmap Nominator et Quality Assurance Team ont été créés. Cette distinction et d'autres récompenses pour les Beatmap Nominator ont été prévues pour remotiver l'équipe actuellement insatisfaite.
+  - Avec une direction moins autoritaire et plus d'utilisateurs capables de nommer des beatmaps après ces changements, les normes de mapping ont cessées d'être strictement contrôlées. Des beatmaps controversées qui n'auraient probablement pas été classées sous l'ancien système (par exemple *[FELT - Rendezvous](https://osu.ppy.sh/beatmapsets/725171#osu/1541573)*) ont atteint un statut classé.
 
 ### Octobre
 
 - **01/10/2017 :** Les [BN tests](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) ont été remplacés par l'examen du QAT des mods anonymes de chaque candidat BN.
-  - Ce changement a été effectué parce que la tricherie aux BN test était devenue impossible à éviter.
+  - Ce changement a été effectué parce que la tricherie aux BN test était devenue monnaie courante.
 
 ### Décembre
 
 - **17/12/2017 :** ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) a cessé de s'impliquer dans l'équipe d'osu!, notamment en participant activement au QAT.
 
-**1847 beatmaps** ont été classés en 2017.
+**1847 beatmaps** ont été classées en 2017.
 
 ## 2018
 
@@ -355,20 +355,20 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - L'objectif était de donner une raison d'être à certains membres du QAT qui estimaient ne pas avoir de rôle spécifique dans la communauté du mapping/modding. Ce sentiment s'explique en grande partie par le fait que la QAT n'est plus guère impliquée dans l'assurance qualité.
 - **03/03/2018 :** Le canal `#modding` a été créé sur le [serveur Discord osu!dev](/wiki/osu!dev_Discord_server).
   - Alors que son objectif était de déplacer les discussions sur le mapping hors du serveur Discord des BN, ce centre de discussion était rarement utilisé en dehors des réunions programmées du QAT.
-- **24/03/2018 :** Le sous-forum Critères de classement a été rouvert pour les discussions publiques sur les propositions et l'UBKRC a été supprimé.
+- **24/03/2018 :** Le sous-forum Critères de classement a été rouvert pour les discussions publiques des propositions et l'UBKRC a été supprimé.
   - L'UBKRC a été interrompu à ce moment-là parce que toutes les sous-sections des critères de classement généraux et par mode de jeu ont été finalisées.
 
 ### Avril
 
-- **01/04/2018 :** La QAT a commencé à évaluer les demandes des BN en examinant les mods non anonymes, par opposition aux mods précédemment anonymes.
+- **01/04/2018 :** La QAT a commencée à évaluer les demandes des BN en examinant les mods non anonymes, par opposition aux mods précédemment anonymes.
   - Cette modification a été apportée car la QAT estimait que les mods anonymes hors contexte ne pouvaient pas déterminer efficacement les capacités d'un moddeur.
-  - Grâce à ce changement, la QAT a déterminé que la partialité ne pouvait être évitée lors de l'évaluation des Beatmap Nominators.
+  - Grâce à ce changement, la QAT a déterminée que la partialité ne pouvait être évitée lors de l'évaluation des Beatmap Nominators.
 - **22/04/2018 :** La QAT a tenu sa première réunion sur le serveur osu!dev dans le but d'accroître la transparence des affaires de la QAT et d'éloigner les discussions internes du serveur Discord des BN.
   - Malgré cette tentative, la plupart des discussions internes étaient toujours traitées sur le serveur Discord des BN.
 
 ### Mai
 
-- **22/05/2018 :** ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) devient un [responsable QAT](/wiki/Modding/QAT_Leaders) après que ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) s'est retiré.
+- **22/05/2018 :** ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) devient un [responsable QAT](/wiki/Modding/QAT_Leaders) après que ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) se soit retiré.
   - Comme son prédécesseur, il a continué à travailler avec l'équipe d'osu! pour gérer les scènes de mapping/modding.
 
 ### Juin
@@ -381,23 +381,23 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Juillet
 
 - **09/07/2018 :** De nouvelles règles d'étalement des maps ont été mises en place, ce qui a complètement modifié la façon dont les difficultés sont créées dans les mapsets classés à l'avenir.
-  - Avant ce changement, toute carte dont le drain time était inférieur à 5 minutes nécessitait un écart de difficulté complet. Après ce changement, les exigences en matière d'écart de difficulté étaient plus souples pour les beatmaps plus longs dont le drain time était inférieur à 5 minutes.
+  - Avant ce changement, toute map dont le drain time était inférieur à 5 minutes nécessitait un écart de difficulté complet. Après ce changement, les exigences en matière d'écart de difficulté étaient plus souples pour les beatmaps plus longues dont le drain time était inférieur à 5 minutes.
   - *Pour plus de détails sur ce changement, lisez son [fil de discussion](https://osu.ppy.sh/community/forums/topics/726474).*
 
 ### Décembbre
 
-- **12/12/2018 :** L'équipe d'osu! a pris une [position négative sur les commissions des beatmap](https://osu.ppy.sh/community/forums/topics/840838).
+- **12/12/2018 :** L'équipe d'osu! a pris une [position négative sur les commissions des beatmaps](https://osu.ppy.sh/community/forums/topics/840838).
   - L'équipe reconnaît que des commissions se produiront, mais s'engage à ne prendre aucune mesure à moins que des membres du BN ou de la QAT soient impliqués.
 - **17/12/2018 :** ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) devient un [responsable QAT](/wiki/Modding/QAT_Leaders) après que ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) s'est retiré.
   - Comme son prédécesseur, il a continué à travailler avec l'équipe d'osu! pour gérer les scènes de mapping/modding.
 - **17/12/2018 :** La QA a été déclarée sans avenir dans son état actuel et les idées de réforme ont été encouragées.
-  - Cette décision a été prise parce que la QAT n'avait pas été impliqué dans quoi que ce soit lié à l'assurance qualité depuis des années, mais un système devait exister pour maintenir les Beatmap Nominators et la communauté de mapping en général.
+  - Cette décision a été prise parce que la QAT n'avait pas été impliquée dans quoi que ce soit lié à l'assurance qualité depuis des années, mais un système devait exister pour maintenir les Beatmap Nominators et la communauté de mapping en général.
   - À l'époque, la QAT suscitait certaines inquiétudes :
-    - Peu d'engagement de la QAT dans les cartes controversées.
+    - Peu d'engagement de la QAT dans les maps controversées.
     - Accessibilité limitée pour l'entrée de nouveaux utilisateurs dans l'équipe, ce qui entraîne une stagnation.
     - Le rôle de la QAT dans la communauté de mapping n'était pas clair.
 
-**2749 beatmaps** ont été classés en 2018. La croissance impressionnante de cette année peut être largement attribuée à l'abandon du rôle d'assurance qualité de la QAT et à une plus grande initiative des Beatmap Nominators.
+**2749 beatmaps** ont été classées en 2018. La croissance impressionnante de cette année peut être largement attribuée à l'abandon du rôle d'assurance qualité de la QAT et à une plus grande initiative des Beatmap Nominators.
 
 ## 2019
 
@@ -413,7 +413,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - Le canal `#mappers-guild` a été créé dans le [serveur Discord osu!dev](/wiki/osu!dev_Discord_server).
 - **13/03/2019 :** La règle exigeant que les nominations consécutives soient espacées d'au moins 24 heures a été supprimée.
   - Cette règle a fait l'objet d'une plainte majeure de la part des mappeurs et des Beatmap Nominators, car elle donnait l'impression de faire perdre inutilement du temps à tout le monde. Si un problème était découvert après la première nomination, le deuxième nominateur évitait souvent de le signaler pour éviter une attente supplémentaire de 24 heures.
-  - Parallèlement à ce changement, les Beatmap Nominators peuvent opposer leur veto aux beatmaps qualifiés. Cette règle existait à l'origine parce que les Beatmap Nominators avaient besoin de 24 heures pour appliquer potentiellement des vetos aux maps avec une nomination.
+  - Parallèlement à ce changement, les Beatmap Nominators peuvent opposer leur veto aux beatmaps qualifiées. Cette règle existait à l'origine parce que les Beatmap Nominators avaient besoin de 24 heures pour appliquer potentiellement des vetos aux maps avec une nomination.
 
 ### Mai
 
@@ -421,9 +421,9 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
   - La Quality Assurance Team a été renommée en [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team).
   - Les Beatmap Nominators sont devenus responsables des disqualifications et de la médiation du veto. La médiation du veto a été traitée par un vote à l'aveugle plutôt que par une discussion.
   - Le site des [Beatmap Nominator](https://bn.mappersguild.com/) a été publié pour automatiser de nombreuses tâches des BN/NAT.
-    - Grâce au site web, les utilisateurs pouvaient poser leur candidature à la BN à tout moment, contrairement au système précédent, basé sur des cycles. De ce fait, les Beatmap Nominators ont été ajoutés à des moments irréguliers plutôt que par grandes vagues.
-    - Les signalements de beatmaps inappropriés et de comportements répréhensibles des BN/NAT sont passés d'un formulaire Google au site web des BN.
-    - Les statistiques et les évaluations de l'activité et de la compétence du modding et des nominateurs des BN sont passées de Google Spreadsheets, douloureusement inefficaces, au site web des BN, ce qui a considérablement augmenté la productivité de la gestion des Beatmap Nominator.
+    - Grâce au site web, les utilisateurs pouvaient poser leur candidature à la BN à tout moment, contrairement au système précédent, basé sur des cycles. De ce fait, les Beatmap Nominators ont été ajoutés par intermitences plutôt que par grandes vagues.
+    - Les signalements de beatmaps inappropriées et de comportements répréhensibles des BN/NAT sont passés d'un formulaire Google au site web des BN.
+    - Les statistiques et les évaluations de l'activité et de la compétence du modding et des nominateurs des BN sont passées de Google Spreadsheets, douloureusement inefficaces, au site web des BN, ce qui a considérablement augmenté la productivité de la gestion des Beatmap Nominators.
 
 ### Août
 
@@ -437,18 +437,18 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 - **22/10/2019 :** ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) est devenu un leader du NAT après que ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) se soit retiré.
   - Les dirigeants des NAT ayant souvent été passifs face aux décisions négatives, Ascendance a joué un rôle de contrôle actif et a annoncé les mauvaises nouvelles concernant les suppressions des NAT. <!-- source is discord logs -->
 
-**3217 beatmaps** ont été classés en 2019.
+**3217 beatmaps** ont été classées en 2019.
 
 ## 2020
 
 ### Février
 
 - **07/02/2020 :** Les premiers badges de profil Elite Nominator ont été attribués pour récompenser les performances exceptionnelles continues des membres de l'équipe des BN.
-  - Elles avaient été prévues à l'origine lors du bouleversement de la QAT deux ans auparavant.
+  - Ils avaient été prévues à l'origine lors du bouleversement de la QAT deux ans auparavant.
 - **21/02/2020 :**  La direction de la NAT en tant que concept a été abandonnée lorsque ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) a quitté la direction du NAT.
   - Les tâches spécifiques aux leaders de la NAT ont été déléguées à l'ensemble de l'équipe.
 - **24/02/2020 :** Le système [Quality Assurance Helper](/wiki/People/The_Team/Beatmap_Nominators/General_Information#quality-assurance-helpers) a été transféré de Trello au [Beatmap Nominator website](https://bn.mappersguild.com/).
-  - Ce changement a été effectué pour tenir compte de l'activité d'assurance qualité dans les évaluations des Beatmap Nominator.
+  - Ce changement a été effectué pour tenir compte de l'activité d'assurance qualité dans les évaluations des Beatmap Nominators.
 
 ### Avril
 
@@ -459,16 +459,16 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 - **02/10/2020 :** Les [Beatmap Nominator Expectations](/wiki/People/The_Team/Beatmap_Nominators/Expectations) ont été établies pour combattre les problèmes de comportement au sein du groupe.
   - Les préoccupations concernaient notamment le manque d'accessibilité, les actions inciviles dans les milieux communautaires et les normes de qualité douteuses en matière de classement.
   - Cela a entraîné le retrait immédiat de 5 Beatmap Nominators.
-- **29/10/2020 :** La compétence du mode de jeu d'un Beatmap Nominator est devenue visible sur le site d'osu!.
+- **29/10/2020 :** La compétence des modes de jeu des Beatmap Nominators sont devenues visibles sur le site d'osu!.
 
 ### Novembre
 
-- **30/11/2020 :** Les beatmaps hybrides ont été retravaillés pour nécessiter 2 nominations par mode de jeu.
+- **30/11/2020 :** Les beatmaps hybrides ont été retravaillées pour nécessiter 2 nominations par mode de jeu.
   - Les nominateurs compétents dans plusieurs modes de jeu peuvent sélectionner un ou plusieurs modes de jeu à nommer sur les mapsets applicables.
 
 ### Décembre
 
-- **17/12/2020 :** La soumission et l'évaluation de l'examen du contenu inapproprié sont passées des discussions sur Discord aux votes à l'aveugle via le site web des [Beatmap Nominator](https://bn.mappersguild.com/).
+- **17/12/2020 :** La soumission et l'évaluation de l'examen du contenu inapproprié sont passées des discussions sur Discord aux votes à l'aveugle via le site web des [Beatmap Nominators](https://bn.mappersguild.com/).
 
 **3580 beatmaps** ont été classées en 2020.
 

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -267,12 +267,12 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 - **05/08/2016 :** Le [blog Quality Assurance Team](/wiki/Quality_Assurance_Team_Blog) a été créé.
   - Les QAT était critiquée pour être trop fermée au reste de la communauté de mapping. Ce blog a donc été créé pour accroître la transparence des décisions des QAT et des activités de la communauté.
-- **26/08/2016 :** Le [Code de conduite] (/wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping) a été mis en place pour définir les attentes en matière de comportement des moddeurs.
+- **26/08/2016 :** Le [Code de conduite](/wiki/Rules/Code_of_Conduct_for_Modding_and_Mapping) a été mis en place pour définir les attentes en matière de comportement des moddeurs.
   - Jusqu'à présent, ces règles et directives étaient considérées comme relevant du bon sens. En les documentant, la modération pourrait être rendue plus cohérente.
 
 ### Septembre
 
-- **30/09/2016 :** Le [Community Mentorship Program] (/wiki/Community_Mentorship_Program) a été relancé après une longue interruption.
+- **30/09/2016 :** Le [Community Mentorship Program](/wiki/Community_Mentorship_Program) a été relancé après une longue interruption.
   - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com/brand-new) et les cycles saisonniers.
   - Le programme était dirigé par ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923)
 

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -273,7 +273,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Septembre
 
 - **30/09/2016 :** Le [Community Mentorship Program](/wiki/Community_Mentorship_Program) a été relancé après une longue interruption.
-  - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com/brand-new) et les cycles saisonniers.
+  - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com/) et les cycles saisonniers.
   - Le programme était dirigé par ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923)
 
 ### Octobre

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -273,7 +273,7 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 ### Septembre
 
 - **30/09/2016 :** Le [Community Mentorship Program](/wiki/Community_Mentorship_Program) a été relancé après une longue interruption.
-  - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com/) et les cycles saisonniers.
+  - Sa nouvelle structure était centrée sur la communication par [Discord](https://discord.com) et les cycles saisonniers.
   - Le programme était dirigé par ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) et ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923)
 
 ### Octobre

--- a/wiki/Mapping_and_Modding_Timeline/fr.md
+++ b/wiki/Mapping_and_Modding_Timeline/fr.md
@@ -88,6 +88,9 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 - **03/10/2010 :** Les MAT ont été autorisés à proposer des beatmaps pour le classement avec des icônes "bubble" normales (![icône bubble](/wiki/shared/icon/bubble.gif)), par opposition aux proto-bulles.
   - Les proto-bulles étaient ignorées par la plupart des membres du BAT, et le MAT n'avait donc aucune utilité sans ce changement.
   - Cela a donné aux MAT beaucoup plus d'influence dans le processus de classement.
+- **10/10/2010 :** Les membres du MAT n'étaient plus autorisés à nommer ou à voter pour les nouveaux membres de leur équipe.
+  - Ayant obtenu des autorisations pour placer des bubbles, il a été supposé que le MAT voterait pour son propre intérêt, ce qui a été empêché avant que des dommages ne soient causés.
+  - Les BAT ont acquis l'entière responsabilité des ajouts des MAT.
 
 ### December
 
@@ -110,9 +113,6 @@ Les systèmes de mapping et de modding sont en constante amélioration. Le **cal
 
 - **08/10/2011 :** Le sous-forum [Ranking Criteria](https://osu.ppy.sh/community/forums/87) est ouvert à la discussion publique sur les propositions des [critères de classement](/wiki/Ranking_Criteria).
   - Ces discussions étaient auparavant tenues par les membres du BAT dans un sous-forum privé.
-- **10/10/2011 :** Les membres du MAT n'étaient plus autorisés à nommer ou à voter pour les nouveaux membres de leur équipe.
-  - Ayant obtenu des autorisations pour placer des bubbles, il a été supposé que le MAT voterait pour son propre intérêt, ce qui a été empêché avant que des dommages ne soient causés.
-  - Les BAT ont acquis l'entière responsabilité des ajouts des MAT.
 
 **1368 beatmaps** ont été classées en 2011. Il s'agit de la première baisse après 4 années de croissance consécutives.
 

--- a/wiki/Mapping_and_Modding_Timeline/id.md
+++ b/wiki/Mapping_and_Modding_Timeline/id.md
@@ -88,9 +88,6 @@ Secara keseluruhan, terdapat **1400 beatmap** yang di-rank sepanjang tahun 2009.
 - **2010-10-03:** Anggota-anggota MAT diberikan kuasa untuk menyematkan ikon `bubble` (![bubble icon](/wiki/shared/icon/bubble.gif)) pada beatmap.
   - Perubahan ini utamanya dipicu oleh fakta di lapangan yang mengindikasikan bahwa sistem proto-bubble yang diberlakukan sebelumnya tidak dianggap penting oleh anggota-anggota BAT.
   - Secara tidak langsung, anggota-anggota MAT diberikan peran dan tanggung jawab yang lebih besar dalam hal moderasi beatmap. <!-- https://osu.ppy.sh/community/forums/topics/38403 -->
-- **2011-10-10:** Anggota-anggota MAT tidak lagi dapat secara langsung mencalonkan atau memberikan masukan seputar nama-nama yang diangkat sebagai MAT ke depannya.
-  - Peraturan ini diberlakukan untuk mencegah praktek kolusi internal yang dikhawatirkan dapat terjadi setelah MAT diberikan kuasa untuk menyematkan ikon bubble.
-  - Anggota-anggota BAT diberikan tanggung jawab penuh untuk menentukan siapa-siapa saja yang diangkat ke dalam dan diberhentikan dari MAT seiring waktu.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 ### Desember
 
@@ -113,6 +110,9 @@ Secara keseluruhan, terdapat **1864 beatmap** yang di-rank sepanjang tahun 2010.
 
 - **2011-10-08:** [Sub-forum Ranking Criteria](https://osu.ppy.sh/community/forums/87) dibuka secara publik sebagai wadah bagi para anggota komunitas untuk dapat berdiskusi seputar hal-hal yang berhubungan dengan [Ranking Criteria](/wiki/Ranking_Criteria) secara luas.
   - Diskusi-diskusi yang menyangkut Ranking Criteria sebelumnya hanya dibatasi kepada anggota-anggota BAT pada sub-forum yang bersifat rahasia. <!-- date is not exact. the earliest thread in the subforum was posted on 2011-10-08 -->
+- **2011-10-10:** Anggota-anggota MAT tidak lagi dapat secara langsung mencalonkan atau memberikan masukan seputar nama-nama yang diangkat sebagai MAT ke depannya.
+  - Peraturan ini diberlakukan untuk mencegah praktek kolusi internal yang dikhawatirkan dapat terjadi setelah MAT diberikan kuasa untuk menyematkan ikon bubble.
+  - Anggota-anggota BAT diberikan tanggung jawab penuh untuk menentukan siapa-siapa saja yang diangkat ke dalam dan diberhentikan dari MAT seiring waktu.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 Secara keseluruhan, terdapat **1368 beatmap** yang di-rank sepanjang tahun 2011. Tahun ini merupakan tahun pertama dalam sejarah osu! di mana jumlah beatmap Ranked per tahunnya mengalami penurunan setelah pada 4 tahun sebelumnya angka ini selalu bertambah dari tahun ke tahun.
 
@@ -146,7 +146,7 @@ Secara keseluruhan, terdapat **1460 beatmap** yang di-rank sepanjang tahun 2012.
 
 ### Mei
 
-- **2013-05-15:** Posisi [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) diperkenalkan kepada publik. <!-- https://osu.ppy.sh/community/forums/topics/132665 -->
+- **2013-05-15:** Posisi [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) diperkenalkan kepada publik. <!-- https://osu.ppy.sh/community/forums/topics/132665 -->
   - Peran BAT manager yang sebelumnya hanya dijabat oleh satu orang kini dipangku oleh tiga orang secara paralel. Setiap anggota Triumvir Conglomerate merupakan perwakilan dari wilayah geografisnya masing-masing, di mana ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) mewakili Amerika Utara, ![][flag_CN] [NatsumeRin](https://osu.ppy.sh/users/151679) mewakili Asia, dan ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) mewakili Eropa.
   - Perubahan ini diberlakukan agar aspirasi para mapper di seluruh dunia dapat lebih terdengar secara merata. Sebelumnya, suara mapper-mapper yang berasal dari Asia cenderung terisolir karena mapper-mapper Asia secara umum lebih banyak berkomunikasi antar satu sama lain melalui media-media sosial di luar osu!.<!-- https://osu.ppy.sh/community/forums/topics/117187 -->
   - Di kala ketiga anggota Triumvir Conglomerate tidak dapat mengambil keputusan yang mutlak atas suatu permasalahan yang ada, ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) dan para petinggi osu! lainnya berhak untuk mengambil tindakan atas nama Triumvir Conglomerate dan anggota-anggota BAT lainnya.
@@ -162,7 +162,7 @@ Secara keseluruhan, terdapat **1460 beatmap** yang di-rank sepanjang tahun 2012.
 
 - **2013-12-12:** Kategori [Qualified](/wiki/Beatmap/Category#qualified) diperkenalkan kepada publik. Beatmap yang telah memperoleh dua nominasi akan terlebih dahulu ditempatkan di kategori Qualified selama satu minggu sebelum dapat sepenuhnya berstatus Ranked.
   - Beatmap yang berada pada kategori Qualified dapat sewaktu-waktu didiskualifikasi apabila terdapat suatu masalah yang ditemukan pada beatmap yang bersangkutan. <!-- https://osu.ppy.sh/community/forums/topics/171257 -->
-- **2013-12-22:** Jabatan [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) dipindahtangankan ke tiga nama baru untuk memberikan angin segar bagi anggota-anggota BAT yang bertugas.
+- **2013-12-22:** Jabatan [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) dipindahtangankan ke tiga nama baru untuk memberikan angin segar bagi anggota-anggota BAT yang bertugas.
   - ![][flag_US] [Charles445](https://osu.ppy.sh/users/85000) ditunjuk sebagai perwakilan Amerika Utara, ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) ditunjuk sebagai perwakilan Asia, dan ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) ditunjuk sebagai perwakilan Eropa yang baru. <!-- https://osu.ppy.sh/community/forums/topics/172289 -->
 
 Secara keseluruhan, terdapat **1327 beatmap** yang di-rank sepanjang tahun 2013.
@@ -243,7 +243,7 @@ Secara keseluruhan, terdapat **1394 beatmap** yang di-rank sepanjang tahun 2015.
 
 - **2016-02-13:** [Ranking Criteria Council](/wiki/Ranking_Criteria/Ranking_Criteria_Council) dibentuk untuk merombak ulang [Ranking Criteria](/wiki/Ranking_Criteria).
   - Anggota-anggota Ranking Criteria Council bertugas untuk menyusun ulang Ranking Criteria dari awal tanpa mempertimbangkan proposal-proposal yang sebelumnya telah dicetuskan pada sub-forum Ranking Criteria.
-  - Layaknya [Triumvir Conglomerate](/wiki/BAT_Managers#triumvir-conglomerate) terdahulu, anggota-anggota Ranking Criteria Council sengaja dipilih untuk dapat mewakili suara-suara yang ada dari berbagai belahan dunia secara merata. Masing-masing mode permainan memiliki 1 mapper dan 1 pemain yang berasal dari benua Amerika, Eropa, dan Asia serta 2 anggota QAT.
+  - Layaknya [Triumvir Conglomerate](/wiki/Modding/BAT_Managers#triumvir-conglomerate) terdahulu, anggota-anggota Ranking Criteria Council sengaja dipilih untuk dapat mewakili suara-suara yang ada dari berbagai belahan dunia secara merata. Masing-masing mode permainan memiliki 1 mapper dan 1 pemain yang berasal dari benua Amerika, Eropa, dan Asia serta 2 anggota QAT.
   - Secara lebih spesifik, Ranking Criteria Council memiliki tugas untuk dapat membuat Ranking Criteria yang terpisah untuk masing-masing mode permainan yang ada (osu!, osu!taiko, osu!catch, dan osu!mania). Dalam kenyataannya, pada akhir masa bakti Ranking Criteria Council hanya mode osu!catch yang memiliki Ranking Criteria-nya tersendiri.
   - Di samping itu, Ranking Criteria Council juga ditugaskan untuk merapikan dokumen Ranking Criteria secara umum. <!-- https://osu.ppy.sh/community/forums/topics/420229 -->
 - **2016-02-24:** Ranking Criteria Council memberlakukan peraturan *mapset spread* baru yang membatasi jumlah tingkat kesulitan pada suatu beatmap.
@@ -275,7 +275,7 @@ Secara keseluruhan, terdapat **1394 beatmap** yang di-rank sepanjang tahun 2015.
 ### September
 
 - **2016-09-30:** Program [Community Mentorship](/wiki/Community_Mentorship_Program) diluncurkan ulang.
-  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com/new) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
+  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com/brand-new) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
   - Program ini diketuai oleh ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) dan ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923). <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### Oktober

--- a/wiki/Mapping_and_Modding_Timeline/id.md
+++ b/wiki/Mapping_and_Modding_Timeline/id.md
@@ -275,7 +275,7 @@ Secara keseluruhan, terdapat **1394 beatmap** yang di-rank sepanjang tahun 2015.
 ### September
 
 - **2016-09-30:** Program [Community Mentorship](/wiki/Community_Mentorship_Program) diluncurkan ulang.
-  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com/brand-new) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
+  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com/) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
   - Program ini diketuai oleh ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) dan ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923). <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### Oktober

--- a/wiki/Mapping_and_Modding_Timeline/id.md
+++ b/wiki/Mapping_and_Modding_Timeline/id.md
@@ -275,7 +275,7 @@ Secara keseluruhan, terdapat **1394 beatmap** yang di-rank sepanjang tahun 2015.
 ### September
 
 - **2016-09-30:** Program [Community Mentorship](/wiki/Community_Mentorship_Program) diluncurkan ulang.
-  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com/) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
+  - Tidak seperti program Community Mentorship terdahulu, program Community Mentorship kali ini menggunakan [Discord](https://discord.com) sebagai sarana komunikasi utama antar para mentor dan *mentee*-nya masing-masing.
   - Program ini diketuai oleh ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) dan ![][flag_AR] [Yuii-](https://osu.ppy.sh/users/2935923). <!-- https://osu.ppy.sh/community/forums/topics/506906 -->
 
 ### Oktober

--- a/wiki/Mapping_and_Modding_Timeline/id.md
+++ b/wiki/Mapping_and_Modding_Timeline/id.md
@@ -88,6 +88,9 @@ Secara keseluruhan, terdapat **1400 beatmap** yang di-rank sepanjang tahun 2009.
 - **2010-10-03:** Anggota-anggota MAT diberikan kuasa untuk menyematkan ikon `bubble` (![bubble icon](/wiki/shared/icon/bubble.gif)) pada beatmap.
   - Perubahan ini utamanya dipicu oleh fakta di lapangan yang mengindikasikan bahwa sistem proto-bubble yang diberlakukan sebelumnya tidak dianggap penting oleh anggota-anggota BAT.
   - Secara tidak langsung, anggota-anggota MAT diberikan peran dan tanggung jawab yang lebih besar dalam hal moderasi beatmap. <!-- https://osu.ppy.sh/community/forums/topics/38403 -->
+- **2010-10-10:** Anggota-anggota MAT tidak lagi dapat secara langsung mencalonkan atau memberikan masukan seputar nama-nama yang diangkat sebagai MAT ke depannya.
+  - Peraturan ini diberlakukan untuk mencegah praktek kolusi internal yang dikhawatirkan dapat terjadi setelah MAT diberikan kuasa untuk menyematkan ikon bubble.
+  - Anggota-anggota BAT diberikan tanggung jawab penuh untuk menentukan siapa-siapa saja yang diangkat ke dalam dan diberhentikan dari MAT seiring waktu.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 ### Desember
 
@@ -110,9 +113,6 @@ Secara keseluruhan, terdapat **1864 beatmap** yang di-rank sepanjang tahun 2010.
 
 - **2011-10-08:** [Sub-forum Ranking Criteria](https://osu.ppy.sh/community/forums/87) dibuka secara publik sebagai wadah bagi para anggota komunitas untuk dapat berdiskusi seputar hal-hal yang berhubungan dengan [Ranking Criteria](/wiki/Ranking_Criteria) secara luas.
   - Diskusi-diskusi yang menyangkut Ranking Criteria sebelumnya hanya dibatasi kepada anggota-anggota BAT pada sub-forum yang bersifat rahasia. <!-- date is not exact. the earliest thread in the subforum was posted on 2011-10-08 -->
-- **2011-10-10:** Anggota-anggota MAT tidak lagi dapat secara langsung mencalonkan atau memberikan masukan seputar nama-nama yang diangkat sebagai MAT ke depannya.
-  - Peraturan ini diberlakukan untuk mencegah praktek kolusi internal yang dikhawatirkan dapat terjadi setelah MAT diberikan kuasa untuk menyematkan ikon bubble.
-  - Anggota-anggota BAT diberikan tanggung jawab penuh untuk menentukan siapa-siapa saja yang diangkat ke dalam dan diberhentikan dari MAT seiring waktu.<!-- https://osu.ppy.sh/community/forums/topics/38806 -->
 
 Secara keseluruhan, terdapat **1368 beatmap** yang di-rank sepanjang tahun 2011. Tahun ini merupakan tahun pertama dalam sejarah osu! di mana jumlah beatmap Ranked per tahunnya mengalami penurunan setelah pada 4 tahun sebelumnya angka ini selalu bertambah dari tahun ke tahun.
 


### PR DESCRIPTION
Proposal for the French translation of the wiki page `Mapping and Modding Timeline`.

Also:

- In `en.md` and `id.md` : fix links and move a section to the right place.

Many links (even those outside the notes) are not accessible.