### PR TITLE
Add CI step for checking if translations are properly marked as outdated

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
 
 jobs:
   ci:
@@ -78,3 +83,65 @@ jobs:
         uses: ibiqlik/action-yamllint@v1.0.0
         with:
           config_file: .yamllint.yaml
+
+      - name: check if translations are marked as outdated
+        shell: bash
+        env:
+          MASK: '---\n(.*\n)*?((outdated: |outdated_since: ).+\n)(.*\n)*?---'
+          PULL_REQUEST_TAG: 'SKIP_OUTDATED_CHECK'
+        run: |
+          # https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+          function echo_red () { echo -e "\e[0;31m$1\e[m"; }
+          function echo_green () { echo -e "\e[0;32m$1\e[m"; }
+
+          function print_error () {
+            echo "::error::You have edited some original articles (en.md), but did not outdate their translations:"
+            while read FILENAME; do
+              echo_red "* $FILENAME"
+            done <<< "$1"
+
+            echo -e "\nIf your changes DON'T NEED to be added to the translations, add $( echo_red $PULL_REQUEST_TAG ) to the pull request."
+            echo -e "Otherwise, add the following to each article's front matter:\n"
+            echo_green "---"
+            echo_green "outdated: true"
+            if [[ -n "$2" ]]; then
+              echo_green "outdated_since: $2"
+            fi
+            echo_green "---"
+          }
+
+          function diff_files () { git diff --diff-filter=d --name-only ${{ github.sha }}^ ${{ github.sha }} "$@"; }
+
+          TRANSLATIONS=$( diff_files 'wiki/**/*.md' ':(exclude)*/en.md' )
+          ORIGINAL_ARTICLES=$( diff_files 'wiki/**/en.md' )
+          if [[ -z "$ORIGINAL_ARTICLES" ]]; then
+            echo "::notice::No original articles are edited, exiting"
+            exit 0
+          fi
+          if ${{ contains(github.event.pull_request.body, env.PULL_REQUEST_TAG) }}; then
+            echo "::notice::Outdated articles check suppressed ($PULL_REQUEST_TAG tag found in the pull request)"
+            exit 0
+          fi
+
+          # obtain directories of the modified en.md files, then list translations in them which:
+          # - are not modified in the PR (assuming that the author took care of them)
+          # - don't have the outdated/outdated_since markers
+
+          MISSED_TRANSLATIONS=$( echo "$ORIGINAL_ARTICLES" | xargs dirname | sort -u | {
+            while read DIRECTORY; do
+              for ARTICLE_NAME in $( ls "$DIRECTORY"/*.md | grep -v en.md || true ); do
+                if ! [[ "$TRANSLATIONS" =~ "$ARTICLE_NAME" ]]; then
+                  grep -LzP -e "$MASK" "$ARTICLE_NAME" || true  # print only names of non-matching files, with multiline match (considering \n)
+                fi
+              done
+            done
+          })
+
+          if [[ -n "$MISSED_TRANSLATIONS" ]]; then
+            # get the first commit of the branch associated with the PR; GitHub's ubuntu-latest has curl/jq: https://github.com/actions/virtual-environments
+            FIRST_COMMIT_HASH=$( curl -sS ${{ github.event.pull_request.commits_url }}?per_page=1 | jq -r '.[0].sha' || true )
+            print_error "$MISSED_TRANSLATIONS" "$FIRST_COMMIT_HASH"
+            exit 1
+          else
+            echo -e "::notice::Either you have edited no original articles, or all translations are properly outdated"
+          fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,7 +100,7 @@ jobs:
               echo_red "* $FILENAME"
             done <<< "$1"
 
-            echo -e "\nIf your changes DON'T NEED to be added to the translations, add $( echo_red $PULL_REQUEST_TAG ) to the pull request."
+            echo -e "\nIf your changes DON'T NEED to be added to the translations, add $( echo_red $PULL_REQUEST_TAG ) anywhere in the description of your pull request."
             echo -e "Otherwise, add the following to each article's front matter:\n"
             echo_green "---"
             echo_green "outdated: true"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,7 +101,7 @@ jobs:
             done <<< "$1"
 
             echo -e "\nIf your changes DON'T NEED to be added to the translations, add $( echo_red $PULL_REQUEST_TAG ) anywhere in the description of your pull request."
-            echo -e "Otherwise, add the following to each article's front matter:\n"
+            echo -e "Otherwise, add the following to each article's front matter (https://osu.ppy.sh/wiki/en/Article_styling_criteria/Formatting#front-matter):\n"
             echo_green "---"
             echo_green "outdated: true"
             if [[ -n "$2" ]]; then


### PR DESCRIPTION
# what

this check protects us from the situations when someone has edited an original article (`en.md`), but forgot to check its translations and mark them as outdated by adding `outdated: true` and `outdated_since: {commit hash}` markers to their front matters.

for cases which can't be handled automatically (say, you're fixing a typo which is only present in English article), it can be silenced by adding `SKIP_OUTDATED_CHECK` to the pull request's message (it may appear everywhere).

example: https://github.com/TicClick/osu-wiki/pull/2. see CI output on individual commits, as well as its status for the whole PR (forced to OK by the tag):
- [error](https://github.com/TicClick/osu-wiki/pull/2/checks?sha=cea95b0a8c752d7b914bde5f8c9728011f657f03) | screenshot: https://user-images.githubusercontent.com/4686101/142972040-358bc307-e6c2-42e9-bae9-89c812c324af.png
- [clean pass](https://github.com/TicClick/osu-wiki/pull/2/checks?sha=5b2017f4b172287c0c12f1607179c883173e9b3f) | screenshot: https://user-images.githubusercontent.com/4686101/142972098-c7be1404-8a39-4d91-a32d-4cef13251972.png
- [suppressed](https://github.com/TicClick/osu-wiki/runs/4295034186) | screenshot: https://user-images.githubusercontent.com/4686101/142972138-aac62d32-4f50-4849-8201-4289125bb319.png

# where

it's... uh, inlined in the `continuous-integration.yml` file. could be moved into a separate script if necessary. if deemed useful, could be sped up by throwing out unnecesary steps like linters. could be moved to a separate workflow and sped up by [caching the repository checked out](https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#caching-dependencies).

# when

The script is triggered on [default `pull_request`-related events](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request) **plus** PR message edits to catch the (dis)appearance of `SKIP_OUTDATED_CHECK`.

# why

## ...the check?

part of #6233. prevents articles expiring silently because of random maintainers' occasional lazy eye syndrom (at least #6197, #6189, #6111, #4651 -- found by me only).

## ...is this a GitHub Action?

- needs to be run on every commit
- should block merge
- may be overriden
- the source is easily accessible and editable
- I honestly don't want to host a bot, or an app, not to mention that it'd have been a bit more complicated

## ...do you think people will follow it?

it prints errors AND direct suggestions on how to fix them. besides, it's important to know which translations are really up to date.