### PR TITLE
Update CWC winners in `Users with unique titles`

### DIFF
--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -27,14 +27,14 @@ Winners of [TWC 2021](/wiki/Tournaments/TWC/2021) with the **osu!taiko Champion*
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-Winners of [CWC 2020](/wiki/Tournaments/CWC/2020) with the **osu!catch Champion** user title:
+Winners of [CWC 2021](/wiki/Tournaments/CWC/2021) with the **osu!catch Champion** user title:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 Winners of [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) with the **osu!mania Champion** user title:
 

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -31,14 +31,14 @@ Gagnants de la [TWC 2021](/wiki/Tournaments/TWC/2021) avec le titre utilisateur 
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-Gagnants de la [CWC 2020](/wiki/Tournaments/CWC/2020) avec le titre utilisateur **osu!catch Champion**:
+Gagnants de la [CWC 2021](/wiki/Tournaments/CWC/2021) avec le titre utilisateur **osu!catch Champion**:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 Gagnants de la [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) avec le titre utilisateur **osu!mania Champion**:
 

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -27,14 +27,14 @@ Berikut merupakan para pemenang [TWC 2021](/wiki/Tournaments/TWC/2021) yang saat
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-Berikut merupakan para pemenang [CWC 2020](/wiki/Tournaments/CWC/2020) yang saat ini menyandang gelar **osu!catch Champion**:
+Berikut merupakan para pemenang [CWC 2021](/wiki/Tournaments/CWC/2021) yang saat ini menyandang gelar **osu!catch Champion**:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 Berikut merupakan para pemenang [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) yang saat ini menyandang gelar **osu!mania Champion**:
 

--- a/wiki/People/Users_with_unique_titles/pl.md
+++ b/wiki/People/Users_with_unique_titles/pl.md
@@ -32,14 +32,14 @@ Zwycięzcy [TWC 2021](/wiki/Tournaments/TWC/2021) otrzymali tytuł **osu!taiko C
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-Zwycięzcy [CWC 2020](/wiki/Tournaments/CWC/2020) otrzymali tytuł **osu!catch Champion**:
+Zwycięzcy [CWC 2021](/wiki/Tournaments/CWC/2021) otrzymali tytuł **osu!catch Champion**:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 Zwycięzcy [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) otrzymali tytuł **osu!mania Champion**:
 

--- a/wiki/People/Users_with_unique_titles/pt-br.md
+++ b/wiki/People/Users_with_unique_titles/pt-br.md
@@ -31,14 +31,14 @@ Vencedores da [TWC 2021](/wiki/Tournaments/TWC/2021) com o título de **osu!taik
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-Vencedores da [CWC 2020](/wiki/Tournaments/CWC/2020) com o título de **osu!catch Champion**:
+Vencedores da [CWC 2021](/wiki/Tournaments/CWC/2021) com o título de **osu!catch Champion**:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 Vencedores da [MWC 4K 2020](/wiki/Tournaments/MWC/2019_4K) com o título de **osu!mania Champion**:
 

--- a/wiki/People/Users_with_unique_titles/th.md
+++ b/wiki/People/Users_with_unique_titles/th.md
@@ -31,14 +31,14 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-ผู้ชนะของ [CWC 2020](/wiki/Tournaments/CWC/2020) พร้อมกับ title **osu!catch Champion**:
+ผู้ชนะของ [CWC 2021](/wiki/Tournaments/CWC/2021) พร้อมกับ title **osu!catch Champion**:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 ผู้ชนะของ [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) พร้อมกับ title **osu!mania Champion**:
 

--- a/wiki/People/Users_with_unique_titles/tr.md
+++ b/wiki/People/Users_with_unique_titles/tr.md
@@ -31,14 +31,14 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-**osu!catch Champion** kullanıcı ünvanına sahip [CWC 2020](/wiki/Tournaments/CWC/2020) kazananları:
+**osu!catch Champion** kullanıcı ünvanına sahip [CWC 2021](/wiki/Tournaments/CWC/2021) kazananları:
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 **osu!mania Champion** kullanıcı ünvanına sahip [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) kazananları:
 

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -27,14 +27,14 @@
 - ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695)
 - ![][flag_JP] [uone](https://osu.ppy.sh/users/5321719)
 
-拥有 **osu!catch Champion** 头衔的 [CWC 2020](/wiki/Tournaments/CWC/2020) 冠军：
+拥有 **osu!catch Champion** 头衔的 [CWC 2021](/wiki/Tournaments/CWC/2021) 冠军：
 
-- ![][flag_KR] [Motion](https://osu.ppy.sh/users/3885626)
+- ![][flag_KR] [\[224\]Hyperw7](https://osu.ppy.sh/users/4158549)
+- ![][flag_KR] [Abstract-](https://osu.ppy.sh/users/3097304)
+- ![][flag_KR] [Berea](https://osu.ppy.sh/users/3657951)
+- ![][flag_KR] [DreStar](https://osu.ppy.sh/users/1808057)
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
-- ![][flag_KR] [R-18](https://osu.ppy.sh/users/4637369)
-- ![][flag_KR] [Rocma](https://osu.ppy.sh/users/566276)
-- ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598)
-- ![][flag_KR] [T s u m i](https://osu.ppy.sh/users/4080520)
+- ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
 拥有 **osu!mania Champion** 头衔的 [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) 冠军：
 


### PR DESCRIPTION
Changes CWC winners from 2020 to 2021 since the tournament has already concluded.

Referenced from [here](https://osu.ppy.sh/wiki/en/Tournaments/CWC/2021#participants).