### PR TITLE
RC - Add guideline about 5:4 aspect ratio

### DIFF
--- a/wiki/Ranking_Criteria/osu!/en.md
+++ b/wiki/Ranking_Criteria/osu!/en.md
@@ -30,8 +30,9 @@ Overall rules and guidelines apply to every kind of osu! difficulty. Rhythm-rela
 - **Spinner ends, slider ends, and slider reverses should have hitsound feedback.** If these are used to represent a held sound and do not align with a distinct sound, having no feedback is acceptable.
 - **Avoid using sound samples for sliderslide, sliderwhistle, and spinnerspin which do not naturally loop.** These hitsounds are continuous, meaning that their files play from start to end and loop as one continuous sound for the length of the object, so using sound files with a clear impact for them might lead to unwanted side effects.
 - **Avoid unjustified difficulty spikes.** Difficulty should be representative of the song's intensity.
+- **Avoid offscreens in 5:4 aspect ratio.** Hit objects that are near to offscreen at 4:3 can create reading difficulties for people, who uses 1280х1024 screens. Test play your beatmap to confirm this.
 
-### Skinning
+### Skinning 
 
 #### Rules
 


### PR DESCRIPTION
I have 16:9 screen, but using native 5:4 since i need switch to another screen sometimes. Recently i saw offscreen at one ranked map (https://osu.ppy.sh/beatmaps/2356116 (tomatsu expert, 02:58:626 (3) https://osu.ppy.sh/ss/16879237/c7fd) ) what created me a reading difficulty and i somehow missed there. Since 5:4 (1280x1024) are being used at official osu! client for 16:9 (https://media.discordapp.net/attachments/312267283563151361/869541148031610920/unknown.png?width=502&height=399), i'd suggest to add 5:4 guideline.