### PR TITLE
Update mania score calculation in en.md

### DIFF
--- a/wiki/Score/en.md
+++ b/wiki/Score/en.md
@@ -196,9 +196,9 @@ The score given by each note is calculated with the following formula:-
 ```
 Score = BaseScore + BonusScore
 
-BaseScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitValue / 320)
+BaseScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) / (HitValue / 320)
 
-BonusScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitBonusValue * Sqrt(Bonus) / 320)
+BonusScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) / (HitBonusValue * Sqrt(Bonus) / 320)
 Bonus = Bonus before this hit + HitBonus - HitPunishment / ModDivider
 Bonus is limited to [0, 100], initially 100.
 


### PR DESCRIPTION
A little mistyping in the mania score calculation formulas.
The multiplier and hit value of each note would be multiplied by the base score of each note, but that is totally wrong.
Taking a map with 400 objects for example, the score difference between a MAX and 300 BonusScore judgement should be around 7 and not 718.
"Duplicate" of #6452 for the french folks.

## Self-check

- [x ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
