### PR TITLE
Establish usage of custom section identifiers in article styling criteria

### DIFF
--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -314,6 +314,30 @@ Section headings must not skip a heading level (i.e. do not go from a level 2 he
 
 *Notice: On the website, heading levels 4 and 5 will not appear in the table of contents. They cannot be linked to directly either.*
 
+### Custom identifiers
+
+It is possible to redefine a section's identifier, which is used for linking to it directly:
+
+```markdown
+## My cooldown has passed. How do I appeal? {#appeal}
+
+## Common restriction reasons and cooldowns {#common-reasons}
+```
+
+Custom identifiers should be used in case the automatically generated ones are too long or contain tricky punctuation marks. For uniform experience, headings in a translated article must use the same identifiers as these in the original article:
+
+```markdown
+## Chat rules <!-- original heading -->
+## Правила чата {#chat-rules} <!-- translated heading -->
+```
+
+This feature can also be used for tagging a specific part of the article which doesn't have a heading. Use it sparingly:
+
+```markdown
+> That's it! You're well on your way to becoming an osu! rhythm champion!
+{#tutorial-quote}
+```
+
 ## Lists
 
 Lists should not go over 4 levels of indentation and should not have an empty line in between each item.

--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -324,14 +324,7 @@ It is possible to redefine a section's identifier, which is used for linking to 
 ## Common restriction reasons and cooldowns {#common-reasons}
 ```
 
-Custom identifiers should be used in case the automatically generated ones are too long or contain tricky punctuation marks. For uniform experience, headings in a translated article must use the same identifiers as these in the original article:
-
-```markdown
-## Chat rules <!-- original heading -->
-## Правила чата {#chat-rules} <!-- translated heading -->
-```
-
-This feature can also be used for tagging a specific part of the article which doesn't have a heading. Use it sparingly:
+Custom identifiers should be used in case the automatically generated ones are too long, contain tricky punctuation marks or images. This feature can also be used for tagging a specific part of the article which doesn't have a heading. Use it sparingly:
 
 ```markdown
 > That's it! You're well on your way to becoming an osu! rhythm champion!

--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -316,7 +316,7 @@ Section headings must not skip a heading level (i.e. do not go from a level 2 he
 
 ### Custom identifiers
 
-It is possible to redefine a section's identifier, which is used for linking to it directly:
+It is possible to redefine a section's identifier, which is used for linking to it directly. Custom identifiers should be used in case the automatically generated ones are too long or contain tricky punctuation marks or images:
 
 ```markdown
 ## My cooldown has passed. How do I appeal? {#appeal}
@@ -324,7 +324,7 @@ It is possible to redefine a section's identifier, which is used for linking to 
 ## Common restriction reasons and cooldowns {#common-reasons}
 ```
 
-Custom identifiers should be used in case the automatically generated ones are too long, contain tricky punctuation marks or images. This feature can also be used for tagging a specific part of the article which doesn't have a heading. Use it sparingly:
+This feature can also be used for tagging a specific part of the article which doesn't have a heading. Use it sparingly:
 
 ```markdown
 > That's it! You're well on your way to becoming an osu! rhythm champion!

--- a/wiki/Article_styling_criteria/Formatting/fr.md
+++ b/wiki/Article_styling_criteria/Formatting/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: a92869bad198adeb411099cc45da9aaf71893c2a
+---
+
 # Mise en forme
 
 *Pour les normes de rédaction, voir : [Critères de style des articles/Rédaction](../Writing)*

--- a/wiki/Article_styling_criteria/Formatting/ru.md
+++ b/wiki/Article_styling_criteria/Formatting/ru.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: a92869bad198adeb411099cc45da9aaf71893c2a
+---
+
 # Оформление статей
 
 *См. также: [Содержание статей](/wiki/Article_style_criteria/Writing)*


### PR DESCRIPTION
part of #5440. the first article to adapt this should be DAMN HELP CENTRE, finally