### PR TITLE
Update `OWC 2021`

### DIFF
--- a/wiki/Tournaments/OWC/2021/en.md
+++ b/wiki/Tournaments/OWC/2021/en.md
@@ -116,15 +116,15 @@ The osu! World Cup 2021 is run by the osu! team and various community members.
 - NoMod
   - [LiSA - Confidence Driver (Skyflame) \[Assurance\]](https://osu.ppy.sh/beatmapsets/1597778#osu/3263082)
   - [IRON ATTACK! - INEXPERIENCE (DeviousPanda) \[EXTRA STAGE\]](https://osu.ppy.sh/beatmapsets/1597785#osu/3263098)
-  - [MIOYAMAZAKI - Byoushin Zenkai Girl (Deca/mnyui) \[Collab Extra\]](https://osu.ppy.sh/beatmapsets/1597860#osu/3263248)
+  - [MIOYAMAZAKI - Byoushin Zenkai Girl (Deca) \[Collab Extra\]](https://osu.ppy.sh/beatmapsets/1597860#osu/3263248)
   - [Camellia - Heartless being (Mir) \[Expert\]](https://osu.ppy.sh/beatmapsets/1597801#osu/3263131)
 - Hidden
   - [BUTAOTOME - Sharekoube (Moph) \[Extreme\]](https://osu.ppy.sh/beatmapsets/1597784#osu/3263097)
-  - [ZUN - Primodrial Beat ~ Pristine Beat (Halfslashed) \[Extra Stage\]](https://osu.ppy.sh/beatmapsets/1597824#osu/3263174)
-- Hard Rock
-  - [Nakamura Meiko - Dispel (Yogurtt) \[play persona 4 golden\]](https://osu.ppy.sh/beatmapsets/1597607#osu/3262706)
+  - [ZUN - Primodrial Beat \~ Pristine Beat (Halfslashed) \[Extra Stage\]](https://osu.ppy.sh/beatmapsets/1597824#osu/3263174)
+- HardRock
+  - [Nakamura Meiko - Dispel (Yogurtt) \[Cataclysm\]](https://osu.ppy.sh/beatmapsets/1597607#osu/3262706)
   - [Lime - Ophelia (Kloyd) \[Hamlet\]](https://osu.ppy.sh/beatmapsets/1597825#osu/3263175)
-- Double Time
+- DoubleTime
   - [Ito Kanako - Koko ni Iru kara (ImpurePug) \[Insane\]](https://osu.ppy.sh/beatmapsets/1597789#osu/3263112)
   - [-45 - NyanNyatothep (Dada) \[Gothic Horror\]](https://osu.ppy.sh/beatmapsets/1597755#osu/3263028)
 


### PR DESCRIPTION
Fixes metadata for one of the songs in the qualifiers mappool/updates the player list for the last time (hopefully).