### PR TITLE
Update mania score calculation in fr.md

### DIFF
--- a/wiki/Score/fr.md
+++ b/wiki/Score/fr.md
@@ -207,9 +207,9 @@ Le score accordé par chaque note est calculé à l'aide de la formule suivante 
 ```
 Score = BaseScore + BonusScore
 
-BaseScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitValue / 320)
+BaseScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) / (HitValue / 320)
 
-BonusScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitBonusValue * Sqrt(Bonus) / 320)
+BonusScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) / (HitBonusValue * Sqrt(Bonus) / 320)
 Bonus = Bonus avant la note + HitBonus - HitPunishment / ModDivider
 Bonus est compris entre [0, 100], vaut 100 au départ.
 


### PR DESCRIPTION
Une petite erreur dans les formules de calcul de score en mania.
La valeur multiplicative et de base serait multipliée par le score de base de chaque note, mais c'est totalement faux.
En prenant une map de 400 objets pour exemple, la différence de score entre un BonusScore d'un jugement MAX et 300 devrait être autour de 7 et non pas 718.
La requête de pull a aussi été faite pour la version anglaise. (#6453)

## Self-check

- [x ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
