### PR TITLE
Add `Beatmap Spotlights Season 4 (Spring 2021)` B, C and D Playlists

### DIFF
--- a/wiki/Beatmap_Spotlights/Seasons/2021_Spring/en.md
+++ b/wiki/Beatmap_Spotlights/Seasons/2021_Spring/en.md
@@ -51,6 +51,30 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Cranky - Libera me (Kloyd) \[Expert\]](https://osu.ppy.sh/beatmapsets/1085726#osu/2270319)
 - [Rigel Theatre - Lurie (DeviousPanda) \[A Story Through Music\]](https://osu.ppy.sh/beatmapsets/909302#osu/1897497)
 
+#### Playlist B
+
+- [Masahiro "Godspeed" Aoki - Blaze (Niva) \[Hard\]](https://osu.ppy.sh/beatmapsets/1323877#osu/2756022)
+- [Polyphia - G.O.A.T. (Mir) \[Yukiyo's Insane\]](https://osu.ppy.sh/beatmapsets/1187509#osu/2810141)
+- [zts - worldenddominator (deetz) \[Last Stand\]](https://osu.ppy.sh/beatmapsets/897884#osu/1875707)
+- [Hana - Gekka Jasmine (2014ver.) (PinkHeart) \[Jasmine\]](https://osu.ppy.sh/beatmapsets/408745#osu/887502)
+- [THE ORAL CIGARETTES - Slowly but surely I go on (help) \[Expert\]](https://osu.ppy.sh/beatmapsets/1212436#osu/2718073)
+
+#### Playlist C
+
+- [3L - Amoritachite Kami To Miyu (TicClick) \[Hard\]](https://osu.ppy.sh/beatmapsets/198034#osu/469800)
+- [kors k - Love Is Eternity (PandaHero) \[Another\]](https://osu.ppy.sh/beatmapsets/836980#osu/1752575)
+- [Halozy - 143 (extended mix) (celerih) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/1132649#osu/2365788)
+- [Rohi - Kanata ni Mau wa Sakura no Shirabe (NatsumeRin) \[RLQuillab Insane\]](https://osu.ppy.sh/beatmapsets/93555#osu/267773)
+- [Venetian Snares - My Half (fergas) \[Downfall\]](https://osu.ppy.sh/beatmapsets/1286665#osu/2671403)
+
+#### Playlist D
+
+- [Mizuki Nana - PHANTOM MINDS (Lasse) \[Hard\]](https://osu.ppy.sh/beatmapsets/1301407#osu/2699267)
+- [Natsushiro Takaaki - Near feat. Hatsune Miku (\[Hatsune Miku\]) \[Time Machine\]](https://osu.ppy.sh/beatmapsets/1284534#osu/2667326)
+- [Gekidan Record feat. Nekomata Master - Houkou Orpheus (DeviousPanda) \[Mystery\]](https://osu.ppy.sh/beatmapsets/1257522#osu/2613064)
+- [NIWASHI - Playing with Ruby (Down) \[Extreme\]](https://osu.ppy.sh/beatmapsets/1306570#osu/2708983)
+- [The Smiths - This Charming Man (dsco) \[Wonder\]](https://osu.ppy.sh/beatmapsets/1241923#osu/2581938)
+
 ### osu!taiko
 
 #### Playlist A
@@ -60,6 +84,30 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [knapsack - retrograde (Ulqui) \[lonely\]](https://osu.ppy.sh/beatmapsets/1283361#taiko/2665243)
 - [Ono Hideyuki - sola (Mapper 31) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/131347#taiko/330868)
 - [Otogibara Era, Warabeda Meiji - 1+1 de Q.E.D.!! (taiko\_ryuki) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/1107475#taiko/2318105)
+
+#### Playlist B
+
+- [Lite Show Magic (t+pazolite vs C-Show) - Crack Traxxxx (Fatfan Kolek) \[TK'S Muzukashii\]](https://osu.ppy.sh/beatmapsets/139525#taiko/361158)
+- [EastNewSound - Hana wa Gensou no Hate Ni (\_Gezo\_) \[Oni\]](https://osu.ppy.sh/beatmapsets/290314#taiko/654058)
+- [Sound Souler - Aqua Stars (eiri-) \[Oni\]](https://osu.ppy.sh/beatmapsets/1204476#taiko/2508101)
+- [pm04034 - Nonspeed (Axer) \[inner oni\]](https://osu.ppy.sh/beatmapsets/1134649#taiko/2387792)
+- [BlackY - Nobodyknows Eden (namaniku) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/768440#taiko/1722532)
+
+#### Playlist C
+
+- [Amon Amarth - Shield Wall (frukoyurdakul) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/1327059#taiko/2750895)
+- [Chroma - tiny tales continue (ensan71714) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/785389#taiko/1648625)
+- [Nana Takahashi - The Party We Have Never Seen (jonathanlfj) \[Nwolf's Oni\]](https://osu.ppy.sh/beatmapsets/405516#taiko/930303)
+- [Nakiri Ayame - Deep Indigo (\[Zeth\]) \[Oni\]](https://osu.ppy.sh/beatmapsets/1194116#taiko/2494752)
+- [Zekk - Ashes (Faputa) \[Activation\]](https://osu.ppy.sh/beatmapsets/1144916#taiko/2390371)
+
+#### Playlist D
+
+- [Silentroom - Nhelv (Nifty) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/928849#taiko/1947270)
+- [t+pazolite - seedy try (Stingy) \[oni\]](https://osu.ppy.sh/beatmapsets/680385#taiko/1438644)
+- [lapix - Carry Me Away (Extended Mix) (Konpaku Sariel) \[Oni\]](https://osu.ppy.sh/beatmapsets/1228198#taiko/2559014)
+- [Kobaryo - Invisible Frenzy (Cychloryn) \[Oni\]](https://osu.ppy.sh/beatmapsets/1083165#taiko/2268907)
+- [Fear, and Loathing in Las Vegas - Rave-Up Tonight (qoot8123) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/244532#taiko/563660)
 
 ### osu!catch
 
@@ -71,6 +119,30 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Amuro vs. Killer - Mei (Camellia's "Yomigae" Remix) (Spectator) \[Rain\]](https://osu.ppy.sh/beatmapsets/1246989#fruits/2653218)
 - [IAHN - Melody of Heaven (Original Mix) (JBHyperion) \[Team Russian Federation's Overdose\]](https://osu.ppy.sh/beatmapsets/1025255#fruits/2144404)
 
+#### Playlist B
+
+- [Kalafina - believe (CLSW) \[Platter\]](https://osu.ppy.sh/beatmapsets/316647#fruits/705528)
+- [Tsukasa - One Way Love (Dapuluous) \[Love\]](https://osu.ppy.sh/beatmapsets/1290396#fruits/2678699)
+- [Nanawo Akari - One Room Sugar Life (Spectator) \[Rain\]](https://osu.ppy.sh/beatmapsets/1286432#fruits/2671349)
+- [Creo - Challenger (Rocma) \[Challenge\]](https://osu.ppy.sh/beatmapsets/966240#fruits/2022498)
+- [ZUTOMAYO - Humanoid (Jemzuu) \[Liyac's Overdose\]](https://osu.ppy.sh/beatmapsets/1052572#fruits/2552702)
+
+#### Playlist C
+
+- [Zekk - SUMMER (Spectator) \[Platter\]](https://osu.ppy.sh/beatmapsets/1393068#fruits/2894330)
+- [Sakuzyo - Magical Musical Master (Rocma) \[Nelly's Rain\]](https://osu.ppy.sh/beatmapsets/1097927#fruits/2315442)
+- [Disasterpeace - Home (JBHyperion) \[Rain\]](https://osu.ppy.sh/beatmapsets/1195922#fruits/2491271)
+- [siqlo - Me & U (Jemzuu) \[Rain\]](https://osu.ppy.sh/beatmapsets/1225300#fruits/2554078)
+- [Synthion - Aurora (wonjae) \[Polaris\]](https://osu.ppy.sh/beatmapsets/1290796#fruits/2679394)
+
+#### Playlist D
+
+- [Feryquitous feat. Sennzai - Rugie (Jemzuu) \[Platter\]](https://osu.ppy.sh/beatmapsets/1338217#fruits/2772123)
+- [Masayoshi Minoshima feat. Ayakura Mei - Lionheart (Secre) \[Heart of Lions\]](https://osu.ppy.sh/beatmapsets/1142369#fruits/2385749)
+- [Raujika - Cry More (Benita) \[Lacrima's Reminiscence\]](https://osu.ppy.sh/beatmapsets/974743#fruits/2414897)
+- [Akiyama Uni - Kanpan Tasogare Shinbun (Ascendance) \[Dance of the Empty-Hearted\]](https://osu.ppy.sh/beatmapsets/633255#fruits/1344066)
+- [xi - Titania (Jemzuu) \[Rocma's Deluge\]](https://osu.ppy.sh/beatmapsets/1278046#fruits/2674095)
+
 ### osu!mania
 
 #### Playlist A
@@ -80,3 +152,27 @@ As of now, joining the weekly multiplayer lobbies requires participants to downl
 - [Tigran Hamasyan - What the Waves Brought (Cut Ver.) (Parachor) \[Rising Tide\]](https://osu.ppy.sh/beatmapsets/1081010#mania/2261508)
 - [The Black Dahlia Murder - Deathmask Divine (Davvy) \[April & Tim's Necromance\]](https://osu.ppy.sh/beatmapsets/1363029#mania/2819895)
 - [John Wasson - Caravan (Evening) \[drown\]](https://osu.ppy.sh/beatmapsets/1086739#mania/2272532)
+
+#### Playlist B
+
+- [DIVERSA - i use raw expectation to unlock placebo. the placebo is the next thing i do. (Parachor) \[.\_//- [Advanced]\]](https://osu.ppy.sh/beatmapsets/610265#mania/1288556)
+- [cillia - FIRST (juankristal) \[MX\]](https://osu.ppy.sh/beatmapsets/512408#mania/1088936)
+- [Feryquitous - Chat perdu (Sillyp) \[MX\]](https://osu.ppy.sh/beatmapsets/1300107#mania/2696985)
+- [Silentroom - Shuu no Hazama (Cut Ver.) (Monheim) \[Insane\]](https://osu.ppy.sh/beatmapsets/1321003#mania/2736533)
+- [Digitalism - Falling (Mipha-) \[Descent\]](https://osu.ppy.sh/beatmapsets/1259322#mania/2617879)
+
+#### Playlist C
+
+- [DAOKO x Yonezu Kenshi - Uchiage Hanabi (Mat) \[Incandescent\]](https://osu.ppy.sh/beatmapsets/672250#mania/1421082)
+- [Exivious - One's Glow (Davvy) \[Essence\]](https://osu.ppy.sh/beatmapsets/1336470#mania/2768715)
+- [lapix - Flamenco House (Umo-) \[kaythen's Insane\]](https://osu.ppy.sh/beatmapsets/1191497#mania/2740046)
+- [DJ SHARPNEL - Touch the angel (pporse) \[K-ON!!\]](https://osu.ppy.sh/beatmapsets/304422#mania/681992)
+- [Camellia - We Could Get More Machinegun Psystyle! (And More Genre Switches) (Hydria) \[Aural Annihilation\]](https://osu.ppy.sh/beatmapsets/1034114#mania/2162156)
+
+#### Playlist D
+
+- [Rush - YYZ (Cut Ver.) (Pope Gadget) \[ilikexd's MX\]](https://osu.ppy.sh/beatmapsets/1285555#mania/2669198)
+- [BEMANI Sound Team "Nekomata Master" - Life is beautiful (-MysticEyes) \[EXTREME\]](https://osu.ppy.sh/beatmapsets/860089#mania/2007200)
+- [PSYQUI - Hysteric Night Girl (feat. Such) (Salty Mermaid) \[Beautiful Night\]](https://osu.ppy.sh/beatmapsets/1064438#mania/2284769)
+- [mustie=DC - Merry Snowy Fantasy feat. Hanon (Murumoo) \[qodtjr's Happy Christmas\]](https://osu.ppy.sh/beatmapsets/1055617#mania/2205806)
+- [xi - Halcyon -Long Version- (Kawawa) \[Halcyon Days\]](https://osu.ppy.sh/beatmapsets/742318#mania/2694154)

--- a/wiki/Beatmap_Spotlights/Seasons/2021_Spring/fr.md
+++ b/wiki/Beatmap_Spotlights/Seasons/2021_Spring/fr.md
@@ -54,6 +54,30 @@ Pour l'instant, les participants doivent télécharger et installer [osu!lazer](
 - [Cranky - Libera me (Kloyd) \[Expert\]](https://osu.ppy.sh/beatmapsets/1085726#osu/2270319)
 - [Rigel Theatre - Lurie (DeviousPanda) \[A Story Through Music\]](https://osu.ppy.sh/beatmapsets/909302#osu/1897497)
 
+#### Playlist B
+
+- [Masahiro "Godspeed" Aoki - Blaze (Niva) \[Hard\]](https://osu.ppy.sh/beatmapsets/1323877#osu/2756022)
+- [Polyphia - G.O.A.T. (Mir) \[Yukiyo's Insane\]](https://osu.ppy.sh/beatmapsets/1187509#osu/2810141)
+- [zts - worldenddominator (deetz) \[Last Stand\]](https://osu.ppy.sh/beatmapsets/897884#osu/1875707)
+- [Hana - Gekka Jasmine (2014ver.) (PinkHeart) \[Jasmine\]](https://osu.ppy.sh/beatmapsets/408745#osu/887502)
+- [THE ORAL CIGARETTES - Slowly but surely I go on (help) \[Expert\]](https://osu.ppy.sh/beatmapsets/1212436#osu/2718073)
+
+#### Playlist C
+
+- [3L - Amoritachite Kami To Miyu (TicClick) \[Hard\]](https://osu.ppy.sh/beatmapsets/198034#osu/469800)
+- [kors k - Love Is Eternity (PandaHero) \[Another\]](https://osu.ppy.sh/beatmapsets/836980#osu/1752575)
+- [Halozy - 143 (extended mix) (celerih) \[Lunatic\]](https://osu.ppy.sh/beatmapsets/1132649#osu/2365788)
+- [Rohi - Kanata ni Mau wa Sakura no Shirabe (NatsumeRin) \[RLQuillab Insane\]](https://osu.ppy.sh/beatmapsets/93555#osu/267773)
+- [Venetian Snares - My Half (fergas) \[Downfall\]](https://osu.ppy.sh/beatmapsets/1286665#osu/2671403)
+
+#### Playlist D
+
+- [Mizuki Nana - PHANTOM MINDS (Lasse) \[Hard\]](https://osu.ppy.sh/beatmapsets/1301407#osu/2699267)
+- [Natsushiro Takaaki - Near feat. Hatsune Miku (\[Hatsune Miku\]) \[Time Machine\]](https://osu.ppy.sh/beatmapsets/1284534#osu/2667326)
+- [Gekidan Record feat. Nekomata Master - Houkou Orpheus (DeviousPanda) \[Mystery\]](https://osu.ppy.sh/beatmapsets/1257522#osu/2613064)
+- [NIWASHI - Playing with Ruby (Down) \[Extreme\]](https://osu.ppy.sh/beatmapsets/1306570#osu/2708983)
+- [The Smiths - This Charming Man (dsco) \[Wonder\]](https://osu.ppy.sh/beatmapsets/1241923#osu/2581938)
+
 ### osu!taiko
 
 #### Playlist A
@@ -63,6 +87,30 @@ Pour l'instant, les participants doivent télécharger et installer [osu!lazer](
 - [knapsack - retrograde (Ulqui) \[lonely\]](https://osu.ppy.sh/beatmapsets/1283361#taiko/2665243)
 - [Ono Hideyuki - sola (Mapper 31) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/131347#taiko/330868)
 - [Otogibara Era, Warabeda Meiji - 1+1 de Q.E.D.!! (taiko\_ryuki) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/1107475#taiko/2318105)
+
+#### Playlist B
+
+- [Lite Show Magic (t+pazolite vs C-Show) - Crack Traxxxx (Fatfan Kolek) \[TK'S Muzukashii\]](https://osu.ppy.sh/beatmapsets/139525#taiko/361158)
+- [EastNewSound - Hana wa Gensou no Hate Ni (\_Gezo\_) \[Oni\]](https://osu.ppy.sh/beatmapsets/290314#taiko/654058)
+- [Sound Souler - Aqua Stars (eiri-) \[Oni\]](https://osu.ppy.sh/beatmapsets/1204476#taiko/2508101)
+- [pm04034 - Nonspeed (Axer) \[inner oni\]](https://osu.ppy.sh/beatmapsets/1134649#taiko/2387792)
+- [BlackY - Nobodyknows Eden (namaniku) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/768440#taiko/1722532)
+
+#### Playlist C
+
+- [Amon Amarth - Shield Wall (frukoyurdakul) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/1327059#taiko/2750895)
+- [Chroma - tiny tales continue (ensan71714) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/785389#taiko/1648625)
+- [Nana Takahashi - The Party We Have Never Seen (jonathanlfj) \[Nwolf's Oni\]](https://osu.ppy.sh/beatmapsets/405516#taiko/930303)
+- [Nakiri Ayame - Deep Indigo (\[Zeth\]) \[Oni\]](https://osu.ppy.sh/beatmapsets/1194116#taiko/2494752)
+- [Zekk - Ashes (Faputa) \[Activation\]](https://osu.ppy.sh/beatmapsets/1144916#taiko/2390371)
+
+#### Playlist D
+
+- [Silentroom - Nhelv (Nifty) \[Muzukashii\]](https://osu.ppy.sh/beatmapsets/928849#taiko/1947270)
+- [t+pazolite - seedy try (Stingy) \[oni\]](https://osu.ppy.sh/beatmapsets/680385#taiko/1438644)
+- [lapix - Carry Me Away (Extended Mix) (Konpaku Sariel) \[Oni\]](https://osu.ppy.sh/beatmapsets/1228198#taiko/2559014)
+- [Kobaryo - Invisible Frenzy (Cychloryn) \[Oni\]](https://osu.ppy.sh/beatmapsets/1083165#taiko/2268907)
+- [Fear, and Loathing in Las Vegas - Rave-Up Tonight (qoot8123) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/244532#taiko/563660)
 
 ### osu!catch
 
@@ -74,6 +122,30 @@ Pour l'instant, les participants doivent télécharger et installer [osu!lazer](
 - [Amuro vs. Killer - Mei (Camellia's "Yomigae" Remix) (Spectator) \[Rain\]](https://osu.ppy.sh/beatmapsets/1246989#fruits/2653218)
 - [IAHN - Melody of Heaven (Original Mix) (JBHyperion) \[Team Russian Federation's Overdose\]](https://osu.ppy.sh/beatmapsets/1025255#fruits/2144404)
 
+#### Playlist B
+
+- [Kalafina - believe (CLSW) \[Platter\]](https://osu.ppy.sh/beatmapsets/316647#fruits/705528)
+- [Tsukasa - One Way Love (Dapuluous) \[Love\]](https://osu.ppy.sh/beatmapsets/1290396#fruits/2678699)
+- [Nanawo Akari - One Room Sugar Life (Spectator) \[Rain\]](https://osu.ppy.sh/beatmapsets/1286432#fruits/2671349)
+- [Creo - Challenger (Rocma) \[Challenge\]](https://osu.ppy.sh/beatmapsets/966240#fruits/2022498)
+- [ZUTOMAYO - Humanoid (Jemzuu) \[Liyac's Overdose\]](https://osu.ppy.sh/beatmapsets/1052572#fruits/2552702)
+
+#### Playlist C
+
+- [Zekk - SUMMER (Spectator) \[Platter\]](https://osu.ppy.sh/beatmapsets/1393068#fruits/2894330)
+- [Sakuzyo - Magical Musical Master (Rocma) \[Nelly's Rain\]](https://osu.ppy.sh/beatmapsets/1097927#fruits/2315442)
+- [Disasterpeace - Home (JBHyperion) \[Rain\]](https://osu.ppy.sh/beatmapsets/1195922#fruits/2491271)
+- [siqlo - Me & U (Jemzuu) \[Rain\]](https://osu.ppy.sh/beatmapsets/1225300#fruits/2554078)
+- [Synthion - Aurora (wonjae) \[Polaris\]](https://osu.ppy.sh/beatmapsets/1290796#fruits/2679394)
+
+#### Playlist D
+
+- [Feryquitous feat. Sennzai - Rugie (Jemzuu) \[Platter\]](https://osu.ppy.sh/beatmapsets/1338217#fruits/2772123)
+- [Masayoshi Minoshima feat. Ayakura Mei - Lionheart (Secre) \[Heart of Lions\]](https://osu.ppy.sh/beatmapsets/1142369#fruits/2385749)
+- [Raujika - Cry More (Benita) \[Lacrima's Reminiscence\]](https://osu.ppy.sh/beatmapsets/974743#fruits/2414897)
+- [Akiyama Uni - Kanpan Tasogare Shinbun (Ascendance) \[Dance of the Empty-Hearted\]](https://osu.ppy.sh/beatmapsets/633255#fruits/1344066)
+- [xi - Titania (Jemzuu) \[Rocma's Deluge\]](https://osu.ppy.sh/beatmapsets/1278046#fruits/2674095)
+
 ### osu!mania
 
 #### Playlist A
@@ -83,3 +155,27 @@ Pour l'instant, les participants doivent télécharger et installer [osu!lazer](
 - [Tigran Hamasyan - What the Waves Brought (Cut Ver.) (Parachor) \[Rising Tide\]](https://osu.ppy.sh/beatmapsets/1081010#mania/2261508)
 - [The Black Dahlia Murder - Deathmask Divine (Davvy) \[April & Tim's Necromance\]](https://osu.ppy.sh/beatmapsets/1363029#mania/2819895)
 - [John Wasson - Caravan (Evening) \[drown\]](https://osu.ppy.sh/beatmapsets/1086739#mania/2272532)
+
+#### Playlist B
+
+- [DIVERSA - i use raw expectation to unlock placebo. the placebo is the next thing i do. (Parachor) \[.\_//- [Advanced]\]](https://osu.ppy.sh/beatmapsets/610265#mania/1288556)
+- [cillia - FIRST (juankristal) \[MX\]](https://osu.ppy.sh/beatmapsets/512408#mania/1088936)
+- [Feryquitous - Chat perdu (Sillyp) \[MX\]](https://osu.ppy.sh/beatmapsets/1300107#mania/2696985)
+- [Silentroom - Shuu no Hazama (Cut Ver.) (Monheim) \[Insane\]](https://osu.ppy.sh/beatmapsets/1321003#mania/2736533)
+- [Digitalism - Falling (Mipha-) \[Descent\]](https://osu.ppy.sh/beatmapsets/1259322#mania/2617879)
+
+#### Playlist C
+
+- [DAOKO x Yonezu Kenshi - Uchiage Hanabi (Mat) \[Incandescent\]](https://osu.ppy.sh/beatmapsets/672250#mania/1421082)
+- [Exivious - One's Glow (Davvy) \[Essence\]](https://osu.ppy.sh/beatmapsets/1336470#mania/2768715)
+- [lapix - Flamenco House (Umo-) \[kaythen's Insane\]](https://osu.ppy.sh/beatmapsets/1191497#mania/2740046)
+- [DJ SHARPNEL - Touch the angel (pporse) \[K-ON!!\]](https://osu.ppy.sh/beatmapsets/304422#mania/681992)
+- [Camellia - We Could Get More Machinegun Psystyle! (And More Genre Switches) (Hydria) \[Aural Annihilation\]](https://osu.ppy.sh/beatmapsets/1034114#mania/2162156)
+
+#### Playlist D
+
+- [Rush - YYZ (Cut Ver.) (Pope Gadget) \[ilikexd's MX\]](https://osu.ppy.sh/beatmapsets/1285555#mania/2669198)
+- [BEMANI Sound Team "Nekomata Master" - Life is beautiful (-MysticEyes) \[EXTREME\]](https://osu.ppy.sh/beatmapsets/860089#mania/2007200)
+- [PSYQUI - Hysteric Night Girl (feat. Such) (Salty Mermaid) \[Beautiful Night\]](https://osu.ppy.sh/beatmapsets/1064438#mania/2284769)
+- [mustie=DC - Merry Snowy Fantasy feat. Hanon (Murumoo) \[qodtjr's Happy Christmas\]](https://osu.ppy.sh/beatmapsets/1055617#mania/2205806)
+- [xi - Halcyon -Long Version- (Kawawa) \[Halcyon Days\]](https://osu.ppy.sh/beatmapsets/742318#mania/2694154)


### PR DESCRIPTION
I haven't seen any updates for this in a while, not sure what the current state of this season is, but I noticed the playlists hadn't been updated, and the season is over, so I went ahead and did it.

I need someone to check line 158 as its diff name is ***f u n k y***.