### PR TITLE
[FR] Update `The Team`, `osu! Alumni`, `Support Team`

### DIFF
--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -1,12 +1,12 @@
-# Support Team
+# Équipe du support
 
 *Pour une équipe qui administre les comptes, voir : [Équipe d'assistance aux comptes](/wiki/People/The_Team/Account_support_team)*
 
-La **Support Team**, également connue sous le nom de **Support Team Redux**, est composée de membres du personnel d'osu! qui se concentrent sur la modération de plusieurs sous-forums : [Development](https://osu.ppy.sh/community/forums/2), [Gameplay & Rankings](https://osu.ppy.sh/community/forums/13) (à l'exception de [Tournaments](https://osu.ppy.sh/community/forums/55) et [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5).
+L'**Équipe du support**, également connue sous le nom de **Support Team Redux**, est composée de membres du personnel d'osu! qui se concentrent sur la modération de plusieurs sous-forums : [Development](https://osu.ppy.sh/community/forums/2), [Gameplay & Rankings](https://osu.ppy.sh/community/forums/13) (à l'exception de [Tournaments](https://osu.ppy.sh/community/forums/55) et [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5).
 
 ## Rôles et responsabilités
 
-La Support Team est responsable de :
+L'Équipe du support est responsable de :
 
 1. Tester et/ou confirmer les rapports de bugs pour en informer les développeurs et leur permettre de les résoudre.
 2. Organisation des fils de discussion dans [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5), en les marquant comme *Resolved*, *Confirmed*, *Invalid*, *Duplicate* et/ou *Added*.
@@ -17,7 +17,7 @@ Si quelqu'un a besoin d'aide sur lesdits sous-forums, les membres de cette équi
 
 La [page de groupe de la Support Team](https://osu.ppy.sh/groups/22) énumère tous les membres de l'équipe.
 
-*Remarque : Tous les membres de la Support Team parlent l'anglais en plus de la ou des langues énumérées ci-dessous, sauf indication contraire.*
+*Remarque : Tous les membres de l'Équipe du support parlent l'anglais en plus de la ou des langues énumérées ci-dessous, sauf indication contraire.*
 
 | Nom | Langues additionnelles |
 | :-- | :-- |

--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -34,6 +34,6 @@ La [page de groupe de la Support Team](https://osu.ppy.sh/groups/22) énumère t
 [flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
 [flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
 [flag_SE]: /wiki/shared/flag/SE.gif "Suède"
 [flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -1,33 +1,30 @@
----
-outdated: true
-outdated_since: c1175ba788c488eb294b1b04c55a6dee798009de
----
+# Support Team
 
-# Équipe du Support
+*Pour une équipe qui administre les comptes, voir : [Équipe d'assistance aux comptes](/wiki/People/The_Team/Account_support_team)*
 
-L'**équipe de support** (aussi connu sous le nom de **Équipe de support Redux**, à ne pas confondre avec l'équipe de support pour les comptes, aussi connu sous le nom d' "Équipe de support") sont des membres du staff d'osu! dont leur objectif premier est d'aider les joueurs par la modération d'une partie des sous-forums du jeu : [Development](https://osu.ppy.sh/community/forums/2), [Gameplay & Rankings](https://osu.ppy.sh/community/forums/13) (sauf [Tournaments](https://osu.ppy.sh/community/forums/55) et [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4), et [Help](https://osu.ppy.sh/community/forums/5).
+La **Support Team**, également connue sous le nom de **Support Team Redux**, est composée de membres du personnel d'osu! qui se concentrent sur la modération de plusieurs sous-forums : [Development](https://osu.ppy.sh/community/forums/2), [Gameplay & Rankings](https://osu.ppy.sh/community/forums/13) (à l'exception de [Tournaments](https://osu.ppy.sh/community/forums/55) et [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5).
 
-## Responsabilités
+## Rôles et responsabilités
 
-L'équipe de support est responsable de :
+La Support Team est responsable de :
 
-1. Tester et/ou confirmer les rapports de bugs puis laisser les développeurs les résoudre,
-2. Organiser les sujets des sections [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5) et leur attribuer un statut : *résolu*, *confirmé*, *non valide*, *doublon* ou *ajouté*.
+1. Tester et/ou confirmer les rapports de bugs pour en informer les développeurs et leur permettre de les résoudre.
+2. Organisation des fils de discussion dans [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5), en les marquant comme *Resolved*, *Confirmed*, *Invalid*, *Duplicate* et/ou *Added*.
 
-Si quelqu'un a besoin d'aide sur lesdits sous-forums, l'équipe de support est là pour ça.
+Si quelqu'un a besoin d'aide sur lesdits sous-forums, les membres de cette équipe sont disponibles pour l'aider.
 
 ## Membres de l'équipe
 
-La liste de tous les membres du [groupe de l'équipe de support](https://osu.ppy.sh/groups/22).
+La [page de groupe de la Support Team](https://osu.ppy.sh/groups/22) énumère tous les membres de l'équipe.
 
-*Veuillez noter que tous les membres de l'équipe de support peuvent également parler anglais en plus des langues listées ci-dessous.*
+*Remarque : Tous les membres de la Support Team parlent l'anglais en plus de la ou des langues énumérées ci-dessous, sauf indication contraire.*
 
-| Nom | Langues parlées |
+| Nom | Langues additionnelles |
 | :-- | :-- |
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  |
-| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Philippin |
+| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Philippine |
 | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | Suédois, Espagnol |
 | ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) |  |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | Allemand |

--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -24,7 +24,7 @@ La [page de groupe de la Support Team](https://osu.ppy.sh/groups/22) énumère t
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) |  |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  |
-| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Philippine |
+| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Philippin |
 | ![][flag_SE] [Saten](https://osu.ppy.sh/users/444506) | Suédois, Espagnol |
 | ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) |  |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | Allemand |

--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -1,6 +1,6 @@
 # Équipe du support
 
-*Pour une équipe qui administre les comptes, voir : [Équipe d'assistance aux comptes](/wiki/People/The_Team/Account_support_team)*
+*Pour une équipe qui administre les comptes, voir : [Équipe de support aux comptes](/wiki/People/The_Team/Account_support_team)*
 
 L'**Équipe du support**, également connue sous le nom de **Support Team Redux**, est composée de membres du personnel d'osu! qui se concentrent sur la modération de plusieurs sous-forums : [Development](https://osu.ppy.sh/community/forums/2), [Gameplay & Rankings](https://osu.ppy.sh/community/forums/13) (à l'exception de [Tournaments](https://osu.ppy.sh/community/forums/55) et [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5).
 
@@ -9,7 +9,7 @@ L'**Équipe du support**, également connue sous le nom de **Support Team Redux*
 L'Équipe du support est responsable de :
 
 1. Tester et/ou confirmer les rapports de bugs pour en informer les développeurs et leur permettre de les résoudre.
-2. Organisation des fils de discussion dans [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5), en les marquant comme *Resolved*, *Confirmed*, *Invalid*, *Duplicate* et/ou *Added*.
+2. Organiser des fils de discussion dans les sous-forums [Feature Requests](https://osu.ppy.sh/community/forums/4) et [Help](https://osu.ppy.sh/community/forums/5), en les marquant comme *Resolved*, *Confirmed*, *Invalid*, *Duplicate* et/ou *Added*.
 
 Si quelqu'un a besoin d'aide sur lesdits sous-forums, les membres de cette équipe sont disponibles pour l'aider.
 

--- a/wiki/People/The_Team/Support_Team/fr.md
+++ b/wiki/People/The_Team/Support_Team/fr.md
@@ -34,6 +34,6 @@ La [page de groupe de la Support Team](https://osu.ppy.sh/groups/22) énumère t
 [flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
 [flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
 [flag_SE]: /wiki/shared/flag/SE.gif "Suède"
 [flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -1,88 +1,104 @@
 ---
-outdated: true
+tags:
+  - osu! staff
+  - osu!team
+  - osu! team
+  - staff
+  - team osu!
+  - staff d'osu!
+  - équipe d'osu!
 ---
 
-# L'Équipe
+# L'équipe
 
-*Afin de trouver la liste des promotions et des retraites, veillez consulter : [Archives de l'équipe](/wiki/Staff_Log)*
+*Pour une liste des promotions et des départs à la retraite, voir : [Staff Log](/wiki/Staff_Log)*
 
-Les personnes listées ci-dessous sont le coeur de l'**osu!team** et sont principalement chargées d'aider à rendre le jeu génial pour tous.
+Les personnes énumérées ci-dessous constituent le noyau de l'**équipe d'osu!** et sont principalement chargées d'aider à rendre le jeu génial pour tout le monde.
 
-| Nom | Role |
+| Nom | Rôle 
 | :-- | :-- |
-| ![][flag_AU] **[peppy](https://osu.ppy.sh/users/2)** | **Créateur d'osu! sur PC** |
+| ![][flag_AU] **[peppy](https://osu.ppy.sh/users/2)** | **Chef de projet** |
+| ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) | Conseiller sur le modding et le mapping |
+| ![][flag_CA] [Azer](https://osu.ppy.sh/users/2155578) | Organisateur et administrateur de la World Cup |
 | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870) | Modération et conseiller communautaire |
-| ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | Aide aux joueurs, Secrétaire de Meganekko |
-| ![][flag_JP] [flyte](https://osu.ppy.sh/users/3103765), [osu!next](https://next.ppy.sh/) | Concepteur principal |
-| ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) | Conseiller en modding et mapping |
-| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Organisation et administration de la coupe du monde |
-| ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Conseiller en modding et mapping |
-| ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) | Conseiller en modding et mapping |
-| ![][flag_JP] [nanaya](https://osu.ppy.sh/users/2387883) | Création du site |
-| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Conseiller général en entretien ménager et modération |
-| ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | Développeur osu!web et [official osu! Featured Artist](https://osu.ppy.sh/beatmaps/artists/1) |
+| ![][flag_US] [ChillierPear](https://osu.ppy.sh/users/9501251) | Organisateur et administrateur de la World Cup |
+| ![][flag_AU] [Ephemeral](https://osu.ppy.sh/users/102335) | Mainteneur de projet et de communauté, Sensibilisation des Featured Artist |
+| ![][flag_JP] [flyte](https://osu.ppy.sh/users/3103765) | Responsable du design, Observateur résident de Creative Cloud |
+| ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) | Conseiller sur le modding et le mapping |
+| ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | Organisateur et administrateur de la World Cup |
+| ![][flag_JP] [nanaya](https://osu.ppy.sh/users/2387883) | Développeur osu!web |
+| ![][flag_PH] [Nathanael](https://osu.ppy.sh/users/2295078) | Gouvernant général, conseiller en modération |
+| ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | Développeur osu!web, [official osu! Featured Artist](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_JP] [notbakaneko](https://osu.ppy.sh/users/10751776) | Développeur osu!web |
-| ![][flag_US] [Nyquill](https://osu.ppy.sh/users/682935) | Développement d'osu!, organisation de la guilde des mappeurs |
-| ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | Conseiller en modding et mapping |
-| ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) | Conseiller en modding et mapping, organisation de la guilde des mappeurs, et professeur de l'[osu!academy](/wiki/osu!academy) |
-| ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | Entretien général et maintenance  du wiki |
-| ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | Aide ménagère générale et assistant des artiste en vedette |
-| ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | développement d'osu!, aimant osu!mania, chasseur de bugs |
-| ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Manager du Project Loved et conseiller communautaire, sensibilisation au Featured Artist |
-| ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Entretien ménager général et assistant de tournoi |
-| ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Espèce en voie de disparition |
+| ![][flag_DE] [Okoratu](https://osu.ppy.sh/users/1623405) | Conseiller sur le modding et le mapping |
+| ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) | Conseiller sur le modding et le mapping, Organisateur de la Mappers' Guild, Sensibilisation des Featured Artist |
+| ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | Gouvernant général, mainteneur du wiki |
+| ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | Gouvernant général |
+| ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | développeur d'osu!, amateur d'osu!mania, chasseur de bugs |
+| ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Responsable du Project Loved, conseiller communautaire, Sensibilisation des Featured Artist |
+| ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Gouvernant général, assistant de tournoi |
+| ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Espèces menacées d'extinction |
 
-## Groupe d'utilisateur
+En plus de ce qui précède, l'[équipe de soutien du compte](Account_support_team) est là pour aider à résoudre les problèmes hors de portée.
 
-Les groupes d'utilisateurs suivants représentent les membres de la communauté qui aident à maintenir osu!. La plupart de ces groupes peuvent être reconnus grâce à la couleur de leur pseudonyme ou de leur texte dans le chat, leur photo de profil et/ou le(s) badge(s) présent(s) sur leur profil.
+## Groupes d'utilisateurs
+
+Les groupes d'utilisateurs suivants sont constitués de membres de la communauté osu! qui contribuent à la maintenance d'osu!. La plupart de ces groupes d'utilisateurs peuvent être reconnus grâce aux couleurs du forum, aux couleurs du tchat en jeu, aux titres des profils et/ou aux badges des profils.
 
 | Nom | Description |
 | :-- | :-- |
-| [Groupe de Nomination des Beatmaps](Beatmap_Nominators) | Contrôlent la qualité des Beatmaps certifiées "Qualified". |
-| [Développeurs](Developers) | Rendent le jeu incroyable en ajoutant de nouvelles fonctionnalités et en corrigeant les bugs. |
-| [Équipe de modération globale](Global_Moderation_Team) | Gardent un œil sur le chat et le forum. |
-| [Nomination Assessment Team](Nomination_Assessment_Team) | Gestion des nominations des beatmaps |
-| [osu! Alumni](osu!_Alumni) | Connus pour leurs nombreuses contributions. |
-| [Project Loved Team](Project_Loved_Team) | Reconnaissent les beatmaps que la communauté aime le plus |
-| [Equipe de Support](Support_Team) | Responsables du support technique et des demandes de fonctionnalités. |
+| [Beatmap Nominators](Beatmap_Nominators) | Des utilisateurs qui vont au-delà de ce qui est demandé pour s'assurer que vos beatmaps sont qualifiées. |
+| [Developers](Developers) | Rendre le jeu génial en ajoutant de nouvelles fonctionnalités et en corrigeant les bugs. |
+| [Global Moderation Team](Global_Moderation_Team) | Surveiller les forums et le tchat en jeu. |
+| [Nomination Assessment Team](Nomination_Assessment_Team) | Gère les Beatmap Nominators |
+| [osu! Alumni](osu!_Alumni) | Ceux qui sont connus pour leur contribution et qui sont partis depuis lors |
+| [Project Loved Team](Project_Loved_Team) | Reconnaître les beatmaps les plus appréciés par la communauté |
+| [Support Team](Support_Team) | Aide/Assistance aux demandes de fonctionnalités |
 
-## Inactifs
+## Membres inactifs de l'équipe centrale
 
 | Nom | Role |
 | :-- | :-- |
-| ![][flag_US] [awp](https://osu.ppy.sh/users/2650) ([Barrel Roll Weekly](http://brw.twinkfish.com/)) | Aide et entretien général, Dessinateur de chibis |
-| ![][flag_NO] [cYsmix](https://osu.ppy.sh/users/272870) | Design audio et [official osu! Featured Artist](https://osu.ppy.sh/beatmaps/artists/2) |
-| ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Organisation et administration de la coupe du monde |
-| ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) | Entretien général du site, Gestion de la communauté |
-| ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) ([blog](http://blog.echo.sh/)) | Développeur d'osu!, intégration du Chat IRC dans le jeu, entretien du site |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | osu! Coffee Hour, diffusion de la Coupe du Monde et organisation de tournois |
-| ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | Développeur d'osu!, osz2/p2p backend |
-| ![][flag_US] Jim ([Brave New Games](http://www.bravegamer.com/)) | Concepteur original du site |
-| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisation et administration de la Coupe du monde, leadership du QAT et community management |
-| ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) ([LuigiHann@Deviantart](http://luigihann.deviantart.com/)) | Designer du magnifique design général d'osu!, contributions au skin par défaut et aux sets d'icônes |
-| ![][flag_US] [mm201](https://osu.ppy.sh/users/30655) | Développeur d'osu!, intégrateur des sliders |
-| ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | Développeur d'osu!iPhone |
-| ![][flag_AU] [phill](https://osu.ppy.sh/users/53) | Conception du forum |
-| ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter, gars extraordinaire |
-| ![][flag_US] [Sarumaru](https://osu.ppy.sh/users/9427) ([Sarumaru@deviantART.com](http://sarumaru.deviantart.com/)) | Créateur et concepteur original de pippi |
-| ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | Meeting minutes, Importantes contributions à la FAQ |
-| ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | Développement des pp |
-| ![][flag_CN] [woc2006](https://osu.ppy.sh/users/1105845) | osu! dev team, osu!mania mode dev |
-| ![][flag_JP] [yelle](https://osu.ppy.sh/users/4916903) | Gestion du magasin osu! |
-| ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) | Professeur de osu!academy, conception media/personnage |
+| ![][flag_CA] [awp](https://osu.ppy.sh/users/2650) | Gouvernant général et helper, artiste chibi. [Barrel Roll Weekly](http://brw.twinkfish.com/) |
+| ![][flag_NO] [cYsmix](https://osu.ppy.sh/users/272870) | Concepteur audio, [official osu! Featured Artist](https://osu.ppy.sh/beatmaps/artists/2) |
+| ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Organisateur et administrateur de la World Cup |
+| ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) | Gouvernant général, Responsable de la communauté |
+| ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | développeur d'osu!, fournisseur de l'intégration IRC pour le chat en jeu, mainteneur du site. [Blog](http://blog.echo.sh/) |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Hôte de osu! Coffee Hour, Streamer de la World Cup, Organisateur de tournoi |
+| ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | développeur d'osu!, fournisseur d'osz2 et de backend p2p |
+| ![][flag_US] Jim | Concepteur original du site, fournisseur d'hébergement à ses débuts. [Brave New Games](http://www.bravegamer.com/) |
+| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Organisateur et administrateur de la World Cup |
+| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisateur et administrateur de la World Cup, Leader de la QAT, responsable de la communauté |
+| ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Concepteur de skin épique, contributeur au skin par défaut et au jeu d'icônes. [DeviantArt](https://luigihann.deviantart.com/) |
+| ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Conseiller sur le modding et le mapping |
+| ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | développeur d'osu!, créateur des mm sliders |
+| ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | Développeur d'osu! iPhone |
+| ![][flag_CA] [Nyquill](https://osu.ppy.sh/users/682935) | développeur d'osu!, Organisateur de la Mappers' Guild |
+| ![][flag_AU] [phill](https://osu.ppy.sh/users/53) | Concepteur du forum |
+| ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter, fabricant de trucs cool - gars extraordinaire |
+| ![][flag_US] [Sarumaru](https://osu.ppy.sh/users/9427) | Concepteur de concepts et d'illustrations originales de Pippi. [DeviantArt](https://sarumaru.deviantart.com/) |
+| ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | Gestionnaire et leader de communauté initiale, compte-rendu de réunion et contributeur de la FAQ |
+| ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | osu! et développeur pp |
+| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Gouvernant général, Organisateur et administrateur de la World Cup, responsable du wiki |
+| ![][flag_CN] [woc2006](https://osu.ppy.sh/users/1105845) | développeur d'osu!, développeur du mode osu!mania |
+| ![][flag_JP] [yelle](https://osu.ppy.sh/users/4916903) | Gérant du [osu!store](https://osu.ppy.sh/store/listing) |
+| ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) | Professeur de la [osu!academy](/wiki/osu!academy), concepteur de médias et de personnages |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentine"
 [flag_AU]: /wiki/shared/flag/AU.gif "Australie"
+[flag_BR]: /wiki/shared/flag/BR.gif "Brésil"
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CL]: /wiki/shared/flag/CL.gif "Chili"
 [flag_CN]: /wiki/shared/flag/CN.gif "Chine"
 [flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
 [flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
 [flag_FR]: /wiki/shared/flag/FR.gif "France"
-[flag_GB]: /wiki/shared/flag/GB.gif "Angleterre"
+[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"
 [flag_GR]: /wiki/shared/flag/GR.gif "Grèce"
 [flag_JP]: /wiki/shared/flag/JP.gif "Japon"
 [flag_MX]: /wiki/shared/flag/MX.gif "Mexique"
 [flag_NL]: /wiki/shared/flag/NL.gif "Pays-Bas"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
-[flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle Zélande"
+[flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle-Zélande"
 [flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
-[flag_US]: /wiki/shared/flag/US.gif "USA"
+[flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -100,5 +100,5 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 [flag_NL]: /wiki/shared/flag/NL.gif "Pays-Bas"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
 [flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle-Zélande"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
 [flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -15,7 +15,7 @@ tags:
 
 Les personnes énumérées ci-dessous constituent le noyau de l'**équipe d'osu!** et sont principalement chargées d'aider à rendre le jeu génial pour tout le monde.
 
-| Nom | Rôle 
+| Nom | Rôle |
 | :-- | :-- |
 | ![][flag_AU] **[peppy](https://osu.ppy.sh/users/2)** | **Chef de projet** |
 | ![][flag_GB] [-Mo-](https://osu.ppy.sh/users/2202163) | Conseiller sur le modding et le mapping |

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -53,7 +53,7 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 | [Nomination Assessment Team](Nomination_Assessment_Team) | Gère les Beatmap Nominators |
 | [osu! Alumni](osu!_Alumni) | Ceux qui sont connus pour leur contribution et qui sont partis depuis lors |
 | [Project Loved Team](Project_Loved_Team) | Reconnaître les beatmaps les plus appréciés par la communauté |
-| [Support Team](Support_Team) | Aide/Assistance aux demandes de fonctionnalités |
+| [Équipe du support](Support_Team) | Aide/Assistance aux demandes de fonctionnalités |
 
 ## Membres inactifs de l'équipe centrale
 

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -34,7 +34,7 @@ Les personnes énumérées ci-dessous constituent le noyau de l'**équipe d'osu!
 | ![][flag_US] [pishifat](https://osu.ppy.sh/users/3178418) | Conseiller sur le modding et le mapping, Organisateur de la Mappers' Guild, Sensibilisation des Featured Artist |
 | ![][flag_MX] [Repflez](https://osu.ppy.sh/users/201392) | Gouvernant général, mainteneur du wiki |
 | ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | Gouvernant général |
-| ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | développeur d'osu!, amateur d'osu!mania, chasseur de bugs |
+| ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | Développeur d'osu!, amateur d'osu!mania, chasseur de bugs |
 | ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Responsable du Project Loved, conseiller communautaire, Sensibilisation des Featured Artist |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Gouvernant général, assistant de tournoi |
 | ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Espèce en voie de disparition |
@@ -43,16 +43,16 @@ En plus de ce qui précède, l'[équipe de support aux comptes](Account_support_
 
 ## Groupes d'utilisateurs
 
-Les groupes d'utilisateurs suivants sont constitués de membres de la communauté osu! qui contribuent à la maintenance d'osu!. La plupart de ces groupes d'utilisateurs peuvent être reconnus grâce aux couleurs du forum, aux couleurs du tchat en jeu, aux titres des profils et/ou aux badges des profils.
+Les groupes d'utilisateurs suivants sont constitués de membres de la communauté d'osu! qui contribuent à la maintenance d'osu!. La plupart de ces groupes d'utilisateurs peuvent être reconnus grâce à leurs couleurs sur le forum, aux couleurs du tchat en jeu, aux titres des profils et/ou aux badges des profils.
 
 | Nom | Description |
 | :-- | :-- |
 | [Beatmap Nominators](Beatmap_Nominators) | Des utilisateurs qui vont au-delà de ce qui est demandé pour s'assurer que vos beatmaps sont qualifiées. |
 | [Developers](Developers) | Rendre le jeu génial en ajoutant de nouvelles fonctionnalités et en corrigeant les bugs. |
 | [Global Moderation Team](Global_Moderation_Team) | Surveiller les forums et le tchat en jeu. |
-| [Nomination Assessment Team](Nomination_Assessment_Team) | Gère les Beatmap Nominators |
-| [osu! Alumni](osu!_Alumni) | Ceux qui sont connus pour leur contribution et qui sont partis depuis lors |
-| [Project Loved Team](Project_Loved_Team) | Reconnaître les beatmaps les plus appréciés par la communauté |
+| [Nomination Assessment Team](Nomination_Assessment_Team) | Gérer les Beatmap Nominators |
+| [osu! Alumni](osu!_Alumni) | Connus pour leur contribution et qui sont partis depuis lors |
+| [Project Loved Team](Project_Loved_Team) | Reconnaître les beatmaps les plus appréciées par la communauté |
 | [Équipe du support](Support_Team) | Aide/Assistance aux demandes de fonctionnalités |
 
 ## Membres inactifs de l'équipe centrale
@@ -63,7 +63,7 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 | ![][flag_NO] [cYsmix](https://osu.ppy.sh/users/272870) | Concepteur audio, [official osu! Featured Artist](https://osu.ppy.sh/beatmaps/artists/2) |
 | ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Organisateur et administrateur de la World Cup |
 | ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) | Gouvernant général, Responsable de la communauté |
-| ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | développeur d'osu!, fournisseur de l'intégration IRC pour le chat en jeu, mainteneur du site. [Blog](http://blog.echo.sh/) |
+| ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | Développeur d'osu!, fournisseur de l'intégration IRC pour le chat en jeu, mainteneur du site. [Blog](http://blog.echo.sh/) |
 | ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Hôte de osu! Coffee Hour, Streamer de la World Cup, Organisateur de tournoi |
 | ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | développeur d'osu!, fournisseur d'osz2 et de backend p2p |
 | ![][flag_US] Jim | Concepteur original du site, fournisseur d'hébergement à ses débuts. [Brave New Games](http://www.bravegamer.com/) |
@@ -73,11 +73,11 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Conseiller sur le modding et le mapping |
 | ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | développeur d'osu!, créateur des mm sliders |
 | ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | Développeur d'osu! iPhone |
-| ![][flag_CA] [Nyquill](https://osu.ppy.sh/users/682935) | développeur d'osu!, Organisateur de la Mappers' Guild |
+| ![][flag_CA] [Nyquill](https://osu.ppy.sh/users/682935) | Développeur d'osu!, Organisateur de la Mappers' Guild |
 | ![][flag_AU] [phill](https://osu.ppy.sh/users/53) | Concepteur du forum |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter, fabricant de trucs cool - gars extraordinaire |
-| ![][flag_US] [Sarumaru](https://osu.ppy.sh/users/9427) | Concepteur de concepts et d'illustrations originales de Pippi. [DeviantArt](https://sarumaru.deviantart.com/) |
-| ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | Gestionnaire et leader de communauté initiale, compte-rendu de réunion et contributeur de la FAQ |
+| ![][flag_US] [Sarumaru](https://osu.ppy.sh/users/9427) | Créateur de concepts et d'illustrations originales de Pippi. [DeviantArt](https://sarumaru.deviantart.com/) |
+| ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | Gérant et leader de communauté initial, compte-rendu de réunion et contributeur de la FAQ |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | osu! et développeur pp |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Gouvernant général, Organisateur et administrateur de la World Cup, responsable du wiki |
 | ![][flag_CN] [woc2006](https://osu.ppy.sh/users/1105845) | développeur d'osu!, développeur du mode osu!mania |

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -100,5 +100,5 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 [flag_NL]: /wiki/shared/flag/NL.gif "Pays-Bas"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
 [flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle-Zélande"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
 [flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -37,9 +37,9 @@ Les personnes énumérées ci-dessous constituent le noyau de l'**équipe d'osu!
 | ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | développeur d'osu!, amateur d'osu!mania, chasseur de bugs |
 | ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Responsable du Project Loved, conseiller communautaire, Sensibilisation des Featured Artist |
 | ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Gouvernant général, assistant de tournoi |
-| ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Espèces menacées d'extinction |
+| ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Espèce en voie de disparition |
 
-En plus de ce qui précède, l'[équipe de soutien du compte](Account_support_team) est là pour aider à résoudre les problèmes hors de portée.
+En plus de ce qui précède, l'[équipe de support aux comptes](Account_support_team) est là pour aider à résoudre les problèmes hors de portée.
 
 ## Groupes d'utilisateurs
 

--- a/wiki/People/The_Team/fr.md
+++ b/wiki/People/The_Team/fr.md
@@ -65,13 +65,13 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 | ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) | Gouvernant général, Responsable de la communauté |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | Développeur d'osu!, fournisseur de l'intégration IRC pour le chat en jeu, mainteneur du site. [Blog](http://blog.echo.sh/) |
 | ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Hôte de osu! Coffee Hour, Streamer de la World Cup, Organisateur de tournoi |
-| ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | développeur d'osu!, fournisseur d'osz2 et de backend p2p |
+| ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | Développeur d'osu!, fournisseur d'osz2 et de backend p2p |
 | ![][flag_US] Jim | Concepteur original du site, fournisseur d'hébergement à ses débuts. [Brave New Games](http://www.bravegamer.com/) |
 | ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Organisateur et administrateur de la World Cup |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisateur et administrateur de la World Cup, Leader de la QAT, responsable de la communauté |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Concepteur de skin épique, contributeur au skin par défaut et au jeu d'icônes. [DeviantArt](https://luigihann.deviantart.com/) |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Conseiller sur le modding et le mapping |
-| ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | développeur d'osu!, créateur des mm sliders |
+| ![][flag_CA] [mm201](https://osu.ppy.sh/users/30655) | Développeur d'osu!, créateur des mm sliders |
 | ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | Développeur d'osu! iPhone |
 | ![][flag_CA] [Nyquill](https://osu.ppy.sh/users/682935) | Développeur d'osu!, Organisateur de la Mappers' Guild |
 | ![][flag_AU] [phill](https://osu.ppy.sh/users/53) | Concepteur du forum |
@@ -80,7 +80,7 @@ Les groupes d'utilisateurs suivants sont constitués de membres de la communaut�
 | ![][flag_GR] [Sinistro](https://osu.ppy.sh/users/5530) | Gérant et leader de communauté initial, compte-rendu de réunion et contributeur de la FAQ |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | osu! et développeur pp |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Gouvernant général, Organisateur et administrateur de la World Cup, responsable du wiki |
-| ![][flag_CN] [woc2006](https://osu.ppy.sh/users/1105845) | développeur d'osu!, développeur du mode osu!mania |
+| ![][flag_CN] [woc2006](https://osu.ppy.sh/users/1105845) | Développeur d'osu!, développeur du mode osu!mania |
 | ![][flag_JP] [yelle](https://osu.ppy.sh/users/4916903) | Gérant du [osu!store](https://osu.ppy.sh/store/listing) |
 | ![][flag_US] [ztrot](https://osu.ppy.sh/users/6347) | Professeur de la [osu!academy](/wiki/osu!academy), concepteur de médias et de personnages |
 

--- a/wiki/People/The_Team/osu!_Alumni/fr.md
+++ b/wiki/People/The_Team/osu!_Alumni/fr.md
@@ -267,7 +267,7 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
 [flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle-Zélande"
 [flag_PE]: /wiki/shared/flag/PE.gif "Pérou"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
 [flag_PL]: /wiki/shared/flag/PL.gif "Pologne"
 [flag_RU]: /wiki/shared/flag/RU.gif "Fédération de Russie"
 [flag_SE]: /wiki/shared/flag/SE.gif "Suède"

--- a/wiki/People/The_Team/osu!_Alumni/fr.md
+++ b/wiki/People/The_Team/osu!_Alumni/fr.md
@@ -1,14 +1,10 @@
----
-outdated: true
----
-
 # osu! Alumni
 
-Les **osu! Alumni** sont les personnes connues pour la contribution qu'ils ont eut avant de partir. Si les ressources étaient disponibles, nous érigerions une statue pour chaque membre sur la place publique.
+Les **osu! Alumni** sont ceux qui sont connus pour leurs contributions et qui sont partis depuis. Si les ressources étaient disponibles, nous érigerions une statue pour chaque membre sur la place de la ville.
 
-La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous les membres.
+La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de tous les membres.
 
-| Nom | Rôles passés |
+| Nom | Rôles antérieurs |
 | :-- | :-- |
 | ![][flag_IT] [-kevincela-](https://osu.ppy.sh/users/266596) | BAT, GMT |
 | ![][flag_ID] [-SiN-](https://osu.ppy.sh/users/10560) | Modérateur de tchat |
@@ -73,12 +69,12 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |
 | ![][flag_AR] [Extor](https://osu.ppy.sh/users/555) | BAT |
 | ![][flag_AU] [eyup](https://osu.ppy.sh/users/88) | BAT |
-| ![][flag_DE] [Ezoda](https://osu.ppy.sh/users/1231180) | Équipe de soutien |
+| ![][flag_DE] [Ezoda](https://osu.ppy.sh/users/1231180) | Équipe d'assistance |
 | ![][flag_SG] [Faust](https://osu.ppy.sh/users/65152) | BAT |
 | ![][flag_US] [foulcoon](https://osu.ppy.sh/users/19883) | BAT |
 | ![][flag_FI] [Fraeon](https://osu.ppy.sh/users/2271) | BAT |
 | ![][flag_TH] [Frostmourne](https://osu.ppy.sh/users/199669) | GMT, QAT |
-| ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | BAT, modérateur de tchat, GMT, QAT |
+| ![][flag_CN] [Fycho](https://osu.ppy.sh/users/1876867) | BAT, Modérateur de tchat, GMT, QAT |
 | ![][flag_CA] [Gabe](https://osu.ppy.sh/users/654108) | BAT, GMT, QAT |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | QAT |
 | ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) | QAT |
@@ -86,16 +82,16 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 | ![][flag_MX] [Gens](https://osu.ppy.sh/users/23062) | BAT |
 | ![][flag_BR] [ghm12](https://osu.ppy.sh/users/2594229) | GMT |
 | ![][flag_PE] [Gonzvlo](https://osu.ppy.sh/users/237733) | BAT |
-| ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, modérateur de tchat, QAT |
+| ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, Modérateur de tchat, QAT |
 | ![][flag_RU] [h3k1ru](https://osu.ppy.sh/users/291211) | GMT |
 | ![][flag_NL] [happy30](https://osu.ppy.sh/users/27767) | BAT |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Gestionnaire des tournois |
-| ![][flag_MY] [HeatKai](https://osu.ppy.sh/users/332555) | BAT, modérateur de tchat |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Gestion des tournois |
+| ![][flag_MY] [HeatKai](https://osu.ppy.sh/users/332555) | BAT, Modérateur de tchat |
 | ![][flag_TR] [heyronii](https://osu.ppy.sh/users/5642779) | GMT |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | GMT |
 | ![][flag_US] [Hitoshirenu Shourai](https://osu.ppy.sh/users/602) | BAT |
 | ![][flag_US] [Hobbes2](https://osu.ppy.sh/users/8157492) | QAT |
-| ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) | BAT, modérateur de tchat, GMT, QAT |
+| ![][flag_HK] [IamKwaN](https://osu.ppy.sh/users/1856463) | BAT, Modérateur de tchat, GMT, QAT |
 | ![][flag_RU] [IceBeam](https://osu.ppy.sh/users/208440) | BAT |
 | ![][flag_CN] [ignorethis](https://osu.ppy.sh/users/27343) | BAT |
 | ![][flag_IT] [Inamaru](https://osu.ppy.sh/users/76382) | GMT |
@@ -106,16 +102,16 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 | ![][flag_US] [James2250](https://osu.ppy.sh/users/16978) | GMT |
 | ![][flag_GB] [jericho2442](https://osu.ppy.sh/users/88904) | BAT |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | BAT |
-| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Gestionnaire des tournois |
+| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Gestion des tournois |
 | ![][flag_MX] [Kai](https://osu.ppy.sh/users/4537) | BAT |
-| ![][flag_CA] [karterfreak](https://osu.ppy.sh/users/1031958) | GMT, créateur de osu!media |
+| ![][flag_CA] [karterfreak](https://osu.ppy.sh/users/1031958) | GMT, Créateur de osu!media |
 | ![][flag_KR] [Kawayi Rika](https://osu.ppy.sh/users/596298) | BAT |
 | ![][flag_MX] [Kenezz](https://osu.ppy.sh/users/167050) | BAT |
 | ![][flag_TH] [Kharl](https://osu.ppy.sh/users/452) | BAT |
 | ![][flag_US] [kingcobra52](https://osu.ppy.sh/users/9934) | BAT |
 | ![][flag_AU] [kingking9](https://osu.ppy.sh/users/1277097) | GMT |
 | ![][flag_CA] [Kitokofox](https://osu.ppy.sh/users/1815420) | Modérateur de tchat |
-| ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | BAT, modérateur de tchat, GMT, QAT |
+| ![][flag_FR] [Kurai](https://osu.ppy.sh/users/77089) | BAT, Modérateur de tchat, GMT, QAT |
 | ![][flag_FR] [Krah](https://osu.ppy.sh/users/1436748) | BAT, GMT, QAT |
 | ![][flag_CL] [Krisom](https://osu.ppy.sh/users/99269) | BAT |
 | ![][flag_KR] [KRZY](https://osu.ppy.sh/users/114017) | Modérateur de tchat |
@@ -168,11 +164,11 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 | ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | osu!dev |
 | ![][flag_CN] [Nymph](https://osu.ppy.sh/users/601990) | BAT |
 | ![][flag_CN] [Nyquill](https://osu.ppy.sh/users/682935) | BAT, GMT |
-| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | Modérateur de tchat, équipe de soutien |
+| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | Modérateur de tchat, Équipe d'assistance |
 | ![][flag_TH] [orioncomet](https://osu.ppy.sh/users/104827) | BAT |
 | ![][flag_FI] [Orkel](https://osu.ppy.sh/users/39385) | Modérateur de tchat |
 | ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345) | BAT |
-| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT, équipe de soutien |
+| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT, Équipe d'assistance |
 | ![][flag_NL] [Pittigbaasje](https://osu.ppy.sh/users/2167433) | GMT |
 | ![][flag_HK] [Pokie](https://osu.ppy.sh/users/207340) | BAT |
 | ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) | BAT |
@@ -219,16 +215,16 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Modérateur de tchat |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, équipe de soutien |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, Équipe d'assistance |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
-| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | GMT, gestionnaire des tournois |
+| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | GMT, Gestion des tournois |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |
 | ![][flag_ID] [Winshley](https://osu.ppy.sh/users/864895) | Modérateur de tchat |
 | ![][flag_HK] [wmfchris](https://osu.ppy.sh/users/7401) | BAT |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | BAT |
 | ![][flag_CN] [xierbaliti](https://osu.ppy.sh/users/34044) | BAT |
-| ![][flag_FR] [XPJ38](https://osu.ppy.sh/users/273531) | Équipe de soutien |
+| ![][flag_FR] [XPJ38](https://osu.ppy.sh/users/273531) | Équipe d'assistance |
 | ![][flag_SE] [Xytox](https://osu.ppy.sh/users/2229274) | GMT |
 | ![][flag_FR] [yaya](https://osu.ppy.sh/users/50163) | BAT |
 | ![][flag_US] [yeahyeahyeahhh](https://osu.ppy.sh/users/58042) | MAT |
@@ -255,7 +251,7 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 [flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
 [flag_FI]: /wiki/shared/flag/FI.gif "Finlande"
 [flag_FR]: /wiki/shared/flag/FR.gif "France"
-[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Unis"
+[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"
 [flag_GR]: /wiki/shared/flag/GR.gif "Grèce"
 [flag_HK]: /wiki/shared/flag/HK.gif "Hong Kong"
 [flag_HR]: /wiki/shared/flag/HR.gif "Croatie"
@@ -273,12 +269,12 @@ La [page de groupe des osu! Alumni](https://osu.ppy.sh/groups/16) liste de tous 
 [flag_PE]: /wiki/shared/flag/PE.gif "Pérou"
 [flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
 [flag_PL]: /wiki/shared/flag/PL.gif "Pologne"
-[flag_RU]: /wiki/shared/flag/RU.gif "Russie"
+[flag_RU]: /wiki/shared/flag/RU.gif "Fédération de Russie"
 [flag_SE]: /wiki/shared/flag/SE.gif "Suède"
 [flag_SG]: /wiki/shared/flag/SG.gif "Singapour"
 [flag_TH]: /wiki/shared/flag/TH.gif "Thaïlande"
 [flag_TR]: /wiki/shared/flag/TR.gif "Turquie"
-[flag_TW]: /wiki/shared/flag/TW.gif "Taïwan"
+[flag_TW]: /wiki/shared/flag/TW.gif "Taiwan"
 [flag_US]: /wiki/shared/flag/US.gif "États-Unis"
 [flag_UY]: /wiki/shared/flag/UY.gif "Uruguay"
 [flag_ZA]: /wiki/shared/flag/ZA.gif "Afrique du Sud"

--- a/wiki/People/The_Team/osu!_Alumni/fr.md
+++ b/wiki/People/The_Team/osu!_Alumni/fr.md
@@ -267,7 +267,7 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 [flag_NO]: /wiki/shared/flag/NO.gif "Norvège"
 [flag_NZ]: /wiki/shared/flag/NZ.gif "Nouvelle-Zélande"
 [flag_PE]: /wiki/shared/flag/PE.gif "Pérou"
-[flag_PH]: /wiki/shared/flag/PH.gif "Philippine"
+[flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
 [flag_PL]: /wiki/shared/flag/PL.gif "Pologne"
 [flag_RU]: /wiki/shared/flag/RU.gif "Fédération de Russie"
 [flag_SE]: /wiki/shared/flag/SE.gif "Suède"

--- a/wiki/People/The_Team/osu!_Alumni/fr.md
+++ b/wiki/People/The_Team/osu!_Alumni/fr.md
@@ -1,6 +1,6 @@
 # osu! Alumni
 
-Les **osu! Alumni** sont ceux qui sont connus pour leurs contributions et qui sont partis depuis. Si les ressources étaient disponibles, nous érigerions une statue pour chaque membre sur la place de la ville.
+Les **osu! Alumni** sont les utilisateurs qui sont connus pour leurs contributions et qui sont partis depuis. Si nous avions de quoi le faire, nous érigerions une statue pour chaque membre sur la place de la ville.
 
 La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de tous les membres.
 
@@ -69,7 +69,7 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 | ![][flag_MY] [ExPew](https://osu.ppy.sh/users/665612) | QAT |
 | ![][flag_AR] [Extor](https://osu.ppy.sh/users/555) | BAT |
 | ![][flag_AU] [eyup](https://osu.ppy.sh/users/88) | BAT |
-| ![][flag_DE] [Ezoda](https://osu.ppy.sh/users/1231180) | Équipe d'assistance |
+| ![][flag_DE] [Ezoda](https://osu.ppy.sh/users/1231180) | Équipe du support |
 | ![][flag_SG] [Faust](https://osu.ppy.sh/users/65152) | BAT |
 | ![][flag_US] [foulcoon](https://osu.ppy.sh/users/19883) | BAT |
 | ![][flag_FI] [Fraeon](https://osu.ppy.sh/users/2271) | BAT |

--- a/wiki/People/The_Team/osu!_Alumni/fr.md
+++ b/wiki/People/The_Team/osu!_Alumni/fr.md
@@ -164,11 +164,11 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 | ![][flag_US] [nuudles](https://osu.ppy.sh/users/21312) | osu!dev |
 | ![][flag_CN] [Nymph](https://osu.ppy.sh/users/601990) | BAT |
 | ![][flag_CN] [Nyquill](https://osu.ppy.sh/users/682935) | BAT, GMT |
-| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | Modérateur de tchat, Équipe d'assistance |
+| ![][flag_AU] [Oinari-sama](https://osu.ppy.sh/users/405508) | Modérateur de tchat, Équipe du support |
 | ![][flag_TH] [orioncomet](https://osu.ppy.sh/users/104827) | BAT |
 | ![][flag_FI] [Orkel](https://osu.ppy.sh/users/39385) | Modérateur de tchat |
 | ![][flag_SG] [Pasonia](https://osu.ppy.sh/users/43345) | BAT |
-| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT, Équipe d'assistance |
+| ![][flag_CA] [Pawsu](https://osu.ppy.sh/users/2371454) | GMT, Équipe du support |
 | ![][flag_NL] [Pittigbaasje](https://osu.ppy.sh/users/2167433) | GMT |
 | ![][flag_HK] [Pokie](https://osu.ppy.sh/users/207340) | BAT |
 | ![][flag_CN] [popner](https://osu.ppy.sh/users/759860) | BAT |
@@ -215,7 +215,7 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 | ![][flag_AU] [tsububu](https://osu.ppy.sh/users/61) | BAT |
 | ![][flag_TR] [UnderminE](https://osu.ppy.sh/users/444223) | Modérateur de tchat |
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
-| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, Équipe d'assistance |
+| ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, Équipe du support |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | GMT, Gestion des tournois |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
@@ -224,7 +224,7 @@ La page [osu! Alumni group page](https://osu.ppy.sh/groups/16) donne la liste de
 | ![][flag_HK] [wmfchris](https://osu.ppy.sh/users/7401) | BAT |
 | ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661) | BAT |
 | ![][flag_CN] [xierbaliti](https://osu.ppy.sh/users/34044) | BAT |
-| ![][flag_FR] [XPJ38](https://osu.ppy.sh/users/273531) | Équipe d'assistance |
+| ![][flag_FR] [XPJ38](https://osu.ppy.sh/users/273531) | Équipe du support |
 | ![][flag_SE] [Xytox](https://osu.ppy.sh/users/2229274) | GMT |
 | ![][flag_FR] [yaya](https://osu.ppy.sh/users/50163) | BAT |
 | ![][flag_US] [yeahyeahyeahhh](https://osu.ppy.sh/users/58042) | MAT |


### PR DESCRIPTION
Update of the translations of the following wiki pages:

- `People/The_Team/Support_Team`
- `People/The_Team`
- `People/The_Team/osu!_Alumni`