### PR TITLE
[DE] Change `osu! wiki` to `osu!-Wiki`

### DIFF
--- a/wiki/Community/osu!dev_Discord_server/de.md
+++ b/wiki/Community/osu!dev_Discord_server/de.md
@@ -28,7 +28,7 @@ Jedes Projekt wird in seinem dafür vorgesehenen Kanal diskutiert:
 | [osu!catch](/wiki/Game_mode/osu!catch) Star Rating und Performancepunkte | `#difficulty-catch` |
 | [osu!mania](/wiki/Game_mode/osu!mania) Star Rating und Performancepunkte | `#difficulty-mania` |
 | [Beatmap Spotlights](/wiki/Beatmap_Spotlights) | `#osu-spotlights` |
-| [osu! wiki](https://github.com/ppy/osu-wiki) | `#osu-wiki` |
+| [osu!-Wiki](https://github.com/ppy/osu-wiki) | `#osu-wiki` |
 | [Project Loved](/wiki/Project_Loved) | `#osu-loved` |
 | [Modding](/wiki/Modding) Diskussionen und [NAT Meetings](/wiki/Modding/NAT_meetings) | `#modding` |
 | [Mappers' Guild](/wiki/Mappers_Guild) | `#mappers-guild` |

--- a/wiki/Disambiguation/de.md
+++ b/wiki/Disambiguation/de.md
@@ -1,6 +1,6 @@
 # Begriffsabgrenzung
 
-Die Begriffsabgrenzung ist ein Prozess der Lösung von Konflikten die entstehen können, wenn der Titel eines Artikels nicht eindeutig ist. Meistens ist dies der Fall dadurch, dass er sich auf mehr als nur ein vom osu! wiki behandeltes Thema bezieht, entweder als Haupt- oder Unterthema.
+Die Begriffsabgrenzung ist ein Prozess der Lösung von Konflikten die entstehen können, wenn der Titel eines Artikels nicht eindeutig ist. Meistens ist dies der Fall dadurch, dass er sich auf mehr als nur ein vom osu!-Wiki behandeltes Thema bezieht, entweder als Haupt- oder Unterthema.
 
 Ein normaler Artikel, mit einem ähnlichen Titel, muss die Kopfnote ["Für andere Bedeutungen"](/wiki/Article_styling_criteria/Formatting#for-other-uses) mit einem Link zur Seite für die Begriffsabgrenzung haben.
 

--- a/wiki/osu!_wiki/de.md
+++ b/wiki/osu!_wiki/de.md
@@ -1,6 +1,6 @@
-# osu! wiki
+# osu!-Wiki
 
-Das **osu! wiki** ist eine Sammlung an öffentlich zugänglichem Wissen, welche von [freiwilligen Mitwirkenden](https://github.com/ppy/osu-wiki/graphs/contributors) betrieben wird. Hier findet sich eine große Breite an Informationen rund um osu!, seine Community sowie verwandte Aktivitäten und Konzepte. Das Wiki dient als offizielle Quelle für Informationen und wird als Dokumentation der Geschichte von osu! angesehen.
+Das **osu!-Wiki** ist eine Sammlung an öffentlich zugänglichem Wissen, welche von [freiwilligen Mitwirkenden](https://github.com/ppy/osu-wiki/graphs/contributors) betrieben wird. Hier findet sich eine große Breite an Informationen rund um osu!, seine Community sowie verwandte Aktivitäten und Konzepte. Das Wiki dient als offizielle Quelle für Informationen und wird als Dokumentation der Geschichte von osu! angesehen.
 
 Alle Diskussionen, über das Wiki allgemein, die Entwicklung und Änderungen von Beiträgen, werden im `#osu-wiki`-Kanal des offiziellen [osu!dev Discord-Servers](/wiki/osu!dev_Discord_server) besprochen. Um zu lernen, wie du mithelfen kannst, siehe dir folgende Artikel an:
 
@@ -9,7 +9,7 @@ Alle Diskussionen, über das Wiki allgemein, die Entwicklung und Änderungen von
 
 ## Geschichte
 
-*Hauptseite: [Geschichte des osu! wiki](/wiki/History_of_osu!/osu!_wiki)*
+*Hauptseite: [Geschichte des osu!-Wikis](/wiki/History_of_osu!/osu!_wiki)*
 
 Der [erste Versuch](https://osu.ppy.sh/community/forums/posts/1175876) eine strukturierte Sammlung zu erstellen, geht zurück auf 2011, als [peppy](/wiki/People/peppy) ein [MediaWiki](https://en.wikipedia.org/wiki/MediaWiki)-Portal aufsetzte. In diesem Portal konnte jeder freiwillig mitwirken. Über die Jahre wurde die Wartung und Instandhaltung des MediaWikis immer schwieriger. Am [26.08.2016](https://discord.com/channels/188630481301012481/218677502141399041/218678017659109376) veranlassten peppy und weitere Freiwillige die Migrierung des Wikis auf GitHub, wo es heute immer noch zu finden ist. Das Wiki wurde seitdem in die osu!-Webseite eingebunden und hat wichtige technische und visuelle Verbesserungen für eine gute Benutzererfahrung erhalten.
 
@@ -27,15 +27,15 @@ Bei der Entwicklung des Wikis wurde immer die Zugänglichkeit berücksichtigt: B
 
 Die Artikel sind nach dem ["GitHub-flavoured Markdown"](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) gestaltet. Zusätzlich implementiert die Webseite eigene nützliche Features, wie zum Beispiel Verlinkungen, eine Titelseite oder Verbesserungen bei der Formatierung.<!-- TODO: article on custom features of the wiki? it could help us ease the ASC a bit as well -->
 
-Artikel werden nach den [Gestaltungskriterien](/wiki/Article_styling_criteria) des osu! wikis gehalten, was bedeutet, dass sie in einer neutralen Sprache geschrieben sind und allgemeinen Formatierungsregeln folgen. Manche Artikel dienen als Liste für häufig gestellte Fragen (FAQ) für ein Thema und verwenden Umgangssprache. Übersetzungen folgen dem Paritätsprinzip für den Inhalt und haben dieselben Formatierungsregeln.
+Artikel werden nach den [Gestaltungskriterien](/wiki/Article_styling_criteria) des osu!-Wikis gehalten, was bedeutet, dass sie in einer neutralen Sprache geschrieben sind und allgemeinen Formatierungsregeln folgen. Manche Artikel dienen als Liste für häufig gestellte Fragen (FAQ) für ein Thema und verwenden Umgangssprache. Übersetzungen folgen dem Paritätsprinzip für den Inhalt und haben dieselben Formatierungsregeln.
 
-Obwohl das osu! wiki *wiki* im Namen trägt, erfüllt es nicht alle Kriterien des [Wiki-Konzepts](https://en.wikipedia.org/wiki/Wiki):
+Obwohl das osu!-Wiki *wiki* im Namen trägt, erfüllt es nicht alle Kriterien des [Wiki-Konzepts](https://en.wikipedia.org/wiki/Wiki):
 
 - Benutzer werden dazu aufgerufen, bereits existierende Artikel zu verbessern und neue zu kreieren, aber Grundlagenkenntnisse über [GitHub](https://github.com) werden erwartet. Dadurch wird die Schwelle für Einsteiger angehoben.
-- Alle Änderungen im osu! wiki werden moderiert und durchlaufen einen Bewertungsprozess, in dem von einem Mitwirkenden Zusammenarbeit erwartet wird.
+- Alle Änderungen im osu!-Wiki werden moderiert und durchlaufen einen Bewertungsprozess, in dem von einem Mitwirkenden Zusammenarbeit erwartet wird.
 
 ## Lizensierung
 
-Der Großteil von Inhalten im osu! wiki wird lizensiert unter [CC-BY-NC 4.0](https://github.com/ppy/osu-wiki/blob/master/LICENCE.md). Das bedeutet, dass die Materialien in einem kostenlosen Kontext verwendet werden dürfen (siehe die [Kurzzusammenfassung](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-4.0-international-(cc-by-nc-4.0))). Einige Inhalte können durch Drittanbieterlizensen abgedeckt sein, wobei in diesem Fall die Drittanbierterlizenz gegenüber der globalen Lizenz dominiert.
+Der Großteil von Inhalten im osu!-Wiki wird lizensiert unter [CC-BY-NC 4.0](https://github.com/ppy/osu-wiki/blob/master/LICENCE.md). Das bedeutet, dass die Materialien in einem kostenlosen Kontext verwendet werden dürfen (siehe die [Kurzzusammenfassung](https://tldrlegal.com/license/creative-commons-attribution-noncommercial-4.0-international-(cc-by-nc-4.0))). Einige Inhalte können durch Drittanbieterlizensen abgedeckt sein, wobei in diesem Fall die Drittanbierterlizenz gegenüber der globalen Lizenz dominiert.
 
 Bitte beachte, dass dies nicht die Verwendung von "osu!" oder der Marke "ppy" in jedweder Software, Ressource, Werbung oder Promotion erlaubt, da diese durch das Markenrecht geschützt sind. Falls du eine Erlaubnis für die Benutzung dieser Begriffe benötigst, [kontaktiere uns](mailto:contact@ppy.sh) bitte.


### PR DESCRIPTION
Changed the term according to the new guidelines: #6451 

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
