### PR TITLE
Update information in `Game_modifier/No_Fail` about the mechanics of pp reduction while playing w/ NoFail enabled

### DIFF
--- a/wiki/Game_modifier/No_Fail/en.md
+++ b/wiki/Game_modifier/No_Fail/en.md
@@ -26,7 +26,7 @@ tags:
 
 The **No Fail** mod is a [game modifier](/wiki/Game_modifier) that prevents the player from failing on [beatmaps](/wiki/Beatmap). Enabling the No Fail mod makes the player incapable of failing a [beatmap](/wiki/Beatmap) even if the [life bar](/wiki/Glossary/Health_bar) drops to zero. Although, if the player has not scored any points during the beatmap, the play *will* fail instead.
 
-Depending on how many misses you get, playing a beatmap with No Fail mod enabled may incur certain penalty to the amount of [performance points](/wiki/Performance_Points) that you gain from the map. Starting from a base value of 1.0x (100%), each miss count will decrease the performance point gain multiplier by -0.02x (0.5%) up to a minimum of 0.9x (90%). For more information about this mechanic, refer to this [news post](https://osu.ppy.sh/home/news/2021-01-14-performance-points-updates).
+Depending on how many misses you get, playing a beatmap with No Fail mod enabled may incur certain penalty to the amount of [performance points](/wiki/Performance_Points) that you gain from a play. Starting from a base value of 1.0x (100%), each miss count will decrease the performance point gain multiplier by -0.02x (0.5%) up to a maximum of 0.9x (90%). For more information about this mechanic, refer to this [news post](https://osu.ppy.sh/home/news/2021-01-14-performance-points-updates).
 
 This mod has the same effect across all [game modes](/wiki/Game_mode).
 

--- a/wiki/Game_modifier/No_Fail/en.md
+++ b/wiki/Game_modifier/No_Fail/en.md
@@ -24,9 +24,9 @@ tags:
 
 ## Description
 
-*Notice: Usage of the No Fail mod reduces the amount of possible [Performance Points](/wiki/Performance_Points) gain by 10%.*
-
 The **No Fail** mod is a [game modifier](/wiki/Game_modifier) that prevents the player from failing on [beatmaps](/wiki/Beatmap). Enabling the No Fail mod makes the player incapable of failing a [beatmap](/wiki/Beatmap) even if the [life bar](/wiki/Glossary/Health_bar) drops to zero. Although, if the player has not scored any points during the beatmap, the play *will* fail instead.
+
+Depending on how many misses you get, playing a beatmap with No Fail mod enabled may incur certain penalty to the amount of [performance points](/wiki/Performance_Points) that you gain from the map. Starting from a base value of 1.0x (100%), each miss count will decrease the performance point gain multiplier by -0.02x (0.5%) up to a minimum of 0.9x (90%). For more information about this mechanic, refer to this [news post](https://osu.ppy.sh/home/news/2021-01-14-performance-points-updates).
 
 This mod has the same effect across all [game modes](/wiki/Game_mode).
 

--- a/wiki/Game_modifier/No_Fail/fr.md
+++ b/wiki/Game_modifier/No_Fail/fr.md
@@ -1,5 +1,6 @@
 ---
 stub: true
+outdated: true
 tags:
   - no fail
   - NF

--- a/wiki/Game_modifier/No_Fail/fr.md
+++ b/wiki/Game_modifier/No_Fail/fr.md
@@ -1,6 +1,7 @@
 ---
 stub: true
 outdated: true
+outdated_since: 77180e4fde6272da6bfab8e8337dcb379b598b64
 tags:
   - no fail
   - NF

--- a/wiki/Game_modifier/No_Fail/id.md
+++ b/wiki/Game_modifier/No_Fail/id.md
@@ -1,5 +1,6 @@
 ---
 stub: true
+outdated: true
 tags:
   - no fail
   - NF

--- a/wiki/Game_modifier/No_Fail/id.md
+++ b/wiki/Game_modifier/No_Fail/id.md
@@ -1,6 +1,7 @@
 ---
 stub: true
 outdated: true
+outdated_since: 77180e4fde6272da6bfab8e8337dcb379b598b64
 tags:
   - no fail
   - NF

--- a/wiki/Game_modifier/No_Fail/ko.md
+++ b/wiki/Game_modifier/No_Fail/ko.md
@@ -1,5 +1,6 @@
 ---
 stub: true
+outdated: true
 tags:
   - 노페일 모드
   - no fail

--- a/wiki/Game_modifier/No_Fail/ko.md
+++ b/wiki/Game_modifier/No_Fail/ko.md
@@ -1,6 +1,7 @@
 ---
 stub: true
 outdated: true
+outdated_since: 77180e4fde6272da6bfab8e8337dcb379b598b64
 tags:
   - 노페일 모드
   - no fail


### PR DESCRIPTION
found while reviewing [#5705](https://github.com/ppy/osu-wiki/pull/5705) earlier.

as it stands the `NoFail` page still lists that "Playing w/ NoFail enabled will reduce the amount of pp gained by 10%", which is no longer the case as per [the January pp update](https://osu.ppy.sh/home/news/2021-01-14-performance-points-updates).