### PR TITLE
[ID] Fix misspelling on `People`

### DIFF
--- a/wiki/People/id.md
+++ b/wiki/People/id.md
@@ -1,7 +1,8 @@
-# Orang - orang
+# Orang-orang
 
-Laman indeks untuk artikel yang berhubungan dengan orang - orang atau grup.
+Berikut ini merupakan daftar artikel-artikel yang membahas seputar orang-orang dan kelompok-kelompok pengguna khusus yang terdapat di lingkungan osu!.
 
 - [Kontributor komunitas](Community_Contributors)
 - [Tim](The_Team)
-- [Pengguna dengan gelar unik](Users_with_unique_titles)
+- [peppy](peppy)
+- [Daftar pengguna dengan gelar khusus](Users_with_unique_titles)


### PR DESCRIPTION
primarily intended to fix `Orang - orang` --> `Orang-orang` as the Indonesian language doesn't use (and has never been using) extra whitespace characters between the words to declare a plural form.

((yeah this has been my pet peeve for a long while orz ;~;))