### PR TITLE
[FR] Add `Help_Centre/Installation_and_registration`, `Store` and `Website`

### DIFF
--- a/wiki/Help_Centre/Installation_and_registration/fr.md
+++ b/wiki/Help_Centre/Installation_and_registration/fr.md
@@ -1,4 +1,5 @@
 ---
+no_native_review: true
 tags:
   - install
   - download

--- a/wiki/Help_Centre/Installation_and_registration/fr.md
+++ b/wiki/Help_Centre/Installation_and_registration/fr.md
@@ -1,0 +1,40 @@
+---
+tags:
+  - install
+  - download
+  - account
+  - profile
+  - register
+  - installation
+  - téléchargement
+  - compte
+  - profil
+  - enregistrement
+  - inscription
+---
+
+# Installation et inscription
+
+*Page principale : [Centre d'aide](/wiki/Help_Centre)*
+
+Cette section est consacrée aux problèmes liés à l'installation d'osu! et à la création de votre propre compte.
+
+## Installation
+
+*Page principale : [Installation](/wiki/Installation)*
+
+### Comment télécharger osu! ?
+
+**Il vous suffit de cliquer sur le lien `Téléchargement` situé sur la [page d'accueil du site officiel d'osu!](https://osu.ppy.sh/home). Vous pouvez également trouver le lien dans la section `Accueil` de la barre de navigation de n'importe quelle page.**
+
+Vous pouvez également [cliquer ici](https://osu.ppy.sh/home/download) pour un lien direct vers la page de téléchargement.
+
+## Inscription
+
+*Page principale : [Registration](/wiki/Registration)*
+
+### Où puis-je m'inscrire sur osu! ?
+
+**Téléchargez osu! [ici](https://osu.ppy.sh/home/download), puis lancez-le. Le jeu vous proposera une section où vous pourrez créer un compte.**
+
+Veillez à fournir une adresse e-mail sur laquelle vous avez le contrôle. Celle-ci est utilisée pour réinitialiser votre mot de passe et envoyer des courriels de vérification si nécessaire. N'utilisez pas d'adresse e-mail jetable.

--- a/wiki/Help_Centre/Store/fr.md
+++ b/wiki/Help_Centre/Store/fr.md
@@ -1,0 +1,133 @@
+---
+tags:
+  - store
+  - product
+  - keyboard
+  - tablet
+  - area
+  - device
+  - setup
+  - pendrive
+  - magasin
+  - produit
+  - clavier
+  - tablette
+  - zone
+  - appareil
+  - configuration
+---
+
+# osu!store et marchandises
+
+*Page principale : [Centre d'aide](/wiki/Help_Centre)*
+
+*Note : Ces produits ne sont plus disponibles à la vente dans la boutique osu!store.*
+
+Vous avez un problème avec un produit de osu!store ? Vérifiez s'il existe une solution à votre problème !
+
+## osu!keyboard
+
+### Comment puis-je configurer le osu!keyboard ?
+
+**Vous pouvez utiliser l'utilitaire de configuration du osu!keyboard, disponible sur [ce lien](https://puu.sh/l6urN/4b6bc800f2.zip).**
+
+Il suffit de l'extraire à n'importe quel endroit de votre ordinateur et d'exécuter l'exécutable !
+
+Le reste devrait être évident.
+
+Si vous avez d'autres problèmes, n'hésitez pas à soumettre un ticket à [support@ppy.sh](mailto:support@ppy.sh) détaillant votre problème.
+
+### Les LEDs de mon osu!keyboard nono ne fonctionnent pas !
+
+**Cela peut être dû à plusieurs raisons : corrosion entre les DEL et la carte mère, ou dans certaines circonstances avec les modèles antérieurs, DEL défectueuses.**
+
+Veuillez contacter [store@ppy.sh](mailto:store@ppy.sh) pour toute demande de renseignements supplémentaires.
+
+#### Vérification de la corrosion des LEDs
+
+**En frottant la base des connecteurs de DEL avec un petit carré de papier d'aluminium, vous éliminerez la plupart des résidus causés par la corrosion.**
+
+Les résidus corrosifs se présentent généralement sous la forme d'un gris noirâtre, ou peuvent apparaître comme des taches étranges sur le métal.
+
+L'élimination de ce résidu peut remettre votre DEL en état de marche. Si c'est le cas, vous savez comment la réparer la prochaine fois !
+
+## osu!tablet
+
+### Ma osu!tablet a cessé de fonctionner ou ne fonctionne pas du tout !
+
+**Ce problème peut être délicat à résoudre car l'osu!tablet est une solution à deux unités (la tablette et le stylo).**
+
+Étant donné que l'osu!tablet est une solution à deux unités (par exemple, une tablette et un stylo), il peut être difficile de savoir quelle unité rencontre des problèmes lorsque les choses tournent mal.
+
+Pour le savoir, effectuez les étapes suivantes :
+
+#### Vérifier les problèmes de votre tablette
+
+**Suivez ces étapes pour vérifier si votre tablette fonctionne normalement :**
+
+1. Retirez en toute sécurité la tablette de votre système et débranchez le câble.
+2. Rebranchez délicatement le câble dans une fente USB de votre système.
+3. Si la tablette fonctionne, la fente lumineuse sur la face de la tablette clignote brièvement en vert puis s'éteint. Ce comportement est normal.
+
+Si le voyant de la tablette ne clignote pas, essayez d'utiliser un autre câble USB. Les câbles fournis avec la tablette peuvent parfois être endommagés pendant le transport ou après une utilisation intensive.
+
+Veuillez contacter [store@ppy.sh](mailto:store@ppy.sh) pour toute demande de renseignements supplémentaires.
+
+#### Vérification des problèmes de votre stylo
+
+**Suivez ces étapes pour vérifier si votre stylo fonctionne normalement :**
+
+- Dévissez la poignée du corps du stylo, exposant ainsi la batterie à l'intérieur.
+- Retirez la pile AAA du stylo.
+- Remplacez la pile par une pile AAA neuve. **Vérifiez d'abord que la nouvelle batterie fonctionne dans un autre appareil.**
+- Assurez-vous que les extrémités positive et négative de la pile sont appropriées dans le stylo. Il existe des marqueurs sur l'appareil qui affichent des marques vous indiquant quelle extrémité va où.
+- Revissez la poignée sur le stylo.
+- Appuyez sur le bouton situé à l'arrière (extrémité gomme) du stylo jusqu'à ce qu'il émette un clic.
+
+Si votre tablette fonctionne correctement, le fait de placer le stylet près de la tablette fera bouger le curseur sur votre écran.
+
+Veuillez contacter [store@ppy.sh](mailto:store@ppy.sh) pour toute demande de renseignements supplémentaires.
+
+## osu!go
+
+### Mon ordinateur ne reconnaît pas osu!go quand je le branche !
+
+**Il s'agit d'un problème connu avec l'un des tout premiers envois de clés USB osu!go, et cela vient du fait que le périphérique n'est pas formaté de manière à fonctionner avec tous les PC.**
+
+Même si cela peut sembler complexe, c'est en fait très facile à résoudre.
+
+Tout d'abord, [téléchargez le paquet contenant les fichiers par défaut d'osu!go](https://assets.ppy.sh/store/utilities/osu!go.zip) et enregistrez-le quelque part sur votre ordinateur.
+
+#### Formatage d'osu!go sous Windows
+
+**Suivez ces étapes pour préparer votre appareil osu!go sous Windows :**
+
+1. Cliquez avec le bouton droit de la souris sur le bouton de menu `Démarrer` et sélectionnez `Gestion dus disques`.
+2. **Dans la vue Gestion des disques, assurez-vous de suivre ces instructions *TRES* attentivement et de les appliquer UNIQUEMENT au périphérique osu!go.** Vous pouvez potentiellement perdre des données si vous manipulez cette boîte de dialogue incorrectement.
+3. Vérifiez l'état dans lequel votre ordinateur reconnaît l'appareil.
+
+### Le dispositif osu!go est présent, mais dans un état "RAW"
+
+**Cela apparaîtra comme ceci dans la boîte de dialogue gestion des disques :**
+
+![](img/raw-status-osu-go.png)
+
+Pour résoudre ce problème, assurez-vous que vous avez sélectionné le périphérique osu!go, faites un clic droit sur la partition RAW, et sélectionnez l'option `Format`. Choisissez soit `NTFS` soit `exFAT` dans la liste déroulante `Fichiers système`.
+
+`exFAT` fonctionnera avec plus de périphériques, mais est légèrement plus lent.
+
+### Le périphérique osu!go n'apparaît pas du tout dans la gestion des disques
+
+**Vous devrez partitionner l'appareil à partir de zéro.**
+
+Veuillez suivre [ce guide](https://staging.tails.boum.org/doc/first_steps/reset/windows.fr.html) pour savoir comment procéder.
+
+### J'ai reformaté le périphérique osu!go et il apparaît maintenant dans la gestion des disques
+
+**Vous avez presque terminé !**
+
+Décompressez l'archive que nous vous avons demandé de télécharger plus tôt (osu!go.zip) dans le lecteur osu!go et vous avez terminé !
+
+### Rien de tout cela n'a fonctionné !
+
+Si vous rencontrez des problèmes avec ce processus, veuillez envoyer un courriel à [store@ppy.sh](mailto:store@ppy.sh) et nous serons heureux de vous aider.

--- a/wiki/Help_Centre/Store/fr.md
+++ b/wiki/Help_Centre/Store/fr.md
@@ -1,4 +1,5 @@
 ---
+no_native_review: true
 tags:
   - store
   - product

--- a/wiki/Help_Centre/Website/fr.md
+++ b/wiki/Help_Centre/Website/fr.md
@@ -1,4 +1,5 @@
 ---
+no_native_review: true
 tags:
   - site
   - block

--- a/wiki/Help_Centre/Website/fr.md
+++ b/wiki/Help_Centre/Website/fr.md
@@ -1,0 +1,103 @@
+---
+tags:
+  - site
+  - block
+  - forum
+  - ticket
+  - appearance
+  - message
+  - page
+  - profile
+  - missing
+  - stats
+  - bloquer
+  - apparence
+  - profil
+  - manquant
+---
+
+# Site web
+
+*Page principale : [Centre d'aide](/wiki/Help_Centre)*
+
+Cette section est consacrée aux problèmes liés au site web d'osu!
+
+## Problèmes courants
+
+### Je n'ai pas reçu de réponse à mon ticket d'assistance et cela fait plus de 2 semaines !
+
+**Dans la plupart des cas, cela est dû à un nombre élevé de tickets entrant dans notre système en même temps.**
+
+Vous pouvez toujours envoyer une réponse unique à votre ticket actuellement ouvert pour demander où en est votre dossier, mais veillez à ne pas le faire plus d'une ou deux fois par semaine. Vous pouvez également nous contacter sur Twitter à l'adresse [@osusupport](https://twitter.com/osusupport) pour poser des questions sur votre ticket.
+
+Dans de rares cas, les tickets d'assistance d'utilisateurs en infraction chronique peuvent être délibérément ignorés, mais l'équipe vous indiquera **toujours** quand elle ne vous répondra plus en premier. Si vous n'avez pas reçu de notification de ce type, vous n'avez pas à vous en inquiéter !
+
+### Puis-je empêcher complètement un autre utilisateur de me contacter ?
+
+**Oui, absolument.**
+
+Si un autre utilisateur vous harcèle par le biais de messages privés, que ce soit sur les forums ou via le client de jeu lui-même, il existe quelques mesures que vous pouvez prendre vous-même pour filtrer ses messages.
+
+#### Empêcher un utilisateur de vous contacter dans le jeu
+
+**Pour empêcher un utilisateur de vous envoyer des messages dans le jeu, il suffit de l'ajouter à votre liste d'ignorés.**
+
+1. Cliquez sur le bouton du menu Options dans le jeu
+2. Tapez `utilisateurs` pour filtrer les options de la liste de la section `Utilisateurs à ignorer (séparer par des espaces) :`.
+3. Ajoutez le nom d'utilisateur de l'utilisateur incriminé à la liste, en séparant chaque nouvel utilisateur par un espace, et en remplaçant tous les espaces dans leur nom par des traits de soulignement (Un utilisateur appelé *The Gatekeeper* devient *The\_Gatekeeper* par exemple).
+
+Vous ne verrez plus les messages de chat publics des utilisateurs de cette liste et ne recevrez plus de messages privés de leur part.
+
+Si vous souhaitez ignorer les highlights les messages privés, ou les messages publics, vous pouvez simplement ajouter respectivement `@h`, `@p`, `@c` à leur nom d'utilisateur. `The_Gatekeeper@c` ignorera les messages de l'utilisateur dans les canaux publics. Il est possible de les combiner : `The_Gatekeeper@ph` ignorera les highlights et les messages privés, mais laissera les messages publics visibles.
+
+#### Bloquer l'envoi de messages privés dans le jeu à tous les non-amis
+
+Si vous souhaitez empêcher toute personne ne figurant pas sur votre liste d'amis de vous envoyer des messages privés, suivez les étapes suivantes. **Remarque : les modérateurs ne sont pas concernés par cette fonctionnalité et peuvent toujours vous envoyer des MP. Si vous pensez qu'un modérateur vous harcèle malgré tout, vous devez contacter [notre équipe d'assistance](mailto:support@ppy.sh).**
+
+1. Cliquez sur le bouton `Options` du menu principal, ou appuyez sur `Ctrl` + `O`.
+2. Tapez `block` pour filtrer la liste des options de la section "Tchat en jeu".
+3. Cliquez sur le paramètre qui apparaît pour l'activer.
+
+Les utilisateurs qui ne figurent pas dans votre liste d'amis ne peuvent plus vous contacter.
+
+#### Empêcher les nouveaux messages privés du forum de vous parvenir
+
+Allez dans vos [paramètres de compte](https://osu.ppy.sh/home/account/edit) et cliquez sur `bloquer les messages privés des personnes qui ne sont pas dans votre liste d’amis` dans la section Confidentialité. Les messages privés des utilisateurs figurant dans votre liste d'amis vous parviendront quand même.
+
+### Que faire si j'ai toujours des problèmes avec un utilisateur après l'avoir bloqué ?
+
+**N'ayez crainte, notre personnel d'assistance vous aidera.**
+
+Si un utilisateur continue de vous harceler par d'autres moyens, ou s'il utilise ses amis ou quelqu'un d'autre pour contourner vos efforts pour le bloquer, veuillez nous envoyer un e-mail à [support@ppy.sh](mailto:support@ppy.sh).
+
+N'oubliez pas d'inclure dans votre e-mail tout journal de discussion ou autre preuve. Notre équipe d'assistance examinera votre cas et le réglera pour vous.
+
+### Que sont ces pages "moi !" que je vois sur les profils des autres joueurs ?
+
+**Les pages moi !, ou pages d'utilisateur, sont des éléments de profil spéciaux auxquels tous les joueurs ayant un [tag supporter](https://osu.ppy.sh/home/support) ont accès. Elles peuvent contenir tout ce que vous voulez : des photos de vos exploits, vos maps, tout ce que vous voulez !**
+
+Les joueurs ayant un [tag supporter](https://osu.ppy.sh/home/support) ont le privilège d'éditer leur propre page qui sera affichée sur leur profil pour que le monde entier puisse la voir. Les pages moi ! peuvent contenir tout ce que vous voulez, tant que cela respecte les [Règles](/wiki/Rules) !
+
+Même si votre [tag supporter](https://osu.ppy.sh/home/support) est épuisée, votre page moi ! **restera visible** et vous pourrez toujours modifier son contenu.
+
+### Le contenu de la page moi ! a disparu !
+
+**Cela peut se produire si votre page moi ! contient du contenu inapproprié, tel que défini par nos [Règles](/wiki/Rules).**
+
+Dans ce cas, vous pouvez ouvrir un ticket avec l'équipe d'assistance en envoyant un e-mail à [accounts@ppy.sh](mailto:accounts@ppy.sh) et discuter de votre situation avec eux.
+
+Si, à un moment donné, vous avez des doutes quant à la pertinence d'un élément pour une page moi !, vous pouvez envoyer un message à l'un des membres de la [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) avec ce que vous envisagez de mettre en ligne et ils vous feront savoir si c'est acceptable.
+
+### Dois-je utiliser mon adresse e-mail pour m'inscrire ?
+
+**Oui. Nous avons besoin de votre adresse e-mail pour vous envoyer des demandes de réinitialisation de mot de passe et des codes de vérification si nécessaire.**
+
+Si vous avez des difficultés à vous connecter via le client de jeu, veuillez vérifier les paramètres de votre pare-feu et de votre antivirus pour vous assurer que le site osu! n'est pas bloqué.
+
+Si vous perdez votre mot de passe ou si vous ne pouvez pas accéder à votre compte, votre e-mail d'inscription est notre premier point de contact avec vous.
+
+### Pourquoi les statistiques de la page de mon profil d'utilisateur sont-elles erronées ?
+
+**Vous regardez peut-être vos statistiques pour un autre mode de jeu !**
+
+Si vous avez été inactif pendant une longue période et que vos statistiques sont affichées de manière incorrecte, il vous suffit de jouer quelques maps pour les afficher à nouveau. Les utilisateurs inactifs ont leurs scores cachés pour que les classements restent frais.


### PR DESCRIPTION
Translation of the following wiki pages:

- `Help_Centre/Installation_and_registration`
- `Help_Centre/Store`
- `Help_Centre/Website`

In `Help_Centre/Store/en.md` : Put an image in `Help_Centre/Store/img` which was hosted on an external site
In  `Help_Centre/Website/en.md` : fix links for GMT