### PR TITLE
[EN] Fix missing 'the' in `osu! wiki`

### DIFF
--- a/wiki/osu!_wiki/en.md
+++ b/wiki/osu!_wiki/en.md
@@ -17,7 +17,7 @@ The [first attempts](https://osu.ppy.sh/community/forums/posts/1175876) of creat
 
 The gateway to the osu! wiki is the [main page](/wiki/Main_Page), which is divided into several high-level categories, each having a general description and including a list of important articles. The articles not listed on the main page, which are typically more specific, can be reached either from other pages using inline links, or through the search feature of the website.
 
-An individual article describes a single term or concept and gives a general overview on adjacent topics. To better illustrate the subject, it is divided into subsections covering different parts of the term. It may also include relevant screenshots or other visual explanations, or link to other articles on topic.<!-- TODO: via the use of infoboxes. uncomment this when they are ready (https://github.com/ppy/osu-wiki/issues/5440) -->
+An individual article describes a single term or concept and gives a general overview on adjacent topics. To better illustrate the subject, it is divided into subsections covering different parts of the term. It may also include relevant screenshots or other visual explanations, or link to other articles on the topic.<!-- TODO: via the use of infoboxes. uncomment this when they are ready (https://github.com/ppy/osu-wiki/issues/5440) -->
 
 Translations in different languages are available for some articles. They are made by the community members themselves, and the choice of language is only limited by the [list of languages](/wiki/Article_styling_criteria/Formatting#locales) supported by the website itself.
 


### PR DESCRIPTION
I noticed a missing 'the' when working on the German translation. Since there is a comment there, I assume that this article will be edited in the future. But I guess I should mention it nonetheless.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
