### PR TITLE
Update `Project Loved` and `Project Loved Team`

### DIFF
--- a/wiki/People/The_Team/Project_Loved_Team/en.md
+++ b/wiki/People/The_Team/Project_Loved_Team/en.md
@@ -6,7 +6,9 @@ tags:
 
 # Project Loved Team
 
-The **Project Loved Team** are members of the osu! community who manage [Project Loved](/wiki/Project_Loved), the voting platform that promotes [beatmaps](/wiki/Beatmap) to the [Loved](/wiki/Beatmap/Category#loved) category.
+The **Project Loved Team** are members of the osu! community who manage [Project Loved](/wiki/Project_Loved), the voting platform that promotes [beatmaps](/wiki/Beatmap) to the [Loved](/wiki/Beatmap/Category#loved) category. They are distinguished by their usergroup badge that reads `LVD` and the username colour that is candy pink on the forums.
+
+The [Project Loved group page](https://osu.ppy.sh/groups/31) lists all of the team members.
 
 ## Captains
 
@@ -35,8 +37,8 @@ The Project Loved Team mostly consists of *captains* for each [game mode](/wiki/
 
 ### osu!mania
 
+- ![][flag_PL] [\_underjoy](https://osu.ppy.sh/users/2235750)
 - ![][flag_US] [-mint-](https://osu.ppy.sh/users/8976576)
-- ![][flag_SG] [Abraxos](https://osu.ppy.sh/users/5025064)
 - ![][flag_US] [Alter-](https://osu.ppy.sh/users/4980256)
 - ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754)
 - ![][flag_US] [Penguinosity](https://osu.ppy.sh/users/10235296)
@@ -47,6 +49,7 @@ The Project Loved Team mostly consists of *captains* for each [game mode](/wiki/
 Coordinators are mainly responsible for making sure all the captains work together to run Project Loved smoothly. They write news and forum posts, maintain tools, and help moderate discussions about Loved.
 
 - ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237)
+- ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983)
 
 ## Beatmap metadata reviewers
 
@@ -58,8 +61,19 @@ Metadata reviewers check through every beatmap that will be put up for voting, a
 - ![][flag_ES] [Nikolayio](https://osu.ppy.sh/users/11279465)
 - ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
 - ![][flag_ES] [RandomeLoL](https://osu.ppy.sh/users/7080063)
+- ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
 
-## Alumni
+## Beatmap content moderators
+
+Content moderators consist of dedicated [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) and [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) members that take part in the assessment of the visual and aural content included in the beatmaps that will be put up for voting.
+
+- ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
+- ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983)
+- ![][flag_TR] [Zeus-](https://osu.ppy.sh/users/5464437)
+
+## Retired members
+
+Below listed are the users, who once were a part of the Project Loved Team.
 
 ### Coordinators
 
@@ -101,7 +115,7 @@ Metadata reviewers check through every beatmap that will be put up for voting, a
 
 ### osu!mania captains
 
-- ![][flag_PL] [\_underjoy](https://osu.ppy.sh/users/2235750)
+- ![][flag_SG] [Abraxos](https://osu.ppy.sh/users/5025064)
 - ![][flag_ES] [aitor98](https://osu.ppy.sh/users/3154852)
 - ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992)
 - ![][flag_PL] [Kamikaze](https://osu.ppy.sh/users/2124783)
@@ -118,7 +132,7 @@ Metadata reviewers check through every beatmap that will be put up for voting, a
 ## Trivia
 
 - ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) created the original team of captains in September 2017 along with the [Captain's Pick](/wiki/Beatmap/History_of_Loved#captain's-pick-and-project-loved-(sep-2017-–-present)) system that was later renamed to Project Loved. Until late 2019, he oversaw and managed the whole project.
-- There is a Project Loved user group on the website with group ID 31, but the listing is not public. It is used for permissions to moderate the [Project Loved forum](https://osu.ppy.sh/community/forums/120) and promote beatmaps to the Loved category.
+- Prior to the 28th of April, 2021, the [Project Loved group page](https://osu.ppy.sh/groups/31) was not public and used only for administrational purposes. As of now, it is publicly available.
   - Until the 16th of April, 2021, the only people that had been in the group were ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350), ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), and ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689). Now, all of the Project Loved Team belongs to the group.
 
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
@@ -140,5 +154,6 @@ Metadata reviewers check through every beatmap that will be put up for voting, a
 [flag_RU]: /wiki/shared/flag/RU.gif "Russian Federation"
 [flag_SE]: /wiki/shared/flag/SE.gif "Sweden"
 [flag_SG]: /wiki/shared/flag/SG.gif "Singapore"
+[flag_TR]: /wiki/shared/flag/TR.gif "Turkey"
 [flag_TW]: /wiki/shared/flag/TW.gif "Taiwan"
 [flag_US]: /wiki/shared/flag/US.gif "United States"

--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 4374cc74effc623b50c0810086911cce5cbf129e
 tags:
   - captain
   - captains

--- a/wiki/People/The_Team/Project_Loved_Team/id.md
+++ b/wiki/People/The_Team/Project_Loved_Team/id.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 4374cc74effc623b50c0810086911cce5cbf129e
 tags:
   - captain
   - captains

--- a/wiki/People/The_Team/Project_Loved_Team/tr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/tr.md
@@ -8,7 +8,9 @@ tags:
 
 # Project Loved Takımı
 
-**Project Loved Takımı**, [beatmaplerin](/wiki/Beatmap) [Sevilen](/wiki/Beatmap/Category#loved) kategorisine eklenmesini sağlayan oylama platformu olan [Project Loved](/wiki/Project_Loved)'ı yöneten osu! topluluğu üyeleridir.
+**Project Loved Takımı**, [beatmaplerin](/wiki/Beatmap) [Sevilen](/wiki/Beatmap/Category#loved) kategorisine eklenmesini sağlayan oylama platformu olan [Project Loved](/wiki/Project_Loved)'ı yöneten osu! topluluğu üyeleridir. Onlar, forumlarda şeker pembesi olan isim renkleri ve `LVD` yazan kullanıcı grubu rozetleri ile ayırt edilirler.
+
+[Project Loved grup sayfası](https://osu.ppy.sh/groups/31) tüm takım üyelerini listeler.
 
 ## Kaptanlar
 
@@ -37,8 +39,8 @@ Project Loved Takımının çoğunluğunu her bir [oyun modunun](/wiki/Game_mode
 
 ### osu!mania
 
+- ![][flag_PL] [\_underjoy](https://osu.ppy.sh/users/2235750)
 - ![][flag_US] [-mint-](https://osu.ppy.sh/users/8976576)
-- ![][flag_SG] [Abraxos](https://osu.ppy.sh/users/5025064)
 - ![][flag_US] [Alter-](https://osu.ppy.sh/users/4980256)
 - ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754)
 - ![][flag_US] [Penguinosity](https://osu.ppy.sh/users/10235296)
@@ -49,6 +51,7 @@ Project Loved Takımının çoğunluğunu her bir [oyun modunun](/wiki/Game_mode
 Koordinatörler temel olarak Project Loved'ın düzgünce işlemesi için tüm kaptanların bir uyum içerisinde çalışıp çalışmadıklarından sorumludurlar. Onlar haber ve forum gönderilerini yazarlar, araç-gereçleri idare ederler, ve Sevilen kategorisiyle ilgili tartışmaların moderasyonunda yardımcı olurlar.
 
 - ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237)
+- ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983)
 
 ## Beatmap metaverisi denetçileri
 
@@ -60,8 +63,17 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 - ![][flag_ES] [Nikolayio](https://osu.ppy.sh/users/11279465)
 - ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
 - ![][flag_ES] [RandomeLoL](https://osu.ppy.sh/users/7080063)
+- ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
 
-## Emekliler
+## Beatmap içeriği moderatörleri
+
+İçerik moderatörleri, kendilerini oylamaya sürülecek olan beatmaplerde bulunan görsel ve işitsel içerikleri denetlemeye adamış [Küresel Moderasyon Takımı](/wiki/People/The_Team/Global_Moderation_Team) ve [Aday Gösterme Denetleme Takımı](/wiki/People/The_Team/Nomination_Assessment_Team) üyelerinden oluşur.
+
+- ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323)
+- ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983)
+- ![][flag_TR] [Zeus-](https://osu.ppy.sh/users/5464437)
+
+## Emekli üyeler
 
 ### Koordinatörler
 
@@ -103,7 +115,7 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 
 ### osu!mania kaptanları
 
-- ![][flag_PL] [\_underjoy](https://osu.ppy.sh/users/2235750)
+- ![][flag_SG] [Abraxos](https://osu.ppy.sh/users/5025064)
 - ![][flag_ES] [aitor98](https://osu.ppy.sh/users/3154852)
 - ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992)
 - ![][flag_PL] [Kamikaze](https://osu.ppy.sh/users/2124783)
@@ -120,7 +132,7 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 ## Ek bilgiler
 
 - ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) orijinal kaptanlar takımını Eylül 2017'de, daha sonra Project Loved ismini alacak olan [Captain's Pick](/wiki/Beatmap/History_of_Loved#captain's-pick-and-project-loved-(sep-2017-–-present)) sistemiyle birlikte oluşturdu. 2019'un sonlarına dek, tüm projeyi gözlemledi ve yönetti.
-- Web sitesinde grup ID'si 31 olan bir Project Loved kullanıcı grubu bulunmaktadır, ancak liste herkese açık değildir. Bu liste [Project Loved forumunun](https://osu.ppy.sh/community/forums/120) moderasyon yetkileri ve beatmaplerin Sevilen kategorisine yükseltilmesinde kullanılır.
+- 28 Nisan 2021 tarihinden önce, [Project Loved grup sayfası](https://osu.ppy.sh/groups/31) herkese açık değildi ve yalnızca yönetimsel amaçlar için kullanılmaktaydı. An itibariyle bu sayfa herkese açık bir şekilde mevcut.
   - 16 Nisan 2021 tarihine kadar bu grupta yalnızca ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350), ![][flag_LT] [huu](https://osu.ppy.sh/users/6044237), ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707), ve ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) bulunmaktaydı. Artık Project Loved Takımının tamamı bu grubun birer üyesidir.
 
 [flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
@@ -142,5 +154,6 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 [flag_RU]: /wiki/shared/flag/RU.gif "Rusya Federasyonu"
 [flag_SE]: /wiki/shared/flag/SE.gif "İsveç"
 [flag_SG]: /wiki/shared/flag/SG.gif "Singapur"
+[flag_TR]: /wiki/shared/flag/TR.gif "Türkiye"
 [flag_TW]: /wiki/shared/flag/TW.gif "Tayvan"
 [flag_US]: /wiki/shared/flag/US.gif "Birleşik Devletler"

--- a/wiki/People/The_Team/Project_Loved_Team/tr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/tr.md
@@ -75,6 +75,8 @@ Metaveri denetçileri oylamaya sunulacak her bir mapi kontrol eder, ve mapperlar
 
 ## Emekli üyeler
 
+Aşağıda listelenen kullanıcılar bir zamanlar Project Loved Takımının bir parçasıydı.
+
 ### Koordinatörler
 
 - ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350)

--- a/wiki/Project_Loved/en.md
+++ b/wiki/Project_Loved/en.md
@@ -28,7 +28,7 @@ There are some very minimal criteria that need to be met for beatmaps to be nomi
 - Its creator is neither banned nor restricted
 - At least one difficulty can be passed
 - It has at least 30 favourites (only applies to osu! maps)
-- Every difficulty has at least 30 seconds of [drain time](/wiki/Gameplay/Drain_time)
+- Every nominated difficulty has at least 30 seconds of [drain time](/wiki/Gameplay/Drain_time)
 
 However, despite nearly all [Pending and Work-in-progress](/wiki/Beatmap/Category#work-in-progress-and-pending) maps meeting these criteria, few are voted into the Loved category due to the more selective nomination and voting requirements.
 

--- a/wiki/Project_Loved/en.md
+++ b/wiki/Project_Loved/en.md
@@ -38,6 +38,8 @@ Beatmaps entering the Loved category are required to follow some additional rule
 - [Song Content Rules](/wiki/Rules/Song_Content_Rules)
 - [Visual Content Considerations](/wiki/Rules/Visual_Content_Considerations)
 
+Additionally, in order to keep the audio quality of the song at a reasonable level, beatmap's audio files should be from the highest quality source available while having an average bit rate no greater than 192kbps.
+
 Any problems with these rules are usually sorted out while the map is up for voting.
 
 ### Nomination priority

--- a/wiki/Project_Loved/id.md
+++ b/wiki/Project_Loved/id.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 4374cc74effc623b50c0810086911cce5cbf129e
+---
+
 # Project Loved
 
 **Project Loved** adalah platform/wadah pemungutan suara yang mempromosikan beatmap ke kategori [Loved](/wiki/Beatmap/Category#loved). Program ini dijalankan oleh [Project Loved Team](/wiki/People/Project_Loved_Team).

--- a/wiki/Project_Loved/ru.md
+++ b/wiki/Project_Loved/ru.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 4374cc74effc623b50c0810086911cce5cbf129e
+---
+
 # Project Loved
 
 **Project Loved** (*проект «Любимые карты»*, также *«Лавд»*) — это платформа для голосования, через которую карты попадают в категорию [Loved](/wiki/Beatmap/Category#loved). Проектом управляет [одноимённая команда](/wiki/People/The_Team/Project_Loved_Team).

--- a/wiki/Project_Loved/tr.md
+++ b/wiki/Project_Loved/tr.md
@@ -28,7 +28,7 @@ Beatmaplerin Sevilen kategorisine aday gösterilebilmesi için karşılaması ge
 - Yaratıcısı banlı ya da kısıtlı olmamalı.
 - En az bir zorluğun geçilebilir olmalı.
 - En az 30 favoriye sahip olmalı (sadece osu! mapleri için geçerlidir)
-- Her zorluk en az 30 saniyelik [akış süresine](/wiki/Gameplay/Drain_time) sahip olmalı.
+- Aday gösterilen her zorluk en az 30 saniyelik [akış süresine](/wiki/Gameplay/Drain_time) sahip olmalı.
 
 Ancak, neredeyse tüm [Beklemede ve Yapım aşamasındaki](/wiki/Beatmap/Category#work-in-progress-and-pending) maplerin bu kriterlere uymasına rağmen, nispeten daha seçici aday gösterme ve oylama gereksinimlerinden dolayı yalnızca birkaçı Sevilen kategorisine eklenmesi için oylanır.
 

--- a/wiki/Project_Loved/tr.md
+++ b/wiki/Project_Loved/tr.md
@@ -38,6 +38,8 @@ Sevilen kategorisine giren beatmapler birtakım ek kuralları takip etmek zorund
 - [Şarkı İçeriği Kuralları](/wiki/Rules/Song_Content_Rules)
 - [Görsel İçerik Hususları](/wiki/Rules/Visual_Content_Considerations)
 
+Ek olarak, şarkının ses kalitesini kabul edilebilir bir seviyede tutmak adına, beatmapin ses dosyaları 192kbps bit oranından yüksek olmaksızın mümkün olan en kaliteli kaynaktan edinilmelidir.
+
 Bu kurallarla ilgili oluşan sorunlar genellikle map oylamaya açıkken çözüme kavuşturulur.
 
 ### Aday gösterme önceliği

--- a/wiki/Project_Loved/uk.md
+++ b/wiki/Project_Loved/uk.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 4374cc74effc623b50c0810086911cce5cbf129e
+---
+
 # Project Loved
 
 **Project Loved** (*проект «Улюблені Мапи»*, також *«Лавед»*) — це платформа для голосування, через яку мапи потрапляють у категорію [Loved](/wiki/Beatmap/Category#loved). Проектом управляє [одноименна команда](/wiki/People/The_Team/Project_Loved_Team).


### PR DESCRIPTION
This pull request contains the following changes:
- in [Project Loved](https://osu.ppy.sh/wiki/Project_Loved) page
  -  apply a minor change in drain time requirements
- in [Project Loved Team](https://osu.ppy.sh/wiki/People/The_Team/Project_Loved_Team) page
  - add information regarding the usergroup badges and colour
  - apply usergroup changes\*
    - add Pachiru to Coordinators
    - add UberFazz to Metadata reviewers 
    - move _underjoy to osu!mania captains
    - move Abraxos to Retired members
  - add a section for Content moderators
  - rename "Alumni" to "Retired members" and add a brief introduction
  - rewrite the trivia about the group ID 31 not being public (it's public now)
- update the Turkish locales accordingly
- outdate translations

@huuishuu please check if anything should be added/changed
  
\*: Staff Log will be updated accordingly alongside other usergroup changes in the following days