### PR TITLE
Update casing of lazer tournament client custom asset folder names

### DIFF
--- a/wiki/osu!tourney/osu!lazer_tournament_client/en.md
+++ b/wiki/osu!tourney/osu!lazer_tournament_client/en.md
@@ -28,9 +28,9 @@ To create a new tournament configuration, create a new directory in the `tournam
 Inside a tournament configuration the necessary assets can be supplied to display flags, videos and mod icons for the mappool. Each category of asset has its own folder: 
 
 - your-tournament
-    - Flags
-    - Mods
-    - Videos
+  - Flags
+  - Mods
+  - Videos
 
 ## Customisation
 

--- a/wiki/osu!tourney/osu!lazer_tournament_client/en.md
+++ b/wiki/osu!tourney/osu!lazer_tournament_client/en.md
@@ -28,9 +28,9 @@ To create a new tournament configuration, create a new directory in the `tournam
 Inside a tournament configuration the necessary assets can be supplied to display flags, videos and mod icons for the mappool. Each category of asset has its own folder: 
 
 - your-tournament
-    - flags
-    - mods
-    - videos
+    - Flags
+    - Mods
+    - Videos
 
 ## Customisation
 
@@ -46,13 +46,13 @@ An example of a flag using the correct specifications is this flag of Australia:
 
 ![][flag_AU]
 
-Flags have to be placed in `<your-tournament>/flags`. The flags can then be referenced in the Team Editor by their filenames without the file extension.
+Flags have to be placed in `<your-tournament>/Flags`. The flags can then be referenced in the Team Editor by their filenames without the file extension.
 
 ### Mods
 
 For custom mod icons, `.jpg` and `.png` files are accepted. The resolution can be anything and the client will fit it in the beatmap panel. For reference, a beatmap panel at 1920x1080 is 563x60 pixels.
 
-Mod icons have to be placed in `<your-tournament>/mods`. The mods can then be referenced by their filenames without the file extension in the Rounds Editor and in the Seeding Results Editor.
+Mod icons have to be placed in `<your-tournament>/Mods`. The mods can then be referenced by their filenames without the file extension in the Rounds Editor and in the Seeding Results Editor.
 
 ### Videos
 
@@ -66,7 +66,7 @@ The files have to adhere to the following specifications:
 - `mp4`, `m4v`, or `avi` file extension
 - Video codec: H.264, Audio codec: none
 
-The video files have to placed in `<your-tournament>/videos` and specific names are required for the correct functionality.
+The video files have to placed in `<your-tournament>/Videos` and specific names are required for the correct functionality.
 
 | Scene | File(s) |
 | :-- | :-- |

--- a/wiki/osu!tourney/osu!lazer_tournament_client/fr.md
+++ b/wiki/osu!tourney/osu!lazer_tournament_client/fr.md
@@ -28,9 +28,9 @@ Pour créer une nouvelle configuration de tournoi, créez un nouveau répertoire
 Dans la configuration d'un tournoi, les actifs nécessaires peuvent être fournis pour afficher des drapeaux, des vidéos et des icônes de mods pour le mappool. Chaque catégorie d'actifs a son propre dossier : 
 
 - your-tournament
-  - flags
-  - mods
-  - videos
+  - Flags
+  - Mods
+  - Videos
 
 ## Personnalisation
 
@@ -46,13 +46,13 @@ Ce drapeau de l'Australie est un exemple de drapeau utilisant les spécification
 
 ![][flag_AU]
 
-Les drapeaux doivent être placés dans`<your-tournament>/flags`. Les drapeaux peuvent ensuite être référencés dans l'éditeur d'équipe par leur nom de fichier sans l'extension de fichier.
+Les drapeaux doivent être placés dans`<your-tournament>/Flags`. Les drapeaux peuvent ensuite être référencés dans l'éditeur d'équipe par leur nom de fichier sans l'extension de fichier.
 
 ### Mods
 
 Pour les icônes de mods personnalisés, les fichiers `.jpg` et `.png` sont acceptés. La résolution peut être quelconque et le client l'adaptera au beatmap panel. Pour référence, un beatmap panel à 1920x1080 est de 563x60 pixels.
 
-Les icônes de mods doivent être placées dans `<your-tournament>/mods`. Les mods peuvent ensuite être référencés par leur nom de fichier sans l'extension dans l'éditeur de tours et dans Seeding Results Editor.
+Les icônes de mods doivent être placées dans `<your-tournament>/Mods`. Les mods peuvent ensuite être référencés par leur nom de fichier sans l'extension dans l'éditeur de tours et dans Seeding Results Editor.
 
 ### Vidéos
 
@@ -66,7 +66,7 @@ Les fichiers doivent respecter les spécifications suivantes :
 - Extension de fichier `mp4`, `m4v` ou `avi`.
 - Codec vidéo : H.264, Codec audio : aucun
 
-Les fichiers vidéo doivent être placés dans le dossier `<your-tournament>/videos` et des noms spécifiques sont nécessaires pour une fonctionnalité correcte.
+Les fichiers vidéo doivent être placés dans le dossier `<your-tournament>/Videos` et des noms spécifiques sont nécessaires pour une fonctionnalité correcte.
 
 | Scène | Fichier(s) |
 | :-- | :-- |


### PR DESCRIPTION
In https://github.com/ppy/osu/pull/15847 (which has been included in a public lazer release - 2021.1202.0, to be exact), I've changed the tournament custom asset folder names to be uppercased rather than lowercased. For most users (read: Windows/macOS users), this will not have any discernible impact on anything; the only case where this matters is Linux. In fact a Linux report was what spurred this change to begin with (https://github.com/ppy/osu/discussions/15837).

This pull request therefore updates the lazer tournament client article to reflect the new casing.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
  - This pull also touches the French translation of the article. While the changes concern only casing of a few folders, and I have a rudimentary enough understanding of French to be somewhat confident that the changes are correct, it may be helpful to have a second pair of eyes here. I've made this change mostly to avoid outdating the translations for no reason.
