### PR TITLE
Update `People/Users_with_unique_titles` to include MWC 4K 2021 winners

### DIFF
--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -334,7 +334,7 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -16,7 +16,6 @@ Winners of [OWC 2020](/wiki/Tournaments/OWC/2020) with the **osu! Champion** use
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 Winners of [TWC 2021](/wiki/Tournaments/TWC/2021) with the **osu!taiko Champion** user title:
@@ -355,7 +354,6 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -36,13 +36,13 @@ Winners of [CWC 2021](/wiki/Tournaments/CWC/2021) with the **osu!catch Champion*
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-Winners of [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) with the **osu!mania Champion** user title:
+Winners of [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) with the **osu!mania 4K Champion** user title:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Official mapping contest winners
@@ -63,6 +63,7 @@ Most official mapping contests offer the **Elite Mapper** title as a first-place
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
@@ -80,6 +81,7 @@ Most official mapping contests offer the **Elite Mapper** title as a first-place
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -149,6 +151,7 @@ The osu!remix contests award the **osu!mixer** title as a first-place prize.
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -244,7 +247,7 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -281,7 +284,6 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -297,16 +299,19 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -326,10 +331,10 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -341,7 +346,7 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -352,6 +357,7 @@ These players earned their titles through either a crazy gameplay achievement or
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -370,6 +376,7 @@ These players earned their titles through either a crazy gameplay achievement or
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"
 [flag_AU]: /wiki/shared/flag/AU.gif "Australia"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belgium"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -328,7 +328,7 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -36,13 +36,13 @@ Les gagnants de la [CWC 2021](/wiki/Tournaments/CWC/2021) avec le titre d'utilis
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-Les gagnants de la [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) avec le titre d'utilisateur **osu!mania Champion** :
+Les gagnants de la [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) avec le titre d'utilisateur **osu!mania 4K Champion** :
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Les gagnants officiels du concours de mapping
@@ -63,6 +63,7 @@ La plupart des concours officiels de mapping offrent le titre de **Elite Mapper*
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
@@ -80,6 +81,7 @@ La plupart des concours officiels de mapping offrent le titre de **Elite Mapper*
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -149,6 +151,7 @@ Les [Featured Artists](/wiki/Featured_Artists) possédant un compte osu! reçoiv
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -238,7 +241,7 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -275,7 +278,6 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -291,16 +293,19 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -320,10 +325,10 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -335,7 +340,7 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -346,6 +351,7 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -364,6 +370,7 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Autriche"
 [flag_AU]: /wiki/shared/flag/AU.gif "Australie"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belgique"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brésil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Canada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chili"

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -16,7 +16,6 @@ Les gagnants de l'[OWC 2020](/wiki/Tournaments/OWC/2020) avec le titre d'utilisa
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 Les gagnants de la [TWC 2021](/wiki/Tournaments/TWC/2021) avec le titre d'utilisateur **osu!taiko Champion** :
@@ -349,7 +348,6 @@ Ces joueurs ont obtenu leur titre soit en réalisant un exploit de jeu fou, soit
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -16,7 +16,6 @@ Berikut merupakan para pemenang [OWC 2020](/wiki/Tournaments/OWC/2020) yang saat
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 Berikut merupakan para pemenang [TWC 2021](/wiki/Tournaments/TWC/2021) yang saat ini menyandang gelar **osu!taiko Champion**:
@@ -349,7 +348,6 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -36,13 +36,13 @@ Berikut merupakan para pemenang [CWC 2021](/wiki/Tournaments/CWC/2021) yang saat
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-Berikut merupakan para pemenang [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) yang saat ini menyandang gelar **osu!mania Champion**:
+Berikut merupakan para pemenang [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) yang saat ini menyandang gelar **osu!mania 4K Champion**:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Pemenang kontes-kontes mapping resmi
@@ -63,6 +63,7 @@ osu! pada umumnya menganugerahkan para pemenang kontes-kontes mapping yang berst
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
@@ -80,6 +81,7 @@ osu! pada umumnya menganugerahkan para pemenang kontes-kontes mapping yang berst
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -149,6 +151,7 @@ osu! menganugerahkan gelar **Featured Artist** kepada para [Featured Artist](/wi
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -238,7 +241,7 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -275,7 +278,6 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -291,16 +293,19 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -320,10 +325,10 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -335,7 +340,7 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -346,6 +351,7 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -364,6 +370,7 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"
 [flag_AU]: /wiki/shared/flag/AU.gif "Australia"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belgia"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brazil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chili"

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -328,7 +328,7 @@ Pemain-pemain berikut memperoleh gelarnya masing-masing atas keberhasilan mereka
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/pl.md
+++ b/wiki/People/Users_with_unique_titles/pl.md
@@ -327,7 +327,7 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/pl.md
+++ b/wiki/People/Users_with_unique_titles/pl.md
@@ -41,13 +41,13 @@ Zwycięzcy [CWC 2021](/wiki/Tournaments/CWC/2021) otrzymali tytuł **osu!catch C
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-Zwycięzcy [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) otrzymali tytuł **osu!mania Champion**:
+Zwycięzcy [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) otrzymali tytuł **osu!mania 4K Champion**:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Zwycięzcy oficjalnych konkursów w tworzeniu beatmap
@@ -68,13 +68,14 @@ Jedną z nagród w większości oficjalnych konkursów w tworzeniu beatmap jest 
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
 - ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197)
 - ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023)
 - ![][flag_AU] [m980](https://osu.ppy.sh/users/3288)
-- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)¹
 - ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993)
 - ![][flag_CN] [Necho](https://osu.ppy.sh/users/4086593)
 - ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430)
@@ -85,6 +86,7 @@ Jedną z nagród w większości oficjalnych konkursów w tworzeniu beatmap jest 
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -148,6 +150,7 @@ Nagrodą w konkursach osu!remix jest tytuł **osu!mixer** dla głównego zwycię
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -237,7 +240,7 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -274,7 +277,6 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -290,16 +292,19 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -319,10 +324,10 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -334,7 +339,7 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -345,6 +350,7 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -363,6 +369,7 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Austria"
 [flag_AU]: /wiki/shared/flag/AU.gif "Australia"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belgia"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brazylia"
 [flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"

--- a/wiki/People/Users_with_unique_titles/pl.md
+++ b/wiki/People/Users_with_unique_titles/pl.md
@@ -21,7 +21,6 @@ Zwycięzcy [OWC 2020](/wiki/Tournaments/OWC/2020) otrzymali tytuł **osu! Champi
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 Zwycięzcy [TWC 2021](/wiki/Tournaments/TWC/2021) otrzymali tytuł **osu!taiko Champion**:
@@ -348,7 +347,6 @@ Poniżsi gracze otrzymali swoje tytuły za znaczące osiągnięcia w grze lub uk
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/pt-br.md
+++ b/wiki/People/Users_with_unique_titles/pt-br.md
@@ -20,7 +20,6 @@ Vencedores da [OWC 2020](/wiki/Tournaments/OWC/2020) com o título de **osu! Cha
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 Vencedores da [TWC 2021](/wiki/Tournaments/TWC/2021) com o título de **osu!taiko Champion**:
@@ -353,7 +352,6 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/pt-br.md
+++ b/wiki/People/Users_with_unique_titles/pt-br.md
@@ -332,7 +332,7 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/pt-br.md
+++ b/wiki/People/Users_with_unique_titles/pt-br.md
@@ -40,13 +40,13 @@ Vencedores da [CWC 2021](/wiki/Tournaments/CWC/2021) com o título de **osu!catc
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-Vencedores da [MWC 4K 2020](/wiki/Tournaments/MWC/2019_4K) com o título de **osu!mania Champion**:
+Vencedores da [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) com o título de **osu!mania 4K Champion**:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Vencedores da competição de mapping em geral
@@ -67,13 +67,14 @@ A maior parte das competições oficiais de mapping oferecem o título de **Elit
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
 - ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197)
 - ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023)
 - ![][flag_AU] [m980](https://osu.ppy.sh/users/3288)
-- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)¹
 - ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993)
 - ![][flag_CN] [Necho](https://osu.ppy.sh/users/4086593)
 - ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430)
@@ -84,6 +85,7 @@ A maior parte das competições oficiais de mapping oferecem o título de **Elit
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -147,6 +149,7 @@ As competições do osu!remix recompensam o título de **osu!mixer** como prêmi
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -242,7 +245,7 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -279,7 +282,6 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -295,16 +297,19 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -324,10 +329,10 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -339,7 +344,7 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -350,6 +355,7 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -368,6 +374,7 @@ Esses jogadores conseguiram seus títulos com alguma conquista maluca ou complet
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Áustria"
 [flag_AU]: /wiki/shared/flag/AU.gif "Austrália"
+[flag_BE]: /wiki/shared/flag/BE.gif "Bélgica"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brasil"
 [flag_CA]: /wiki/shared/flag/CA.gif "Canadá"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"

--- a/wiki/People/Users_with_unique_titles/th.md
+++ b/wiki/People/Users_with_unique_titles/th.md
@@ -336,7 +336,7 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/th.md
+++ b/wiki/People/Users_with_unique_titles/th.md
@@ -20,7 +20,6 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 ผู้ชนะของ [TWC 2021](/wiki/Tournaments/TWC/2021) พร้อมกับ title **osu!taiko Champion**:
@@ -357,7 +356,6 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/th.md
+++ b/wiki/People/Users_with_unique_titles/th.md
@@ -40,13 +40,13 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-ผู้ชนะของ [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) พร้อมกับ title **osu!mania Champion**:
+ผู้ชนะของ [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) พร้อมกับ title **osu!mania Champion**:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### การแข่ง Mapping ของ Official
@@ -67,13 +67,14 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
 - ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197)
 - ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023)
 - ![][flag_AU] [m980](https://osu.ppy.sh/users/3288)
-- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)¹
 - ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993)
 - ![][flag_CN] [Necho](https://osu.ppy.sh/users/4086593)
 - ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430)
@@ -84,6 +85,7 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -147,6 +149,7 @@ Titles ของผู้เล่นนั้นปกติจะเกี่�
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -246,7 +249,7 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -283,7 +286,6 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -299,16 +301,19 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -328,10 +333,10 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -343,7 +348,7 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -354,6 +359,7 @@ Storyboarders ที่แสดงความสามารถในการ
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -372,6 +378,7 @@ Storyboarders ที่แสดงความสามารถในการ
 
 [flag_AT]: /wiki/shared/flag/AT.gif "ออสเตรีย"
 [flag_AU]: /wiki/shared/flag/AU.gif "ออสเตรเลีย"
+[flag_BE]: /wiki/shared/flag/BE.gif "เบลเยี่ยม"
 [flag_BR]: /wiki/shared/flag/BR.gif "บราซิล"
 [flag_CA]: /wiki/shared/flag/CA.gif "แคนาดา"
 [flag_CL]: /wiki/shared/flag/CL.gif "ชิลี"

--- a/wiki/People/Users_with_unique_titles/tr.md
+++ b/wiki/People/Users_with_unique_titles/tr.md
@@ -40,13 +40,13 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-**osu!mania Champion** kullanıcı ünvanına sahip [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) kazananları:
+**osu!mania 4K Champion** kullanıcı ünvanına sahip [MWC 4K 2021](/wiki/Tournaments/MWC/2020_4K) kazananları:
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### Genel mapping yarışmalarının kazananları
@@ -67,13 +67,14 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
 - ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197)
 - ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023)
 - ![][flag_AU] [m980](https://osu.ppy.sh/users/3288)
-- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)
+- ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515)¹
 - ![][flag_US] [MMzz](https://osu.ppy.sh/users/128993)
 - ![][flag_CN] [Necho](https://osu.ppy.sh/users/4086593)
 - ![][flag_FR] [Nofool](https://osu.ppy.sh/users/672430)
@@ -84,6 +85,7 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -147,6 +149,7 @@ osu! hesabına sahip [Featured Artist](/wiki/Featured_Artists)'lere ilişkilerin
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -242,7 +245,7 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -279,7 +282,6 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -295,16 +297,19 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -324,10 +329,10 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -339,7 +344,7 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -350,6 +355,7 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -368,6 +374,7 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 
 [flag_AT]: /wiki/shared/flag/AT.gif "Avusturya"
 [flag_AU]: /wiki/shared/flag/AU.gif "Avustralya"
+[flag_BE]: /wiki/shared/flag/BE.gif "Belçika"
 [flag_BR]: /wiki/shared/flag/BR.gif "Brezilya"
 [flag_CA]: /wiki/shared/flag/CA.gif "Kanada"
 [flag_CL]: /wiki/shared/flag/CL.gif "Şili"

--- a/wiki/People/Users_with_unique_titles/tr.md
+++ b/wiki/People/Users_with_unique_titles/tr.md
@@ -332,7 +332,7 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |

--- a/wiki/People/Users_with_unique_titles/tr.md
+++ b/wiki/People/Users_with_unique_titles/tr.md
@@ -20,7 +20,6 @@ Kullanıcı ünvanları genellikle ait oldukları [kullanıcı gruplarına](/wik
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 **osu!taiko Champion** kullanıcı ünvanına sahip [TWC 2021](/wiki/Tournaments/TWC/2021) kazananları:
@@ -353,7 +352,6 @@ Bu oyuncular ya oyunda çılgın bir başarım elde ederek ya da belirli bir zor
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -16,7 +16,6 @@
 - ![][flag_US] [fieryrage](https://osu.ppy.sh/users/3533958)
 - ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650)
 - ![][flag_US] [kablaze](https://osu.ppy.sh/users/3043603)
-- ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296)
 - ![][flag_US] [Vaxei](https://osu.ppy.sh/users/4787150)
 
 拥有 **osu!taiko Champion** 头衔的 [TWC 2021](/wiki/Tournaments/TWC/2021) 冠军：
@@ -349,7 +348,6 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_KR] [Spectator](https://osu.ppy.sh/users/702598) | Elite Mapper: Aspirant |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Pro Tester |
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
-| ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
 | ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -36,13 +36,13 @@
 - ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506)
 - ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519)
 
-拥有 **osu!mania Champion** 头衔的 [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) 冠军：
+拥有 **osu!mania 4K Champion** 头衔的 [MWC 4K 2021](/wiki/Tournaments/MWC/2020_4K) 冠军：
 
 - ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061)
-- ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387)
-- ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824)
+- ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829)
+- ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579)
+- ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876)
 - ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019)
-- ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468)
 - ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363)
 
 ### 常规作图大赛获奖者
@@ -63,6 +63,7 @@
 - ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377)
 - ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377)
 - ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378)
+- ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667)
 - ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611)
 - ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308)
 - ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804)
@@ -80,6 +81,7 @@
 - ![][flag_CN] [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
 - ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057)
 - ![][flag_LY] [Soul Evans](https://osu.ppy.sh/users/4490770)
+- ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405)
 - ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340)
 - ![][flag_RU] [xbopost](https://osu.ppy.sh/users/6842421)
 - ![][flag_SE] [Xgor](https://osu.ppy.sh/users/98661)
@@ -149,6 +151,7 @@ osu!remix 大赛将 **osu!mixer** 作为冠军头衔。
 | ![][flag_JP] [Namirin](https://osu.ppy.sh/users/2264828) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |
 | ![][flag_AU] [nekodex](https://osu.ppy.sh/users/102) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |
 | ![][flag_US] [onumi](https://osu.ppy.sh/users/11204867) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |
 | ![][flag_ES] [sotuiofficial](https://osu.ppy.sh/users/14779258) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |
@@ -238,7 +241,7 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_KR] [Acylica](https://osu.ppy.sh/users/1943309) | Elite Mapper |
 | ![][flag_CA] [Agatsu](https://osu.ppy.sh/users/5579871) | Elite Nominator |
 | ![][flag_US] [Aireu](https://osu.ppy.sh/users/1650010) | osu! Champion |
-| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania Champion |
+| ![][flag_BR] [Amerom](https://osu.ppy.sh/users/5691061) | osu!mania 4K Champion |
 | ![][flag_US] [antiPLUR](https://osu.ppy.sh/users/7318723) | Featured Artist |
 | ![][flag_US] [Apraxia](https://osu.ppy.sh/users/4194445) | osu! Champion |
 | ![][flag_US] [Ascendance](https://osu.ppy.sh/users/2931883) | Elite Mapper |
@@ -275,7 +278,6 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_TW] [Firce777](https://osu.ppy.sh/users/274072) | Elite Mapper |
 | ![][flag_JP] [Gamu](https://osu.ppy.sh/users/611174) | Elite Mapper |
 | ![][flag_JP] [Grape\_Tea](https://osu.ppy.sh/users/9540073) | osu!taiko Champion |
-| ![][flag_BR] [Guilhermeziat](https://osu.ppy.sh/users/3661387) | osu!mania Champion |
 | ![][flag_SE] [Helblinde](https://osu.ppy.sh/users/48053) | Featured Artist |
 | ![][flag_GB] [hypercyte](https://osu.ppy.sh/users/9155377) | Elite Mapper |
 | ![][flag_US] [im a fancy lad](https://osu.ppy.sh/users/4908650) | osu! Champion |
@@ -291,16 +293,19 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_RO] [kitazawakyouhei](https://osu.ppy.sh/users/15440027) | Featured Artist |
 | ![][flag_CA] [ktgster](https://osu.ppy.sh/users/53378) | Elite Mapper |
 | ![][flag_FR] [Kurokotei](https://osu.ppy.sh/users/398275) | Featured Artist |
+| ![][flag_RU] [kuyusu](https://osu.ppy.sh/users/11758667) | Elite Mapper |
 | ![][flag_NL] [Kyshiro](https://osu.ppy.sh/users/640611) | Elite Mapper |
-| ![][flag_BR] [Kyut](https://osu.ppy.sh/users/9328824) | osu!mania Champion |
 | ![][flag_DE] [Lasse](https://osu.ppy.sh/users/896613) | Elite Nominator II |
 | ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | World Cup Organizer |
+| ![][flag_BR] [LeMarcinho](https://osu.ppy.sh/users/13347579) | osu!mania 4K Champion |
+| ![][flag_BR] [Lenn](https://osu.ppy.sh/users/11236829) | osu!mania 4K Champion |
 | ![][flag_NL] [Lesjuh](https://osu.ppy.sh/users/44308) | Elite Mapper |
 | ![][flag_TW] [Licnect](https://osu.ppy.sh/users/352804) | Elite Mapper |
+| ![][flag_BR] [Liight00](https://osu.ppy.sh/users/13601876) | osu!mania 4K Champion |
 | ![][flag_AU] [Lilac](https://osu.ppy.sh/users/58197) | Elite Mapper |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Popcorn Fairy |
 | ![][flag_ID] [LordRaika](https://osu.ppy.sh/users/3265023) | Elite Mapper |
-| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania Champion |
+| ![][flag_BR] [Lothus](https://osu.ppy.sh/users/9530019) | osu!mania 4K Champion |
 | ![][flag_US] [LuigiHann](https://osu.ppy.sh/users/1079) | Resident Skinner |
 | ![][flag_AU] [m980](https://osu.ppy.sh/users/3288) | Elite Mapper |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Elite Mapper II |
@@ -320,10 +325,10 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_AU] [phill_old](https://osu.ppy.sh/users/53) | ¿ |
 | ![][flag_FI] [PianoLuigi](https://osu.ppy.sh/users/9665915) | Elite Mapper |
 | ![][flag_FI] [ProfessionalBox](https://osu.ppy.sh/users/3250792) | Elite Mapper: Aspirant |
-| ![][flag_BR] [Punnies](https://osu.ppy.sh/users/8700468) | osu!mania Champion |
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |
@@ -335,7 +340,7 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_FR] [Shinwoir](https://osu.ppy.sh/users/8984574) | osu!mixer |
 | ![][flag_RU] [Shmiklak](https://osu.ppy.sh/users/5504231) | Elite Storyboarder |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | osu!mania Paragon |
-| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania Champion |
+| ![][flag_BR] [SillyFangirl](https://osu.ppy.sh/users/2288363) | osu!mania 4K Champion |
 | ![][flag_SG] [Sinnoh](https://osu.ppy.sh/users/4236057) | Elite Mapper |
 | ![][flag_US] [skymuted](https://osu.ppy.sh/users/7734050) | Featured Artist |
 | ![][flag_TW] [SnowNiNo_](https://osu.ppy.sh/users/2506267) | Elite Mapper: Aspirant |
@@ -346,6 +351,7 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_FR] [Supairo](https://osu.ppy.sh/users/2837231) | Elite Mapper: Aspirant |
 | ![][flag_US] [SWAGGYSWAGSTER](https://osu.ppy.sh/users/7813296) | osu! Champion |
 | ![][flag_JP] [syaron105](https://osu.ppy.sh/users/8741695) | osu!taiko Champion |
+| ![][flag_BE] [Sylas](https://osu.ppy.sh/users/3906405) | Elite Mapper |
 | ![][flag_KR] [Taeyang](https://osu.ppy.sh/users/2732340) | Elite Mapper |
 | ![][flag_US] [Thievley](https://osu.ppy.sh/users/4717672) | osu!artist |
 | ![][flag_RU] [tieff](https://osu.ppy.sh/users/89619) | Featured Artist |
@@ -364,6 +370,7 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 
 [flag_AT]: /wiki/shared/flag/AT.gif "奥地利"
 [flag_AU]: /wiki/shared/flag/AU.gif "澳大利亚"
+[flag_BE]: /wiki/shared/flag/BE.gif "比利时"
 [flag_BR]: /wiki/shared/flag/BR.gif "巴西"
 [flag_CA]: /wiki/shared/flag/CA.gif "加拿大"
 [flag_CL]: /wiki/shared/flag/CL.gif "智利"

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -328,7 +328,7 @@ osu!团队为社区成员举办了艺术比赛，使他们有机会设计或重�
 | ![][flag_KR] [qwhj1027](https://osu.ppy.sh/users/7547506) | osu!catch Champion |
 | ![][flag_US] [RBRat3](https://osu.ppy.sh/users/307202) | osu!painter |
 | ![][flag_FR] [Realazy](https://osu.ppy.sh/users/918297) | Elite Mapper |
-| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist
+| ![][flag_CA] [Redside](https://osu.ppy.sh/users/16039046) | Featured Artist |
 | ![][flag_KR] [Rells](https://osu.ppy.sh/users/7937519) | osu!catch Champion |
 | ![][flag_US] [RLC](https://osu.ppy.sh/users/1047883) | Elite Mapper |
 | ![][flag_PH] [rtnario](https://osu.ppy.sh/users/16222702) | Featured Artist |


### PR DESCRIPTION
also added one FA ([Redside](http://osu.ppy.sh/users/16039046)) and a couple of Elite Mapper names ([Sylas](http://osu.ppy.sh/users/3906405)/[kuyusu](http://osu.ppy.sh/users/11758667)) that haven't been included in the list yet into the wiki page.