### PR TITLE
Update `The_Team/Nomination_Assessment_Team`

### DIFF
--- a/wiki/People/The_Team/Nomination_Assessment_Team/bg.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/bg.md
@@ -63,9 +63,9 @@ NAT държи потенциалните NAT членове в списъка �
 
 | Име | Допълнителен език | Основни отговорности |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Немски | Оценка |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Немски | Оценка |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Кантонски, Китайски | Оценка |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Оценка |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Оценка |
 
 ### osu!catch
 
@@ -79,6 +79,7 @@ NAT държи потенциалните NAT членове в списъка �
 
 | Име | Допълнителен език | Основни отговорности |
 | :-- | :-- | :-- |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Оценка |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Арабски, Френски | Оценка |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Оценка |
 
@@ -86,6 +87,7 @@ NAT държи потенциалните NAT членове в списъка �
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Белгия"
 [flag_CL]: /wiki/shared/flag/CL.gif "Чили"
+[flag_DE]: /wiki/shared/flag/DE.gif "Германия"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Алжир"
 [flag_ES]: /wiki/shared/flag/ES.gif "Испания"
 [flag_GB]: /wiki/shared/flag/GB.gif "Великобритания"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/en.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/en.md
@@ -62,9 +62,9 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 
 | Name | Additional languages | Primary responsibilities |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | German | Evaluation |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | German | Evaluation |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Cantonese, Chinese | Evaluation |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluation |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluation |
 
 ### osu!catch
 
@@ -78,7 +78,7 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 
 | Name | Additional languages | Primary responsibilities |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Evaluation |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arabic, French | Evaluation |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Evaluation |
 
@@ -86,6 +86,7 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Belgium"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"
+[flag_DE]: /wiki/shared/flag/DE.gif "Germany"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Algeria"
 [flag_ES]: /wiki/shared/flag/ES.gif "Spain"
 [flag_GB]: /wiki/shared/flag/GB.gif "United Kingdom"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/es.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/es.md
@@ -65,9 +65,9 @@ La [página del grupo de evaluación de nominaciones](https://osu.ppy.sh/groups/
 
 | Nombre | Idiomas adicionales | Responsabilidades primarias |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Alemán | Evaluación |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Alemán | Evaluación |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Cantonés, chino | Evaluación |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluación |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluación |
 
 ### osu!catch
 
@@ -81,12 +81,13 @@ La [página del grupo de evaluación de nominaciones](https://osu.ppy.sh/groups/
 
 | Nombre | Idiomas adicionales | Responsabilidades primarias |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Evaluación |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Árabe, francés | Evaluación |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Evaluación |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Bélgica"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"
+[flag_DE]: /wiki/shared/flag/DE.gif "Alemania"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Algeria"
 [flag_ES]: /wiki/shared/flag/ES.gif "España"
 [flag_GB]: /wiki/shared/flag/GB.gif "Reino Unido"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/fr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/fr.md
@@ -62,9 +62,9 @@ La [page du groupe de la Nomination Assessment Team](https://osu.ppy.sh/groups/7
 
 | Nom | Langues supplémentaires | Principales responsabilités |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Allemand | Évaluation |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Allemand | Évaluation |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Cantonais, Chinois | Évaluation |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Évaluation |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Évaluation |
 
 ### osu!catch
 
@@ -78,12 +78,13 @@ La [page du groupe de la Nomination Assessment Team](https://osu.ppy.sh/groups/7
 
 | Nom | Langues supplémentaires | Principales responsabilités |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Évaluation |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arabe, Français | Évaluation |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Évaluation |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Belgique"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chili"
+[flag_DE]: /wiki/shared/flag/DE.gif "Allemagne"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Algérie"
 [flag_ES]: /wiki/shared/flag/ES.gif "Espagne"
 [flag_GB]: /wiki/shared/flag/GB.gif "Royaume-Uni"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/id.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/id.md
@@ -62,9 +62,9 @@ Halaman daftar [Nomination Assessment Team](https://osu.ppy.sh/groups/7). Sebaga
 
 | Nama | Bahasa tambahan | Tanggung Jawab Utama |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Jerman | Evaluasi |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Jerman | Evaluasi |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Kanton, Mandarin | Evaluasi |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluasi |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Evaluasi |
 
 ### osu!catch
 
@@ -78,12 +78,13 @@ Halaman daftar [Nomination Assessment Team](https://osu.ppy.sh/groups/7). Sebaga
 
 | Nama | Bahasa tambahan | Tanggung Jawab Utama |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Evaluasi |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arab, Prancis | Evaluasi |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Evaluasi |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Belgia"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chili"
+[flag_DE]: /wiki/shared/flag/DE.gif "Jerman"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Aljazair"
 [flag_ES]: /wiki/shared/flag/ES.gif "Spanyol"
 [flag_GB]: /wiki/shared/flag/GB.gif "Britania Raya"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/pt-br.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/pt-br.md
@@ -64,9 +64,9 @@ A [página do grupo de usuário da Equipe de Avaliação de Nomeação](https://
 
 | Nome | Línguas adicionais | Responsabilidades primárias |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Alemão | Avaliação |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Alemão | Avaliação |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Cantonês, Chinês | Avaliação |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Avaliação |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Avaliação |
 
 ### osu!catch
 
@@ -80,12 +80,13 @@ A [página do grupo de usuário da Equipe de Avaliação de Nomeação](https://
 
 | Nome | Línguas adicionais | Responsabilidades primárias |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Avaliação |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Árabe, Francês | Avaliação |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Avaliação |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Bélgica"
 [flag_CL]: /wiki/shared/flag/CL.gif "Chile"
+[flag_DE]: /wiki/shared/flag/DE.gif "Alemanha"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Argélia"
 [flag_ES]: /wiki/shared/flag/ES.gif "Espanha"
 [flag_GB]: /wiki/shared/flag/GB.gif "Reino Unido"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/ru.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/ru.md
@@ -64,9 +64,9 @@ NAT самостоятельно отслеживает появление но�
 
 | Имя | Языки | Сферы деятельности |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Немецкий | Аттестация номинаторов |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Немецкий | Аттестация номинаторов |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Кантонский диалект, китайский | Аттестация номинаторов |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Аттестация номинаторов |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Аттестация номинаторов |
 
 ### osu!catch
 
@@ -80,12 +80,13 @@ NAT самостоятельно отслеживает появление но�
 
 | Имя | Языки | Сферы деятельности |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Аттестация номинаторов |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Арабский, французский | Аттестация номинаторов |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Аттестация номинаторов |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Бельгия"
 [flag_CL]: /wiki/shared/flag/CL.gif "Чили"
+[flag_DE]: /wiki/shared/flag/DE.gif "Германия"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Алжир"
 [flag_ES]: /wiki/shared/flag/ES.gif "Испания"
 [flag_GB]: /wiki/shared/flag/GB.gif "Великобритания"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/th.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/th.md
@@ -62,9 +62,9 @@ NAT มีการเฝ้ามองผู้สมัคร NAT ที่�
 
 | ชื่อ | ภาษาเพิ่มเติม | หน้าที่หลัก |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | เยอรมัน | การประเมิน |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | เยอรมัน | การประเมิน |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | กวางตุ้ง, จีน | การประเมิน |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | การประเมิน |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | การประเมิน |
 
 ### osu!catch
 
@@ -78,12 +78,13 @@ NAT มีการเฝ้ามองผู้สมัคร NAT ที่�
 
 | ชื่อ | ภาษาเพิ่มเติม | หน้าที่หลัก |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | การประเมิน |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | อาหรับ, ฝรั่งเศส | การประเมิน |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | การประเมิน |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "เบลเยียม"
 [flag_CL]: /wiki/shared/flag/CL.gif "ชิลี"
+[flag_DE]: /wiki/shared/flag/DE.gif "เยอรมนี"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "แอลจีเรีย"
 [flag_ES]: /wiki/shared/flag/ES.gif "สเปน"
 [flag_GB]: /wiki/shared/flag/GB.gif "สหราชอาณาจักร"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/tr.md
@@ -62,9 +62,9 @@ NAT uzun zaman periyodlarıyla potansiyel NAT üyelerini gözetler, ve genellikl
 
 | İsim | Ek diller | Birincil sorumluluklar |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | Almanca | Değerlendirme |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | Almanca | Değerlendirme |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | Kantonca, Çince | Değerlendirme |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | Değerlendirme |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | Değerlendirme |
 
 ### osu!catch
 
@@ -78,12 +78,13 @@ NAT uzun zaman periyodlarıyla potansiyel NAT üyelerini gözetler, ve genellikl
 
 | İsim | Ek diller | Birincil sorumluluklar |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | Değerlendirme |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | Arapça, Fransızca | Değerlendirme |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Değerlendirme |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "Belçika"
 [flag_CL]: /wiki/shared/flag/CL.gif "Şili"
+[flag_DE]: /wiki/shared/flag/DE.gif "Almanya"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "Cezayir"
 [flag_ES]: /wiki/shared/flag/ES.gif "İspanya"
 [flag_GB]: /wiki/shared/flag/GB.gif "Birleşik Krallık"

--- a/wiki/People/The_Team/Nomination_Assessment_Team/zh.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/zh.md
@@ -58,9 +58,9 @@ NAT 会长期关注潜在的 NAT 候选人，并偶尔进行讨论已决定是�
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_HK] [Capu](https://osu.ppy.sh/users/2474015) | 德语 | 评估 |
+| ![][flag_DE] [Capu](https://osu.ppy.sh/users/2474015) | 德语 | 评估 |
 | ![][flag_HK] [Faputa](https://osu.ppy.sh/users/845733) | 粤语，中文 | 评估 |
-| ![][flag_HK] [radar](https://osu.ppy.sh/users/7131099) |  | 评估 |
+| ![][flag_US] [radar](https://osu.ppy.sh/users/7131099) |  | 评估 |
 
 ### osu!catch
 
@@ -74,12 +74,13 @@ NAT 会长期关注潜在的 NAT 候选人，并偶尔进行讨论已决定是�
 
 | 名字 | 语言 | 主要任务 |
 | :-- | :-- | :-- |
-| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese |
+| ![][flag_ES] [Quenlla](https://osu.ppy.sh/users/4725379) | Spanish, Portuguese, Galician, Italian, Japanese | 评估 |
 | ![][flag_DZ] [Scotty](https://osu.ppy.sh/users/11085809) | 阿拉伯语，法语 | 评估 |
 | ![][flag_US] [Unpredictable](https://osu.ppy.sh/users/7560872) |  | 评估 |
 
 [flag_BE]: /wiki/shared/flag/BE.gif "比利时"
 [flag_CL]: /wiki/shared/flag/CL.gif "智利"
+[flag_DE]: /wiki/shared/flag/DE.gif "德国"
 [flag_DZ]: /wiki/shared/flag/DZ.gif "阿尔及利亚"
 [flag_ES]: /wiki/shared/flag/ES.gif "西班牙"
 [flag_GB]: /wiki/shared/flag/GB.gif "英国"


### PR DESCRIPTION
Fix Capu and radar's flag : DE and US
Add Quenlla role(s) : Evaluation

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
