### PR TITLE
Add article sections clarifying tournament bans and their reach

### DIFF
--- a/wiki/Help_Centre/Account/en.md
+++ b/wiki/Help_Centre/Account/en.md
@@ -49,7 +49,7 @@ Refer to *[Account Restrictions](/wiki/Help_Centre/Account_Restrictions)* for mo
 
 Tournament bans are as the name describes - a ban from participation in all officially supported tournaments. This includes playing, staffing or assisting a tournament in any way.
 
-A user may receive a tournament ban for deliberately breaking the osu! community rules during tournament play, depending on the severity of the offense. Examples of such bad behaviour include attempting to gain an unfair advantage in an officially supported tournament by any means, being abusive to anyone involved in a tournament, being deliberately disruptive to the running of a tournament, and more.
+A user may receive a tournament ban for deliberately breaking the osu! community rules during tournament play, depending on the severity of the offense. Examples of such bad behaviour include attempting to gain an unfair advantage in an officially supported tournament by any means or being abusive to anyone involved in a tournament, being deliberately disruptive to the running of a tournament.
 
 Most tournament bans have a set duration, anywhere from 3 months to a year or more. Some bans may be permanent. Regardless of the duration of the ban, all tournament bans are **final** and cannot be appealed like restrictions can.
 

--- a/wiki/Help_Centre/Account/en.md
+++ b/wiki/Help_Centre/Account/en.md
@@ -47,9 +47,9 @@ Refer to *[Account Restrictions](/wiki/Help_Centre/Account_Restrictions)* for mo
 
 ### What is a tournament ban?
 
-Tournament bans are as the name describes - a ban from participation in all officially supported tournaments. This includes playing, staffing or assisting a tournament in any way.
+Tournament bans are as the name describes - a ban from participation in all officially supported tournaments.
 
-A user may receive a tournament ban for deliberately breaking the osu! community rules during tournament play, depending on the severity of the offense. Examples of such bad behaviour include attempting to gain an unfair advantage in an officially supported tournament by any means or being abusive to anyone involved in a tournament, being deliberately disruptive to the running of a tournament.
+A user may receive a tournament ban for deliberately breaking the osu! community rules during tournament play, depending on the severity of the offense. Examples of such bad behaviour include attempting to gain an unfair advantage in an officially supported tournament by any means, being abusive to anyone involved in a tournament or being deliberately disruptive to the running of a tournament.
 
 Most tournament bans have a set duration, anywhere from 3 months to a year or more. Some bans may be permanent. Regardless of the duration of the ban, all tournament bans are **final** and cannot be appealed like restrictions can.
 

--- a/wiki/Help_Centre/Account/en.md
+++ b/wiki/Help_Centre/Account/en.md
@@ -43,6 +43,16 @@ In situations where we are absolutely assured that foul play or wrongdoing has t
 
 Refer to *[Account Restrictions](/wiki/Help_Centre/Account_Restrictions)* for more information on account restrictions and the appeal process.
 
+## Tournament bans
+
+### What is a tournament ban?
+
+Tournament bans are as the name describes - a ban from participation in all officially supported tournaments. This includes playing, staffing or assisting a tournament in any way.
+
+A user may receive a tournament ban for deliberately breaking the osu! community rules during tournament play, depending on the severity of the offense. Examples of such bad behaviour include attempting to gain an unfair advantage in an officially supported tournament by any means, being abusive to anyone involved in a tournament, being deliberately disruptive to the running of a tournament, and more.
+
+Most tournament bans have a set duration, anywhere from 3 months to a year or more. Some bans may be permanent. Regardless of the duration of the ban, all tournament bans are **final** and cannot be appealed like restrictions can.
+
 ## Sign-in
 
 ### I've forgotten my username and password!

--- a/wiki/Help_Centre/Account/fr.md
+++ b/wiki/Help_Centre/Account/fr.md
@@ -20,6 +20,8 @@ tags:
   - drapeau
   - nom d'utilisateur
   - suppression
+outdated: true
+outdated_since: c0e3ac1f17bcbdd620c144f55f813351bf320b83
 ---
 
 # Compte

--- a/wiki/Help_Centre/Account/id.md
+++ b/wiki/Help_Centre/Account/id.md
@@ -19,6 +19,8 @@ tags:
   - piranti
   - nama pengguna
   - penghapusan
+outdated: true
+outdated_since: c0e3ac1f17bcbdd620c144f55f813351bf320b83
 ---
 
 # Akun

--- a/wiki/Help_Centre/Account/zh.md
+++ b/wiki/Help_Centre/Account/zh.md
@@ -20,6 +20,8 @@ tags:
   - 设备
   - 用户名
   - 删除
+outdated: true
+outdated_since: c0e3ac1f17bcbdd620c144f55f813351bf320b83
 ---
 
 # 帐号

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -26,9 +26,9 @@ In addition, all promotional material or any services associated with a tourname
 
 ### Integrity
 
-To ensure officially supported tournaments run smoothly, users under an active (or permanent) tournament ban/cooldown are **not** permitted to play in, staff or assist in the running, maintenance or development of such tournaments in any way.
+Hosts are expected to ensure that their tournaments run smoothly and with minimal disruption where possible.
 
-This includes anything from design to commentary, mappooling, refereeing, playtesting and other positions not listed. Put simply, if they are tournament banned, they should not be anywhere near an officially supported tournament in any capacity except as an observer.
+Users under an active (or permanent) tournament ban/cooldown may be enlisted as general help (aka, any non-staff role such as a commentator, streamer, etc) in an officially supported tournament at the host's discretion, but we encourage careful consideration of such choices as said individuals have already run afoul of the rules once (or more). They may not act as hosts, mappoolers, playtesters, or any other trusted position that has ready access to confidential information which could influence the outcome of the tournament if shared.
 
 ### Players
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -24,6 +24,12 @@ Community-run tournaments receiving this support are expected to abide by the fo
 
 In addition, all promotional material or any services associated with a tournament receiving official support should adhere to the [osu! community rules](/wiki/Rules). This includes things like Twitter accounts, Discord servers, and so on.
 
+### Integrity
+
+To ensure officially supported tournaments have the best experience possible, users under an active (or permanent) tournament ban/cooldown are **not** permitted to play in, staff or assist in the running, maintenance or development of said tournament in any way.
+
+This includes anything from design to commentary, mappooling, refereeing, playtesting and other positions not listed. Put simply, if they are tournament banned, they should not be anywhere near an officially supported tournament in any capacity except as an observer.
+
 ### Players
 
 Participants in officially supported tournaments are expected to adhere to the [osu! community rules](/wiki/Rules) at all times, regardless of their rank, accomplishments, or other achievements.
@@ -39,6 +45,7 @@ A major part of being an officially supported tournament is access to the screen
 Tournament organisers will be expected to provide the following:
 
 - A comma-separated list (or spreadsheet) including player usernames and user IDs
+- A second comma-separated list (or spreadsheet) including staff/assistant usernames and user IDs (basically for anyone involved in the running or development of the tournament)
 - If the tournament is team-based, this list must reflect the grouping of players in their teams of play, complete with any team name or other identifying marker
 
 The comma-separated list should look like this:
@@ -47,6 +54,10 @@ The comma-separated list should look like this:
 Player1, 1234567
 Player2, 1234567
 Player3, 1234567
+
+HostGuy, 1234567
+RefLady, 1234567
+CommentatorThing, 1234567
 ```
 
 Once screening concludes, the osu! Support Team will provide a list of any players from your tournament that failed screening and are not considered eligible for tournament play. No individual reasons will be given for why a player does not pass screening.

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -26,7 +26,7 @@ In addition, all promotional material or any services associated with a tourname
 
 ### Integrity
 
-To ensure officially supported tournaments have the best experience possible, users under an active (or permanent) tournament ban/cooldown are **not** permitted to play in, staff or assist in the running, maintenance or development of said tournament in any way.
+To ensure officially supported tournaments run smoothly, users under an active (or permanent) tournament ban/cooldown are **not** permitted to play in, staff or assist in the running, maintenance or development of such tournaments in any way.
 
 This includes anything from design to commentary, mappooling, refereeing, playtesting and other positions not listed. Put simply, if they are tournament banned, they should not be anywhere near an officially supported tournament in any capacity except as an observer.
 


### PR DESCRIPTION
This clarifies an existing expectation that was overlooked. The verdict on this is not final and the wording could be subject to change.

This also includes an addition to the screening process to require organizers to send lists of their staff alongside their players.