### PR TITLE
[FR] Remove `outdated` status in `Game modifier/Half Time`

### DIFF
--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -1,7 +1,5 @@
 ---
 stub: true
-outdated: true
-outdated_since: d70ed2a1ee643d5908b44860b9158f00c3de626f
 tags:
   - half time
   - mod

--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -41,7 +41,7 @@ Par conséquent, l'utilisation du mod Half Time entraînera une augmentation du 
 
 ### osu!catch
 
-Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM est abaissé du même facteur que dans les autres modes. Cependant, la vitesse de l'attrapeur est également réduite. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
+Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM est réduite du même facteur que dans les autres modes. Cependant, la vitesse de l'attrapeur est également réduite. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
 
 ## Le saviez-vous ?
 

--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -41,7 +41,7 @@ Par conséquent, l'utilisation du mod Half Time entraînera une augmentation du 
 
 ### osu!catch
 
-Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM et la vitesse de l'attrapeur sont réduits par le même facteur que dans les autres modes. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
+Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM est abaissé du même facteur que dans les autres modes. Cependant, la vitesse de l'attrapeur est également réduite. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
 
 ## Le saviez-vous ?
 

--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -39,7 +39,7 @@ Par conséquent, l'utilisation du mod Half Time entraînera une augmentation du 
 
 ### osu!catch
 
-Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM est réduite du même facteur que dans les autres modes. Cependant, la vitesse de l'attrapeur est également réduite. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
+Dans le mode [osu!catch](/wiki/Game_mode/osu!catch), le BPM et la vitesse de l'attrapeur sont réduits par le même facteur que dans les autres modes. Tous les [fruits](/wiki/Hit_object/Fruit), [drop](/wiki/Hit_object/Juice_stream#drop), [droplets](/wiki/Hit_object/Juice_stream#droplet) et [bananes](/wiki/Hit_object/Banana) restent intacts.
 
 ## Le saviez-vous ?
 


### PR DESCRIPTION
Removed the status of outdated in the `Half Time` wiki article.

The change that was made in the meantime has already been made in #5607, except that since the branch was not up to date on the old PR, I was not able to remove the `outdated` that had been put.