### PR TITLE
[FR] Add `Contests/KCC/1`, `KCC`, `Aspire` and `A Labour of Love`, Update `Contests/FBC`

### DIFF
--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -52,7 +52,7 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
     - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Mappers' Pick*
-      - Panélistes :
+    - Panélistes :
       - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
       - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
       - ![][flag_CN] [Garden](https://osu.ppy.sh/users/2849992)
@@ -71,7 +71,7 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
     - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Musicians' Pick*
-      - Panélistes :
+    - Panélistes :
       - ![][flag_CA] Kuba Oms
       - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)
       - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
@@ -79,12 +79,12 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
       - ![][flag_US] [Will Stetson](https://osu.ppy.sh/users/4909088)
       - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
 - **Prix général** (combinaison des deux panels axés sur tous les domaines)
-    - **Deuxième place :** 3 mois d'osu!supporter + badge de profil *Overall runner-up*
-    - **Gagnant :**
-      - 6 mois d'abonnement à osu!supporter
-      - badge de profil *Overall winner*
-      - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
-      - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
+  - **Deuxième place :** 3 mois d'osu!supporter + badge de profil *Overall runner-up*
+  - **Gagnant :**
+    - 6 mois d'abonnement à osu!supporter
+    - badge de profil *Overall winner*
+    - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
+    - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
 
 Si une équipe gagne dans plusieurs des catégories ci-dessus, elle sera récompensée par un badge de profil reflétant toutes les catégories pertinentes.
 

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -1,0 +1,212 @@
+# A Labour of Love contest
+
+Un concours à plusieurs niveaux lancé en novembre 2020 pour célébrer la beatmap [**Kuba Oms - My Love**](https://osu.ppy.sh/beatmapsets/163112).
+
+Les soumissions à ce concours comprennent les éléments suivants :
+
+- Remix de la musique *Kuba Oms - My Love* ([download stems here](https://assets.ppy.sh/contests/files/115/a_labour_of_love_stems.zip))
+- La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria) (osu! uniquement)
+- Storyboard or custom video
+
+## Liens
+
+- [Liste des concours](https://osu.ppy.sh/contests/115)
+- [Annonce du concours](https://osu.ppy.sh/home/news/2020-11-30-a-labour-of-love)
+- [Annonce du vote](https://osu.ppy.sh/home/news/2021-03-26-a-labour-of-love-voting-open)
+- [Résumé des résultats](https://osu.ppy.sh/home/news/2021-04-27-results-a-labour-of-love)
+
+## Équipes
+
+| Nom de l'équipe | Remixeur(s) | Beatmapper(s) | Créateur(s) de storyboard/vidéo | Entrée |
+| :-- | :-- | :-- | :-- | :-- |
+| Bowkutoly Encore | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109), ![][flag_ID] [gokugohan12468](https://osu.ppy.sh/users/2013571) | ![][flag_GB] [Agent Encore](https://osu.ppy.sh/users/18121148), ![][flag_US] [BowLL](https://osu.ppy.sh/users/10198015), ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | [Link](https://osu.ppy.sh/beatmapsets/1389153#osu/2868826) |
+| Daniel Gaming | ![][flag_US] [Sooph](https://osu.ppy.sh/users/12001243) | ![][flag_ID] [Tocorn](https://osu.ppy.sh/users/9564072), ![][flag_US] [phyr](https://osu.ppy.sh/users/13181574) | ![][flag_US] [Malishiosu](https://osu.ppy.sh/users/12521528) | [Link](https://osu.ppy.sh/beatmapsets/1390683#osu/2871703) |
+| Dolbit Normalno | ![][flag_RU] [DestoppeD](https://osu.ppy.sh/users/19611631) | ![][flag_RU] [NeilPerry](https://osu.ppy.sh/users/841391), ![][flag_CA] [Sing](https://osu.ppy.sh/users/3795679), ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | ![][flag_RU] [Tommy Phelps](https://osu.ppy.sh/users/10974581) | [Link](https://osu.ppy.sh/beatmapsets/1388552#osu/2867790) |
+| Down | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | [Link](https://osu.ppy.sh/beatmapsets/1348553#osu/2792430) |
+| extremely valid | ![][flag_US] [BilliumMoto](https://osu.ppy.sh/users/3862471), ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515), ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334), ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | [Link](https://osu.ppy.sh/beatmapsets/1388906#osu/2868388) |
+| humilde | ![][flag_AR] [pm04034](https://osu.ppy.sh/users/12704335) | ![][flag_AR] [Megafan](https://osu.ppy.sh/users/6632605), ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | [Link](https://osu.ppy.sh/beatmapsets/1382737#osu/2856702) |
+| Incoherent Sound | ![][flag_MY] [takehirotei](https://osu.ppy.sh/users/11793794) | ![][flag_MY] [Kardshark](https://osu.ppy.sh/users/4724315), ![][flag_MY] [\[MY\]xArief](https://osu.ppy.sh/users/12694468), ![][flag_MY] [\[-Chocola-\]](https://osu.ppy.sh/users/6781232) | ![][flag_MY] [GhostFY](https://osu.ppy.sh/users/7798305) | [Link](https://osu.ppy.sh/beatmapsets/1390004#osu/2870603) |
+| le fishe au chocolat | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309), ![][flag_CA] [J1_](https://osu.ppy.sh/users/5918561), ![][flag_AR] [Lince Cosmico](https://osu.ppy.sh/users/6070370), ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | [Link](https://osu.ppy.sh/beatmapsets/1389401#osu/2869375) |
+| Lovers | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905) | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905), ![][flag_RU] [adioni](https://osu.ppy.sh/users/8894794), ![][flag_RU] [Delette](https://osu.ppy.sh/users/7835664) | ![][flag_UA] [PantyDev](https://osu.ppy.sh/users/5420543) | [Link](https://osu.ppy.sh/beatmapsets/1388590#osu/2867851) |
+| Moyai | ![][flag_TR] [SAMString](https://osu.ppy.sh/users/7273976) | ![][flag_GB] [Aistre](https://osu.ppy.sh/users/4879380), ![][flag_GG] [Patrick Cake](https://osu.ppy.sh/users/11266329), ![][flag_RS] [Seolv](https://osu.ppy.sh/users/8067876) | ![][flag_CA] [TheDuckMask](https://osu.ppy.sh/users/7405768) | [Link](https://osu.ppy.sh/beatmapsets/1389249#osu/2868999) |
+| Pentangle of Ambivalence | ![][flag_BR] [Maemi no Yume](https://osu.ppy.sh/users/4377273) | ![][flag_BR] [Kalindraz](https://osu.ppy.sh/users/2313166), ![][flag_BR] [Sakura Airi](https://osu.ppy.sh/users/8682057) | ![][flag_BR] [K4L1](https://osu.ppy.sh/users/11334594) | [Link](https://osu.ppy.sh/beatmapsets/1389127#osu/2868791) |
+| schoolboy fans | ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231), ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494), ![][flag_RU] [Daycore](https://osu.ppy.sh/users/5596337), ![][flag_UA] [wajinshu](https://osu.ppy.sh/users/6339790) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | [Link](https://osu.ppy.sh/beatmapsets/1382412#osu/2856191) |
+| Team Name | ![][flag_US] [Absolute Zero](https://osu.ppy.sh/users/4847256), ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | ![][flag_CA] [Gordon](https://osu.ppy.sh/users/7856835), ![][flag_US] [Cheri](https://osu.ppy.sh/users/5226970) | ![][flag_US] [Fluffy91021](https://osu.ppy.sh/users/9149167) | [Link](https://osu.ppy.sh/beatmapsets/1389031#osu/2868617) |
+| Team Red but Blue | ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046), ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_CA] [Chompy](https://osu.ppy.sh/users/7427035), ![][flag_CA] [Zer0-G](https://osu.ppy.sh/users/12577911) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_US] [Tofumang](https://osu.ppy.sh/users/4817223) | [Link](https://osu.ppy.sh/beatmapsets/1388993#osu/2868551) |
+
+## Programme
+
+- **3 mois :** Le concours est ouvert aux soumissions.
+- **2-3 semaines :** Les soumissions sont jugées par des jurys distincts pour les mappeurs et les musiciens.
+- **2 semaines :** Le vote de la communauté est ouvert pour les 5 meilleures soumissions globales.
+
+## Prix
+
+Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et un panel de musiciens. Chaque groupe ayant sa propre spécialité, l'équipe ayant obtenu le meilleur score dans chaque groupe recevra un prix distinct.
+
+- **Vote communautaire**
+    - Prix
+        - **Deuxième place :** 3 mois d'osu!supporter 
+        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Community Pick*.
+- **Panel de mapping** (en se concentrant sur la qualité du mapping)
+    - Prix
+        - **Deuxième place :** 3 mois d'osu!supporter 
+        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Mappers' Pick*
+    - Panélistes :
+        - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
+        - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
+        - ![][flag_CN] [Garden](https://osu.ppy.sh/users/2849992)
+        - ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645)
+        - ![][flag_PL] [Kalibe](https://osu.ppy.sh/users/3376777)
+        - ![][flag_KR] [Luscent](https://osu.ppy.sh/users/2688581)
+        - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
+        - ![][flag_CZ] [NyarkoO](https://osu.ppy.sh/users/6622567)
+        - ![][flag_KR] [Sonnyc](https://osu.ppy.sh/users/11771)
+        - ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547)
+        - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
+        - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
+        - ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926)
+        - ![][flag_PL] [Zelq](https://osu.ppy.sh/users/8953955)
+- **Panel de musiciens** (en se concentrer sur la qualité des remixes)
+    - Prix
+        - **Deuxième place :** 3 mois d'osu!supporter 
+        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Musicians' Pick*
+    - Panélistes :
+        - ![][flag_CA] Kuba Oms
+        - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)
+        - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
+        - ![][flag_US] [Dictate](https://osu.ppy.sh/users/5983379)
+        - ![][flag_US] [Will Stetson](https://osu.ppy.sh/users/4909088)
+        - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
+- **Prix général** (combinaison des deux panels axés sur tous les domaines)
+    - **Deuxième place :** 3 mois d'osu!supporter + badge de profil *Overall runner-up*
+    - **Gagnant :**
+        - 6 mois d'abonnement à osu!supporter
+        - badge de profil *Overall winner*
+        - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
+        - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
+
+Si une équipe gagne dans plusieurs des catégories ci-dessus, elle sera récompensée par un badge de profil reflétant toutes les catégories pertinentes.
+
+## Règles
+
+- **La soumission doit être une "expérience complète de beatmap" comprenant les éléments suivants :**
+    - Remix de la chanson **Kuba Oms - My Love**
+    - La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria)
+    - Storyboard ou vidéo personnalisée
+- **La soumission doit être au format `.osz`.**
+- **Les beatmap doivent être dans le mode de jeu *osu!* uniquement.** Comparer les beatmaps de différents modes dans un scénario de jugement n'est malheureusement pas réaliste.
+- **Les beatmaps doivent respecter les [critères de classement](/wiki/Ranking_Criteria).** Bien que nous puissions être indulgents pour les erreurs, les soumissions qui ne pourraient pas être classées sans changements majeurs seront remises en question.
+- **Le nom et les membres de l'équipe doivent être confirmés par [ce formulaire](https://docs.google.com/forms/d/e/1FAIpQLScjtVsUWIArvf--pKA0RLiCdXuO1_wO2Va2ICjenEcz9ZqI5Q/viewform).** Si votre pays ne prend pas en charge les formulaires Google, [envoyez un message à pishifat](https://osu.ppy.sh/community/chat?sendto=3178418). Les équipes sont limitées à 5 membres.
+- **Les soumissions ne doivent pas être qualifiées avant la fin du vote communautaire.**
+
+Les équipes sont encouragées à présenter leurs soumissions dans le cadre de ce concours avant l'annonce des résultats.
+
+## Droits d'utilisation des remixes
+
+Les conditions d'utilisation suivantes ont été fournies par Kuba Oms : *Les remixeurs peuvent publier leurs remixes sur tous les médias sociaux, mais ils ne peuvent pas vendre, diffuser, distribuer, licencier ou utiliser les remixes pour un gain monétaire sans le consentement écrit de Kuba Oms.*
+
+## Résultats
+
+Pour plus d'informations sur les résultats, voir l'[aperçu détaillé des résultats](https://docs.google.com/spreadsheets/d/e/2PACX-1vTts0zpdjKdCUS3oCP4XZ18vh5ckEDqL_Jvy2eh0B4kC8je09bCGwYcpOWgjaXXy0251c3f33u7BDjv/pubhtml) et le [résumé des résultats](http://osu.ppy.sh/home/news/2021-04-27-results-a-labour-of-love).
+
+### Panel des musiciens
+
+| Rang | Nom de l'équipe |
+| :-- | :-- |
+| 1 | extremely valid |
+| 2 | Pentangle of Ambivalence |
+| 3 | Team Red but Blue |
+| 4 | Incoherent Sound |
+| 5 | Moyai |
+| 6 | schoolboy fans |
+| 7 | Daniel Gaming |
+| 8 | Lovers |
+| 9 | le fishe au chocolat |
+| 10 | humilde |
+| 11 | Dolbit Normalno |
+| 12 | Team Name |
+| 13 | Bowkutoly Encore |
+| 14 | Down |
+
+### Panel de mapping
+
+| Rang | Nom de l'équipe |
+| :-- | :-- |
+| 1 | extremely valid |
+| 2 | Dolbit Normalno |
+| 3 | le fishe au chocolat |
+| 4 | Moyai |
+| 5 | schoolboy fans |
+| 6 | Pentangle of Ambivalence |
+| 7 | Incoherent Sound |
+| 8 | Team Red but Blue |
+| 9 | Lovers |
+| 10 | humilde |
+| 11 | Daniel Gaming |
+| 12 | Team Name |
+| 13 | Bowkutoly Encore |
+| 14 | Down |
+
+### Panel global
+
+| Rang | Nom de l'équipe |
+| :-- | :-- |
+| 1 | extremely valid |
+| 2 | schoolboy fans |
+| 3 | Dolbit Normalno |
+| 4 | Incoherent Sound |
+| 5 | le fishe au chocolat |
+| 6 | Team Red but Blue |
+| 7 | Moyai |
+| 8 | Pentangle of Ambivalence |
+| 9 | Lovers |
+| 10 | Daniel Gaming |
+| 11 | humilde |
+| 12 | Team Name |
+| 13 | Bowkutoly Encore |
+| 14 | Down |
+
+### Vote communautaire
+
+| Rang | Nom de l'équipe | Total des votes |
+| :-- | :-- | :-- |
+| 1 | Team Red but Blue | 1379 |
+| 2 | extremely valid | 1079 |
+| 3 | schoolboy fans | 1054 |
+| 4 | Pentangle of Ambivalence | 963 |
+| 5 | Dolbit Normalno | 843 |
+| 6 | Incoherent Sound | 833 |
+| 7 | le fishe au chocolat | 643 |
+| 8 | Moyai | 430 |
+| N/A | Lovers | N/A |
+| N/A | Daniel Gaming | N/A |
+| N/A | humilde | N/A |
+| N/A | Team Name | N/A |
+| N/A | Bowkutoly Encore | N/A |
+| N/A | Down | N/A |
+
+[flag_AR]: /wiki/shared/flag/AR.gif "Argentine"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belgique"
+[flag_BR]: /wiki/shared/flag/BR.gif "Brésil"
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_CL]: /wiki/shared/flag/CL.gif "Chili"
+[flag_CN]: /wiki/shared/flag/CN.gif "Chine"
+[flag_CZ]: /wiki/shared/flag/CZ.gif "République tchèque"
+[flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
+[flag_DK]: /wiki/shared/flag/DK.gif "Danemark"
+[flag_FI]: /wiki/shared/flag/FI.gif "Finlande"
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
+[flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"
+[flag_GG]: /wiki/shared/flag/GG.gif "Guernesey"
+[flag_ID]: /wiki/shared/flag/ID.gif "Indonésie"
+[flag_JP]: /wiki/shared/flag/JP.gif "Japon"
+[flag_KR]: /wiki/shared/flag/KR.gif "Corée du Sud"
+[flag_MY]: /wiki/shared/flag/MY.gif "Malaisie"
+[flag_PL]: /wiki/shared/flag/PL.gif "Pologne"
+[flag_RS]: /wiki/shared/flag/RS.gif "Serbie"
+[flag_RU]: /wiki/shared/flag/RU.gif "Fédération de Russie"
+[flag_TH]: /wiki/shared/flag/TH.gif "Thaïlande"
+[flag_TR]: /wiki/shared/flag/TR.gif "Turquie"
+[flag_UA]: /wiki/shared/flag/UA.gif "Ukraine"
+[flag_US]: /wiki/shared/flag/US.gif "États-Unis"

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -47,11 +47,11 @@ Le concours sera jugé par un panel de mappeurs (comprenant des storyboarders) e
 - **Vote communautaire**
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Community Pick*.
+    - **Gagnant :** 6 mois d'osu!supporter + badge de profil *Community Pick*.
 - **Panel de mappeurs** (qui se concentre sur la qualité du mapping)
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Mappers' Pick*
+    - **Gagnant :** 6 mois d'osu!supporter + badge de profil *Mappers' Pick*
     - Panélistes :
       - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
       - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
@@ -70,7 +70,7 @@ Le concours sera jugé par un panel de mappeurs (comprenant des storyboarders) e
 - **Panel de musiciens** (qui se concentre sur la qualité des remixes)
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Musicians' Pick*
+    - **Gagnant :** 6 mois d'osu!supporter + badge de profil *Musicians' Pick*
     - Panélistes :
       - ![][flag_CA] Kuba Oms
       - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -45,55 +45,55 @@ Les soumissions à ce concours comprennent les éléments suivants :
 Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et un panel de musiciens. Chaque groupe ayant sa propre spécialité, l'équipe ayant obtenu le meilleur score dans chaque groupe recevra un prix distinct.
 
 - **Vote communautaire**
-    - Prix
-        - **Deuxième place :** 3 mois d'osu!supporter 
-        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Community Pick*.
+  - Prix
+    - **Deuxième place :** 3 mois d'osu!supporter 
+    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Community Pick*.
 - **Panel de mapping** (en se concentrant sur la qualité du mapping)
-    - Prix
-        - **Deuxième place :** 3 mois d'osu!supporter 
-        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Mappers' Pick*
-    - Panélistes :
-        - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
-        - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
-        - ![][flag_CN] [Garden](https://osu.ppy.sh/users/2849992)
-        - ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645)
-        - ![][flag_PL] [Kalibe](https://osu.ppy.sh/users/3376777)
-        - ![][flag_KR] [Luscent](https://osu.ppy.sh/users/2688581)
-        - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
-        - ![][flag_CZ] [NyarkoO](https://osu.ppy.sh/users/6622567)
-        - ![][flag_KR] [Sonnyc](https://osu.ppy.sh/users/11771)
-        - ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547)
-        - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
-        - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
-        - ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926)
-        - ![][flag_PL] [Zelq](https://osu.ppy.sh/users/8953955)
+  - Prix
+    - **Deuxième place :** 3 mois d'osu!supporter 
+    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Mappers' Pick*
+      - Panélistes :
+      - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
+      - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
+      - ![][flag_CN] [Garden](https://osu.ppy.sh/users/2849992)
+      - ![][flag_DE] [Icekalt](https://osu.ppy.sh/users/5410645)
+      - ![][flag_PL] [Kalibe](https://osu.ppy.sh/users/3376777)
+      - ![][flag_KR] [Luscent](https://osu.ppy.sh/users/2688581)
+      - ![][flag_DE] [Mordred](https://osu.ppy.sh/users/7265097)
+      - ![][flag_CZ] [NyarkoO](https://osu.ppy.sh/users/6622567)
+      - ![][flag_KR] [Sonnyc](https://osu.ppy.sh/users/11771)
+      - ![][flag_CL] [Uberzolik](https://osu.ppy.sh/users/1314547)
+      - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
+      - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
+      - ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926)
+      - ![][flag_PL] [Zelq](https://osu.ppy.sh/users/8953955)
 - **Panel de musiciens** (en se concentrer sur la qualité des remixes)
-    - Prix
-        - **Deuxième place :** 3 mois d'osu!supporter 
-        - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Musicians' Pick*
-    - Panélistes :
-        - ![][flag_CA] Kuba Oms
-        - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)
-        - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
-        - ![][flag_US] [Dictate](https://osu.ppy.sh/users/5983379)
-        - ![][flag_US] [Will Stetson](https://osu.ppy.sh/users/4909088)
-        - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
+  - Prix
+    - **Deuxième place :** 3 mois d'osu!supporter 
+    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Musicians' Pick*
+      - Panélistes :
+      - ![][flag_CA] Kuba Oms
+      - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)
+      - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
+      - ![][flag_US] [Dictate](https://osu.ppy.sh/users/5983379)
+      - ![][flag_US] [Will Stetson](https://osu.ppy.sh/users/4909088)
+      - ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406)
 - **Prix général** (combinaison des deux panels axés sur tous les domaines)
     - **Deuxième place :** 3 mois d'osu!supporter + badge de profil *Overall runner-up*
     - **Gagnant :**
-        - 6 mois d'abonnement à osu!supporter
-        - badge de profil *Overall winner*
-        - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
-        - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
+      - 6 mois d'abonnement à osu!supporter
+      - badge de profil *Overall winner*
+      - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
+      - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
 
 Si une équipe gagne dans plusieurs des catégories ci-dessus, elle sera récompensée par un badge de profil reflétant toutes les catégories pertinentes.
 
 ## Règles
 
 - **La soumission doit être une "expérience complète de beatmap" comprenant les éléments suivants :**
-    - Remix de la chanson **Kuba Oms - My Love**
-    - La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria)
-    - Storyboard ou vidéo personnalisée
+  - Remix de la chanson **Kuba Oms - My Love**
+  - La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria)
+  - Storyboard ou vidéo personnalisée
 - **La soumission doit être au format `.osz`.**
 - **Les beatmap doivent être dans le mode de jeu *osu!* uniquement.** Comparer les beatmaps de différents modes dans un scénario de jugement n'est malheureusement pas réaliste.
 - **Les beatmaps doivent respecter les [critères de classement](/wiki/Ranking_Criteria).** Bien que nous puissions être indulgents pour les erreurs, les soumissions qui ne pourraient pas être classées sans changements majeurs seront remises en question.

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -17,7 +17,7 @@ Les soumissions à ce concours comprennent les éléments suivants :
 
 ## Équipes
 
-| Nom de l'équipe | Remixeur(s) | Beatmapper(s) | Créateur(s) de storyboard/vidéo | Entrée |
+| Nom de l'équipe | Remixeur(s) | Beatmapper(s) | Créateur(s) de storyboard/vidéo | Participation |
 | :-- | :-- | :-- | :-- | :-- |
 | Bowkutoly Encore | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109), ![][flag_ID] [gokugohan12468](https://osu.ppy.sh/users/2013571) | ![][flag_GB] [Agent Encore](https://osu.ppy.sh/users/18121148), ![][flag_US] [BowLL](https://osu.ppy.sh/users/10198015), ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | [Link](https://osu.ppy.sh/beatmapsets/1389153#osu/2868826) |
 | Daniel Gaming | ![][flag_US] [Sooph](https://osu.ppy.sh/users/12001243) | ![][flag_ID] [Tocorn](https://osu.ppy.sh/users/9564072), ![][flag_US] [phyr](https://osu.ppy.sh/users/13181574) | ![][flag_US] [Malishiosu](https://osu.ppy.sh/users/12521528) | [Link](https://osu.ppy.sh/beatmapsets/1390683#osu/2871703) |
@@ -86,7 +86,7 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
     - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
     - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
 
-Si une équipe gagne dans plusieurs des catégories ci-dessus, elle sera récompensée par un badge de profil reflétant toutes les catégories pertinentes.
+Si une équipe gagne dans plusieurs des catégories citées ci-dessus, elle sera récompensée par un badge de profil reflétant toutes les catégories pertinentes.
 
 ## Règles
 

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -6,7 +6,7 @@ Les soumissions à ce concours comprennent les éléments suivants :
 
 - Remix de la musique *Kuba Oms - My Love* ([download stems here](https://assets.ppy.sh/contests/files/115/a_labour_of_love_stems.zip))
 - La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria) (osu! uniquement)
-- Storyboard or custom video
+- Storyboard ou vidéo personnalisée
 
 ## Liens
 
@@ -17,22 +17,22 @@ Les soumissions à ce concours comprennent les éléments suivants :
 
 ## Équipes
 
-| Nom de l'équipe | Remixeur(s) | Beatmapper(s) | Créateur(s) de storyboard/vidéo | Participation |
+| Nom de l'équipe | Remixeur(s) | Mappeur(s) | Créateur(s) de storyboard/vidéo | Participation |
 | :-- | :-- | :-- | :-- | :-- |
-| Bowkutoly Encore | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109), ![][flag_ID] [gokugohan12468](https://osu.ppy.sh/users/2013571) | ![][flag_GB] [Agent Encore](https://osu.ppy.sh/users/18121148), ![][flag_US] [BowLL](https://osu.ppy.sh/users/10198015), ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | [Link](https://osu.ppy.sh/beatmapsets/1389153#osu/2868826) |
-| Daniel Gaming | ![][flag_US] [Sooph](https://osu.ppy.sh/users/12001243) | ![][flag_ID] [Tocorn](https://osu.ppy.sh/users/9564072), ![][flag_US] [phyr](https://osu.ppy.sh/users/13181574) | ![][flag_US] [Malishiosu](https://osu.ppy.sh/users/12521528) | [Link](https://osu.ppy.sh/beatmapsets/1390683#osu/2871703) |
-| Dolbit Normalno | ![][flag_RU] [DestoppeD](https://osu.ppy.sh/users/19611631) | ![][flag_RU] [NeilPerry](https://osu.ppy.sh/users/841391), ![][flag_CA] [Sing](https://osu.ppy.sh/users/3795679), ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | ![][flag_RU] [Tommy Phelps](https://osu.ppy.sh/users/10974581) | [Link](https://osu.ppy.sh/beatmapsets/1388552#osu/2867790) |
-| Down | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | [Link](https://osu.ppy.sh/beatmapsets/1348553#osu/2792430) |
-| extremely valid | ![][flag_US] [BilliumMoto](https://osu.ppy.sh/users/3862471), ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515), ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334), ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | [Link](https://osu.ppy.sh/beatmapsets/1388906#osu/2868388) |
-| humilde | ![][flag_AR] [pm04034](https://osu.ppy.sh/users/12704335) | ![][flag_AR] [Megafan](https://osu.ppy.sh/users/6632605), ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | [Link](https://osu.ppy.sh/beatmapsets/1382737#osu/2856702) |
-| Incoherent Sound | ![][flag_MY] [takehirotei](https://osu.ppy.sh/users/11793794) | ![][flag_MY] [Kardshark](https://osu.ppy.sh/users/4724315), ![][flag_MY] [\[MY\]xArief](https://osu.ppy.sh/users/12694468), ![][flag_MY] [\[-Chocola-\]](https://osu.ppy.sh/users/6781232) | ![][flag_MY] [GhostFY](https://osu.ppy.sh/users/7798305) | [Link](https://osu.ppy.sh/beatmapsets/1390004#osu/2870603) |
-| le fishe au chocolat | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309), ![][flag_CA] [J1_](https://osu.ppy.sh/users/5918561), ![][flag_AR] [Lince Cosmico](https://osu.ppy.sh/users/6070370), ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | [Link](https://osu.ppy.sh/beatmapsets/1389401#osu/2869375) |
-| Lovers | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905) | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905), ![][flag_RU] [adioni](https://osu.ppy.sh/users/8894794), ![][flag_RU] [Delette](https://osu.ppy.sh/users/7835664) | ![][flag_UA] [PantyDev](https://osu.ppy.sh/users/5420543) | [Link](https://osu.ppy.sh/beatmapsets/1388590#osu/2867851) |
-| Moyai | ![][flag_TR] [SAMString](https://osu.ppy.sh/users/7273976) | ![][flag_GB] [Aistre](https://osu.ppy.sh/users/4879380), ![][flag_GG] [Patrick Cake](https://osu.ppy.sh/users/11266329), ![][flag_RS] [Seolv](https://osu.ppy.sh/users/8067876) | ![][flag_CA] [TheDuckMask](https://osu.ppy.sh/users/7405768) | [Link](https://osu.ppy.sh/beatmapsets/1389249#osu/2868999) |
-| Pentangle of Ambivalence | ![][flag_BR] [Maemi no Yume](https://osu.ppy.sh/users/4377273) | ![][flag_BR] [Kalindraz](https://osu.ppy.sh/users/2313166), ![][flag_BR] [Sakura Airi](https://osu.ppy.sh/users/8682057) | ![][flag_BR] [K4L1](https://osu.ppy.sh/users/11334594) | [Link](https://osu.ppy.sh/beatmapsets/1389127#osu/2868791) |
-| schoolboy fans | ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231), ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494), ![][flag_RU] [Daycore](https://osu.ppy.sh/users/5596337), ![][flag_UA] [wajinshu](https://osu.ppy.sh/users/6339790) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | [Link](https://osu.ppy.sh/beatmapsets/1382412#osu/2856191) |
-| Team Name | ![][flag_US] [Absolute Zero](https://osu.ppy.sh/users/4847256), ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | ![][flag_CA] [Gordon](https://osu.ppy.sh/users/7856835), ![][flag_US] [Cheri](https://osu.ppy.sh/users/5226970) | ![][flag_US] [Fluffy91021](https://osu.ppy.sh/users/9149167) | [Link](https://osu.ppy.sh/beatmapsets/1389031#osu/2868617) |
-| Team Red but Blue | ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046), ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_CA] [Chompy](https://osu.ppy.sh/users/7427035), ![][flag_CA] [Zer0-G](https://osu.ppy.sh/users/12577911) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_US] [Tofumang](https://osu.ppy.sh/users/4817223) | [Link](https://osu.ppy.sh/beatmapsets/1388993#osu/2868551) |
+| Bowkutoly Encore | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109), ![][flag_ID] [gokugohan12468](https://osu.ppy.sh/users/2013571) | ![][flag_GB] [Agent Encore](https://osu.ppy.sh/users/18121148), ![][flag_US] [BowLL](https://osu.ppy.sh/users/10198015), ![][flag_TH] [Raytoly](https://osu.ppy.sh/users/8121109) | [Lien](https://osu.ppy.sh/beatmapsets/1389153#osu/2868826) |
+| Daniel Gaming | ![][flag_US] [Sooph](https://osu.ppy.sh/users/12001243) | ![][flag_ID] [Tocorn](https://osu.ppy.sh/users/9564072), ![][flag_US] [phyr](https://osu.ppy.sh/users/13181574) | ![][flag_US] [Malishiosu](https://osu.ppy.sh/users/12521528) | [Lien](https://osu.ppy.sh/beatmapsets/1390683#osu/2871703) |
+| Dolbit Normalno | ![][flag_RU] [DestoppeD](https://osu.ppy.sh/users/19611631) | ![][flag_RU] [NeilPerry](https://osu.ppy.sh/users/841391), ![][flag_CA] [Sing](https://osu.ppy.sh/users/3795679), ![][flag_RU] [Mirash](https://osu.ppy.sh/users/2841009) | ![][flag_RU] [Tommy Phelps](https://osu.ppy.sh/users/10974581) | [Lien](https://osu.ppy.sh/beatmapsets/1388552#osu/2867790) |
+| Down | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | ![][flag_KR] [Down](https://osu.ppy.sh/users/4694602) | [Lien](https://osu.ppy.sh/beatmapsets/1348553#osu/2792430) |
+| extremely valid | ![][flag_US] [BilliumMoto](https://osu.ppy.sh/users/3862471), ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515), ![][flag_GB] [DeviousPanda](https://osu.ppy.sh/users/4966334), ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | [Lien](https://osu.ppy.sh/beatmapsets/1388906#osu/2868388) |
+| humilde | ![][flag_AR] [pm04034](https://osu.ppy.sh/users/12704335) | ![][flag_AR] [Megafan](https://osu.ppy.sh/users/6632605), ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | ![][flag_TH] [ohm002](https://osu.ppy.sh/users/4468239) | [Lien](https://osu.ppy.sh/beatmapsets/1382737#osu/2856702) |
+| Incoherent Sound | ![][flag_MY] [takehirotei](https://osu.ppy.sh/users/11793794) | ![][flag_MY] [Kardshark](https://osu.ppy.sh/users/4724315), ![][flag_MY] [\[MY\]xArief](https://osu.ppy.sh/users/12694468), ![][flag_MY] [\[-Chocola-\]](https://osu.ppy.sh/users/6781232) | ![][flag_MY] [GhostFY](https://osu.ppy.sh/users/7798305) | [Lien](https://osu.ppy.sh/beatmapsets/1390004#osu/2870603) |
+| le fishe au chocolat | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309), ![][flag_CA] [J1_](https://osu.ppy.sh/users/5918561), ![][flag_AR] [Lince Cosmico](https://osu.ppy.sh/users/6070370), ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | ![][flag_DK] [-Tochi](https://osu.ppy.sh/users/3664366) | [Lien](https://osu.ppy.sh/beatmapsets/1389401#osu/2869375) |
+| Lovers | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905) | ![][flag_UA] [XenjeS](https://osu.ppy.sh/users/10166905), ![][flag_RU] [adioni](https://osu.ppy.sh/users/8894794), ![][flag_RU] [Delette](https://osu.ppy.sh/users/7835664) | ![][flag_UA] [PantyDev](https://osu.ppy.sh/users/5420543) | [Lien](https://osu.ppy.sh/beatmapsets/1388590#osu/2867851) |
+| Moyai | ![][flag_TR] [SAMString](https://osu.ppy.sh/users/7273976) | ![][flag_GB] [Aistre](https://osu.ppy.sh/users/4879380), ![][flag_GG] [Patrick Cake](https://osu.ppy.sh/users/11266329), ![][flag_RS] [Seolv](https://osu.ppy.sh/users/8067876) | ![][flag_CA] [TheDuckMask](https://osu.ppy.sh/users/7405768) | [Lien](https://osu.ppy.sh/beatmapsets/1389249#osu/2868999) |
+| Pentangle of Ambivalence | ![][flag_BR] [Maemi no Yume](https://osu.ppy.sh/users/4377273) | ![][flag_BR] [Kalindraz](https://osu.ppy.sh/users/2313166), ![][flag_BR] [Sakura Airi](https://osu.ppy.sh/users/8682057) | ![][flag_BR] [K4L1](https://osu.ppy.sh/users/11334594) | [Lien](https://osu.ppy.sh/beatmapsets/1389127#osu/2868791) |
+| schoolboy fans | ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231), ![][flag_RU] [Shadren](https://osu.ppy.sh/users/745494), ![][flag_RU] [Daycore](https://osu.ppy.sh/users/5596337), ![][flag_UA] [wajinshu](https://osu.ppy.sh/users/6339790) | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | [Lien](https://osu.ppy.sh/beatmapsets/1382412#osu/2856191) |
+| Team Name | ![][flag_US] [Absolute Zero](https://osu.ppy.sh/users/4847256), ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | ![][flag_CA] [Gordon](https://osu.ppy.sh/users/7856835), ![][flag_US] [Cheri](https://osu.ppy.sh/users/5226970) | ![][flag_US] [Fluffy91021](https://osu.ppy.sh/users/9149167) | [Lien](https://osu.ppy.sh/beatmapsets/1389031#osu/2868617) |
+| Team Red but Blue | ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046), ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_CA] [Chompy](https://osu.ppy.sh/users/7427035), ![][flag_CA] [Zer0-G](https://osu.ppy.sh/users/12577911) | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323), ![][flag_US] [Tofumang](https://osu.ppy.sh/users/4817223) | [Lien](https://osu.ppy.sh/beatmapsets/1388993#osu/2868551) |
 
 ## Programme
 
@@ -42,16 +42,16 @@ Les soumissions à ce concours comprennent les éléments suivants :
 
 ## Prix
 
-Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et un panel de musiciens. Chaque groupe ayant sa propre spécialité, l'équipe ayant obtenu le meilleur score dans chaque groupe recevra un prix distinct.
+Le concours sera jugé par un panel de mappeurs (comprenant des storyboarders) et un panel de musiciens. Chaque groupe ayant sa propre spécialité, l'équipe ayant obtenu le meilleur score dans chaque groupe recevra un prix distinct.
 
 - **Vote communautaire**
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Community Pick*.
-- **Panel de mapping** (en se concentrant sur la qualité du mapping)
+    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Community Pick*.
+- **Panel de mappeurs** (qui se concentre sur la qualité du mapping)
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Mappers' Pick*
+    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Mappers' Pick*
     - Panélistes :
       - ![][flag_DE] [Celektus](https://osu.ppy.sh/users/4294993)
       - ![][flag_FI] [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
@@ -67,10 +67,10 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
       - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
       - ![][flag_BE] [yaspo](https://osu.ppy.sh/users/4945926)
       - ![][flag_PL] [Zelq](https://osu.ppy.sh/users/8953955)
-- **Panel de musiciens** (en se concentrer sur la qualité des remixes)
+- **Panel de musiciens** (qui se concentre sur la qualité des remixes)
   - Prix
     - **Deuxième place :** 3 mois d'osu!supporter 
-    - **Gagnant :**  6 mois d'abonnement à osu!supporter + badge de profil *Musicians' Pick*
+    - **Gagnant :**  6 mois d'osu!supporter + badge de profil *Musicians' Pick*
     - Panélistes :
       - ![][flag_CA] Kuba Oms
       - ![][flag_JP] [A__](https://osu.ppy.sh/users/12011880)
@@ -81,7 +81,7 @@ Le concours sera jugé par un panel de mappeurs (y compris les storyboarders) et
 - **Prix général** (combinaison des deux panels axés sur tous les domaines)
   - **Deuxième place :** 3 mois d'osu!supporter + badge de profil *Overall runner-up*
   - **Gagnant :**
-    - 6 mois d'abonnement à osu!supporter
+    - 6 mois d'osu!supporter
     - badge de profil *Overall winner*
     - Titres d'utilisateur *Elite Mapper*, *Elite Storyboarder*, et *osu!mixer*
     - Soumission groupée avec les nouveaux téléchargements d'osu! et passage rapide au statut Classée
@@ -95,10 +95,10 @@ Si une équipe gagne dans plusieurs des catégories citées ci-dessus, elle sera
   - La beatmap suivra les [critères de classement](/wiki/Ranking_Criteria)
   - Storyboard ou vidéo personnalisée
 - **La soumission doit être au format `.osz`.**
-- **Les beatmap doivent être dans le mode de jeu *osu!* uniquement.** Comparer les beatmaps de différents modes dans un scénario de jugement n'est malheureusement pas réaliste.
-- **Les beatmaps doivent respecter les [critères de classement](/wiki/Ranking_Criteria).** Bien que nous puissions être indulgents pour les erreurs, les soumissions qui ne pourraient pas être classées sans changements majeurs seront remises en question.
-- **Le nom et les membres de l'équipe doivent être confirmés par [ce formulaire](https://docs.google.com/forms/d/e/1FAIpQLScjtVsUWIArvf--pKA0RLiCdXuO1_wO2Va2ICjenEcz9ZqI5Q/viewform).** Si votre pays ne prend pas en charge les formulaires Google, [envoyez un message à pishifat](https://osu.ppy.sh/community/chat?sendto=3178418). Les équipes sont limitées à 5 membres.
-- **Les soumissions ne doivent pas être qualifiées avant la fin du vote communautaire.**
+- **Les beatmaps doivent être dans le mode de jeu *osu!* uniquement.** Comparer les beatmaps de différents modes dans un scénario de jugement n'est malheureusement pas réaliste.
+- **Les beatmaps doivent respecter les [critères de classement](/wiki/Ranking_Criteria).** Bien que nous puissions être indulgents avec les erreurs, les beatmaps qui ne pourraient pas être classées sans changements majeurs seront remises en question.
+- **Le nom et les membres de l'équipe doivent être confirmés via [ce formulaire](https://docs.google.com/forms/d/e/1FAIpQLScjtVsUWIArvf--pKA0RLiCdXuO1_wO2Va2ICjenEcz9ZqI5Q/viewform).** Si votre pays ne prend pas en charge les formulaires Google, [envoyez un message à pishifat](https://osu.ppy.sh/community/chat?sendto=3178418). Les équipes sont limitées à 5 membres.
+- **Les beatmaps ne doivent pas être dans la catégorie Qualifiée avant la fin du vote communautaire.**
 
 Les équipes sont encouragées à présenter leurs soumissions dans le cadre de ce concours avant l'annonce des résultats.
 
@@ -110,7 +110,7 @@ Les conditions d'utilisation suivantes ont été fournies par Kuba Oms : *Les re
 
 Pour plus d'informations sur les résultats, voir l'[aperçu détaillé des résultats](https://docs.google.com/spreadsheets/d/e/2PACX-1vTts0zpdjKdCUS3oCP4XZ18vh5ckEDqL_Jvy2eh0B4kC8je09bCGwYcpOWgjaXXy0251c3f33u7BDjv/pubhtml) et le [résumé des résultats](http://osu.ppy.sh/home/news/2021-04-27-results-a-labour-of-love).
 
-### Panel des musiciens
+### Panel de musiciens
 
 | Rang | Nom de l'équipe |
 | :-- | :-- |
@@ -129,7 +129,7 @@ Pour plus d'informations sur les résultats, voir l'[aperçu détaillé des rés
 | 13 | Bowkutoly Encore |
 | 14 | Down |
 
-### Panel de mapping
+### Panel de mappeurs
 
 | Rang | Nom de l'équipe |
 | :-- | :-- |

--- a/wiki/Contests/A_Labour_of_Love_Contest/fr.md
+++ b/wiki/Contests/A_Labour_of_Love_Contest/fr.md
@@ -1,6 +1,6 @@
 # A Labour of Love contest
 
-Un concours à plusieurs niveaux lancé en novembre 2020 pour célébrer la beatmap [**Kuba Oms - My Love**](https://osu.ppy.sh/beatmapsets/163112).
+A Labour of Love est un concours à plusieurs niveaux lancé en novembre 2020 pour célébrer la beatmap [**Kuba Oms - My Love**](https://osu.ppy.sh/beatmapsets/163112).
 
 Les soumissions à ce concours comprennent les éléments suivants :
 

--- a/wiki/Contests/Aspire/fr.md
+++ b/wiki/Contests/Aspire/fr.md
@@ -1,0 +1,12 @@
+---
+stub: true
+tags:
+  - MBC
+  - MBC 6
+  - Monthly Beatmapping Contest
+  - Monthly Beatmapping Contest 6
+---
+
+# Aspire
+
+**Aspire** est un [concours](/wiki/Contests) de [beatmapping](/wiki/Beatmapping)  où les mappeurs sont encouragés à ignorer complètement les [critères de classement](/wiki/Ranking_Criteria) et à explorer des mécanismes de jeu qui ne sont pas habituellement utilisés.

--- a/wiki/Contests/Aspire/fr.md
+++ b/wiki/Contests/Aspire/fr.md
@@ -9,4 +9,4 @@ tags:
 
 # Aspire
 
-**Aspire** est un [concours](/wiki/Contests) de [beatmapping](/wiki/Beatmapping)  où les mappeurs sont encouragés à ignorer complètement les [critères de classement](/wiki/Ranking_Criteria) et à explorer des mécanismes de jeu qui ne sont pas habituellement utilisés.
+**Aspire** est un [concours](/wiki/Contests) de [beatmapping](/wiki/Beatmapping) dans lequel les mappeurs sont encouragés à ignorer complètement les [critères de classement](/wiki/Ranking_Criteria) et à explorer des mécanismes de jeu qui ne sont pas habituellement utilisés.

--- a/wiki/Contests/FBC/fr.md
+++ b/wiki/Contests/FBC/fr.md
@@ -16,7 +16,7 @@ Depuis l'édition 2017, les musiques choisies ont une durée inférieure à 3 mi
 
 ## FBC 2015
 
-L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu : osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, dans les modes osu!catch et osu!mania, il n'y avait pas assez de participants pour récompenser les vainqueurs d'un badge.
+L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu : osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, dans les modes osu!catch et osu!mania, il n'y avait pas suffisamment de participants pour récompenser les vainqueurs d'un badge.
 
 La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtube.com/watch?v=NuQfuYxf6lk) d'une durée de 5:06 minutes.
 
@@ -24,7 +24,7 @@ La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtu
 
 ### Vainqueurs du mode osu!
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Kin](https://osu.ppy.sh/users/480689) |
@@ -32,7 +32,7 @@ La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtu
 
 ### Vainqueurs du mode osu!taiko
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Aldwych](https://osu.ppy.sh/users/1416484) |
@@ -40,14 +40,14 @@ La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtu
 
 ### Vainqueurs du mode osu!mania
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_CA] [Julie](https://osu.ppy.sh/users/2420987) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Todestrieb](https://osu.ppy.sh/users/4056690) |
 
 ### Vainqueurs du mode osu!catch
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [rezoons](https://osu.ppy.sh/users/1893035) |
 
@@ -73,7 +73,7 @@ La musique sélectionnée pour le mode osu! et osu!catch était [Phantom Sage - 
 
 ### Vainqueurs
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_CA] [sheela](https://osu.ppy.sh/users/1138027) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
@@ -93,7 +93,7 @@ La musique sélectionnée pour le mode osu! et osu!catch était [Phantom Sage - 
 
 ## FBC 2017
 
-Cette édition était la première édition qui utilise une musique de moins de 3 minutes. De plus, elle était la première à permettre au mapset vainqueur (hébergé par le vainqueur du tournoi) de contenir les difficultés des trois premiers joueurs.
+Cette édition était la première édition à utiliser une musique de moins de 3 minutes. De plus, elle était la première à permettre au mapset vainqueur (hébergé par le vainqueur du tournoi) de contenir les difficultés des trois premiers mappeurs.
 
 La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia](https://soundcloud.com/ak_q/bofu2017-excelsia).
 
@@ -101,7 +101,7 @@ La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia
 
 ### Vainqueurs
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Sotarks](https://osu.ppy.sh/users/4452992) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [BOUYAAA](https://osu.ppy.sh/users/405449) |
@@ -120,7 +120,7 @@ La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia
 
 ## FBC 2018
 
-Cette édition était la première à proposer une musique d'un Featured Artist dans ce tournoi. De plus, c'était la première à voir deux joueurs être ex-aequo dans le classement.
+Cette édition était la première à proposer une musique d'un Featured Artist dans ce tournoi. De plus, c'était la première à voir deux participants ex-aequo dans le classement.
 
 La musique sélectionnée pour cette édition du tournoi est [Thaehan - Sunrise](https://www.youtube.com/watch?v=F1_EyWi68hE).
 
@@ -128,7 +128,7 @@ La musique sélectionnée pour cette édition du tournoi est [Thaehan - Sunrise]
 
 ### Vainqueurs
 
-| Place | Joueurs |
+| Place | Mappeurs |
 | :-: | :-- |
 | ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) |
 | ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_CA] [celerih](https://osu.ppy.sh/users/4696296) |

--- a/wiki/Contests/FBC/fr.md
+++ b/wiki/Contests/FBC/fr.md
@@ -6,7 +6,7 @@ tags:
 
 # French Beatmapping Contest
 
-La **French Beatmapping Contest** (***FBC***) est un tournoi de mapping uniquement accessible aux personnes francophones. Dans chaque édition, les mappeurs doivent réaliser une difficulté de niveau Insane ou plus.
+Le **French Beatmapping Contest** (***FBC***) est un tournoi de mapping uniquement accessible aux personnes francophones. Dans chaque édition, les mappeurs doivent réaliser une difficulté de niveau Insane ou plus.
 
 Les points sont attribués en suivant les critères de notation suivants : **Structure**, **Pertinence**, **Créativité**, **Impression du juge** et **Hitsounds**. Il est possible que les critères changent si nécessaire.
 

--- a/wiki/Contests/FBC/fr.md
+++ b/wiki/Contests/FBC/fr.md
@@ -10,13 +10,13 @@ Le **French Beatmapping Contest** (***FBC***) est un tournoi de mapping uniqueme
 
 Les points sont attribués en suivant les critères de notation suivants : **Structure**, **Pertinence**, **Créativité**, **Impression du juge** et **Hitsounds**. Il est possible que les critères changent si nécessaire.
 
-Les trois premiers mappeurs d'un tournoi recevront chacun un titre de osu!supporter d'une durée qui peut varier en fonction des éditions. Cependant, le vainqueur de chaque édition recevra un badge personnalisé qui s'affichera sur son profil osu!.
+Les trois premiers mappeurs d'un tournoi recevront chacun un tag osu!supporter d'une durée qui peut varier en fonction des éditions. Cependant, le vainqueur de chaque édition recevra un badge personnalisé qui s'affichera sur son profil osu!.
 
-Depuis l'édition 2017, les musiques choisies ont une durée inférieure à 3 minutes et les difficultés en dessous du niveau Insane sont mappées par les organisateurs des tournois ou bien par des membres de la communauté de mapping francophone.
+Depuis l'édition 2017, les musiques choisies ont une durée inférieure à 3 minutes et les difficultés en dessous du niveau Insane sont mappées par les organisateurs des tournois ou par des membres de la communauté de mapping francophone.
 
 ## FBC 2015
 
-L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu : osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, en mode osu!catch et osu!mania, il n'y avait pas assez de participants pour récompenser les vainqueurs d'un badge.
+L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu : osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, dans les modes osu!catch et osu!mania, il n'y avait pas assez de participants pour récompenser les vainqueurs d'un badge.
 
 La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtube.com/watch?v=NuQfuYxf6lk) d'une durée de 5:06 minutes.
 

--- a/wiki/Contests/FBC/fr.md
+++ b/wiki/Contests/FBC/fr.md
@@ -6,50 +6,50 @@ tags:
 
 # French Beatmapping Contest
 
-Le **French Beatmapping Contest** (***FBC***) est un tournoi de mapping uniquement accessible aux personnes francophones. Dans chaque édition, les mappeurs doivent réaliser une difficulté de niveau Insane ou plus.
+La **French Beatmapping Contest** (***FBC***) est un tournoi de mapping uniquement accessible aux personnes francophones. Dans chaque édition, les mappeurs doivent réaliser une difficulté de niveau Insane ou plus.
 
-Les points sont attribués en suivant les critères de notation suivants: **Structure**, **Pertinence**, **Créativité**, **Impression du juge** et **Hitsounds**. Il est possible que les critères changent si nécessaire.
+Les points sont attribués en suivant les critères de notation suivants : **Structure**, **Pertinence**, **Créativité**, **Impression du juge** et **Hitsounds**. Il est possible que les critères changent si nécessaire.
 
-Les trois premiers mappeurs d'un tournoi recevront chacun un titre de osu!supporter d'une durée qui peut varier en fonction des éditions. Cependant, le vainqueur de chaque édition recevra un badge personalisé qui s'affichera sur son profil osu!.
+Les trois premiers mappeurs d'un tournoi recevront chacun un titre de osu!supporter d'une durée qui peut varier en fonction des éditions. Cependant, le vainqueur de chaque édition recevra un badge personnalisé qui s'affichera sur son profil osu!.
 
 Depuis l'édition 2017, les musiques choisies ont une durée inférieure à 3 minutes et les difficultés en dessous du niveau Insane sont mappées par les organisateurs des tournois ou bien par des membres de la communauté de mapping francophone.
 
 ## FBC 2015
 
-L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu: osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, en mode osu!catch et osu!mania, il n'y avait pas assez de participants pour récompenser les vainqueurs d'un badge.
+L'édition 2015 était la première édition à avoir réuni les 4 modes de jeu : osu!, osu!taiko, osu!catch, osu!mania. Malheureusement, en mode osu!catch et osu!mania, il n'y avait pas assez de participants pour récompenser les vainqueurs d'un badge.
 
 La musique sélectionnée pour ce concours était [ANTI - Koi](https://www.youtube.com/watch?v=NuQfuYxf6lk) d'une durée de 5:06 minutes.
 
-![FBC 2015 Badge](img/fbc2015.png)
+![Badge de la FBC 2015](img/fbc2015.png)
 
 ### Vainqueurs du mode osu!
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_FR] [Kin](https://osu.ppy.sh/users/480689) |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_FR] [rezoons](https://osu.ppy.sh/users/1893035) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Kin](https://osu.ppy.sh/users/480689) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_FR] [rezoons](https://osu.ppy.sh/users/1893035) |
 
 ### Vainqueurs du mode osu!taiko
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_FR] [Aldwych](https://osu.ppy.sh/users/1416484) |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_FR] [Gezoda](https://osu.ppy.sh/users/481582) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Aldwych](https://osu.ppy.sh/users/1416484) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_FR] [Gezoda](https://osu.ppy.sh/users/481582) |
 
 ### Vainqueurs du mode osu!mania
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_CA] [Julie](https://osu.ppy.sh/users/2420987) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_FR] [Todestrieb](https://osu.ppy.sh/users/4056690) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_CA] [Julie](https://osu.ppy.sh/users/2420987) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Todestrieb](https://osu.ppy.sh/users/4056690) |
 
 ### Vainqueurs du mode osu!catch
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_FR] [rezoons](https://osu.ppy.sh/users/1893035) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [rezoons](https://osu.ppy.sh/users/1893035) |
 
 ### Organisation
 
@@ -69,15 +69,15 @@ Cette édition du tournoi était la dernière édition à utiliser une musique a
 
 La musique sélectionnée pour le mode osu! et osu!catch était [Phantom Sage - Holystone](https://www.youtube.com/watch?v=gnZXoRb--z4) tandis que la musique pour les modes osu!taiko et osu!mania était [Weyheyhey!! - Throw It Away](https://www.youtube.com/watch?v=qtQ8Xo4p9js).
 
-![FBC 2016 Badge](img/fbc2016.png)
+![Badge de la FBC 2016](img/fbc2016.png)
 
 ### Vainqueurs
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_CA] [sheela](https://osu.ppy.sh/users/1138027) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_CA] [sheela](https://osu.ppy.sh/users/1138027) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [Secretpipe](https://osu.ppy.sh/users/2208964) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_FR] [Nozhomi](https://osu.ppy.sh/users/2716981) |
 
 ### Organisation
 
@@ -93,7 +93,7 @@ La musique sélectionnée pour le mode osu! et osu!catch était [Phantom Sage - 
 
 ## FBC 2017
 
-Cette édition était la première édition qui utilise une musique de moins de 3 minutes. De plus, elle était la première à permettre au mapset vainqueur (hebergé par le vainqueur du tournoi) de contenir les difficultés des trois premiers joueurs.
+Cette édition était la première édition qui utilise une musique de moins de 3 minutes. De plus, elle était la première à permettre au mapset vainqueur (hébergé par le vainqueur du tournoi) de contenir les difficultés des trois premiers joueurs.
 
 La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia](https://soundcloud.com/ak_q/bofu2017-excelsia).
 
@@ -103,9 +103,9 @@ La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_FR] [Sotarks](https://osu.ppy.sh/users/4452992) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_FR] [BOUYAAA](https://osu.ppy.sh/users/405449) |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_CH] [Irreversible](https://osu.ppy.sh/users/1287964) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Sotarks](https://osu.ppy.sh/users/4452992) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_FR] [BOUYAAA](https://osu.ppy.sh/users/405449) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_CH] [Irreversible](https://osu.ppy.sh/users/1287964) |
 
 ### Organisation
 
@@ -120,7 +120,7 @@ La musique sélectionnée pour cette édition du tournoi était [ak+q - Excelsia
 
 ## FBC 2018
 
-Cette édition était la première à proposer une musique de Featured Artist dans ce tournoi. De plus, c'était la première à voir deux joueurs être ex-aequo dans le classement.
+Cette édition était la première à proposer une musique d'un Featured Artist dans ce tournoi. De plus, c'était la première à voir deux joueurs être ex-aequo dans le classement.
 
 La musique sélectionnée pour cette édition du tournoi est [Thaehan - Sunrise](https://www.youtube.com/watch?v=F1_EyWi68hE).
 
@@ -130,9 +130,9 @@ La musique sélectionnée pour cette édition du tournoi est [Thaehan - Sunrise]
 
 | Place | Joueurs |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) |
-| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | ![][flag_CA] [celerih](https://osu.ppy.sh/users/4696296) |
-| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | ![][flag_CA] [J1_](https://osu.ppy.sh/users/5918561), ![][flag_FR] [PoNo](https://osu.ppy.sh/users/4610047) |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_CA] [celerih](https://osu.ppy.sh/users/4696296) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_CA] [J1_](https://osu.ppy.sh/users/5918561), ![][flag_FR] [PoNo](https://osu.ppy.sh/users/4610047) |
 
 ### Organisation
 

--- a/wiki/Contests/KCC/1/fr.md
+++ b/wiki/Contests/KCC/1/fr.md
@@ -8,7 +8,7 @@ tags:
 
 ![Bannière de la KCC2021](img/banner.png)
 
-Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping osu!mania pour les utilisateurs de ![][flag_KR] Corée du Sud. Il s'agit de la première édition du concours de mapping coréen.
+Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping osu!mania pour les utilisateurs venant de ![][flag_KR] Corée du Sud. Il s'agit de la première édition du concours de mapping coréen.
 
 ## Programme du concours
 
@@ -79,7 +79,7 @@ Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping o
 ### Règlement du concours
 
 - Ce concours est réservé au mode osu!mania.
-- Seuls les Coréens peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de vérifier que vous êtes coréen.
+- Seuls les coréens peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de vérifier que vous êtes coréen.
 - Vous devez choisir une musique que vous souhaitez mapper lors de votre inscription (une musique pour Instrumentale et une pour Vocal). Vous pouvez mapper une de ces deux musiques après la fin du vote.
 - Le client d'osu! doit être capable de charger et de lire votre soumission.
 - La soumission doit être au format `.osz`.

--- a/wiki/Contests/KCC/1/fr.md
+++ b/wiki/Contests/KCC/1/fr.md
@@ -79,18 +79,18 @@ Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping o
 ### Règlement du concours
 
 - Ce concours est réservé au mode osu!mania.
-- Seuls les personnes coréennes peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de prouver que vous êtes Coréen.
+- Seules les personnes coréennes peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de prouver que vous êtes Coréen.
 - Vous devez choisir une musique que vous souhaitez mapper lors de votre inscription (une musique pour la catégorie Instrumentale et une pour la catégorie Vocal). Vous pouvez mapper une de ces deux musiques après la fin du vote.
 - Le client d'osu! doit être capable de charger et de lire votre beatmap.
 - La beatmap doit être au format `.osz`.
 - Les hitsounds personnalisés sont autorisés.
 - Le titre, l'artiste, le fichier MP3, la source, les tags et le fond ne doivent PAS être modifiés. Cependant, le point de prévisualisation peut être personnalisé.
-- Les vidéos, skins et storyboards ne sont PAS autorisés. Cependant, les sons des storyboards peuvent être modifiés.
+- Les vidéos, skins et storyboards ne sont PAS autorisés. Cependant, les hitsounds des storyboards peuvent être modifiés.
 - Le nombre de keys de la beatmap doit être entre 4K et 9K.
 - Le mod Auto doit être en mesure d'effectuer un full combo (score de 1 000 000) sur votre beatmap.
 - La beatmap doit être terminée par le concurrent seul. Aucune collaboration n'est autorisée.
 - Les beatmaps ne doivent pas être publiées sur le site d'osu! par le biais du Beatmap Submission System (BSS). Toutes les soumissions au concours doivent être anonymes pendant les phases de jugement afin d'éviter toute partialité.
-- Une seule difficulté de la beatmap est autorisée. Si plusieurs difficultés sont soumises, celle qui a le plus grand nombre d'étoiles sera celle acceptée.
+- Une seule difficulté est autorisée. Si plusieurs difficultés sont soumises, celle qui a le plus grand nombre d'étoiles sera celle acceptée.
 - Seules les difficultés Insane ou plus sont autorisées. Veuillez consulter les règles spécifiques aux difficultés dans les [critères de classement](/wiki/Ranking_Criteria).
 - Si vous soumettez plusieurs maps, la dernière sera celle prise en compte.
 - L'envoi d'une participation implique la compréhension et l'acceptation des règles énoncées ci-dessus.

--- a/wiki/Contests/KCC/1/fr.md
+++ b/wiki/Contests/KCC/1/fr.md
@@ -8,15 +8,15 @@ tags:
 
 ![Bannière de la KCC2021](img/banner.png)
 
-Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping osu!mania pour les utilisateurs venant de ![][flag_KR] Corée du Sud. Il s'agit de la première édition du concours de mapping coréen.
+Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping osu!mania pour les utilisateurs venant de ![][flag_KR] Corée du Sud. Il s'agit de la première édition du Korean Charting Contest.
 
 ## Programme du concours
 
 | Événement | Horodatage (UTC+09) |
 | --: | :-- |
-| Phase d'inscription, vote par musique | 01/02/2021/07/02/2021 |
-| Phase de soumission | 08/02/2021/07/03/2021 |
-| Phase de jugement | 08/03/2021/21/03/2021 |
+| Phase d'inscription, vote de musique | 01/02/2021 - 07/02/2021 |
+| Phase de soumission | 08/02/2021 - 07/03/2021 |
+| Phase de jugement | 08/03/2021 - 21/03/2021 |
 | Annonce des résultats | 22/03/2021 |
 
 ## Prix
@@ -79,27 +79,27 @@ Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping o
 ### Règlement du concours
 
 - Ce concours est réservé au mode osu!mania.
-- Seuls les coréens peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de vérifier que vous êtes coréen.
-- Vous devez choisir une musique que vous souhaitez mapper lors de votre inscription (une musique pour Instrumentale et une pour Vocal). Vous pouvez mapper une de ces deux musiques après la fin du vote.
-- Le client d'osu! doit être capable de charger et de lire votre soumission.
-- La soumission doit être au format `.osz`.
+- Seuls les personnes coréennes peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de prouver que vous êtes Coréen.
+- Vous devez choisir une musique que vous souhaitez mapper lors de votre inscription (une musique pour la catégorie Instrumentale et une pour la catégorie Vocal). Vous pouvez mapper une de ces deux musiques après la fin du vote.
+- Le client d'osu! doit être capable de charger et de lire votre beatmap.
+- La beatmap doit être au format `.osz`.
 - Les hitsounds personnalisés sont autorisés.
-- Le titre, l'artiste, le MP3, la source, les balises et le fond ne doivent PAS être modifiés. Cependant, le point de prévisualisation peut être personnalisé.
+- Le titre, l'artiste, le fichier MP3, la source, les tags et le fond ne doivent PAS être modifiés. Cependant, le point de prévisualisation peut être personnalisé.
 - Les vidéos, skins et storyboards ne sont PAS autorisés. Cependant, les sons des storyboards peuvent être modifiés.
-- La soumission doit être de 4K ~ 9K.
-- Le mod Auto doit être en mesure d'effectuer un full combo (score de 1 000 000) de votre soumission.
-- La soumission doit être terminée par le concurrent seul. Aucune collaboration n'est autorisée.
-- Les soumissions ne doivent pas être téléchargées sur le site d'osu! par le biais du Beatmap Submission System (BSS). Toutes les soumissions au concours sont anonymes pendant les phases de jugement afin d'éviter toute partialité.
-- Une seule difficulté de la beatmap est autorisée. Si plusieurs difficultés sont soumises, celle qui a le plus grand nombre d'étoiles sera acceptée.
-- Seules les difficultés suivantes sont autorisées : Insane ou supérieure. Veuillez consulter les règles spécifiques aux difficultés dans les [critères de classement](/wiki/Ranking_Criteria).
-- Si vous soumettez plusieurs maps, la dernière sera votre dernière entrée.
+- Le nombre de keys de la beatmap doit être entre 4K et 9K.
+- Le mod Auto doit être en mesure d'effectuer un full combo (score de 1 000 000) sur votre beatmap.
+- La beatmap doit être terminée par le concurrent seul. Aucune collaboration n'est autorisée.
+- Les beatmaps ne doivent pas être publiées sur le site d'osu! par le biais du Beatmap Submission System (BSS). Toutes les soumissions au concours doivent être anonymes pendant les phases de jugement afin d'éviter toute partialité.
+- Une seule difficulté de la beatmap est autorisée. Si plusieurs difficultés sont soumises, celle qui a le plus grand nombre d'étoiles sera celle acceptée.
+- Seules les difficultés Insane ou plus sont autorisées. Veuillez consulter les règles spécifiques aux difficultés dans les [critères de classement](/wiki/Ranking_Criteria).
+- Si vous soumettez plusieurs maps, la dernière sera celle prise en compte.
 - L'envoi d'une participation implique la compréhension et l'acceptation des règles énoncées ci-dessus.
 
 ### Critères de jugement
 
 Pour chaque difficulté admissible soumise, le jury attribuera des points en fonction des critères suivants :
 
-- **Expertise (25 pts) :** La façon dont la soumission démontre des techniques concernant la structure, la représentation de la musique, le flox, les hitsounds, etc.
+- **Expertise (25 pts) :** La façon dont la soumission démontre des techniques concernant la structure, la représentation de la musique, le flow, les hitsounds, etc.
 - **Cohésion (25 pts) :** La cohérence de la soumission en ce qui concerne la structure, la représentation de la musique, le flow, les hitsounds, etc., notamment entre les différentes sections.
 - **Créativité (25 pts) :** Dans quelle mesure la proposition fait preuve d'originalité et d'unicité par rapport aux autres propositions, avec un respect raisonnable de la jouabilité.
 - **Impression des juges (25 pts) :** Il s'agit de la partie de la note laissée aux préférences personnelles des juges sur la soumission.

--- a/wiki/Contests/KCC/1/fr.md
+++ b/wiki/Contests/KCC/1/fr.md
@@ -1,0 +1,110 @@
+---
+tags:
+  - KCC2021
+  - KCC 2021
+---
+
+# Korean Charting Contest 2021
+
+![Bannière de la KCC2021](img/banner.png)
+
+Le **Korean Charting Contest 2021** (***KCC2021***) est un concours de mapping osu!mania pour les utilisateurs de ![][flag_KR] Corée du Sud. Il s'agit de la première édition du concours de mapping coréen.
+
+## Programme du concours
+
+| Événement | Horodatage (UTC+09) |
+| --: | :-- |
+| Phase d'inscription, vote par musique | 01/02/2021/07/02/2021 |
+| Phase de soumission | 08/02/2021/07/03/2021 |
+| Phase de jugement | 08/03/2021/21/03/2021 |
+| Annonce des résultats | 22/03/2021 |
+
+## Prix
+
+| Places | Prix(s) |
+| :-: | :-- |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | 40,000 KRW, badge de profil |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | 20,000 KRW |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | 10,000 KRW |
+
+![badge de la KCC2021](img/badge.png)
+
+## Organisation
+
+| Position | Membre(s) |
+| :-- | :-- |
+| Organisateur | ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783) |
+| Responsable | ![][flag_KR] [Oni Suika](https://osu.ppy.sh/users/4848023) |
+| Designer | ![][flag_KR] [POCARI SWEAT](https://osu.ppy.sh/users/5082685) |
+| Juges | ![][flag_PL] [_underjoy](https://osu.ppy.sh/users/6392061), ![][flag_KR] [Garalulu](https://osu.ppy.sh/users/757783), ![][flag_GT] [Hoto Cocoa](https://osu.ppy.sh/users/6974536), ![][flag_KR] [Kawawa](https://osu.ppy.sh/users/4647754), ![][flag_KR] [Pengdoll](https://osu.ppy.sh/users/6392061) |
+
+## Liens
+
+- [Sujet du forum](https://osu.ppy.sh/community/forums/topics/1230057)
+- [Feuille de résultats](https://docs.google.com/spreadsheets/d/1O0Ygpning0te62S850M42oPo0lCYd1Ct8VeYnAWRcYE/edit?usp=sharing)
+- [Entrées](https://lulu.s-ul.eu/D2M3x9LH)
+
+## Liste des musiques
+
+### Instrumentale
+
+- cYsmix - Moonlight Sonata (3:24) / 128bpm
+- Frums - Turnstile Jumper (2:37) / 321bpm
+- onumi - DESIRE (2:28) / 209bpm
+- Sakuzyo - First Dance (3:12) / 116bpm
+- **Zekk - Kaleidoscope (2:11) / 155bpm**
+
+### Vocal
+
+- Alice Schach and the Magic Orchestra - Chocolate Missile (2:57) / 175bpm
+- HyuN - Last Paradise (feat. Serentium) (2:42) / 89bpm
+- Memme - Geurida (2:45) / 180bpm
+- mk feat.橘花音 - Awaking Beat-From the next generation- (3:51) / 178bpm
+- **YUC'e - Sengoku HOP (3:25) / 110bpm**
+
+### Résultats du vote
+
+![Résultats du vote de la KCC2021](img/voteresult.jpg)
+
+## Résultats
+
+| Places | Mappeur |
+| :-: | :-- |
+| ![Couronne en or](/wiki/shared/crown-gold.png "Première place") | ![][flag_KR] [11Bit](https://osu.ppy.sh/users/14804526) |
+| ![Couronne d'argent](/wiki/shared/crown-silver.png "Seconde place") | ![][flag_KR] [Sherie](https://osu.ppy.sh/users/9113475) |
+| ![Couronne de bronze](/wiki/shared/crown-bronze.png "Troisième place") | ![][flag_CA] [arpia97](https://osu.ppy.sh/users/6363008) |
+
+## Règles
+
+### Règlement du concours
+
+- Ce concours est réservé au mode osu!mania.
+- Seuls les Coréens peuvent participer à ce concours. Si votre drapeau de profil n'indique pas que vous êtes en ![][flag_KR] Corée du Sud pour des raisons telles que la résidence à l'étranger, vous pouvez quand même participer si vous êtes en mesure de vérifier que vous êtes coréen.
+- Vous devez choisir une musique que vous souhaitez mapper lors de votre inscription (une musique pour Instrumentale et une pour Vocal). Vous pouvez mapper une de ces deux musiques après la fin du vote.
+- Le client d'osu! doit être capable de charger et de lire votre soumission.
+- La soumission doit être au format `.osz`.
+- Les hitsounds personnalisés sont autorisés.
+- Le titre, l'artiste, le MP3, la source, les balises et le fond ne doivent PAS être modifiés. Cependant, le point de prévisualisation peut être personnalisé.
+- Les vidéos, skins et storyboards ne sont PAS autorisés. Cependant, les sons des storyboards peuvent être modifiés.
+- La soumission doit être de 4K ~ 9K.
+- Le mod Auto doit être en mesure d'effectuer un full combo (score de 1 000 000) de votre soumission.
+- La soumission doit être terminée par le concurrent seul. Aucune collaboration n'est autorisée.
+- Les soumissions ne doivent pas être téléchargées sur le site d'osu! par le biais du Beatmap Submission System (BSS). Toutes les soumissions au concours sont anonymes pendant les phases de jugement afin d'éviter toute partialité.
+- Une seule difficulté de la beatmap est autorisée. Si plusieurs difficultés sont soumises, celle qui a le plus grand nombre d'étoiles sera acceptée.
+- Seules les difficultés suivantes sont autorisées : Insane ou supérieure. Veuillez consulter les règles spécifiques aux difficultés dans les [critères de classement](/wiki/Ranking_Criteria).
+- Si vous soumettez plusieurs maps, la dernière sera votre dernière entrée.
+- L'envoi d'une participation implique la compréhension et l'acceptation des règles énoncées ci-dessus.
+
+### Critères de jugement
+
+Pour chaque difficulté admissible soumise, le jury attribuera des points en fonction des critères suivants :
+
+- **Expertise (25 pts) :** La façon dont la soumission démontre des techniques concernant la structure, la représentation de la musique, le flox, les hitsounds, etc.
+- **Cohésion (25 pts) :** La cohérence de la soumission en ce qui concerne la structure, la représentation de la musique, le flow, les hitsounds, etc., notamment entre les différentes sections.
+- **Créativité (25 pts) :** Dans quelle mesure la proposition fait preuve d'originalité et d'unicité par rapport aux autres propositions, avec un respect raisonnable de la jouabilité.
+- **Impression des juges (25 pts) :** Il s'agit de la partie de la note laissée aux préférences personnelles des juges sur la soumission.
+
+[flag_CA]: /wiki/shared/flag/CA.gif "Canada"
+[flag_GT]: /wiki/shared/flag/GT.gif "Guatemala"
+[flag_KR]: /wiki/shared/flag/KR.gif "Corée du Sud"
+[flag_PL]: /wiki/shared/flag/PL.gif "Pologne"

--- a/wiki/Contests/KCC/fr.md
+++ b/wiki/Contests/KCC/fr.md
@@ -1,0 +1,5 @@
+# Korean Charting Contest
+
+Page d'index pour l'ensemble de la série Korean Charting Contest.
+
+- [Korean Charting Contest 2021](1)


### PR DESCRIPTION
Translation of the following wiki pages:

- `Contests/A_Labour_of_Love_Contest`
- `Contests/Aspire`
- `Contests/KCC/1`
- `Contests/KCC`

Proposal to update the French translation of the wiki page `Contests/FBC`.