### PR TITLE
[Proposal] Allow "map" and "mapper" as acceptable terminology in ASC

### DIFF
--- a/wiki/Article_styling_criteria/Writing/en.md
+++ b/wiki/Article_styling_criteria/Writing/en.md
@@ -243,8 +243,7 @@ These words must be spelt as follows (spacing must match):
 
 Some words have variants. Their preferred spelling must be used and is as follows:
 
-- `beatmap` instead of `map`.
-- `creator` instead of `beatmapper` or `mapper`.
+- `creator` or `mapper` instead of `beatmapper`.
 - `mapped` instead of `beatmapped`.
 - `BN` or `Beatmap Nominators` when referring to the *Beatmap Nominators*.
 - `sign in` instead of `log in`, unless the name of a button or link says otherwise.

--- a/wiki/Article_styling_criteria/Writing/fr.md
+++ b/wiki/Article_styling_criteria/Writing/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: d966364ea9a5eaf4de1e02201ce0f3716944e0ef
+---
+
 # Rédaction
 
 *Pour les normes de mise en forme, voir : [Critères de style des articles/Mise en forme](../Formatting)*


### PR DESCRIPTION
Related to [this discussion](https://discord.com/channels/188630481301012481/218677502141399041/868150618911567924), this PR proposes that the word "mapper" be allowed to be used as an alternative spelling to "creator" in wiki articles, as well as allow the use of "map" to be a viable alternative to the word "beatmap"