### PR TITLE
Add glossary stubs to the `osu!catch Ranking Criteria`

### DIFF
--- a/wiki/Ranking_Criteria/osu!catch/en.md
+++ b/wiki/Ranking_Criteria/osu!catch/en.md
@@ -2,11 +2,49 @@
 
 ***Notice: This article is an extension of the [general ranking criteria](/wiki/Ranking_Criteria).***
 
-The **osu!catch Ranking Criteria** are rules and guidelines that apply to the creation of osu!catch-specific difficulties. In order to get a osu!catch-specific difficulty ranked, it is mandatory the creation obeys to the listed criteria. While **all rules must be followed in any circumstance**, guidelines may be ignored under exceptional circumstances. These exceptional circumstances must be justified by an exhaustive explanation as of why the guideline has been ignored and why not ignoring it will interfere with the overall quality of the creation.
+This set of **osu!catch ranking criteria** lays out [rules and guidelines](/wiki/Ranking_Criteria#general-terms) that [osu!catch](/wiki/Game_mode/osu!catch)-specific [beatmaps](/wiki/Beatmap) must follow in order to progress through the [beatmap ranking procedure](/wiki/Beatmap_ranking_procedure).
 
-## Glossary
+## Overall
 
-These terms frequently appear when getting in touch with osu!catch difficulties and are also used within the Ranking Criteria.
+Overall rules and guidelines apply to every kind of osu!catch difficulty. Rhythm-related rules and guidelines apply to approximately 180 BPM beatmaps with 4/4 time signatures. If your song is drastically faster or slower, some variables might be different, as detailed in [Scaling BPM on the Ranking Criteria](/wiki/Ranking_Criteria/Scaling_BPM).
+
+### General
+
+#### Rules
+
+- **Your map must theoretically be possible to SS.** This means it must be possible to catch absolutely all [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop) and [droplets](/wiki/Hit_object/Juice_stream#droplet).
+- **Each beatmap must use at least two different custom [combo colours](/wiki/Glossary/Combo_colour) unless the default skin is forced.** The [combo colours](/wiki/Glossary/Combo_colour) must not blend with the beatmap's background/storyboard/video in any case. This is so hit objects are always visible to the player and custom skin's [combo colours](/wiki/Glossary/Combo_colour) do not blend with the background accidentally.
+- **Do not use keysounds without hitnormal support.** If sounds blend perfectly with the song, feedback for hitting notes is minimal.
+
+#### Guidelines
+
+- **All circles and slider heads should represent a sound existing in the music.** This is usually a distinct sound, but can also represent a continuous sound with an indistinguishable start or end.
+- **Sliderends of extended sliders should be snapped according to the song's beat structure.** If the song is using a straight beat, 1/4, 1/8, and 1/16 should be used. If the song is using a swing beat, 1/6 or 1/12 should be used. If the song has a sound in a different snap from what was recommended, snapping to an actual beat always takes priority.
+- **[Dashes](/wiki/Glossary/Dash) and [hyperdashes](/wiki/Glossary/Hyperdash) should not be used when the destination of the [dash](/wiki/Glossary/Dash) or [hyperdash](/wiki/Glossary/Hyperdash) is located near the left or right border of the playfield.** This creates an uncomfortable movement as the catcher is forcibly stopped upon reaching the border of the playfield (x:16 on the left and x:496 on the right).
+- **Ensure [combos](/wiki/Beatmapping/Combo) do not reach unreasonable lengths.** Caught [fruits](/wiki/Hit_object/Fruit) will stack up on the plate and can potentially obstruct the player's view. Bear in mind that slider tails, repeats and [spinner](/wiki/Hit_object/Spinner) [bananas](/wiki/Hit_object/Banana) also count as "[fruits](/wiki/Hit_object/Fruit)". New Combos should be placed regularly to clear the plate and avoid this.
+- **Try to have at least one [spinner](/wiki/Hit_object/Spinner) in each difficulty to create variety in the map and fluctuation among scores.** However, if a [spinner](/wiki/Hit_object/Spinner) just doesn't fit anywhere in the song, then there's no need to force one.
+- **[Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should have the same value as the [Approach Rate](/wiki/Beatmapping/Approach_rate).** This is just a standardised value, as Overall Difficulty does not affect gameplay nor does the number of [fruits](/wiki/Hit_object/Fruit) a [spinner](/wiki/Hit_object/Spinner) has. Overall Difficulty only affects the maximum score of a difficulty.
+  - If a difficulty uses a lower Approach Rate than one or more difficulties in the difficulty level below it, then the Overall Difficulty should be equal to that of the highest Overall Difficulty value in the previous difficulty level.
+- **Slider tick rate should be set according to the song.** For example if your song only uses 1/3 snapping, using tick rate 2 or 4 would not be fitting.
+- **Use the same slider tick rate on every difficulty** as it is a property of the music rather than the mapping. However, lower difficulties may use lower tick rates to reduce accuracy requirements for newer players, providing they still follow the rhythm of the song. Using high tick rates purely to increase score/combo/difficulty is senseless.
+- **Avoid using [combo colours](/wiki/Glossary/Combo_colour) with ~50 luminosity or lower.** Dark colours impact the readability of [fruits](/wiki/Hit_object/Fruit) with low background dim.
+- **Avoid using [combo colours](/wiki/Glossary/Combo_colour) with ~220 luminosity or higher if Kiai time is used.** Light colours create bright pulses during Kiai time, which can be unpleasant to the eyes.
+
+### Skinning
+
+#### Rules
+
+- **Custom catchers must be included in v2 skin format.** This is to ensure correct display on all skins. The required filenames are `fruit-catcher-idle.png`, `fruit-catcher-kiai.png` and `fruit-catcher-fail.png`.
+- **Custom objects must include all necessary elements and be coloured in a scale of grey colours.** This is to ensure that your images are clearly defined and of acceptable quality. The needed elements can be found at [Skinning/osu!catch](/wiki/Skinning/osu!catch). Additionally, it is recommendable to use transparent elements for the overlays.
+- **Skinned elements must be the same size as their default skin counterparts.** This is so they represent the hitbox properly and don't alter gameplay. The current dimensions used in the default skin are 128x128 pixels for the [fruits](/wiki/Hit_object/Fruit), 82x103 for the [drops](/wiki/Hit_object/Juice_stream#drop) and 306x320 for the catcher.
+
+#### Guidelines
+
+- **Custom catchers should additionally include the element `lighting.png` to complete the skin set.** This element is however optional to add and has default dimensions of 184x184 pixels, though it may vary depending on the desired visibility of the element.
+
+## Difficulty-specific
+
+Difficulty-specific rules and guidelines do only apply to the difficulty level they are listed for and therefore *do not apply to **every** osu!catch difficulty*. Rhythm-related rules and guidelines apply to approximately 180 BPM beatmaps. If your song is drastically faster or slower, some variables might be different, as detailed in [Scaling BPM on the Ranking Criteria](/wiki/Ranking_Criteria/Scaling_BPM).
 
 ### Difficulty names
 
@@ -18,23 +56,7 @@ These terms frequently appear when getting in touch with osu!catch difficulties 
 - ![](/wiki/shared/diff/insane-c.png) Rain
 - ![](/wiki/shared/diff/expert-c.png) Overdose
 
-### Gameplay
-
-- **Fruit:** A large object representing a hitcircle, slider head, tail or repeat.
-- **Drop:** A medium-sized object representing a slider tick.
-- **Droplet:** A small object representing a slider body. Missing these will reduce your accuracy, but unlike fruits and drops, will not result in a combo break.
-- **Banana:** An object found during spinners. These award bonus points, but do not contribute to accuracy and are not required to obtain max combo.
-- **Active object:** An object that must be caught in order to maintain combo, namely fruits and drops.
-- **Walk:** Any spacing between two objects where no dash is needed to catch both.
-- **Dash:** A spacing between two objects that requires the use of the dash key to catch both.
-- **Hyperdash:** Objects generated when the spacing between two active objects is too far apart to be caught by normal dashing. During play, this is characterized by a coloured outline on the first object. The term is also used to describe the movement between the two objects.
-- **Trigger distance:** The minimum spacing between two active objects at which a hyperdash is generated between them.
-- **Edge dash:** A very large spacing between two active objects where the required trigger distance is not reached, and as such, a hyperdash is not generated. The first object must be caught with the edge of the plate in order to catch the second object at all.
-- **Basic-snapped dash/hyperdash:** Any dash or hyperdash whose time between active objects is at least twice the time required to allow dashes or hyperdashes, respectively. As an example, a hyperdash between objects separated by 250 ms in a Platter classifies as a basic-snapped hyperdash.
-- **Higher-snapped dash/hyperdash:** Any dash or hyperdash that doesn't meet the requirement to be a basic-snapped one (i.e. the time between the objects is less than the threshold to be classified as basic).
-- **Antiflow:** A strong direction or velocity change that goes against a player's natural movement pattern.
-
-#### Snapping reference table
+### Snapping reference table
 
 | Difficulty | Basic-snapped dash | Higher-snapped dash | Basic-snapped hyperdash | Higher-snapped hyperdash |
 | :-- | :-- | :-- | :-- | :-- |
@@ -44,163 +66,123 @@ These terms frequently appear when getting in touch with osu!catch difficulties 
 | **Rain** | 125 ms or higher | 62-124 ms | 125 ms or higher | 62-124 ms |
 | **Overdose** | - | - | - | - |
 
-## Overall
-
-Overall rules and guidelines apply to every kind of osu!catch difficulty. Rhythm-related rules and guidelines apply to approximately 180 BPM beatmaps with 4/4 time signatures. If your song is drastically faster or slower, some variables might be different, as detailed in [Scaling BPM on the Ranking Criteria](/wiki/Ranking_Criteria/Scaling_BPM).
-
-### General
-
-#### Rules
-
-- **Your map must theoretically be possible to SS.** This means it must be possible to catch absolutely all fruits, drops and droplets.
-- **Each beatmap must use at least two different custom combo colours unless the default skin is forced.** The combo colours must not blend with the beatmap's background/storyboard/video in any case. This is so hit objects are always visible to the player and custom skin's combo colours do not blend with the background accidentally.
-- **Do not use keysounds without hitnormal support.** If sounds blend perfectly with the song, feedback for hitting notes is minimal.
-
-#### Guidelines
-
-- **All circles and slider heads should represent a sound existing in the music.** This is usually a distinct sound, but can also represent a continuous sound with an indistinguishable start or end.
-- **Sliderends of extended sliders should be snapped according to the song's beat structure.** If the song is using a straight beat, 1/4, 1/8, and 1/16 should be used. If the song is using a swing beat, 1/6 or 1/12 should be used. If the song has a sound in a different snap from what was recommended, snapping to an actual beat always takes priority.
-- **Dashes and hyperdashes should not be used when the destination of the dash or hyperdash is located near the left or right border of the playfield.** This creates an uncomfortable movement as the catcher is forcibly stopped upon reaching the border of the playfield (x:16 on the left and x:496 on the right).
-- **Ensure combos do not reach unreasonable lengths.** Caught fruits will stack up on the plate and can potentially obstruct the player's view. Bear in mind that slider tails, repeats and spinner bananas also count as "fruits". New Combos should be placed regularly to clear the plate and avoid this.
-- **Try to have at least one spinner in each difficulty to create variety in the map and fluctuation among scores.** However, if a spinner just doesn't fit anywhere in the song, then there's no need to force one.
-- **Overall Difficulty should have the same value as the Approach Rate.** This is just a standardised value, as Overall Difficulty does not affect gameplay nor does the number of fruits a spinner has. Overall Difficulty only affects the maximum score of a difficulty. However, if a difficulty uses a lower Approach Rate than one or more difficulties in the difficulty level below it, then the Overall Difficulty should be equal to that of the highest Overall Difficulty value in the previous difficulty level.
-- **Slider tick rate should be set according to the song.** For example if your song only uses 1/3 snapping, using tick rate 2 or 4 would not be fitting.
-- **Use the same slider tick rate on every difficulty** as it is a property of the music rather than the mapping. However, lower difficulties may use lower tick rates to reduce accuracy requirements for newer players, providing they still follow the rhythm of the song. Using high tick rates purely to increase score/combo/difficulty is senseless.
-- **Avoid using combo colours with ~50 luminosity or lower.** Dark colours impact the readability of fruits with low background dim.
-- **Avoid using combo colours with ~220 luminosity or higher if Kiai time is used.** Light colours create bright pulses during Kiai time, which can be unpleasant to the eyes.
-
-### Skinning
-
-#### Rules
-
-- **Custom catchers must be included in v2 skin format.** This is to ensure correct display on all skins. The required filenames are `fruit-catcher-idle.png`, `fruit-catcher-kiai.png` and `fruit-catcher-fail.png`.
-- **Custom objects must include all necessary elements and be coloured in a scale of grey colours.** This is to ensure that your images are clearly defined and of acceptable quality. The needed elements can be found at [Skinning/osu!catch](/wiki/Skinning/osu!catch). Additionally, it is recommendable to use transparent elements for the overlays.
-- **Skinned elements must be the same size as their default skin counterparts.** This is so they represent the hitbox properly and don't alter gameplay. The current dimensions used in the default skin are 128x128 pixels for the fruits, 82x103 for the drops and 306x320 for the catcher.
-
-#### Guidelines
-
-- **Custom catchers should additionally include the element `lighting.png` to complete the skin set.** This element is however optional to add and has default dimensions of 184x184 pixels, though it may vary depending on the desired visibility of the element.
-
-## Difficulty-specific
-
-Difficulty-specific rules and guidelines do only apply to the difficulty level they are listed for and therefore *do not apply to **every** osu!catch difficulty*. Rhythm-related rules and guidelines apply to approximately 180 BPM beatmaps. If your song is drastically faster or slower, some variables might be different, as detailed in [Scaling BPM on the Ranking Criteria](/wiki/Ranking_Criteria/Scaling_BPM).
-
 ### ![](/wiki/shared/diff/easy-c.png) Cup
 
 #### Rules
 
-- **Dashes and hyperdashes of any kind are disallowed.** This is to ensure an easy starting experience to beginner players. In order to test that out, it must be possible to achieve an SS rank on the difficulty without making use of the dash key.
-- **At least 250 ms must be left between circles/sliders and the start and end of spinners.** This is to ensure readability.
+- **[Dashes](/wiki/Glossary/Dash) and [hyperdashes](/wiki/Glossary/Hyperdash) of any kind are disallowed.** This is to ensure an easy starting experience to beginner players. In order to test that out, it must be possible to achieve an SS rank on the difficulty without making use of the dash key.
+- **At least 250 ms must be left between circles/sliders and the start and end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
 
 #### Guidelines
 
-- **Combos should not exceed 8 objects including slider tails and repeats.** Spinners are an exception.
+- **[Combos](/wiki/Beatmapping/Combo) should not exceed 8 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/1 pattern.** 1/2 and/or 1/3 patterns should be used sparingly.
 
 #### Difficulty setting guidelines
 
-- Approach Rate / Overall Difficulty should be between 4 and 6.
-- HP Drain Rate should be between 2 and 3.
-- Circle Size should be between 2 and 3.
+- [Approach Rate](/wiki/Beatmapping/Approach_rate) / [Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should be between 4 and 6.
+- [HP Drain Rate](/wiki/Beatmapping/HP_drain_rate) should be between 2 and 3.
+- [Circle Size](/wiki/Beatmapping/Circle_size) should be between 2 and 3.
 
 ### ![](/wiki/shared/diff/normal-c.png) Salad
 
 #### Rules
 
-- **Hyperdashes of any kind are disallowed.** This is to ensure a manageable step in difficulty for novice players.
-- **Dashes must have at least a 125 ms gap between their two objects.**
-- **Dashes that are basic-snapped must not be used more than two times between consecutive fruits.**
-- **Dashes that are higher-snapped must always be followed by a walk.**
-- **Edge dashes must not be used.** They require extremely precise timing which cannot be expected of less-experienced players.
-- **At least 250 ms must be left between circles/sliders and the start and end of spinners.** This is to ensure readability.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) of any kind are disallowed.** This is to ensure a manageable step in difficulty for novice players.
+- **[Dashes](/wiki/Glossary/Dash) must have at least a 125 ms gap between their two objects.**
+- **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than two times between consecutive [fruits](/wiki/Hit_object/Fruit).**
+- **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must always be followed by a [walk](/wiki/Glossary/Walk).**
+- **[Edge dashes](/wiki/Glossary/Edge_dash) must not be used.** They require extremely precise timing which cannot be expected of less-experienced players.
+- **At least 250 ms must be left between circles/sliders and the start and end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
+- **Individual 1/3 and/or 1/4 patterns must not persist for more than one bar (4 and 5 objects respectively).**
 
 #### Guidelines
 
-- **All distances should be clear on whether they require the player to walk or dash.** This is to ensure that players can easily recognize patterns that require dashing.
-- **Dashes that are basic-snapped should not be used consecutively when different beat snaps are used.** For example, a 1/1 dash followed by a 1/2 dash.
-- **Dashes that are higher-snapped should not be followed by antiflow patterns.**
-- **Combos should not exceed 10 objects including slider tails and repeats.** Spinners are an exception.
+- **All distances should be clear on whether they require the player to [walk](/wiki/Glossary/Walk) or [dash](/wiki/Glossary/Dash).** This is to ensure that players can easily recognize patterns that require dashing.
+- **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 [dash](/wiki/Glossary/Dash) followed by a 1/2 [dash](/wiki/Glossary/Dash).
+- **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) patterns.**
+- **[Combos](/wiki/Beatmapping/Combo) should not exceed 10 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/1 and 1/2 pattern.** 1/3 and/or 1/4 patterns should be used sparingly.
 
 #### Difficulty setting guidelines
 
-- Approach Rate / Overall Difficulty should be between 6 and 7.
-- HP Drain Rate should be between 3 and 4.
-- Circle Size should be between 2.5 and 3.5.
+- [Approach Rate](/wiki/Beatmapping/Approach_rate) / [Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should be between 6 and 7.
+- [HP Drain Rate](/wiki/Beatmapping/HP_drain_rate) should be between 3 and 4.
+- [Circle Size](/wiki/Beatmapping/Circle_size) should be between 2.5 and 3.5.
 
 ### ![](/wiki/shared/diff/hard-c.png) Platter
 
 #### Rules
 
-- **Hyperdashes must have at least a 125 ms gap between their two objects.**
-- **Hyperdashes cannot be used on individual drops and/or slider repetitions.** The accuracy and control required is unreasonable at this level and can create a situation where the player potentially fails to read the slider path.
-- **Hyperdashes of a different beat snap must not be used between consecutive fruits.** For example, a 1/2 hyperdash followed by a 1/4 hyperdash.
-- **Hyperdashes that are basic-snapped must not be used more than two times between consecutive fruits.**
-- **Hyperdashes that are higher-snapped must not be used in conjunction with any other dashes or hyperdashes.**
-- **Dashes must have at least a 62 ms gap between their two objects.**
-- **Dashes that are basic-snapped must not be used more than four times between consecutive fruits.**
-- **Dashes that are higher-snapped can be used up to two times between consecutive fruits, provided there isn't a direction change between them.**
-- **Edge dashes must not be used.** They require extremely precise timing which cannot be expected of less-experienced players.
-- **At least 125 ms must be left between circles/sliders and the start of spinners.** This is to ensure readability.
-- **At least 250 ms must be left between circles/sliders and the end of spinners.** This is to ensure readability.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) must have at least a 125 ms gap between their two objects.**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) cannot be used on individual [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions.** The accuracy and control required is unreasonable at this level and can create a situation where the player potentially fails to read the slider path.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) of a different beat snap must not be used between consecutive [fruits](/wiki/Hit_object/Fruit).** For example, a 1/2 [hyperdash](/wiki/Glossary/Hyperdash) followed by a 1/4 [hyperdash](/wiki/Glossary/Hyperdash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than two times between consecutive [fruits](/wiki/Hit_object/Fruit).**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with any other [dashes](/wiki/Glossary/Dash) or [hyperdashes](/wiki/Glossary/Hyperdash).**
+- **[Dashes](/wiki/Glossary/Dash) must have at least a 62 ms gap between their two objects.**
+- **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than four times between consecutive [fruits](/wiki/Hit_object/Fruit).**
+- **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) can be used up to two times between consecutive [fruits](/wiki/Hit_object/Fruit), provided there isn't a direction change between them.**
+- **[Edge dashes](/wiki/Glossary/Edge_dash) must not be used.** They require extremely precise timing which cannot be expected of less-experienced players.
+- **At least 125 ms must be left between circles/sliders and the start of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
+- **At least 250 ms must be left between circles/sliders and the end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
 
 #### Guidelines
 
-- **Strong hyperdashes should not be used.** For basic-snapped hyperdashes, a limit of 1.5 times the trigger distance is recommended. For higher-snapped hyperdashes, a limit of 1.3 times the trigger distance is recommended instead.
-- **Hyperdashes that are basic-snapped may be used in conjunction with antiflow patterns.** If used, the spacing should not exceed a distance snap of 1.2 times the trigger distance when followed by a walk, or 1.1 times the trigger distance when followed by a basic-snapped dash.
-- **Hyperdashes that are higher-snapped should not be followed by antiflow patterns.** If used, the spacing should not exceed a distance snap of 1.1 times the trigger distance and the movement after the hyperdash must be a walk.
-- **Combos should not exceed 12 objects including slider tails and repeats.** Spinners are an exception.
+- **Strong [hyperdashes](/wiki/Glossary/Hyperdash) should not be used.** For [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) [hyperdashes](/wiki/Glossary/Hyperdash), a limit of 1.5 times the [trigger distance](/wiki/Glossary/Trigger_distance) is recommended. For [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) [hyperdashes](/wiki/Glossary/Hyperdash), a limit of 1.3 times the [trigger distance](/wiki/Glossary/Trigger_distance) is recommended instead.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) may be used in conjunction with [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.2 times the [trigger distance](/wiki/Glossary/Trigger_distance) when followed by a [walk](/wiki/Glossary/Walk), or 1.1 times the [trigger distance](/wiki/Glossary/Trigger_distance) when followed by a [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) [dash](/wiki/Glossary/Dash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.1 times the [trigger distance](/wiki/Glossary/Trigger_distance) and the movement after the [hyperdash](/wiki/Glossary/Hyperdash) must be a [walk](/wiki/Glossary/Walk).
+- **[Combos](/wiki/Beatmapping/Combo) should not exceed 12 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/2 and/or 1/3 pattern.** 1/4 and/or 1/6 patterns should be used sparingly.
 
 #### Difficulty setting guidelines
 
-- Approach Rate / Overall Difficulty should be between 7 and 8.2.
-- HP Drain Rate should be between 4 and 5.
-- Circle Size should be between 3 and 4.
+- [Approach Rate](/wiki/Beatmapping/Approach_rate) / [Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should be between 7 and 8.2.
+- [HP Drain Rate](/wiki/Beatmapping/HP_drain_rate) should be between 4 and 5.
+- [Circle Size](/wiki/Beatmapping/Circle_size) should be between 3 and 4.
 
 ### ![](/wiki/shared/diff/insane-c.png) Rain
 
 #### Rules
 
-- **Hyperdashes and dashes must have at least a 62 ms gap between their two objects.**
-- **Hyperdashes that are basic-snapped must not be used more than four times between consecutive fruits.**
-- **Hyperdashes that are basic-snapped must not be used more than two times within a slider.** The slider path must be simple and easy-to-follow.
-- **Hyperdashes that are higher-snapped must not be used in conjunction with higher-snapped dashes or any other hyperdashes.**
-- **Hyperdashes that are higher-snapped must not be used within a slider.**
-- **At least 125 ms must be left between circles/sliders and the start and end of spinners.** This is to ensure readability.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) and [dashes](/wiki/Glossary/Dash) must have at least a 62 ms gap between their two objects.**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than four times between consecutive [fruits](/wiki/Hit_object/Fruit).**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than two times within a slider.** The slider path must be simple and easy-to-follow.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) [dashes](/wiki/Glossary/Dash) or any other [hyperdashes](/wiki/Glossary/Hyperdash).**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used within a slider.**
+- **At least 125 ms must be left between circles/sliders and the start and end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
 
 #### Guidelines
 
-- **Hyperdashes should not be used on individual drops and/or slider repetitions.**
-- **Hyperdashes that are basic-snapped should not be used consecutively when different beat snaps are used.** For example, a 1/1 hyperdash followed by a 1/2 hyperdash.
-- **Hyperdashes that are higher-snapped should not be followed by antiflow dashes with a gap lower than 250ms.**
-- **Edge dashes may only be used singularly (not in conjunction with other dashes or hyperdashes).**
-- **Combos should not exceed 16 objects including slider tails and repeats.** Spinners are an exception.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) should not be used on individual [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions.**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 [hyperdash](/wiki/Glossary/Hyperdash) followed by a 1/2 [hyperdash](/wiki/Glossary/Hyperdash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) [dashes](/wiki/Glossary/Dash) with a gap lower than 250ms.**
+- **[Edge dashes](/wiki/Glossary/Edge_dash) may only be used singularly (not in conjunction with other [dashes](/wiki/Glossary/Dash) or [hyperdashes](/wiki/Glossary/Hyperdash)).**
+- **[Combos](/wiki/Beatmapping/Combo) should not exceed 16 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/2 + 1/4 and/or 1/3 + 1/6 pattern.** 1/8 patterns and higher should be used sparingly.
 
 #### Difficulty setting guidelines
 
-- Approach Rate / Overall Difficulty should be between 7 and 9.
-- HP Drain Rate should be between 5 and 6.
-- Circle Size should be between 3 and 5.
+- [Approach Rate](/wiki/Beatmapping/Approach_rate) / [Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should be between 7 and 9.
+- [HP Drain Rate](/wiki/Beatmapping/HP_drain_rate) should be between 5 and 6.
+- [Circle Size](/wiki/Beatmapping/Circle_size) should be between 3 and 5.
 
 ### ![](/wiki/shared/diff/expert-c.png) Overdose
 
 #### Rules
 
-- **At least 62 ms must be left between circles/sliders and the start of spinners.** This is to ensure readability.
-- **At least 125 ms must be left between circles/sliders and the end of spinners.** This is to ensure readability.
+- **At least 62 ms must be left between circles/sliders and the start of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
+- **At least 125 ms must be left between circles/sliders and the end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
 
 #### Guidelines
 
-- **Hyperdashes should only be used on drops and/or slider repetitions when the slider path is simple and easy-to-follow.** This is to prevent chaotic or unreasonably difficult slider movement, as transitioning into and out of complex slider shapes with hyperdash is usually uncomfortable to play and a major penalty to accuracy for little benefit.
-- **1/8 and higher hyperdashes should not be used between consecutive object pairs.**
-- **Edge dashes may be used with caution for a maximum of three consecutive objects, and should not be used after hyperdashes.**
-- **Combos should not exceed 16 objects including slider tails and repeats.** Spinners are an exception.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) should only be used on [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions when the slider path is simple and easy-to-follow.** This is to prevent chaotic or unreasonably difficult slider movement, as transitioning into and out of complex slider shapes with [hyperdash](/wiki/Glossary/Hyperdash) is usually uncomfortable to play, and a major penalty to accuracy for little benefit.
+- **1/8 and higher [hyperdashes](/wiki/Glossary/Hyperdash) should not be used between consecutive object pairs.**
+- **[Edge dashes](/wiki/Glossary/Edge_dash) may be used with caution for a maximum of three consecutive objects, and should not be used after [hyperdashes](/wiki/Glossary/Hyperdash).**
+- **[Combos](/wiki/Beatmapping/Combo) should not exceed 16 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/2 + 1/4 and/or 1/3 + 1/6 pattern.** 1/8 patterns and higher should be used sparingly.
 
 #### Difficulty setting guidelines
 
-- Approach Rate / Overall Difficulty should be between 8 and 10.
-- HP Drain Rate should be between 6 and 7.
-- Circle Size should be between 3 and 6.
+- [Approach Rate](/wiki/Beatmapping/Approach_rate) / [Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should be between 8 and 10.
+- [HP Drain Rate](/wiki/Beatmapping/HP_drain_rate) should be between 6 and 7.
+- [Circle Size](/wiki/Beatmapping/Circle_size) should be between 3 and 6.

--- a/wiki/Ranking_Criteria/osu!catch/en.md
+++ b/wiki/Ranking_Criteria/osu!catch/en.md
@@ -94,7 +94,6 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 - **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must always be followed by a [walk](/wiki/Glossary/Walk).**
 - **[Edge dashes](/wiki/Glossary/Edge_dash) must not be used.** They require extremely precise timing which cannot be expected of less-experienced players.
 - **At least 250 ms must be left between circles/sliders and the start and end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
-- **Individual 1/3 and/or 1/4 patterns must not persist for more than one bar (4 and 5 objects respectively).**
 
 #### Guidelines
 

--- a/wiki/Ranking_Criteria/osu!catch/en.md
+++ b/wiki/Ranking_Criteria/osu!catch/en.md
@@ -13,16 +13,16 @@ Overall rules and guidelines apply to every kind of osu!catch difficulty. Rhythm
 #### Rules
 
 - **Your map must theoretically be possible to SS.** This means it must be possible to catch absolutely all [fruits](/wiki/Hit_object/Fruit), [drops](/wiki/Hit_object/Juice_stream#drop) and [droplets](/wiki/Hit_object/Juice_stream#droplet).
-- **Each beatmap must use at least two different custom [combo colours](/wiki/Glossary/Combo_colour) unless the default skin is forced.** The [combo colours](/wiki/Glossary/Combo_colour) must not blend with the beatmap's background/storyboard/video in any case. This is so hit objects are always visible to the player and custom skin's [combo colours](/wiki/Glossary/Combo_colour) do not blend with the background accidentally.
+- **Each beatmap must use at least two different custom [combo colours](/wiki/Glossary/Combo_colour) unless the default skin is forced.** The combo colours must not blend with the beatmap's background/storyboard/video in any case. This is so hit objects are always visible to the player and custom skin's combo colours do not blend with the background accidentally.
 - **Do not use keysounds without hitnormal support.** If sounds blend perfectly with the song, feedback for hitting notes is minimal.
 
 #### Guidelines
 
 - **All circles and slider heads should represent a sound existing in the music.** This is usually a distinct sound, but can also represent a continuous sound with an indistinguishable start or end.
 - **Sliderends of extended sliders should be snapped according to the song's beat structure.** If the song is using a straight beat, 1/4, 1/8, and 1/16 should be used. If the song is using a swing beat, 1/6 or 1/12 should be used. If the song has a sound in a different snap from what was recommended, snapping to an actual beat always takes priority.
-- **[Dashes](/wiki/Glossary/Dash) and [hyperdashes](/wiki/Glossary/Hyperdash) should not be used when the destination of the [dash](/wiki/Glossary/Dash) or [hyperdash](/wiki/Glossary/Hyperdash) is located near the left or right border of the playfield.** This creates an uncomfortable movement as the catcher is forcibly stopped upon reaching the border of the playfield (x:16 on the left and x:496 on the right).
-- **Ensure [combos](/wiki/Beatmapping/Combo) do not reach unreasonable lengths.** Caught [fruits](/wiki/Hit_object/Fruit) will stack up on the plate and can potentially obstruct the player's view. Bear in mind that slider tails, repeats and [spinner](/wiki/Hit_object/Spinner) [bananas](/wiki/Hit_object/Banana) also count as "[fruits](/wiki/Hit_object/Fruit)". New Combos should be placed regularly to clear the plate and avoid this.
-- **Try to have at least one [spinner](/wiki/Hit_object/Spinner) in each difficulty to create variety in the map and fluctuation among scores.** However, if a [spinner](/wiki/Hit_object/Spinner) just doesn't fit anywhere in the song, then there's no need to force one.
+- **[Dashes](/wiki/Glossary/Dash) and [hyperdashes](/wiki/Glossary/Hyperdash) should not be used when the destination of the dash or hyperdash is located near the left or right border of the playfield.** This creates an uncomfortable movement as the catcher is forcibly stopped upon reaching the border of the playfield (x:16 on the left and x:496 on the right).
+- **Ensure [combos](/wiki/Beatmapping/Combo) do not reach unreasonable lengths.** Caught [fruits](/wiki/Hit_object/Fruit) will stack up on the plate and can potentially obstruct the player's view. Bear in mind that slider tails, repeats and [spinner](/wiki/Hit_object/Spinner) [bananas](/wiki/Hit_object/Banana) also count as "fruits". New combos should be placed regularly to clear the plate and avoid this.
+- **Try to have at least one [spinner](/wiki/Hit_object/Spinner) in each difficulty to create variety in the map and fluctuation among scores.** However, if a spinner just doesn't fit anywhere in the song, then there's no need to force one.
 - **[Overall Difficulty](/wiki/Beatmapping/Overall_difficulty) should have the same value as the [Approach Rate](/wiki/Beatmapping/Approach_rate).** This is just a standardised value, as Overall Difficulty does not affect gameplay nor does the number of [fruits](/wiki/Hit_object/Fruit) a [spinner](/wiki/Hit_object/Spinner) has. Overall Difficulty only affects the maximum score of a difficulty.
   - If a difficulty uses a lower Approach Rate than one or more difficulties in the difficulty level below it, then the Overall Difficulty should be equal to that of the highest Overall Difficulty value in the previous difficulty level.
 - **Slider tick rate should be set according to the song.** For example if your song only uses 1/3 snapping, using tick rate 2 or 4 would not be fitting.
@@ -98,7 +98,7 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 #### Guidelines
 
 - **All distances should be clear on whether they require the player to [walk](/wiki/Glossary/Walk) or [dash](/wiki/Glossary/Dash).** This is to ensure that players can easily recognize patterns that require dashing.
-- **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 [dash](/wiki/Glossary/Dash) followed by a 1/2 [dash](/wiki/Glossary/Dash).
+- **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 dash followed by a 1/2 dash.
 - **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) patterns.**
 - **[Combos](/wiki/Beatmapping/Combo) should not exceed 10 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/1 and 1/2 pattern.** 1/3 and/or 1/4 patterns should be used sparingly.
@@ -115,9 +115,9 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) must have at least a 125 ms gap between their two objects.**
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) cannot be used on individual [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions.** The accuracy and control required is unreasonable at this level and can create a situation where the player potentially fails to read the slider path.
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) of a different beat snap must not be used between consecutive [fruits](/wiki/Hit_object/Fruit).** For example, a 1/2 [hyperdash](/wiki/Glossary/Hyperdash) followed by a 1/4 [hyperdash](/wiki/Glossary/Hyperdash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) of a different beat snap must not be used between consecutive [fruits](/wiki/Hit_object/Fruit).** For example, a 1/2 hyperdash followed by a 1/4 hyperdash.
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than two times between consecutive [fruits](/wiki/Hit_object/Fruit).**
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with any other [dashes](/wiki/Glossary/Dash) or [hyperdashes](/wiki/Glossary/Hyperdash).**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with any other [dashes](/wiki/Glossary/Dash) or hyperdashes.**
 - **[Dashes](/wiki/Glossary/Dash) must have at least a 62 ms gap between their two objects.**
 - **[Dashes](/wiki/Glossary/Dash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than four times between consecutive [fruits](/wiki/Hit_object/Fruit).**
 - **[Dashes](/wiki/Glossary/Dash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) can be used up to two times between consecutive [fruits](/wiki/Hit_object/Fruit), provided there isn't a direction change between them.**
@@ -127,9 +127,9 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 
 #### Guidelines
 
-- **Strong [hyperdashes](/wiki/Glossary/Hyperdash) should not be used.** For [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) [hyperdashes](/wiki/Glossary/Hyperdash), a limit of 1.5 times the [trigger distance](/wiki/Glossary/Trigger_distance) is recommended. For [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) [hyperdashes](/wiki/Glossary/Hyperdash), a limit of 1.3 times the [trigger distance](/wiki/Glossary/Trigger_distance) is recommended instead.
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) may be used in conjunction with [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.2 times the [trigger distance](/wiki/Glossary/Trigger_distance) when followed by a [walk](/wiki/Glossary/Walk), or 1.1 times the [trigger distance](/wiki/Glossary/Trigger_distance) when followed by a [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) [dash](/wiki/Glossary/Dash).
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.1 times the [trigger distance](/wiki/Glossary/Trigger_distance) and the movement after the [hyperdash](/wiki/Glossary/Hyperdash) must be a [walk](/wiki/Glossary/Walk).
+- **Strong [hyperdashes](/wiki/Glossary/Hyperdash) should not be used.** For [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) hyperdashes, a limit of 1.5 times the [trigger distance](/wiki/Glossary/Trigger_distance) is recommended. For [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) hyperdashes, a limit of 1.3 times the trigger distance is recommended instead.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) may be used in conjunction with [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.2 times the [trigger distance](/wiki/Glossary/Trigger_distance) when followed by a [walk](/wiki/Glossary/Walk), or 1.1 times the trigger distance when followed by a basic-snapped [dash](/wiki/Glossary/Dash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) patterns.** If used, the spacing should not exceed a distance snap of 1.1 times the [trigger distance](/wiki/Glossary/Trigger_distance) and the movement after the hyperdash must be a [walk](/wiki/Glossary/Walk).
 - **[Combos](/wiki/Beatmapping/Combo) should not exceed 12 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
 - **Note density should follow a mostly 1/2 and/or 1/3 pattern.** 1/4 and/or 1/6 patterns should be used sparingly.
 
@@ -146,14 +146,14 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) and [dashes](/wiki/Glossary/Dash) must have at least a 62 ms gap between their two objects.**
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than four times between consecutive [fruits](/wiki/Hit_object/Fruit).**
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) must not be used more than two times within a slider.** The slider path must be simple and easy-to-follow.
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) [dashes](/wiki/Glossary/Dash) or any other [hyperdashes](/wiki/Glossary/Hyperdash).**
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used in conjunction with higher-snapped [dashes](/wiki/Glossary/Dash) or any other hyperdashes.**
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) must not be used within a slider.**
 - **At least 125 ms must be left between circles/sliders and the start and end of [spinners](/wiki/Hit_object/Spinner).** This is to ensure readability.
 
 #### Guidelines
 
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) should not be used on individual [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions.**
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 [hyperdash](/wiki/Glossary/Hyperdash) followed by a 1/2 [hyperdash](/wiki/Glossary/Hyperdash).
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [basic-snapped](/wiki/Glossary/Snapping#basic-snapped) should not be used consecutively when different beat snaps are used.** For example, a 1/1 hyperdash followed by a 1/2 hyperdash.
 - **[Hyperdashes](/wiki/Glossary/Hyperdash) that are [higher-snapped](/wiki/Glossary/Snapping#higher-snapped) should not be followed by [antiflow](/wiki/Beatmapping/Antiflow) [dashes](/wiki/Glossary/Dash) with a gap lower than 250ms.**
 - **[Edge dashes](/wiki/Glossary/Edge_dash) may only be used singularly (not in conjunction with other [dashes](/wiki/Glossary/Dash) or [hyperdashes](/wiki/Glossary/Hyperdash)).**
 - **[Combos](/wiki/Beatmapping/Combo) should not exceed 16 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.
@@ -174,7 +174,7 @@ Difficulty-specific rules and guidelines do only apply to the difficulty level t
 
 #### Guidelines
 
-- **[Hyperdashes](/wiki/Glossary/Hyperdash) should only be used on [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions when the slider path is simple and easy-to-follow.** This is to prevent chaotic or unreasonably difficult slider movement, as transitioning into and out of complex slider shapes with [hyperdash](/wiki/Glossary/Hyperdash) is usually uncomfortable to play, and a major penalty to accuracy for little benefit.
+- **[Hyperdashes](/wiki/Glossary/Hyperdash) should only be used on [drops](/wiki/Hit_object/Juice_stream#drop) and/or slider repetitions when the slider path is simple and easy-to-follow.** This is to prevent chaotic or unreasonably difficult slider movement, as transitioning into and out of complex slider shapes with hyperdash is usually uncomfortable to play, and a major penalty to accuracy for little benefit.
 - **1/8 and higher [hyperdashes](/wiki/Glossary/Hyperdash) should not be used between consecutive object pairs.**
 - **[Edge dashes](/wiki/Glossary/Edge_dash) may be used with caution for a maximum of three consecutive objects, and should not be used after [hyperdashes](/wiki/Glossary/Hyperdash).**
 - **[Combos](/wiki/Beatmapping/Combo) should not exceed 16 objects including slider tails and repeats.** [Spinners](/wiki/Hit_object/Spinner) are an exception.


### PR DESCRIPTION
This PR:
- Replaces the old glossary and adds stubs that have been added in #5587 
- Overall clean-up to be more aligned with the osu! RC

Note: the `snapping reference table` is kept in the RC for clarification as this is quite hard to understand for newer mappers. (This table also exists in the Snapping glossary so not sure if it's better to remove it from this page or keep it)