### PR TITLE
Replace Google form/sheet links with Loved website in `Project Loved` wiki page

### DIFF
--- a/wiki/Beatmap/History_of_Loved/en.md
+++ b/wiki/Beatmap/History_of_Loved/en.md
@@ -44,7 +44,7 @@ After a few rounds of the original style of polling, Toy decided to use a slight
 
 <!-- TODO: Documentation of ~2018 and on -->
 
-In December 2020, development efforts for the [official Project Loved website](https://loved.sh/) began and shortly after was launched merely as an admin page for the coordinators. By mid-2021, the website was made available for the rest of the team. Eventually, in August 2021, the Google forms and sheets used for beatmap submissions and viewing were fully deprecated and begun to be hosted on the website instead.
+In December 2020, development efforts for the official [Project Loved website](https://loved.sh/) began, and shortly after it was launched, merely as an admin page for the coordinators at first. By mid-2021, the website was made available for the rest of the team. Eventually, in August 2021, the Google forms and sheets used for beatmap submissions and viewing were fully deprecated and begun to be hosted on the website instead.
 
 ## Present day
 

--- a/wiki/Beatmap/History_of_Loved/en.md
+++ b/wiki/Beatmap/History_of_Loved/en.md
@@ -44,6 +44,8 @@ After a few rounds of the original style of polling, Toy decided to use a slight
 
 <!-- TODO: Documentation of ~2018 and on -->
 
+In December 2020, development efforts for the [official Project Loved website](https://loved.sh/) began and shortly after was launched merely as an admin page for the coordinators. By mid-2021, the website was made available for the rest of the team. Eventually, in August 2021, the Google forms and sheets used for beatmap submissions and viewing were fully deprecated and begun to be hosted on the website instead.
+
 ## Present day
 
 [Project Loved](/wiki/Project_Loved) is the current system being used to move maps to Loved. More details and information about how to get beatmaps up for voting in Project Loved can be found in its wiki article.

--- a/wiki/Beatmap/History_of_Loved/fr.md
+++ b/wiki/Beatmap/History_of_Loved/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 91dc02f939d9a5eae9217bbbc7fb4d76c6001c89
+---
+
 # L'histoire de la catégorie Loved
 
 La catégorie de beatmaps [Loved](/wiki/Beatmap/Category#loved) est actuellement gérée par le [Project Loved](/wiki/Project_Loved). Cependant, cela n'a pas toujours été le cas. Project Loved est le troisième système principal qui a promu les beatmaps au rang de Loved ; avant lui, il y avait d'autres méthodes pour le faire, ainsi que de longues périodes de stagnation pour la catégorie Loved.

--- a/wiki/Project_Loved/en.md
+++ b/wiki/Project_Loved/en.md
@@ -8,12 +8,12 @@ Beatmaps are moved to Loved by a nomination and voting process.
 
 Members of the Project Loved Team called **captains** regularly nominate beatmaps for a specific game mode. These sets almost always come from submissions from the osu! community.
 
-To submit a beatmap for Loved, please visit the [beatmap submission page of the Project Loved website](https://loved.sh/submit) and fill out the form. Upon submitting, it will be publicly visible under the listing of its respective game mode along with other submissions. Below are the listings where these submissions can be viewed:
+To submit a beatmap for Loved, please visit the [beatmap submission page](https://loved.sh/submit) of the Project Loved website and fill out the form. Upon submitting, you will be able to view your submission under the listing of its respective game mode along with the others. Below are the listings where these submissions can be viewed:
 
-- [osu! submission listing](https://loved.sh/submissions/osu)
-- [osu!taiko submission listing](https://loved.sh/submissions/taiko)
-- [osu!catch submission listing](https://loved.sh/submissions/fruits)
-- [osu!mania submission listing](https://loved.sh/submissions/mania)
+- [osu! submissions](https://loved.sh/submissions/osu)
+- [osu!taiko submissions](https://loved.sh/submissions/taiko)
+- [osu!catch submissions](https://loved.sh/submissions/fruits)
+- [osu!mania submissions](https://loved.sh/submissions/mania)
 
 Nominated mapsets are then posted to the [Project Loved forum](https://osu.ppy.sh/community/forums/120), where community members may vote whether they want the mapset to be Loved or not. Maps reaching a specified threshold percentage of "Yes" votes at their polls' end time will be moved to the Loved category.
 
@@ -47,3 +47,8 @@ There are no strict rules governing which maps a captain must nominate for Loved
 ## Further information
 
 All of the organisation and planning for Project Loved is done in the `#osu-loved` channel of the [osu!dev Discord server](https://discord.gg/ppy). There is also a `#project-loved` channel in the [osu! Community Discord server](https://discord.gg/0Vxo9AsejDkGlk3H). Any questions, concerns, or suggestions may be directed there.
+
+In addition to the discussion channels mentioned above, osu!taiko and osu!mania communities have their own dedicated Discord hubs, which you may join via the following links:
+
+- [osu!taiko Project Loved Discord server](https://discord.com/invite/GhfjtZ6)
+- [osu!mania Project Loved Discord server](https://discord.gg/Ededv7m)

--- a/wiki/Project_Loved/en.md
+++ b/wiki/Project_Loved/en.md
@@ -6,16 +6,14 @@
 
 Beatmaps are moved to Loved by a nomination and voting process.
 
-Members of the Project Loved Team called **captains** regularly nominate beatmaps for a specific game mode. Almost always, these sets come from submissions from the osu! community. The current Loved submission forms and listings can be found via the following links:
+Members of the Project Loved Team called **captains** regularly nominate beatmaps for a specific game mode. These sets almost always come from submissions from the osu! community.
 
-- [osu!/osu!catch form](https://docs.google.com/forms/d/e/1FAIpQLSdbgHOVqMF8wQQKSdddW1JhC10ff6C7fb4JbEW7PBQTn9gAqg/viewform)
-- [osu!taiko form](https://docs.google.com/forms/d/e/1FAIpQLSclPWyjFByhHP45AtKD49y0RSl1TK5UOzD4dVdvjfJJQ1aCXQ/viewform)
-- [osu!mania form](https://docs.google.com/forms/d/e/1FAIpQLSeaGfoQNGMqw4qQcqRPItUZILh2fGwJR6ly6cZNY9OWPXkFhw/viewform)
-- [osu!/osu!catch listing](https://docs.google.com/spreadsheets/d/1HgHwtO3kIzT8R4ocEJMZTosADrGJRJOFL-TZI97tZS4/edit)
-- [osu!taiko listing](https://docs.google.com/spreadsheets/d/1Nk96z_xat_7ypsDF1sCTDO4i_CnHarcrCbGoTmgwHHE/edit)
-- [osu!mania listing](https://docs.google.com/spreadsheets/d/1sjkTwUSvQ5Me-6rK61rToTg2bU-yX9X29CXdzttvhtM/edit)
+To submit a beatmap for Loved, please visit the [beatmap submission page of the Project Loved website](https://loved.sh/submit) and fill out the form. Upon submitting, it will be publicly visible under the listing of its respective game mode along with other submissions. Below are the listings where these submissions can be viewed:
 
-*Note: If your access to Google Forms is restricted, you may also contact any of the [Project Loved Team members](/wiki/People/The_Team/Project_Loved_Team#team-members) to have a map submitted on your behalf.*
+- [osu! submission listing](https://loved.sh/submissions/osu)
+- [osu!taiko submission listing](https://loved.sh/submissions/taiko)
+- [osu!catch submission listing](https://loved.sh/submissions/fruits)
+- [osu!mania submission listing](https://loved.sh/submissions/mania)
 
 Nominated mapsets are then posted to the [Project Loved forum](https://osu.ppy.sh/community/forums/120), where community members may vote whether they want the mapset to be Loved or not. Maps reaching a specified threshold percentage of "Yes" votes at their polls' end time will be moved to the Loved category.
 
@@ -30,7 +28,7 @@ There are some very minimal criteria that need to be met for beatmaps to be nomi
 - It has at least 30 favourites (only applies to osu! maps)
 - Every nominated difficulty has at least 30 seconds of [drain time](/wiki/Gameplay/Drain_time)
 
-However, despite nearly all [Pending and Work-in-progress](/wiki/Beatmap/Category#work-in-progress-and-pending) maps meeting these criteria, few are voted into the Loved category due to the more selective nomination and voting requirements.
+Although many [Pending and Work-in-progress](/wiki/Beatmap/Category#work-in-progress-and-pending) maps meet these criteria, few are voted into the Loved category due to the more selective nomination and voting requirements.
 
 Beatmaps entering the Loved category are required to follow some additional rule sets:
 

--- a/wiki/Project_Loved/tr.md
+++ b/wiki/Project_Loved/tr.md
@@ -6,16 +6,14 @@
 
 Beatmapler, bir aday gösterme ve oylama süreci ile Sevilenlere eklenir.
 
-**Kaptanlar** olarak bilinen Project Loved Takımı üyeleri spesifik bir oyun modu için beatmap setlerini düzenli olarak aday gösterirler. Neredeyse her zaman, bu setler osu! topluluğundan gelen gönderilerden seçilir. Mevcut Sevilen gönderi formlarına ve listelerine aşağıdaki linklerden ulaşılabilir:
+**Kaptanlar** olarak bilinen Project Loved Takımı üyeleri spesifik bir oyun modu için beatmap setlerini düzenli olarak aday gösterirler. Bu setler hemen hemen her zaman osu! topluluğundan gelen gönderiler arasından seçilir.
 
-- [osu!/osu!catch formu](https://docs.google.com/forms/d/e/1FAIpQLSdbgHOVqMF8wQQKSdddW1JhC10ff6C7fb4JbEW7PBQTn9gAqg/viewform)
-- [osu!taiko formu](https://docs.google.com/forms/d/e/1FAIpQLSclPWyjFByhHP45AtKD49y0RSl1TK5UOzD4dVdvjfJJQ1aCXQ/viewform)
-- [osu!mania formu](https://docs.google.com/forms/d/e/1FAIpQLSeaGfoQNGMqw4qQcqRPItUZILh2fGwJR6ly6cZNY9OWPXkFhw/viewform)
-- [osu!/osu!catch listesi](https://docs.google.com/spreadsheets/d/1HgHwtO3kIzT8R4ocEJMZTosADrGJRJOFL-TZI97tZS4/edit)
-- [osu!taiko listesi](https://docs.google.com/spreadsheets/d/1Nk96z_xat_7ypsDF1sCTDO4i_CnHarcrCbGoTmgwHHE/edit)
-- [osu!mania listesi](https://docs.google.com/spreadsheets/d/1sjkTwUSvQ5Me-6rK61rToTg2bU-yX9X29CXdzttvhtM/edit)
+Sevilen kategorisine eklenmesini istediğiniz bir beatmapi göndermek için lütfen [Project Loved web sitesinin beatmap gönderme sayfasını](https://loved.sh/submit) ziyaret edin ve formu doldurun. Formu göndermenizle birlikte, gönderiminiz diğer gönderimlerle birlikte ilgili oyun modunun listesinde herkese açık bir şekilde görünür olacaktır. Aşağıda bu gönderimlerin görülebileceği listeler mevcuttur:
 
-*Not: Eğer Google Formlara erişiminiz kısıtlıysa, bir beatmapi sizin adınıza göndermesi için herhangi bir [Project Loved Takım üyesiyle](/wiki/People/The_Team/Project_Loved_Team#team-members) iletişime geçebilirsiniz.*
+- [osu! gönderimleri](https://loved.sh/submissions/osu)
+- [osu!taiko gönderimleri](https://loved.sh/submissions/taiko)
+- [osu!catch gönderimleri](https://loved.sh/submissions/fruits)
+- [osu!mania gönderimleri](https://loved.sh/submissions/mania)
 
 Aday gösterilen map setleri daha sonrasında, topluluk üyelerinin map setinin Sevilen olmasını isteyip istemediklerini oylayabilecekleri [Project Loved forumunda](https://osu.ppy.sh/community/forums/120) paylaşılır. Oylamaların bitiminde "Evet" oyları belirli bir yüzdeliğe ulaşan mapler Sevilen kategorisine eklenir.
 
@@ -30,7 +28,7 @@ Beatmaplerin Sevilen kategorisine aday gösterilebilmesi için karşılaması ge
 - En az 30 favoriye sahip olmalı (sadece osu! mapleri için geçerlidir)
 - Aday gösterilen her zorluk en az 30 saniyelik [akış süresine](/wiki/Gameplay/Drain_time) sahip olmalı.
 
-Ancak, neredeyse tüm [Beklemede ve Yapım aşamasındaki](/wiki/Beatmap/Category#work-in-progress-and-pending) maplerin bu kriterlere uymasına rağmen, nispeten daha seçici aday gösterme ve oylama gereksinimlerinden dolayı yalnızca birkaçı Sevilen kategorisine eklenmesi için oylanır.
+Birçok [Beklemede ve Yapım aşamasındaki](/wiki/Beatmap/Category#work-in-progress-and-pending) mapin bu kriterlere uymasına rağmen, nispeten daha seçici aday gösterme ve oylama gereksinimlerinden dolayı yalnızca birkaçı Sevilen kategorisine eklenmesi için oylanır.
 
 Sevilen kategorisine giren beatmapler birtakım ek kuralları takip etmek zorundadır:
 
@@ -49,3 +47,8 @@ Bir kaptanın Sevilen için aday göstermesi gereken mapler ile ilgili katı bir
 ## Daha fazla bilgi
 
 Project Loved için yapılan organizasyonun ve planlamanın tamamı [osu!dev Discord sunucusundaki](https://discord.gg/ppy) `#osu-loved` kanalında yürütülür. [osu! Topluluk Discord sunucusunda](https://discord.gg/0Vxo9AsejDkGlk3H) da bir `#project-loved` kanalı mevcuttur. Her türlü sorularınızı, endişelerinizi, veya önerilerinizi burada belirtebilirsiniz.
+
+Yukarıda adı geçen tartışma mecralarının yanısıra, osu!taiko ve osu!mania toplulukları kendi Discord sunucularına sahiptir. Bunlara katılmak için aşağıdaki linkleri kullanabilirsiniz:
+
+- [osu!taiko Project Loved Discord sunucusu](https://discord.com/invite/GhfjtZ6)
+- [osu!mania Project Loved Discord sunucusu](https://discord.gg/Ededv7m)


### PR DESCRIPTION
additionally;
- minor wording adjustments
- add a paragraph regarding the [Project Loved website](https://loved.sh/) and the deprecation of the Google forms/sheets to `History of Loved`

@huuishuu 