### PR TITLE
[PT-BR] Add some articles in `Beatmap`, `Legal`, and `Rules` directories

### DIFF
--- a/wiki/Beatmap/Guest_difficulty/pt-br.md
+++ b/wiki/Beatmap/Guest_difficulty/pt-br.md
@@ -5,6 +5,7 @@ tags:
   - guest beatmap
   - guest difficulties
   - guest map
+no_native_review: true
 ---
 
 # Dificuldade de convidado

--- a/wiki/Beatmap/Guest_difficulty/pt-br.md
+++ b/wiki/Beatmap/Guest_difficulty/pt-br.md
@@ -1,0 +1,16 @@
+---
+stub: true
+tags:
+  - GD
+  - guest beatmap
+  - guest difficulties
+  - guest map
+---
+
+# Dificuldade de convidado
+
+*Para obter o regulamento relativo as dificuldades de convidados, veja: [Critérios de Classificação](/wiki/Ranking_Criteria)*
+
+Uma **dificuldade de convidado** (ou *GD* para abreviar) é uma [dificuldade](/wiki/Beatmap/Difficulty) de um [beatmap](/wiki/Beatmap) que não é criado pelo [host do beatmap](/wiki/Beatmap/Beatmap_host). Elas geralmente podem ser identificadas por seu nome de dificuldade contendo o nome de usuário do criador do convidado. Um beatmap com vários criadores também é conhecido como uma [dificuldade colaborativa](/wiki/Beatmap/Beatmap_collaborations).
+
+Muitas dificuldades dos hóspedes são frequentemente solicitadas por mensagens privadas entre os criadores. Embora GDs também possam ser solicitados em [filas de modding](https://osu.ppy.sh/community/forums/60).

--- a/wiki/Legal/Copyright/pt-br.md
+++ b/wiki/Legal/Copyright/pt-br.md
@@ -1,0 +1,63 @@
+---
+legal: true
+---
+
+# Política de direitos autorais de osu!
+
+osu! é um jogo fortemente voltado para a comunidade. Todos os níveis do jogo (beatmaps) são criados e carregados por membros da comunidade, muitas vezes sem a obtenção correta da permissão dos detentores de direitos autorais relevantes. Fazemos o possível para não anunciar ou lucrar diretamente com o conteúdo carregado, e o jogo é inteiramente financiado por doações de usuários.
+
+Grande parte das doações que recebemos é usada para reinvestir no [licenciamento de músicas](/wiki/Legal/Music_Licensing). Averiguações sobre licenciamento podem ser enviadas para [music@ppy.sh](mailto:music@ppy.sh).
+
+Falhando nisso, osu! adotou a seguinte política com relação à violação de direitos autorais, de acordo com o Digital Millennium Copyright Act, 17 U.S.C. 512.
+
+As informações de contato do Agente Designado de osu! Para Receber Notificação de Infração Reivindicada ("Agente Designado") estão listadas no final desta política e estão arquivadas no Escritório de Direitos Autorais dos Estados Unidos ([https://www.copyright.gov/dmca-directory/](https://www.copyright.gov/dmca-directory/)). osu! leva muito a sério os direitos autorais e outros direitos de propriedade intelectual.
+
+É política do osu!:
+
+1. bloquear rapidamente o acesso a ou remover o conteúdo que acredita de boa fé pode conter material que infrinja os direitos autorais de terceiros; e
+2. remover e interromper o serviço para infratores reincidentes.
+
+## Denunciar violações de direitos autorais
+
+Se você acredita que o conteúdo reside ou é acessível através do website ou serviço de osu! viola seus direitos autorais, favor enviar um aviso de alegada violação de direitos autorais contendo as seguintes informações para o Agente Designado listado abaixo (consulte um especialista legal ou consulte o 17 U.S.C. 512 (c) para confirmar esses requisitos):
+
+1. Uma assinatura física ou eletrônica de uma pessoa autorizada a agir em nome do proprietário dos direitos autorais supostamente violados;
+2. Identificação dos trabalhos protegidos por direitos autorais alegadamente violados, ou se vários trabalhos protegidos por direitos autorais em um único site online forem cobertos por uma única notificação, uma lista representativa de tais trabalhos naquele site;
+3. Identificação do material que supostamente infringe ou é objeto de atividade infratora e que deve ser removido ou cujo acesso deve ser desabilitado, e informações razoavelmente suficientes para permitir osu! para localizar o material;
+4. Informações de contato do notificador, como endereço, número de telefone e, se disponível, endereço de e-mail;
+5. Uma declaração de que o notificador acredita de boa fé que o uso do material da forma reclamada não foi autorizado pelo proprietário dos direitos autorais, seu agente ou pela lei; e
+6. Uma declaração de que as informações na notificação são precisas e, sob pena de perjúrio, de que a parte notificante está autorizada a agir em nome do proprietário dos direitos autorais supostamente violados.
+
+Assim que um aviso completo e adequado de alegada violação de direitos autorais for recebido pelo Agente Designado, ou se osu! acreditar, de boa fé, que um arquivo no serviço osu! pode conter material que viola direitos autorais:
+
+É política do osu!:
+
+1. remover ou desativar o acesso ao conteúdo identificado no aviso de infração reivindicada;
+2. notificar o provedor de conteúdo, membro ou usuário de que removeu ou desabilitou o acesso ao conteúdo; e
+3. encerrar, em circunstâncias apropriadas, assinantes e titulares de contas que sejam infratores reincidentes.
+
+## Envio de contra-notificações
+
+Se o provedor de conteúdo, membro ou usuário acredita que o conteúdo que foi removido ou ao qual o acesso foi desabilitado não está infringindo, ou o provedor de conteúdo, membro ou usuário acredita que tem o direito de postar e usar tal conteúdo do proprietário dos direitos autorais, o agente do proprietário dos direitos autorais ou, de acordo com a lei, o provedor de conteúdo, membro ou usuário pode enviar uma contra-notificação contendo as seguintes informações ao Agente Designado listado abaixo:
+
+1. Uma assinatura física ou eletrônica do provedor de conteúdo, membro ou usuário;
+2. Identificação do conteúdo que foi removido ou cujo acesso foi desativado e o local em que o material apareceu antes de ser removido ou o acesso a ele foi desativado;
+3. Uma declaração, sob pena de perjúrio, de que o provedor de conteúdo, membro ou usuário acredita de boa fé que o material foi removido ou desabilitado como resultado de um engano ou identificação incorreta do material a ser removido ou desabilitado; e
+4. Nome do provedor de conteúdo, membro ou usuário, endereço, número de telefone e, se disponível, endereço de e-mail e uma declaração de que tal pessoa ou entidade consente com a jurisdição do Tribunal do Distrito Federal para o distrito judicial em que o provedor de conteúdo, membro ou o endereço do usuário está localizado, ou se o endereço do provedor de conteúdo, membro ou usuário estiver localizado fora dos Estados Unidos, no condado de Los Angeles, Califórnia, e essa pessoa ou entidade aceitará a notificação do processo da pessoa que forneceu a notificação do alegado violação ou um agente de tal pessoa.
+
+Se uma contra-notificação for recebida pelo Agente Designado, osu! pode enviar uma cópia da contranotificação à parte reclamante original informando essa pessoa que pode substituir o conteúdo removido ou deixar de desativá-lo em 10 dias úteis. A menos que o proprietário dos direitos autorais entre com uma ação buscando um mandado contra o provedor de conteúdo, membro ou usuário, o conteúdo removido pode ser substituído, ou o acesso a ele restaurado, em 10 a 14 dias úteis ou mais após o recebimento da contra-notificação, em critério exclusivo de osu!.
+
+## Detalhes de contato do Agente Designado
+
+**Email:** [copyright@ppy.sh](mailto:copyright@ppy.sh) (resposta em 24 horas garantida)
+
+**Endereço postal:**
+
+```
+Dean Herbert
+41 Gregory Street
+Wembley, WA, 6014
+Australia
+```
+
+*Atualizado por último em 7 de Novembro de 2019. [Veja o histórico aqui](https://github.com/ppy/osu-wiki/commits/master/wiki/Legal/Copyright/en.md).*

--- a/wiki/Legal/Copyright/pt-br.md
+++ b/wiki/Legal/Copyright/pt-br.md
@@ -1,5 +1,6 @@
 ---
 legal: true
+no_native_review: true
 ---
 
 # Política de direitos autorais de osu!

--- a/wiki/Legal/Music_Licensing/pt-br.md
+++ b/wiki/Legal/Music_Licensing/pt-br.md
@@ -1,0 +1,35 @@
+---
+legal: true
+---
+
+# Licenciamento musical em osu!
+
+100% do conteúdo de osu! (geralmente conhecidos como "[beatmaps](/wiki/Beatmap)" ou níveis) é disponibilizado por usuários. Mesmo que tentemos guiar os usuários a adquirir permissões corretamente, frequentemente há casos de músicas/artes disponibilizadas sem obter permissão.
+
+osu! nunca visou lucrar – nos esforçamos para não fazer publicidade ou lucrar diretamente do conteúdo publicado (visando não explorar o mesmo), porém entendemos que isso frequentemente não é considerado o suficiente.
+
+Visando fazer nosso melhor para apoiar os artistas que fazem desse jogo o que é, qualquer excesso de fundo advindo de doações de usuários é reinvestido em esforços de licenciamento musical. Estamos em um processo contínuo de procurar artistas (apresentados em postagens de usuários, tanto existentes como novas) para obter licenciamento e difundir consciência sobre nosso programa de [Artistas em Destaque](/wiki/Featured_Artists).
+
+Artistas interessados em juntar-se ao programa de Artistas em Destaque podem contatar osu! para negociar o licenciamento.
+
+## Uso de música em osu!
+
+Sendo um jogo de ritmo, cada nível publicado por usuários em osu! é sincronizado ao ritmo de uma música.
+
+Usuários podem pesquisar por e fazer download de níveis na [listagem de beatmaps](https://osu.ppy.sh/beatmapsets) inserindo o artista, título ou outras informações relevantes da música. A maior parte dos níveis baixados incluem a música, dados do nível criados pelo usuário, uma imagem de fundo, e efeitos sonoros de jogabilidade.
+
+Quando enviando níveis, os criadores são incentivados a receber permissão de uso para todos os ativos de detentores de direitos autorais relevantes de acordo com nossas [Diretrizes de Uso de Conteúdo](/wiki/Rules/Content_Usage_Guidelines).
+
+## Termo de licenciamento de Artistas em Destaque
+
+As músicas licenciadas por osu! serão disponibilizadas gratuitamente para download na [listagem de Artistas em Destaque](https://osu.ppy.sh/beatmaps/artists) em arquivos `.osz`, que são modelos de beatmap. Uma pré-visualização de um minuto é gerada automaticamente para cada faixa, e está disponível para streaming na página do artista. Visto que as músicas são usadas como um catálogo para os membros da comunidade criarem beatmaps, algumas delas podem não ser usadas imediatamente como conteúdo no jogo.
+
+Procuramos cobrir o uso dentro do jogo, do site relacionado e conteúdo de vídeo. Observe que isso não cobre, necessariamente, seu uso em outras plataformas, nos casos em que há lucro envolvido. Alguns artistas podem solicitar participação nos lucros em tais casos (quando a plataforma permitir, p. ex. uploads do usuário para o YouTube).
+
+Toda música licenciada por osu! é feita em termos não exclusivos, permitindo o licenciamento simultâneo por outras plataformas (é nossa convicção que não devemos limitar a boa música apenas à nossa plataforma). Geralmente, preferimos negociar licenças em termos perpétuos devido à natureza do uso (os usuários esperam que suas criações fiquem disponíveis indefinidamente). O pagamento é fornecido como um royalty único, fixo e negociável.
+
+## Contato
+
+**Email:** [music@ppy.sh](mailto:music@ppy.sh)
+
+Se você estiver interessado em negociar o licenciamento de sua obra dentro de osu!, favor entrar em contato conosco através do endereço de e-mail acima com amostras de sua obra. Nós iremos decidir se sua música se encaixa bem em osu! detalhar os termos da licença.

--- a/wiki/Legal/Music_Licensing/pt-br.md
+++ b/wiki/Legal/Music_Licensing/pt-br.md
@@ -1,5 +1,6 @@
 ---
 legal: true
+no_native_review: true
 ---
 
 # Licenciamento musical em osu!

--- a/wiki/Legal/pt-br.md
+++ b/wiki/Legal/pt-br.md
@@ -1,0 +1,8 @@
+# Legal
+
+Página índice para todos os artigos legais. Seus links também podem ser encontrados no rodapé do website de osu!.
+
+- [Política de direitos autorais de osu!](Copyright)
+- [Licenciamento musical em osu!](Music_Licensing)
+- [Política de privacidade de osu!](Privacy)
+- [Termos de Serviço de osu!](Terms)

--- a/wiki/Legal/pt-br.md
+++ b/wiki/Legal/pt-br.md
@@ -1,3 +1,7 @@
+---
+no_native_review: true
+---
+
 # Legal
 
 Página índice para todos os artigos legais. Seus links também podem ser encontrados no rodapé do website de osu!.

--- a/wiki/Rules/Content_Usage_Guidelines/pt-br.md
+++ b/wiki/Rules/Content_Usage_Guidelines/pt-br.md
@@ -1,3 +1,7 @@
+---
+no_native_review: true
+---
+
 # Diretrizes de uso de conteúdo
 
 Como um mapeador, você deve ter permissão dos detentores de direitos autorais relevantes para recursos de áudio/visual/gameplay incluídos em seus envios de beatmap. Sem permissão, seus beatmaps correm o risco de serem removidos e você de ter o acesso negado ao sistema de envio, de acordo com a [política de direitos autorais de osu!](/wiki/Legal/Copyright).

--- a/wiki/Rules/Content_Usage_Guidelines/pt-br.md
+++ b/wiki/Rules/Content_Usage_Guidelines/pt-br.md
@@ -1,0 +1,45 @@
+# Diretrizes de uso de conteúdo
+
+Como um mapeador, você deve ter permissão dos detentores de direitos autorais relevantes para recursos de áudio/visual/gameplay incluídos em seus envios de beatmap. Sem permissão, seus beatmaps correm o risco de serem removidos e você de ter o acesso negado ao sistema de envio, de acordo com a [política de direitos autorais de osu!](/wiki/Legal/Copyright).
+
+Para garantir que sua conta permaneça em boa situação, é recomendável criar mapas de ritmo usando recursos que sejam qualquer um dos seguintes:
+
+- legalmente liberado para uso em osu!
+- permitido para uso por seu(s) criador(es)
+- livre de direitos autorais
+
+## Áudio
+
+Fornecemos aos mapeadores uma biblioteca de músicas licenciadas por meio do programa [Artistas em Destaque](/wiki/Featured_Artists). Cada música na [listagem](https://osu.ppy.sh/beatmaps/artists) é gratuita para uso em osu! e não corre o risco de ser removida.
+
+Ao procurar músicas fora do catálogo de artistas em destaque de osu!, verifique se seu criador declarou explicitamente os termos de uso. Essas informações geralmente podem ser encontradas nas seções de descrição das plataformas de lançamento de música de um artista (ex. Bandcamp, Soundcloud, YouTube) ou em seu site pessoal. Se uma música for licenciada sob uma [Licença Creative Common](https://creativecommons.org/licenses/by-nc-sa/3.0/) ou estiver disponível para uso não comercial, é seguro criar e enviar um beatmap para ela.
+
+Se você deseja criar um beatmap para uma música e seus direitos de uso não estão claros, é recomendável entrar em contato com o artista para obter permissão. A maioria dos artistas tem métodos de contato rotulados em suas plataformas de lançamento de música, sites pessoais e mídia social.
+
+Isso pode parecer um grande obstáculo, mas vimos que os mapeadores têm muito sucesso e recebem a aprovação dos artistas apenas tendo a coragem de perguntar antes de usar o conteúdo sem permissão. Mencionar que osu! é um jogo gratuito sem anúncios pode ajudar, e você pode vinculá-los à nossa página de [licenciamento](/wiki/Legal/Music_Licensing) para dá-los uma ideia melhor de como o conteúdo é consumido.
+
+Embora músicas sejam frequentemente restritas por direitos autorais, efeitos sonoros usados para hitsounds personalizados estão mais frequentemente disponíveis gratuitamente. Por exemplo, a orquestra da Philharmonia fornece [amostras de som de instrumentos](https://philharmonia.co.uk/resources/sound-samples/) gratuitas e [Freesound](https://freesound.org) permite pesquisas de amostras de som filtradas por direitos de uso.
+
+## Visual
+
+Os recursos visuais incluem um plano de fundo/storyboard/vídeo de um beatmap e seguem os mesmos requisitos de uso dos recursos de áudio.
+
+Assim como com as músicas, recomendamos buscar a opinião de um artista sobre os termos de uso e pedir permissão quando esses termos não forem claros. Por exemplo, se você estiver interessado em usar um plano de fundo de um artista no pixiv, localize seu perfil para os termos de uso ou envie uma mensagem pedindo permissão.
+
+Muitos sites de hospedagem de imagens têm filtros de pesquisa para Licenciamento Criativo Comum ou uso não comercial. Alguns sites que mapeadores usam com frequência para encontrar seus planos de fundo livres de direitos autorais incluem:
+
+- [pixabay](https://pixabay.com/)
+- [Unsplash](https://unsplash.com/)
+- [Pexels](https://www.pexels.com/)
+
+Se você recebeu a permissão de um músico para usar sua música, a capa do álbum ou qualquer outra arte oficial do artista também é provavelmente viável para uso como pano de fundo/storyboard. Porém, novamente, peça permissão se isso não estiver claro.
+
+## Jogabilidade
+
+Ao enviar um mapa de batidas, você deve ter permissão para recursos relacionados ao jogo, como [dificuldades de convidados](/wiki/Beatmap/Guest_difficulty) ou gráficos de outros jogos de ritmo.
+
+Não toleramos envios que apresentem jogabilidade (objetos de acerto) correspondentes aos de outros jogos, pois isso não respeita a comunidade de jogos de ritmo.
+
+---
+
+Embora às vezes possa ser difícil entrar em contato com os criadores de recursos audiovisuais, os mapeadores costumam estar abertos para que outras pessoas façam upload e creditem suas dificuldades! Observe que o plágio do conteúdo do jogo também é inaceitável, portanto, quaisquer dificuldades não criadas exclusivamente por você devem ser identificadas de acordo.


### PR DESCRIPTION
Adds Brazilian Portuguese localizations from [this gist (with some fixes)](https://gist.githubusercontent.com/peppy/0dce52d6d956ba282b679a5eedd555a0/raw/34a273e75f0087c7bfdc75d88f7ff1b1c6378235/gistfile1.txt) to the following pages:

- `Beatmap/Guest_difficulty`
- `Legal/Copyright`
- `Legal/Music_Licensing`
- ` Rules/Content_Usage_Guidelines`