### PR TITLE
Update `Project Loved Team` To Reflect Username Change

### DIFF
--- a/wiki/People/The_Team/Project_Loved_Team/en.md
+++ b/wiki/People/The_Team/Project_Loved_Team/en.md
@@ -19,8 +19,8 @@ The Project Loved Team mostly consists of *captains* for each [game mode](/wiki/
 - ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
 - ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
 - ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983)
+- ![][flag_US] [kotkeone](https://osu.ppy.sh/users/10083084)
 - ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
-- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
 
 ### osu!taiko
 

--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -21,8 +21,8 @@ La Project Loved Team se compose principalement de *capitaines* pour chaque [mod
 - ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
 - ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
 - ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983)
+- ![][flag_US] [kotkeone](https://osu.ppy.sh/users/10083084)
 - ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
-- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
 
 ### osu!taiko
 

--- a/wiki/People/The_Team/Project_Loved_Team/id.md
+++ b/wiki/People/The_Team/Project_Loved_Team/id.md
@@ -21,8 +21,8 @@ Sebagian besar anggota Project Loved Team merupakan tokoh-tokoh komunitas terpil
 - ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
 - ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
 - ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983)
+- ![][flag_US] [kotkeone](https://osu.ppy.sh/users/10083084)
 - ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
-- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
 
 ### osu!taiko
 

--- a/wiki/People/The_Team/Project_Loved_Team/ru.md
+++ b/wiki/People/The_Team/Project_Loved_Team/ru.md
@@ -21,8 +21,8 @@ tags:
 - ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
 - ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
 - ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983)
+- ![][flag_US] [kotkeone](https://osu.ppy.sh/users/10083084)
 - ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
-- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
 
 ### osu!taiko
 

--- a/wiki/People/The_Team/Project_Loved_Team/tr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/tr.md
@@ -21,8 +21,8 @@ Project Loved Takımının çoğunluğunu her bir [oyun modunun](/wiki/Game_mode
 - ![][flag_GB] [Bubbleman](https://osu.ppy.sh/users/5182050)
 - ![][flag_US] [DigitalHypno](https://osu.ppy.sh/users/4384207)
 - ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983)
+- ![][flag_US] [kotkeone](https://osu.ppy.sh/users/10083084)
 - ![][flag_US] [UberFazz](https://osu.ppy.sh/users/8646059)
-- ![][flag_US] [Wixonater](https://osu.ppy.sh/users/10083084)
 
 ### osu!taiko
 


### PR DESCRIPTION
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

`Wixonater` changed username to `kotkeone` so just quickly updating the wiki page for the Project Loved Team to reflect that. Changed it on all locales except the ones that are outdated.