### PR TITLE
Update outdated information on `Mappers' Guild`

### DIFF
--- a/wiki/Mappers_Guild/en.md
+++ b/wiki/Mappers_Guild/en.md
@@ -30,13 +30,13 @@ Quests reward mappers for following certain requirements when creating their fea
 
 Each quest has its own party size/rank specifications, price to accept, and deadline. All members of a party must pay the listed price to accept the quest. Prices are usually higher for gimmicky quests and solo quests.
 
-Quests expire after 3 months of inactivity. Any user can re-open quests by spending their available pool of Mappers' Guild points.
+Quests will automatically expire after 3 months of inactivity. Any user can re-open quests by spending their available pool of Mappers' Guild points.
 
 Quest participation is not required for members of the Mappers' Guild. If a user wants to, they may create beatmaps alone to earn rewards.
 
 ### Rewards
 
-Rewards are distributed through a points system. When a user reaches a specified points threshold, they earn a different rank signified by a profile badge. There are three profile badge tiers at 100, 250, and 500 points respectively.
+Rewards are distributed through a points system. When a user reaches a specified points threshold, they earn a different rank signified by a profile badge. There are four profile badge tiers at 100, 250, 500, and 1000 points respectively.
 
 Rewards are based on a user's total points. A user's available points are a subsection of their total points following the same model as osu!'s [kudosu](/wiki/Modding/Kudosu) "total earned" and "available" pools.
 

--- a/wiki/Mappers_Guild/fr.md
+++ b/wiki/Mappers_Guild/fr.md
@@ -2,6 +2,8 @@
 tags:
   - Mapper's Guild
   - MG
+outdated: true
+outdated_since: 1e0790f39673fbd138af78b285f3f06a3e9e7ca0
 ---
 
 # La Mappers' Guild

--- a/wiki/Mappers_Guild/id.md
+++ b/wiki/Mappers_Guild/id.md
@@ -37,7 +37,7 @@ Partisipasi *quest* tidak memerlukan seluruh anggota Mapper's Guild. Jika seoran
 
 ### Imbalan
 
-Imbalan didistribusikan melalui sistem poin. Ketika seorang pengguna telah mencapai dalam titik pencapaian, mereka memperoleh peringkat yang berbeda dengan ditandainya sebuah lencana profil. Ada tiga tingkatan profil untuk tiap pencapaian yang masing - masing diberikan pada 100, 250, dan 500 poin.
+Imbalan didistribusikan melalui sistem poin. Ketika seorang pengguna telah mencapai dalam titik pencapaian, mereka memperoleh peringkat yang berbeda dengan ditandainya sebuah lencana profil. Ada empat tingkatan profil untuk tiap pencapaian yang masing - masing diberikan pada 100, 250, 500, dan 1000 poin.
 
 Imbalan diberikan berdasarkan peroleh poin tiap pengguna. Poin yang tersedia pengguna adalah sub-bagian dari total poin mereka, sistem ini juga mengikuti model [kudosu](/wiki/Modding/Kudosu) "total yang diperoleh" dan "tersedia".
 

--- a/wiki/Mappers_Guild/ko.md
+++ b/wiki/Mappers_Guild/ko.md
@@ -2,6 +2,8 @@
 tags:
   - Mapper's Guild
   - MG
+outdated: true
+outdated_since: 1e0790f39673fbd138af78b285f3f06a3e9e7ca0
 ---
 
 # 매퍼스 길드

--- a/wiki/Mappers_Guild/tr.md
+++ b/wiki/Mappers_Guild/tr.md
@@ -2,6 +2,8 @@
 tags:
   - Mapper's Guild
   - MG
+outdated: true
+outdated_since: 1e0790f39673fbd138af78b285f3f06a3e9e7ca0
 ---
 
 # Mappers' Guild

--- a/wiki/Mappers_Guild/zh.md
+++ b/wiki/Mappers_Guild/zh.md
@@ -3,6 +3,8 @@ tags:
   - Mapper's Guild
   - MG
   - 谱师工会
+outdated: true
+outdated_since: 1e0790f39673fbd138af78b285f3f06a3e9e7ca0
 ---
 
 # 谱师工会（Mappers' Guild）


### PR DESCRIPTION
created via https://github.com/github/dev 

i wanna test the new github online vscode editor that TicClick recommended in #osu-wiki earlier so i thought i'll just try to push a minor correction for starters c:

---

edit : since i've been asked about this yeah that line is indeed already outdated as there's a Tier 4 badge by now

![image](https://user-images.githubusercontent.com/36564236/132032645-afad9ab2-22c5-4eb2-b55d-657537c8b57b.png)
