### PR TITLE
Improve tags for game mod articles 

### DIFF
--- a/wiki/Game_modifier/Double_Time/en.md
+++ b/wiki/Game_modifier/Double_Time/en.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - double time
+  - doubletime
   - double-time
   - DT
   - mod

--- a/wiki/Game_modifier/Double_Time/fr.md
+++ b/wiki/Game_modifier/Double_Time/fr.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - double time
+  - doubletime
   - double-time
   - DT
   - mod

--- a/wiki/Game_modifier/Double_Time/id.md
+++ b/wiki/Game_modifier/Double_Time/id.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - double time
+  - doubletime
   - double-time
   - DT
   - mod

--- a/wiki/Game_modifier/Double_Time/ko.md
+++ b/wiki/Game_modifier/Double_Time/ko.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - double time
+  - doubletime
   - double-time
   - DT
   - mod

--- a/wiki/Game_modifier/Half_Time/en.md
+++ b/wiki/Game_modifier/Half_Time/en.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - half time
+  - halftime
   - mod
   - game modifier
   - HT

--- a/wiki/Game_modifier/Half_Time/fr.md
+++ b/wiki/Game_modifier/Half_Time/fr.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - half time
+  - halftime
   - mod
   - game modifier
   - HT

--- a/wiki/Game_modifier/Half_Time/id.md
+++ b/wiki/Game_modifier/Half_Time/id.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - half time
+  - halftime
   - mod
   - game modifier
   - HT

--- a/wiki/Game_modifier/Hard_Rock/en.md
+++ b/wiki/Game_modifier/Hard_Rock/en.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - hard rock
+  - hardrock
   - mod
   - game modifier
   - HR

--- a/wiki/Game_modifier/Hard_Rock/fr.md
+++ b/wiki/Game_modifier/Hard_Rock/fr.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - hard rock
+  - hardrock
   - mod
   - game modifier
   - HR

--- a/wiki/Game_modifier/Hard_Rock/id.md
+++ b/wiki/Game_modifier/Hard_Rock/id.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - hard rock
+  - hardrock
   - mod
   - game modifier
   - HR

--- a/wiki/Game_modifier/No_Fail/en.md
+++ b/wiki/Game_modifier/No_Fail/en.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - no fail
+  - nofail
   - NF
   - mod
   - game modifier

--- a/wiki/Game_modifier/No_Fail/fr.md
+++ b/wiki/Game_modifier/No_Fail/fr.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - no fail
+  - nofail
   - NF
   - mod
   - game modifier

--- a/wiki/Game_modifier/No_Fail/id.md
+++ b/wiki/Game_modifier/No_Fail/id.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - no fail
+  - nofail
   - NF
   - mod
   - game modifier

--- a/wiki/Game_modifier/No_Fail/ko.md
+++ b/wiki/Game_modifier/No_Fail/ko.md
@@ -3,7 +3,6 @@ stub: true
 outdated: true
 outdated_since: 77180e4fde6272da6bfab8e8337dcb379b598b64
 tags:
-  - 노페일 모드
   - no fail
   - nofail
   - NF

--- a/wiki/Game_modifier/No_Fail/ko.md
+++ b/wiki/Game_modifier/No_Fail/ko.md
@@ -5,6 +5,7 @@ outdated_since: 77180e4fde6272da6bfab8e8337dcb379b598b64
 tags:
   - 노페일 모드
   - no fail
+  - nofail
   - NF
   - mod
   - game modifier

--- a/wiki/Game_modifier/No_Fail/zh-tw.md
+++ b/wiki/Game_modifier/No_Fail/zh-tw.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 tags:
-  - no fail
+  - nofail
   - NF
   - mod
   - game modifier


### PR DESCRIPTION
helps you find the articles if you search for `hardrock` and the likes.
in addition, there's no point in repeating the article's name in the tags, as titles are matched against the query anyway