### PR TITLE
[ID] Cleanup/Rewrite `Beatmap_Ranking_Procedure/Ranking_Queue`

### DIFF
--- a/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
+++ b/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
@@ -3,14 +3,14 @@ tags:
   - qualified queue
   - ranked queue
   - ranking ETA
-  - antrian peringkat
+  - antrian ranking
   - tahap kualifikasi
 ---
 
 # Antrian peringkat beatmap
 
-**Antrian peringkat** (*Ranking queue*) mengatur pemindahan [beatmap-beatmap](/wiki/Beatmap) dari [Qualified](/wiki/Beatmap/Category#qualified) ke [Ranked](/wiki/Beatmap/Category#ranked). Setiap hari, 10 beatmap dari masing-masing [mode permainan](/wiki/Game_mode) dipindahkan dari Qualified ke Ranked, jika beatmap-beatmap tersebut sudah berada di kategori Qualified setidaknya selama 7 hari. Waktu di mana beatmap-beatmap tersebut menjadi ranked adalah acak.
+**Antrian ranking beatmap** (*beatmap ranking queue*) merupakan sebuah sistem yang mengatur laju perpindahan beatmap dari [Qualified](/wiki/Beatmap/Category#qualified) menuju ke [Ranked](/wiki/Beatmap/Category#ranked). Setiap harinya, sistem ini akan secara otomatis memindahkan beatmap-beatmap yang telah berstatus Qualified selama setidaknya 7 hari (hingga maks. 10 beatmap per [mode permainan](/wiki/Game_mode) per harinya) menuju ke Ranked. Adapun waktu di mana beatmap-beatmap yang ada berpindah setiap harinya pada umumnya tidak menentu.
 
-## Diskualifikasi dan re-kualifikasi
+## Proses diskualifikasi dan kualifikasi ulang (*re-qualification*)
 
-Saat sebuah beatmap terkena [diskualifikasi](/wiki/Beatmap_ranking_procedure#pengulangan-nominasi), waktu yang sudah berjalan saat berada di kategori Qualified akan tetap tersimpan. Jika beatmap tersebut telah dikualifikasi lagi, beatmap tersebut akan masuk ke antrian peringkat dan melanjutkan sisa waktu yang sebelumnya sudah ditempuh. Kemampuan untuk "melewati" waktu yang telah dihabiskan dalam batas antrian pada 6 hari adalah untuk memastikan bahwa beatmap-beatmap tersebut selalu berada di kategori Qualified setidaknya selama satu hari penuh.
+Pada saat suatu beatmap [didiskualifikasi](/wiki/Beatmap_ranking_procedure#nomination-resets), lama waktu yang telah dihabiskan oleh beatmap tersebut di dalam kategori Qualified serta posisinya di dalam antrian ranking yang ada akan secara otomatis dicatat oleh sistem. Apabila di kemudian waktu beatmap tersebut dikualifikasikan ulang (*re-qualified*), beatmap yang bersangkutan akan kembali memasuki antrian ranking beatmap pada posisinya terdahulu tanpa harus menunggu lagi dari awal antrian. Meskipun demikian, suatu beatmap harus menunggu setidaknya 24 jam sejak waktu kualifikasi terakhirnya untuk dapat berpindah dari Qualified ke Ranked demi mencegah terdapatnya hal-hal yang tidak diinginkan. 

--- a/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
+++ b/wiki/Beatmap_ranking_procedure/Ranking_queue/id.md
@@ -7,7 +7,7 @@ tags:
   - tahap kualifikasi
 ---
 
-# Antrian peringkat beatmap
+# Antrian ranking beatmap
 
 **Antrian ranking beatmap** (*beatmap ranking queue*) merupakan sebuah sistem yang mengatur laju perpindahan beatmap dari [Qualified](/wiki/Beatmap/Category#qualified) menuju ke [Ranked](/wiki/Beatmap/Category#ranked). Setiap harinya, sistem ini akan secara otomatis memindahkan beatmap-beatmap yang telah berstatus Qualified selama setidaknya 7 hari (hingga maks. 10 beatmap per [mode permainan](/wiki/Game_mode) per harinya) menuju ke Ranked. Adapun waktu di mana beatmap-beatmap yang ada berpindah setiap harinya pada umumnya tidak menentu.
 


### PR DESCRIPTION
An update/cleanup to the Indonesian localization of the `Ranking Queue` page (http://osu.ppy.sh/wiki/id/Beatmap_ranking_procedure/Ranking_queue). 

((this was primarily done to address the fact that the current translation mistakenly refers the word "ranking" in "ranking queue" to something as in "player ranking" or "global leaderboard ranking" instead of "(to) rank a beatmap"))