### PR TITLE
[ID] Add `Help_Centre/Installation_and_registration`

### DIFF
--- a/wiki/Help_Centre/Installation_and_registration/en.md
+++ b/wiki/Help_Centre/Installation_and_registration/en.md
@@ -19,7 +19,7 @@ This section is dedicated to issues with installing osu! and creating your own a
 
 ### How do I download osu!?
 
-**Simply click `Download` found at the center of the [official osu! website homepage](https://osu.ppy.sh/home). You may also find the link through the `home` dropdown section found at the navigation bar on any page.**
+**Simply click `Download now` found at the center of the [official osu! website homepage](https://osu.ppy.sh/home). You may also find the link through the `home` dropdown section found at the navigation bar on any page.**
 
 Alternatively, [click here](https://osu.ppy.sh/home/download) for a direct link to the download page.
 

--- a/wiki/Help_Centre/Installation_and_registration/en.md
+++ b/wiki/Help_Centre/Installation_and_registration/en.md
@@ -19,7 +19,7 @@ This section is dedicated to issues with installing osu! and creating your own a
 
 ### How do I download osu!?
 
-**Simply click `Download now` found at the center of the [official osu! website homepage](https://osu.ppy.sh/home). You may also find the link through the `home` dropdown section found at the navigation bar on any page.**
+**Simply click `Download` found at the center of the [official osu! website homepage](https://osu.ppy.sh/home). You may also find the link through the `home` dropdown section found at the navigation bar on any page.**
 
 Alternatively, [click here](https://osu.ppy.sh/home/download) for a direct link to the download page.
 

--- a/wiki/Help_Centre/Installation_and_registration/id.md
+++ b/wiki/Help_Centre/Installation_and_registration/id.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - install
+  - download
+  - account
+  - profile
+  - register
+  - instalasi
+  - pengunduhan
+  - akun
+  - profil
+  - pendaftaran
+---
+
+# Instalasi dan pendaftaran
+
+*Laman utama: [Pusat bantuan](/wiki/Help_Centre)*
+
+Laman ini akan membahas berbagai permasalahan dan pertanyaan yang sering diutarakan seputar instalasi dan pendaftaran akun osu! secara garis besar.
+
+## Instalasi
+
+*Laman utama: [Instalasi](/wiki/Installation)*
+
+### Di mana saya dapat mengunduh osu!?
+
+**Kamu dapat mengunduh osu! melalui tombol `Unduh sekarang` yang ada pada [laman utama (*homepage*) osu!](https://osu.ppy.sh/home), atau dengan mengarahkan kursor kamu pada menu `beranda` yang ada pada bagian atas layar dan memilih `unduh` pada daftar pilihan yang muncul setelahnya.**
+
+Apabila kamu tidak ingin repot, [klik tautan ini](https://osu.ppy.sh/home/download).
+
+## Pendaftaran
+
+*Laman utama: [Pendaftaran](/wiki/Registration)*
+
+### Bagaimana caranya bagi saya untuk dapat membuat akun osu!? 
+
+**[Unduh osu! terlebih dahulu](https://osu.ppy.sh/home/download), lalu instal dan jalankan. Apabila sudah, ikuti instruksi-instruksi yang tertera pada layar untuk dapat membuat akun baru.**
+
+Pastikan kamu mendaftar dengan menggunakan alamat email yang aktif dan dapat kamu akses setiap saat (bukan alamat email yang bersifat sementara/*throwaway mail*). Apabila sewaktu-waktu kamu kehilangan atau tidak dapat mengingat kata sandi milikmu, kami dapat menggunakan alamat email ini untuk memulihkan akses menuju akunmu.

--- a/wiki/Help_Centre/id.md
+++ b/wiki/Help_Centre/id.md
@@ -25,7 +25,7 @@ Harap pilih jenis permasalahan yang paling menggambarkan masalah yang kamu hadap
 | [Akun](/wiki/Help_Centre/Account) | osu!supporter, pembatasan akun (*restriction*), proses *login*, penggantian nama pengguna, data profil |
 | [Beatmapping dan Editor](/wiki/Help_Centre/Beatmapping) | Pengelolaan beatmap, kepemilikan beatmap, sistem kuota beatmap (*beatmap slots*) |
 | [Klien](/wiki/Help_Centre/Client) | *Bug* dan *crash*, permainan, koneksi, performa |
-| [Instalasi dan registrasi](/wiki/Help_Centre/Installation_and_registration) | Pengunduhan, pembuatan akun |
+| [Instalasi dan pendaftaran](/wiki/Help_Centre/Installation_and_registration) | Pengunduhan, pembuatan akun |
 | [osu!store](/wiki/Help_Centre/Store) | osu!go, osu!keyboard, osu!tablet, berbagai piranti dan cinderamata resmi lainnya |
 | [Situs web](/wiki/Help_Centre/Website) | Pemblokiran pengguna, layanan dukungan, tampilan situs web |
 


### PR DESCRIPTION
Indonesian translation of the `Help_Centre/Installation_and_registration` wiki page (http://osu.ppy.sh/wiki/en/Help_Centre/Installation_and_registration).

Also included a quick fix for an error in the English article that I found, where the download button on the main page was incorrectly referred to as `Download` instead of `Download now`.

![image](https://user-images.githubusercontent.com/36564236/129468676-eb02a8cb-7acc-4e8c-81ba-7a0413164d92.png)

---

edit : why did GitHub automatically sent a review request to both peppy and ephemeral out of the blue O_o
