### PR TITLE
Update information about username revert limitations in `Help_Centre/Account`

### DIFF
--- a/wiki/Help_Centre/Account/en.md
+++ b/wiki/Help_Centre/Account/en.md
@@ -150,7 +150,7 @@ We grant free reverts for a user's direct previous username. Simply contact [acc
 
 Changes to any other previous names must be [purchased via the store](https://osu.ppy.sh/store/products/32).
 
-We only grant this one time per account, so please consider carefully before requesting!
+Username reverts are limited to one per year, so please consider carefully before requesting!
 
 ### My username has been changed back/reverted!
 


### PR DESCRIPTION
I recently emailed support to get my username reverted and I was told that reverts were limited to one per year rather than one per account. I assume this is true since it came from support, so I thought it would probably be a good idea to edit it. 

![image](https://user-images.githubusercontent.com/47828274/123676798-4b6cf000-d83c-11eb-9ab9-756f6140e5a4.png)
