### PR TITLE
Update `Beatmap description` article to be more accurate and remove the `explicit lyrics` section

### DIFF
--- a/wiki/Beatmap/Beatmap_description/en.md
+++ b/wiki/Beatmap/Beatmap_description/en.md
@@ -21,4 +21,3 @@ Many beatmap descriptions contain at least one image (often an animated [GIF](ht
 A "difficulty section" is a list of all the guest difficulties and their creators located in a beatmap description. This is mostly used to showcase the difficulties of a beatmap. Difficulty sections usually have images for the icons.
 
 The difficulty icons can be found in the [Difficulty article](/wiki/Beatmap/Difficulty).
-

--- a/wiki/Beatmap/Beatmap_description/en.md
+++ b/wiki/Beatmap/Beatmap_description/en.md
@@ -1,6 +1,6 @@
 # Beatmap description
 
-**Beatmap descriptions** are small areas under a [beatmap](/wiki/Beatmap)'s page that give players information about said beatmap using [BBCode](/wiki/BBCode). Most [Ranked](/wiki/Beatmap/Category#ranked) beatmaps use at least one image, a number (depending on how many beatmaps the creator has Ranked), and a difficulty section.
+**Beatmap descriptions** are small areas under a [beatmap](/wiki/Beatmap)'s page that give players information about said beatmap using [BBCode](/wiki/BBCode). Most [Ranked](/wiki/Beatmap/Category#ranked) beatmaps use at least one image, a number (depending on how many beatmaps the creator has created), and a difficulty section.
 
 ## Uses and information
 
@@ -9,7 +9,6 @@
 Popular beatmap descriptions often include the following:
 
 - A list of all the guest difficulties and their creators
-- An "18+ lyrics" warning (if neccessary)
 - Information that would help a player decide whether they want to download the beatmap or not
 - An edits list or changelog
 
@@ -22,3 +21,4 @@ Many beatmap descriptions contain at least one image (often an animated [GIF](ht
 A "difficulty section" is a list of all the guest difficulties and their creators located in a beatmap description. This is mostly used to showcase the difficulties of a beatmap. Difficulty sections usually have images for the icons.
 
 The difficulty icons can be found in the [Difficulty article](/wiki/Beatmap/Difficulty).
+

--- a/wiki/Beatmap/Beatmap_description/fr.md
+++ b/wiki/Beatmap/Beatmap_description/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: c08929c17cf02a4642967c8acebddd893f775be9
+---
+
 # Descriptions des beatmaps
 
 Les **descriptions des beatmaps** sont de petites zones sous la page d'une [beatmap](/wiki/Beatmap) qui donnent aux joueurs des informations sur ladite beatmap en utilisant le [BBCode](/wiki/BBCode). La plupart des beatmaps [classées](/wiki/Beatmap/Category#ranked) utilisent au moins une image, un nombre (dépendant du nombre de beatmaps classées par le créateur) et une section de difficulté.

--- a/wiki/Beatmap/Beatmap_description/id.md
+++ b/wiki/Beatmap/Beatmap_description/id.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: c08929c17cf02a4642967c8acebddd893f775be9
+---
+
 # Deskripsi beatmap
 
 **Deskripsi beatmap** adalah area kecil yang berada di bawah halaman [beatmap](/wiki/Beatmap) yang memberikan informasi tentang beatmap tersebut kepada player dan terdapat [BBCode](/wiki/BBCode) di dalamnya. Kebanyakan beatmap [ranked](/wiki/Beatmap/Category#ranked) menggunakan setidaknya satu gambar, sebuah angka (tergantung berapa banyak beatmap dari kreator yang sudah Ranked), dan sebuah difficulty section.

--- a/wiki/Beatmap/Beatmap_description/zh-tw.md
+++ b/wiki/Beatmap/Beatmap_description/zh-tw.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: c08929c17cf02a4642967c8acebddd893f775be9
+---
+
 # 圖譜說明
 
 **圖譜說明**是[圖譜](/wiki/Beatmap)頁面下的小區塊，用 [BBCode](/wiki/BBCode) 撰寫關於此圖譜的資訊。多數 [Ranked](/wiki/Beatmap/Category#ranked) 的圖譜會至少使用一張圖片，一個數字 (根據製譜者已製作多少張 Ranked 圖譜)，及難度列表。


### PR DESCRIPTION
most people have numbers in their description depending on how much they CREATED, not ranked (sorry for that error) and remove the 'An 18+ lyric warning (if necessary)'. I was originally going to make it say 'explicit lyric warning' because it's not 18+ but I remembered there's a option for explicit lyrics on the site now.

(sorry translators)