### PR TITLE
Apply alternative name order Ranking Criteria amendment

### DIFF
--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -106,7 +106,7 @@ Changes to the rules and guidelines in this document are proposed and discussed 
 
 #### Romanisation
 
-- **Artist names are to be romanised in the order they are printed in the unicode fields.**
+- **An artist's name is to be romanised in the order it is printed in the unicode field, unless an alternative order for the romanised name is provided by the artist.**
 - **Loan words from other languages have to use the original words in their stead when attempting to romanise them.**
 - **When a song uses repeat words in the title or in the artist where one is in unicode, and the other as a basic romanisation, the romanised field must use the provided romanisation only and remove the duplicate word.**
 - **Umlauts must be romanised into two-letter equivalents: `ü` to `ue`, `ö` to `oe`, `ä` to `ae` and `ß` to `ss`.**


### PR DESCRIPTION
Simple change ratifying the suggestions made in [this thread](https://osu.ppy.sh/community/forums/topics/1317453) some month ago that never came to fruition.

This should allow sets like Sabaku de to be freed from limbo.