### PR TITLE
Fix autogenerated identifiers of the headings with images

### DIFF
--- a/wiki/Mascots/en.md
+++ b/wiki/Mascots/en.md
@@ -6,13 +6,13 @@ A YouTube video showcasing the osu! mascots can be seen at [Mascot Showcase](htt
 
 ## Official
 
-### ![osu! icon](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi, stylized with a lowercase "p", is the osu! game mode mascot that joined on 2008-07. She is also known as pippidon in osu!taiko and appeared in [Yandere Simulator](https://yanderesimulator.com) as an NPC. The initial concept art was created by [Sarumaru](https://osu.ppy.sh/users/9427), the pippidon sprite was created by [crystalsuicune](https://osu.ppy.sh/users/9974), and the current art was designed by [Daru](https://osu.ppy.sh/users/32480).
 
-### ![osu!catch icon](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *For the news posts, see: [Meet Yuzu!](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) and [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu)*
 
@@ -20,7 +20,7 @@ pippi, stylized with a lowercase "p", is the osu! game mode mascot that joined o
 
 Yuzu is the osu!catch mascot that joined on 2014-06-22. He was born on 2000-04-10, is 172 centimetres tall, and weighs 65 kilograms. His current art design was designed by [Thievley](https://osu.ppy.sh/users/4717672). Whereas his initial art design and catcher sprites were done by [ztrot](https://osu.ppy.sh/users/6347); Daru created the comboburst art.
 
-### ![osu!mania icon](/wiki/shared/mode/mania.png) Mani & Mari
+### ![](/wiki/shared/mode/mania.png) Mani & Mari
 
 *For more information, see: [Introducing Mani and Mari, the New osu!mania Mascots.](https://osu.ppy.sh/home/news/2020-09-17-introducing-mani-mari-osumania)*
 
@@ -30,7 +30,7 @@ Designed by [xiemon](https://osu.ppy.sh/users/5203667) after being scouted from 
 
 Mani is something of a maverick, always looking to explore new styles and things, while his sister Mari (formerly known as Maria) is a rigid, classical perfectionist with a penchant for the spotlight. The two get along like oil and water.
 
-### ![osu!taiko icon](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *For the news post, see: [The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 

--- a/wiki/Mascots/fr.md
+++ b/wiki/Mascots/fr.md
@@ -6,13 +6,13 @@ Une [Présentation des mascottes](https://youtu.be/mJF2cAs_MrI) est disponible.
 
 ## Officiel
 
-### ![Icône osu!](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi, stylisée avec un "p" minuscule, est la mascotte d'osu! qui a été créer en juillet 2008. Elle est aussi connue sous le nom de pippidon dans osu!taiko et apparait dans le jeu [Yandere Simulator](https://yanderesimulator.com) comme un personnage non joueur. Le concept art initial à été créer par [Sarumaru](https://osu.ppy.sh/users/9427), le sprite de pippidon à été créer par [crystalsuicune](https://osu.ppy.sh/users/9974) et le dessin actuel à été conçu par [Daru](https://osu.ppy.sh/users/32480).
 
-### ![Icône osu!catch](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *Pour voir les posts des nouvelle, voir : [Meet Yuzu!](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) et [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu)*
 
@@ -20,7 +20,7 @@ pippi, stylisée avec un "p" minuscule, est la mascotte d'osu! qui a été crée
 
 Yuzu est la mascotte osu!catch qui nous as rejoins le 22 juin 2014. Il est né le 10 avril 2000, mesure 172 cm et pèse 65 kg. Son design actuel a été conçu par [Thievley](https://osu.ppy.sh/users/4717672). Alors que sa conception artistique initiale et ses sprites attrapeurs ont été réalisés par [ztrot](https://osu.ppy.sh/users/6347); Daru à créer le design du comboburst.
 
-### ![Icône osu!mania](/wiki/shared/mode/mania.png) Maria
+### ![](/wiki/shared/mode/mania.png) Maria
 
 *Pour voir les posts des nouvelle, voir : [Meet Maria - osu!mania’s new mascot!](https://osu.ppy.sh/home/news/2016-04-20-meet-maria-osumanias-new-mascot)*
 
@@ -28,7 +28,7 @@ Yuzu est la mascotte osu!catch qui nous as rejoins le 22 juin 2014. Il est né l
 
 Maria est la mascotte osu!mania qui nous a rejoins le 4 mars 2016. Son design à été conçu par Daru.
 
-### ![Icône osu!taiko](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *Pour voir les posts des nouvelle, voir : [The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 

--- a/wiki/Mascots/id.md
+++ b/wiki/Mascots/id.md
@@ -10,13 +10,13 @@ Terdapat sebuah video di Youtube yang menampilkan maskot osu!, konten tersebut b
 
 ## Resmi
 
-### ![Ikon osu!](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi, dituliskan dengan huruf "p" kecil, adalah maskot osu! yang bergabung pada Juli 2008. Dia juga dikenal sebagai pippidon di mode osu!taiko dan pippi merupakan salah satu NPC di game [Yandere Simulator](https://yanderesimulator.com). Konsep awal pippi awalnya dirancang oleh [Sarumaru](https://osu.ppy.sh/users/9427), sprite pippidon dibuat oleh [crystalsuicune](https://osu.ppy.sh/users/9974), dan konsep pippi yang terkini dirancang oleh [Daru](https://osu.ppy.sh/users/32480).
 
-### ![Ikon osu!catch](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *Untuk postingan beritanya, lihat: [Meet Yuzu](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) dan [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu).*
 
@@ -24,7 +24,7 @@ pippi, dituliskan dengan huruf "p" kecil, adalah maskot osu! yang bergabung pada
 
 Yuzu adalah maskot osu!catch yang telah bergabung sejak 22 Juni 2014. Yuzu lahir pada 10 April 2000, tingginya 172cm, dan beratnya 65kg. Desain versi terbaru dirancang oleh [Thievley](https://osu.ppy.sh/users/4717672). Sedangkan konsep awal dan sprite catcher Yuzu dirancang oleh [ztrot](https://osu.ppy.sh/users/6347) lalu Daru membuat comboburst-nya.
 
-### ![Ikon osu!mania](/wiki/shared/mode/mania.png) Maria
+### ![](/wiki/shared/mode/mania.png) Maria
 
 *Untuk postingan beritanya, lihat: [Meet Maria - osu!mania’s new mascot!](https://osu.ppy.sh/home/news/2016-04-20-meet-maria-osumanias-new-mascot).*
 
@@ -32,7 +32,7 @@ Yuzu adalah maskot osu!catch yang telah bergabung sejak 22 Juni 2014. Yuzu lahir
 
 Maria adalah maskot osu!mania yang bergabung pada 4 Maret 2016. Maria dirancang oleh Daru.
 
-### ![Ikon osu!taiko](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *Untuk postingan beritanya, lihat: [The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here).*
 

--- a/wiki/Mascots/pt-br.md
+++ b/wiki/Mascots/pt-br.md
@@ -10,13 +10,13 @@ Um vídeo do YouTube mostrando as mascotes do osu! pode ser visto em [Mascot Sho
 
 ## Oficial
 
-### ![osu! icon](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi, estilizado em letra minúscula "p", é a mascote do osu! que se juntou em 2008-07. Ela também é conhecida como pippidon no osu!taiko e apareceu em [Yandere Simulator](https://yanderesimulator.com) como uma NPC. A arte conceitual inicial foi criada por [Sarumaru](https://osu.ppy.sh/users/9427), a sprite da pippidon for criada por [crystalsuicune](https://osu.ppy.sh/users/9974), e a arte atual foi projetada por [Daru](https://osu.ppy.sh/users/32480).
 
-### ![osu!catch icon](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *Para os posts de notícias, veja: [Meet Yuzu!](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) e [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu)*
 
@@ -24,7 +24,7 @@ pippi, estilizado em letra minúscula "p", é a mascote do osu! que se juntou em
 
 Yuzu é a mascote do osu!catch que se juntou em 2014-06-22. Nascido em 2000-04-10, ele tem 172 centímetros de altura, e pesa 65 quilogramas. A sua arte atual foi projetada por [Thievley](https://osu.ppy.sh/users/4717672). Enquanto que o projeto de sua arte inicial e sprites de catcher foram feitas por [ztrot](https://osu.ppy.sh/users/6347); Daru criou sua arte de comboburst.
 
-### ![osu!mania icon](/wiki/shared/mode/mania.png) Maria
+### ![](/wiki/shared/mode/mania.png) Maria
 
 *Para o post de notícias, veja: [Meet Maria - osu!mania’s new mascot!](https://osu.ppy.sh/home/news/2016-04-20-meet-maria-osumanias-new-mascot)*
 
@@ -32,7 +32,7 @@ Yuzu é a mascote do osu!catch que se juntou em 2014-06-22. Nascido em 2000-04-1
 
 Maria é a mascote de osu!mania que se juntou em 2016-03-04. Sua arte foi projetada por Daru.
 
-### ![osu!taiko icon](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *Para o post de notícias, veja: [The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 

--- a/wiki/Mascots/tr.md
+++ b/wiki/Mascots/tr.md
@@ -6,13 +6,13 @@ Maskotlar hakkında bir video [Mascot Showcase](https://youtu.be/mJF2cAs_MrI).
 
 ## Resmi
 
-### ![osu! ikonu](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi, ayrıca pippidon, küçük "p" ile stilize edilir, 2008-07 tarihinde katılan standart osu! maskotudur. osu!taiko'da pippidon olarak da bilinir ve [Yandere Simulator](https://yanderesimulator.com) 'de bir NPC'dir. İlk konsept tasarımı [Sarumaru](https://osu.ppy.sh/users/9427) tarafından yapılmıştır, pippidon sprite'ı [crystalsuicune](https://osu.ppy.sh/users/9974) tarafından yapılmıştır, ve şu anki tasarımı [Daru](https://osu.ppy.sh/users/32480) tarafından yapılmıştır.
 
-### ![osu!catch ikonu](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *Haber gönderileri için, bknz: [Meet Yuzu!](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) ve [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu)*
 
@@ -20,7 +20,7 @@ pippi, ayrıca pippidon, küçük "p" ile stilize edilir, 2008-07 tarihinde kat�
 
 Yuzu, 2014-06-22 tarihinde katılan osu!catch maskotudur. 2000-04-10 tarihinde doğdu, 172 santimetre boyunda, ve 65 kilo ağırlığında. şu anki tasarımı [Thievley](https://osu.ppy.sh/users/4717672) tarafından tasarlanmıştır. Oysa ilk tasarımı ve yakalayıcı sprite'ı [ztrot](https://osu.ppy.sh/users/6347) tarafından yapılmıştır; Daru kombo patlaması resmini oluşturdu..
 
-### ![osu!mania ikonu](/wiki/shared/mode/mania.png) Maria
+### ![](/wiki/shared/mode/mania.png) Maria
 
 *Haber gönderileri için, bknz: [Meet Maria - osu!mania's new mascot!](https://osu.ppy.sh/home/news/2016-04-20-meet-maria-osumanias-new-mascot)*
 
@@ -28,7 +28,7 @@ Yuzu, 2014-06-22 tarihinde katılan osu!catch maskotudur. 2000-04-10 tarihinde d
 
 Maria, 2016-03-04 tarihinde katılan osu! Mania maskotudur. Kendisi Daru tarafından tasarlanmıştır.
 
-### ![osu!taiko ikonu](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *Haber gönderileri için, bknz: [The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 

--- a/wiki/Mascots/zh.md
+++ b/wiki/Mascots/zh.md
@@ -6,13 +6,13 @@
 
 ## 官方
 
-### ![osu! 图标](/wiki/shared/mode/osu.png) pippi
+### ![](/wiki/shared/mode/osu.png) pippi
 
 ![pippi](img/pippi.png "pippi")
 
 pippi（注意开头是小写“p”）是 osu! 游戏模式的吉祥物，于 2008 年 7 月加入。她在 osu!taiko 模式中也被称为 pippidon。同时，她也曾作为 NPC 出现于 [病娇模拟器](https://yanderesimulator.com) 中。她的初始艺术形象由 [Sarumaru](https://osu.ppy.sh/users/9427) 设计，pippidon 艺术形象由 [crystalsuicune](https://osu.ppy.sh/users/9974) 设计，而现在的艺术形象则是由 [Daru](https://osu.ppy.sh/users/32480) 设计。
 
-### ![osu!catch 图标](/wiki/shared/mode/catch.png) Yuzu
+### ![](/wiki/shared/mode/catch.png) Yuzu
 
 *关于新闻帖子，参见：[Meet Yuzu!](https://osu.ppy.sh/home/news/2014-06-21-meet-yuzu) 和 [Introducing Yuzu's New Look](https://osu.ppy.sh/home/news/2019-01-09-introducing-yuzu)*
 
@@ -20,7 +20,7 @@ pippi（注意开头是小写“p”）是 osu! 游戏模式的吉祥物，于 2
 
 Yuzu 是 osu!catch 游戏模式的吉祥物，于 2014 年 6 月 22 日加入。他出生于 2000 年 4 月 10 日，身高 172 厘米，体重 65 千克。现在的形象由 [Thievley](https://osu.ppy.sh/users/4717672) 设计，而最初的艺术形象和接水果小人是由 [ztrot](https://osu.ppy.sh/users/6347) 设计。Daru 设计了他在 comboburst 时出现在屏幕上的形象。
 
-### ![osu!mania 图标](/wiki/shared/mode/mania.png) Mani & Mari
+### ![](/wiki/shared/mode/mania.png) Mani & Mari
 
 *获取更多信息，参见：[Introducing Mani and Mari, the New osu!mania Mascots.](https://osu.ppy.sh/home/news/2020-09-17-introducing-mani-mari-osumania)*
 
@@ -30,7 +30,7 @@ Mani 和 Mari 由 [xiemon](https://osu.ppy.sh/users/5203667) 设计，在 [Most 
 
 Mani 是个特立独行的人，他总是渴望探索新花样和新事物。同时，他的妹妹 Mari（以前又被叫做 Maria）是一个传统、保守的理想主义者，也希望成为聚光灯下的焦点。因性格迥异，他们之间水火不相容。
 
-### ![osu!taiko 图标](/wiki/shared/mode/taiko.png) Mocha
+### ![](/wiki/shared/mode/taiko.png) Mocha
 
 *关于新闻帖子，参见：[The new osu!taiko mascot is here!](https://osu.ppy.sh/home/news/2017-05-25-the-new-osutaiko-mascot-is-here)*
 

--- a/wiki/Ranking_Criteria/Difficulty_Naming/zh.md
+++ b/wiki/Ranking_Criteria/Difficulty_Naming/zh.md
@@ -8,7 +8,7 @@
 
 *注：特殊难度名称 **Marathon** 历史上曾被用来允许提交更长的歌曲，从而也常被用于只有一个难度的谱面集。现在，这个名称没有特殊含义，一般只被用于特别长的歌曲或混编。*
 
-### ![osu!](/wiki/shared/mode/osu.png "osu!") osu!
+### ![](/wiki/shared/mode/osu.png "osu!") osu!
 
 - ![](/wiki/shared/diff/easy-o.png) Easy（简单）
 - ![](/wiki/shared/diff/normal-o.png) Normal（普通）
@@ -16,7 +16,7 @@
 - ![](/wiki/shared/diff/insane-o.png) Insane（疯狂）
 - ![](/wiki/shared/diff/expert-o.png) Expert（专家）
 
-### ![osu!taiko](/wiki/shared/mode/taiko.png "osu!taiko") osu!taiko
+### ![](/wiki/shared/mode/taiko.png "osu!taiko") osu!taiko
 
 - ![](/wiki/shared/diff/easy-t.png) Kantan（简单）
 - ![](/wiki/shared/diff/normal-t.png) Futsuu（普通）
@@ -25,7 +25,7 @@
 - ![](/wiki/shared/diff/expert-t.png) Inner/Ura Oni（里鬼）
 - ![](/wiki/shared/diff/expertplus-t.png) Hell Oni（地狱）
 
-### ![osu!catch](/wiki/shared/mode/catch.png "osu!catch") osu!catch
+### ![](/wiki/shared/mode/catch.png "osu!catch") osu!catch
 
 - ![](/wiki/shared/diff/easy-c.png) Cup
 - ![](/wiki/shared/diff/normal-c.png) Salad
@@ -33,7 +33,7 @@
 - ![](/wiki/shared/diff/insane-c.png) Rain
 - ![](/wiki/shared/diff/expert-c.png) Overdose
 
-### ![osu!mania](/wiki/shared/mode/mania.png "osu!mania") osu!mania
+### ![](/wiki/shared/mode/mania.png "osu!mania") osu!mania
 
 - ![](/wiki/shared/diff/easy-m.png) Easy
 - ![](/wiki/shared/diff/normal-m.png) Normal

--- a/wiki/Ranking_Criteria/osu!taiko/es.md
+++ b/wiki/Ranking_Criteria/osu!taiko/es.md
@@ -83,7 +83,7 @@ Estas pautas pueden ser quebradas bajo circunstancias **especiales**. Estas exce
 
 Si el BPM del mapa ha sido modificado para tener el doble o la mitad de pulsos por minuto, el Slider Velocity base, las reglas y las pautas mencionadas aquí deben ser ajustadas apropiadamente.
 
-### ![Kantan](/wiki/shared/diff/easy-t.png "Kantan") Kantan
+### ![](/wiki/shared/diff/easy-t.png "Kantan") Kantan
 
 #### Reglas
 
@@ -102,7 +102,7 @@ Si el BPM del mapa ha sido modificado para tener el doble o la mitad de pulsos p
 - El Overall Difficulty debe estar ajustado a 4 o un número menor.
 - El HP Drain Rate debe estar ajustado a 6 o un número mayor. En caso de que haya un número alto de notas (debido a la longitud de la canción) puede ser ajustado a un número ligeramente menor a 6.
 
-### ![Futsuu](/wiki/shared/diff/normal-t.png "Futsuu") Futsuu
+### ![](/wiki/shared/diff/normal-t.png "Futsuu") Futsuu
 
 #### Reglas
 
@@ -130,7 +130,7 @@ Si planeas usar un __Futsuu como la dificultad más baja de tu mapset__, debe ad
 - El Overall Difficulty debe estar ajustado a 5 o un número menor.
 - El HP Drain Rate debe estar ajustado a 5 o un número mayor. En caso de que haya un número alto de notas (debido a la longitud de la canción) puede ser ajustado a un número ligeramente menor a 5.
 
-### ![Muzukashii](/wiki/shared/diff/hard-t.png "Muzukashii") Muzukashii
+### ![](/wiki/shared/diff/hard-t.png "Muzukashii") Muzukashii
 
 #### Reglas
 
@@ -152,7 +152,7 @@ Si planeas usar un __Futsuu como la dificultad más baja de tu mapset__, debe ad
 - El Overall Difficulty debe estar ajustado a 5 o un número menor.
 - El HP Drain Rate debe estar ajustado a 5 o un número mayor. En caso de que haya un número alto de notas (debido a la longitud de la canción) puede ser ajustado a un número ligeramente menor a 6.
 
-### ![Oni](/wiki/shared/diff/insane-t.png "Oni") Oni
+### ![](/wiki/shared/diff/insane-t.png "Oni") Oni
 
 #### Reglas
 
@@ -171,7 +171,7 @@ Si planeas usar un __Futsuu como la dificultad más baja de tu mapset__, debe ad
 - El Overall Difficulty debe estar ajustado a 5 o un número menor.
 - El HP Drain Rate debe estar ajustado a 5 o un número mayor. En caso de que haya un número alto de notas (debido a la longitud de la canción) puede ser ajustado a un número ligeramente menor a 5.
 
-### ![Inner/Ura Oni](/wiki/shared/diff/expert-t.png "Inner/Ura Oni") Inner/Ura Oni
+### ![](/wiki/shared/diff/expert-t.png "Inner/Ura Oni") Inner/Ura Oni
 
 #### Pautas
 


### PR DESCRIPTION
otherwise the alt text makes its way both into the section's identifier and ToC:

![image](https://user-images.githubusercontent.com/4686101/136273074-10d90ecf-75a3-4819-85f8-22b75fc64d6e.png)
