### PR TITLE
Fix ThatsNotAName's Flag in `Project Loved Team`

### DIFF
--- a/wiki/People/The_Team/Project_Loved_Team/en.md
+++ b/wiki/People/The_Team/Project_Loved_Team/en.md
@@ -135,7 +135,7 @@ Below listed are the users, who once were a part of the Project Loved Team.
 ### Other
 
 - ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
-- ![][flag_HU] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
+- ![][flag_US] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
 - ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
 
 ## Trivia

--- a/wiki/People/The_Team/Project_Loved_Team/fr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/fr.md
@@ -137,7 +137,7 @@ Vous trouverez ci-dessous la liste des utilisateurs qui ont fait partie de la Pr
 ### Éditeurs vidéo
 
 - ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
-- ![][flag_HU] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
+- ![][flag_US] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
 - ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
 
 ## Le saviez-vous ?

--- a/wiki/People/The_Team/Project_Loved_Team/id.md
+++ b/wiki/People/The_Team/Project_Loved_Team/id.md
@@ -137,7 +137,7 @@ Di bawah ini tercantum pengguna yang pernah menjadi bagian Project Loved Team
 ### Editor video
 
 - ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
-- ![][flag_HU] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
+- ![][flag_US] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
 - ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
 
 ## Trivia

--- a/wiki/People/The_Team/Project_Loved_Team/ru.md
+++ b/wiki/People/The_Team/Project_Loved_Team/ru.md
@@ -137,7 +137,7 @@ tags:
 ### Редакторы видео
 
 - ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
-- ![][flag_HU] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
+- ![][flag_US] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
 - ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
 
 ## Факты

--- a/wiki/People/The_Team/Project_Loved_Team/tr.md
+++ b/wiki/People/The_Team/Project_Loved_Team/tr.md
@@ -137,7 +137,7 @@ Aşağıda listelenen kullanıcılar bir zamanlar Project Loved Takımının bir
 ### Video editörleri
 
 - ![][flag_GB] [Striiker](https://osu.ppy.sh/users/7291594)
-- ![][flag_HU] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
+- ![][flag_US] [ThatsNotAName](https://osu.ppy.sh/users/9682904)
 - ![][flag_HU] [verto](https://osu.ppy.sh/users/2015300)
 
 ## Ek bilgiler


### PR DESCRIPTION
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Fixes ThatsNotAName's flag on the Project Loved Team pages. Incorrectly marked as Hungary when they are from the United States.