### PR TITLE
Fix skinning contest newspost crown images

### DIFF
--- a/news/2021-12-02-skinning-contest-tides-of-winter-announcement.md
+++ b/news/2021-12-02-skinning-contest-tides-of-winter-announcement.md
@@ -75,9 +75,9 @@ Now that all the rules are out of the way, let's unveil the prizes that will be 
 
 | Placing | Prizes |
 | :-: | :-- |
-| ![Gold Crown](/wiki/shared/gold_crown.png "1st place") | Profile badge themed around their submission, 6 months of osu!supporter |
-| ![Silver Crown](/wiki/shared/silver_crown.png "2nd place") | Profile badge themed around their submission, 4 months of osu!supporter |
-| ![Bronze Crown](/wiki/shared/silver_crown.png "3rd place") | Profile badge themed around their submission, 2 months of osu!supporter |
+| ![Gold Crown](/wiki/shared/crown-gold.png "1st place") | Profile badge themed around their submission, 6 months of osu!supporter |
+| ![Silver Crown](/wiki/shared/crown-silver.png "2nd place") | Profile badge themed around their submission, 4 months of osu!supporter |
+| ![Bronze Crown](/wiki/shared/crown-bronze.png "3rd place") | Profile badge themed around their submission, 2 months of osu!supporter |
 
 ---
 


### PR DESCRIPTION
Fixes the image files referenced in the skinning contest newspost that just went live as they currently don't display.