### PR TITLE
Significantly offload scoring sections of the `Game mode` articles

### DIFF
--- a/wiki/Game_mode/osu!/en.md
+++ b/wiki/Game_mode/osu!/en.md
@@ -100,13 +100,13 @@ If [Auto Pilot](/wiki/Game_modifier/Autopilot) game modifier was used, only the 
 
 ## Scoring
 
-[The osu! score](/wiki/Gameplay/Score/osu!) is a weighted sum of all hit objects' values. It depends on the following:
+[Score in osu!](/wiki/Gameplay/Score/osu!) is a weighted sum of multiple components of gameplay. It depends on the following:
 
-- [Judgement](/wiki/Gameplay/Judgement/osu!) determines an object's base scoring value (300, 100, 50, or 0 in case of a miss). For [hit circles](/wiki/Hit_object/Hit_circle), well-timed key presses are valued more, both in terms of score and accuracy. [Sliders](/wiki/Hit_object/Slider) and [spinners](/wiki/Hit_object/Spinner) don't have hit windows, but will break active combo, possibly with a miss, if not cleared properly. Objects with higher judgement also provide higher [health](/wiki/Beatmapping/Health) boost.
+- [Judgement](/wiki/Gameplay/Judgement/osu!) determines a hit object's base scoring value (300, 100, 50, or 0 in case of a miss). For [hit circles](/wiki/Hit_object/Hit_circle), well-timed key presses are valued more, both in terms of score and accuracy. [Sliders](/wiki/Hit_object/Slider) and [spinners](/wiki/Hit_object/Spinner) don't have hit windows, but will break combo when missed or not cleared properly. Getting a higher judgement also provides a higher [health](/wiki/Beatmapping/Health) boost.
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss or a [slider break](/wiki/Gameplay/Slider_break).
 
-When combo is maintained, the total score grows exponentially. Objects closer to the end of the map are worth orders of magnitude more points than the ones in the beginning, which means that a player will lose way more score on them in case of mistimed hits. As a result, it's possible and very common for a score with lower accuracy to have higher amount of points and beat the score with higher accuracy.
+When combo is maintained, the total score grows exponentially. Objects closer to the end of the map are worth orders of magnitude more points than the ones in the beginning, which means that a player will lose way more potential score on them in case of mistimed hits. As a result, it's possible and very common for a score with lower accuracy to have a higher amount of points and beat a score with higher accuracy.
 
 After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 50s, and misses.
 

--- a/wiki/Game_mode/osu!/en.md
+++ b/wiki/Game_mode/osu!/en.md
@@ -108,7 +108,7 @@ If [Auto Pilot](/wiki/Game_modifier/Autopilot) game modifier was used, only the 
 
 When combo is maintained, the total score grows exponentially. Objects closer to the end of the map are worth orders of magnitude more points than the ones in the beginning, which means that a player will lose way more potential score on them in case of mistimed hits. As a result, it's possible and very common for a score with lower accuracy to have a higher amount of points and beat a score with higher accuracy.
 
-After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 50s, and misses.
+After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on the amount of 300s, 50s, and misses.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!/en.md
+++ b/wiki/Game_mode/osu!/en.md
@@ -100,150 +100,15 @@ If [Auto Pilot](/wiki/Game_modifier/Autopilot) game modifier was used, only the 
 
 ## Scoring
 
-*Scoring values can be found in [osu! scoring system](/wiki/Score/osu!).*
+[The osu! score](/wiki/Gameplay/Score/osu!) is a weighted sum of all hit objects' values. It depends on the following:
 
-Scoring section details all the intricacies of scoring, including mathematical formula.
+- [Judgement](/wiki/Gameplay/Judgement/osu!) determines an object's base scoring value (300, 100, 50, or 0 in case of a miss). For [hit circles](/wiki/Hit_object/Hit_circle), well-timed key presses are valued more, both in terms of score and accuracy. [Sliders](/wiki/Hit_object/Slider) and [spinners](/wiki/Hit_object/Spinner) don't have hit windows, but will break active combo, possibly with a miss, if not cleared properly. Objects with higher judgement also provide higher [health](/wiki/Beatmapping/Health) boost.
+- [Accuracy](/wiki/Gameplay/Accuracy#osu!) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss or a [slider break](/wiki/Gameplay/Slider_break).
 
-### Grades
+When combo is maintained, the total score grows exponentially. Objects closer to the end of the map are worth orders of magnitude more points than the ones in the beginning, which means that a player will lose way more score on them in case of mistimed hits. As a result, it's possible and very common for a score with lower accuracy to have higher amount of points and beat the score with higher accuracy.
 
-| Grade | Condition |
-| :-: | :-- |
-| SS | 100% accuracy |
-| S | Over 90% 300s, less than 1% 50s and no misses |
-| A | Over 80% 300s and no misses **OR** over 90% 300s |
-| B | Over 70% 300s and no misses **OR** over 80% 300s |
-| C | Over 60% 300s |
-| D | Anything else |
-
-A silver S or SS can be obtained by using the *[Hidden](/wiki/Game_modifier/Hidden)* and/or *[Flashlight](/wiki/Game_modifier/Flashlight)* mod.
-
-### Accuracy
-
-Accuracy is calculated by weighting the judgement gained on each note by its value and dividing by the maximum possible amount.
-
-In other words: `Accuracy = Total points of hits / (Total number of hits * 300p)`
-
-| Term | Formula |
-| :-: | :-- |
-| **Total points of hits** | `(50s * 50p) + (100s * 100p) + (300s * 300p)` |
-| **Total number of hits** | `Misses + 50s + 100s + 300s` |
-| **s** | Number of |
-| **p** | points |
-
-In other words, each *Miss* counts as 0 points, each *50* counts as 50 points, each *100* as 100 points and each *300* as 300 points.
-
-Add them all together and divide the sum with the number of hits multiplied by 300.
-
-- If only 300s: a result of 1.00, which means 100% accuracy.
-- If only 100s: a result of 0.3333 (i.e. 100/300), which means 33.33% accuracy.
-
-### Score
-
-The score given by each hit circle and end of a slider is calculated with the following formula:
-
-`Score = Hit Value + (Hit Value * ((Combo multiplier * Difficulty multiplier * Mod multiplier) / 25))`
-
-| Term | Meaning |
-| :-: | :-- |
-| **Hit Value** | The hit circle judgement (50, 100 or 300), any slider ticks and spinner's bonus |
-| **Combo multiplier** | (Combo before this hit - 1) or 0; whichever is higher |
-| **Difficulty multiplier** | The difficulty setting for the beatmap (see next header) |
-| **Mod multiplier** | The multiplier of the selected mods |
-
-Additionally each slider start, end and repeat tick awards 30 points, each slider middle tick awards 10 points and each spin of a spinner awards 100 points.
-
-Additional bonus of 1,000 points given for each spin of a spinner after the spinner meter is full.
-
-#### How to calculate the Difficulty multiplier
-
-[Circle Size (CS)](/wiki/Beatmap_Editor/Song_Setup), [HP Drain (HP)](/wiki/Beatmap_Editor/Song_Setup) and [Overall Difficulty (OD)](/wiki/Beatmap_Editor/Song_Setup) each give a tick on *difficulty point*.
-
-The accumulated *difficulty points* affect the **Difficulty multiplier** as so:
-
-| Difficulty points range | Difficulty multiplier |
-| :-: | :-- |
-| 0 - 5 | 2x multiplier |
-| 6 - 12 | 3x multiplier |
-| 13 - 17 | 4x multiplier |
-| 18 - 24 | 5x multiplier |
-| 25 - 30 | 6x multiplier |
-
-The limited highest is 27 difficulty points with CS7, OD10 and HP10. The limited lowest is 2 difficulty points with CS2, OD0 and HP0.
-
-CS cannot normally go below 2 or above 7 (requires direct modification to the `.osu` file).
-
-Note that game modifiers (like Hard Rock/Easy) will not change the **Difficulty multiplier**. It will only account for original values only.
-
-### Hit objects judgement
-
-**Hit circles:**
-
-- A 300, 100 or 50 given from a normal hit circle depending on how accurately the player tap on it.
-- A miss given if the player do not click on the hit circle at all or click on it way too early.
-
-**Sliders:**
-
-- The judgement for sliders does not depend on the accuracy of the initial hit.
-- Sliders consist of slider ticks, which include the start, end and repeat points of the slider.
-- A 300 given if the player successfully gets all slider ticks, a 100 given if the player gets at least half of them, and a 50 given if the player manages to collect even one of the ticks.
-- Tapping a slider **too early** does not incur a miss but will **reset** the score multiplier to **0**.
-  - Not collecting the slider ticks, shown or otherwise, will not incur a miss, but will **reset** the score multiplier to **0**.
-  - Missing the slider end does not incur a miss but will **not** increment the score multiplier.
-- A miss given if the player collects none of the slider ticks.
-
-**Spinner:**
-
-- A 300, 100 or 50 given depending on the number of spins done compared to the length of the spinner.
-- A miss if the player unable to expand the spinner circle to a satisfactory limit for a 50 to be given.
-  - v1 skin behaviour: A miss if the player unable to fill the meter shown on both sides of the spinner to a satisfactory limit for a 50 to be given.
-
-### Score/Combo Multiplier
-
-**The following each add a point to the score/combo multiplier:**
-
-- A successful tap on the hit circle.
-- A successful tap at the start of a slider.
-- The slider ball collected a slider tick successfully.
-- The slider ball touched the end or a reverse arrow of a slider successfully.
-- A successful completed/semi-completed spinner.
-
-**The following will reset the score multiplier to zero:**
-
-- Missing a hit circle.
-- Tapping a slider start early.
-- Missing a slider start or slider tick.
-- Failed to expand the spinner circle to a satisfactory size.
-  - v1 skin behaviour: Failed to fill up at least half the gauge of a spinner.
-
-**The following will not increase or reset the score multiplier:**
-
-- Missing a slider end (will result in getting Katu or 100/50 Hit).
-- Spinner: 1,000 Bonus
-
-## Health bar
-
-The system used to calculate health drain and health gain is complicated so it will not be explained in detail. It all revolves around the HP difficulty setting which can only be set by the mapper itself.
-
-**The following will result in health recovery:**
-
-- A successful tap on the hit circle (better judgement leads to more health gain; the last hit circle in a colour combo awards more health).
-- A successful tap on a slider start.
-- The slider ball collected a slider tick successfully.
-- The slider ball touched the end or a reverse arrow of a slider successfully (better judgement at the end tick leads to more health gain).
-- Completing a spinner and continuous spinning in the spinner duration (better judgement at the end of the spinner leads to more health gain).
-
-**The following will result in health loss:**
-
-- Constant health drain.
-- Miss was given.
-- Missing a hit circle.
-- Tapping a slider start early.
-- Missing a slider tick, or slider reverse arrow.
-- Failed to complete a spinner for a 50 to be given.
-
-**The following will reserve health in the health bar:**
-
-- Break time.
+After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 50s, and misses.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!/en.md
+++ b/wiki/Game_mode/osu!/en.md
@@ -104,11 +104,11 @@ If [Auto Pilot](/wiki/Game_modifier/Autopilot) game modifier was used, only the 
 
 - [Judgement](/wiki/Gameplay/Judgement/osu!) determines a hit object's base scoring value (300, 100, 50, or 0 in case of a miss). For [hit circles](/wiki/Hit_object/Hit_circle), well-timed key presses are valued more, both in terms of score and accuracy. [Sliders](/wiki/Hit_object/Slider) and [spinners](/wiki/Hit_object/Spinner) don't have hit windows, but will break combo when missed or not cleared properly. Getting a higher judgement also provides a higher [health](/wiki/Beatmapping/Health) boost.
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
-- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss or a [slider break](/wiki/Gameplay/Slider_break).
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: clearing a hit object contributes more to the total score when combo is high and vice versa. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss or a [slider break](/wiki/Gameplay/Slider_break).
 
 When combo is maintained, the total score grows exponentially. Objects closer to the end of the map are worth orders of magnitude more points than the ones in the beginning, which means that a player will lose way more potential score on them in case of mistimed hits. As a result, it's possible and very common for a score with lower accuracy to have a higher amount of points and beat a score with higher accuracy.
 
-After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 50s, and misses.
+After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 50s, and misses.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!/id.md
+++ b/wiki/Game_mode/osu!/id.md
@@ -1,4 +1,7 @@
-<!-- TODO: strange descriptions in many places and unhelpful order if you're trying to see what this game mode is all about. -->
+---
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
+---
 
 # osu! (mode permainan)
 

--- a/wiki/Game_mode/osu!/tr.md
+++ b/wiki/Game_mode/osu!/tr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
+---
+
 # osu! (oyun modu)
 
 *Diğer kullanımlar için, bakınız: [osu! (anlam ayrımı)](/wiki/Disambiguation/osu!).*

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -80,7 +80,7 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets decrease accuracy when missed, but do not break combo.
 
-After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!catch), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of missed objects.
+After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!catch), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on the amount of missed objects.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -76,6 +76,7 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 
 [Score in osu!catch](/wiki/Gameplay/Score/osu!catch) is a weighted sum of multiple components of gameplay. It depends on the following:
 
+- [Judgement](/wiki/Gameplay/Judgement) only provides fixed score values for each caught hit object and does not depend on hit accuracy.
 - [Base scoring values](/wiki/Gameplay/Judgement/osu!catch) of objects are fixed and do not depend on [judgement](/wiki/Gameplay/Judgement).
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets decrease accuracy when missed, but do not break combo.

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -77,7 +77,6 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 [Score in osu!catch](/wiki/Gameplay/Score/osu!catch) is a weighted sum of multiple components of gameplay. It depends on the following:
 
 - [Judgement](/wiki/Gameplay/Judgement) only provides fixed score values for each caught hit object and does not depend on hit accuracy.
-- [Base scoring values](/wiki/Gameplay/Judgement/osu!catch) of objects are fixed and do not depend on [judgement](/wiki/Gameplay/Judgement).
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets decrease accuracy when missed, but do not break combo.
 

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -74,111 +74,13 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 
 ## Scoring
 
-*Scoring values can be found in [osu!catch scoring system](/wiki/Score/osu!catch).*
+[The osu!catch score](/wiki/Gameplay/Score/osu!catch) is a weighted sum of all hit objects' values. It depends on the following:
 
-Scoring section details all the intricacies of scoring, including mathematical formula.
+- [Base scoring values](/wiki/Gameplay/Judgement/osu!catch) of objects are fixed and do not depend on [judgement](/wiki/Gameplay/Judgement).
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases available F[health](/wiki/Beatmapping/Health).
+- [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets, when missed, only decrease accuracy, but do not break combo.
 
-### Grades
-
-| Grade | Condition |
-| :-: | :-- |
-| SS | 100.00% Accuracy |
-| S | 98.01% to 99.99% Accuracy (an 'S' rank is possible even with several misses, like in *osu!mania*). |
-| A | 94.01% to 98.00% Accuracy |
-| B | 90.01% to 94.00% Accuracy |
-| C | 85.01% to 90.00% Accuracy |
-| D | Any other accuracy under 85.00%. |
-
-A silver S or SS can be obtained by using the *[Hidden](/wiki/Game_modifier/Hidden)* and/or *[Flashlight](/wiki/Game_modifier/Flashlight)* mod.
-
-### Accuracy
-
-Accuracy is defined by how much caught over how much missed, excluding spinner's bananas.
-
-In other words: `Accuracy = Total numbers of fruits caught / Total number of fruits`
-
-| Term | Formula |
-| :-: | :-- |
-| **Total numbers of fruits caught** | Droplets + Drops + Fruits |
-| **Total numbers of fruits** | Misses + Miss droplets + Droplets + Drops + Fruits |
-
-**Exception:**
-
-- Note that bananas (or spinner fruit) are considered to be bonus or extra points obtainable and does not count towards accuracy.
-
-Note that if using the API to calculate the accuracy, number of droplets is under **count50** and number of miss droplets is under **countkatu**.
-
-### Score
-
-Scoring for osu!catch follows the same multiplier as in [osu!](/wiki/Game_mode/osu!). However, the fruit that adds up the score is different from osu!.
-
-- A regular sized fruit gives a score of 300 times the multiplier.
-- A large juice drop (slider tick) gives a score of 100.
-- The smallest drop (also called "droplet", or slider trail/path) gives a score of 10.
-- Each collected bananas (collected during spinner duration) will give a static score of 1,100 regardless of mod and combo multiplier.
-
-Combo will not be lost for missing droplets (considered as *Miss Droplet* in server leaderboard) in this mode but a drop of Accuracy and score gain from it.
-
-`Score = Hit Value + [Hit Value * ((Combo multiplier * Difficulty multiplier * Mod multiplier) / 25)]`
-
-| Term | Meaning |
-| :-: | :-- |
-| **Hit Value** | The hit circle judgement (50, 100 or 300), any slider ticks, and spinner's bonus |
-| **Combo multiplier** | (Combo before this hit - 1) or 0; whichever is higher |
-| **Difficulty multiplier** | The difficulty setting for the beatmap |
-| **Mod multiplier** | The multiplier of the selected mods |
-
-**Note:** There is a difference between osu! and osu!catch's scoring methods:
-
-- 300s and a combo increment are not given to a finished spinner
-- Reverse slider ticks are counted as a full score of a hit
-  - Note that in osu!, a reverse tick only gives 30 points
-
-### Hit objects judgement
-
-**All except bananas:**
-
-- Full score when collected.
-- Miss when failed.
-
-**Bananas:**
-
-- Constant score of 1,100 per banana collected.
-- Nothing happens for missed bananas.
-
-### Score/Combo Multiplier
-
-**The following each add a point to the score/combo multiplier:**
-
-- Collecting the fruits.
-- Collecting the juice drops.
-
-**The following will reset the score multiplier to zero:**
-
-- Missed the fruits.
-- Missed the juice drops.
-
-**The following will not increase or reset the score multiplier:**
-
-- Collecting the droplets.
-- Collecting the bananas.
-
-## Health bar
-
-The system used to calculate health drain and health gain is complicated so it will not be explained in detail. It all revolves around the HP difficulty setting which can only be set by the mapper itself.
-
-**The following will result in health recovery:**
-
-- Collecting any fruits, juice drops, or bananas.
-
-**The following will result in health loss:**
-
-- Constant life drain.
-- Not collecting any fruits or juice drops.
-
-**The following will reserve health in the health bar:**
-
-- Break time.
+After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!catch), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of missed objects.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -77,7 +77,7 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 [Score in osu!catch](/wiki/Gameplay/Score/osu!catch) is a weighted sum of multiple components of gameplay. It depends on the following:
 
 - [Judgement](/wiki/Gameplay/Judgement) only provides fixed score values for each caught hit object and does not depend on hit accuracy.
-- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: clearing a hit object contributes more to the total score when combo is high and vice versa. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets decrease accuracy when missed, but do not break combo.
 
 After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!catch), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on the amount of missed objects.

--- a/wiki/Game_mode/osu!catch/en.md
+++ b/wiki/Game_mode/osu!catch/en.md
@@ -74,11 +74,11 @@ The placement of in-game cursor does not matter when playing normally. If [Relax
 
 ## Scoring
 
-[The osu!catch score](/wiki/Gameplay/Score/osu!catch) is a weighted sum of all hit objects' values. It depends on the following:
+[Score in osu!catch](/wiki/Gameplay/Score/osu!catch) is a weighted sum of multiple components of gameplay. It depends on the following:
 
 - [Base scoring values](/wiki/Gameplay/Judgement/osu!catch) of objects are fixed and do not depend on [judgement](/wiki/Gameplay/Judgement).
-- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases available F[health](/wiki/Beatmapping/Health).
-- [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets, when missed, only decrease accuracy, but do not break combo.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. In osu!catch, combo may be [broken](/wiki/Glossary/Combobreak) by missing a large fruit or a drop, which also decreases [health](/wiki/Beatmapping/Health).
+- [Accuracy](/wiki/Gameplay/Accuracy#osu!catch) shows how many objects were caught in total. Small droplets decrease accuracy when missed, but do not break combo.
 
 After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!catch), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of missed objects.
 

--- a/wiki/Game_mode/osu!catch/fr.md
+++ b/wiki/Game_mode/osu!catch/fr.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
 ---
 
 # osu!catch

--- a/wiki/Game_mode/osu!mania/en.md
+++ b/wiki/Game_mode/osu!mania/en.md
@@ -186,10 +186,10 @@ The **[05 March 2015 (2015-03-05) update](https://osu.ppy.sh/home/changelog)** g
 
 ## Scoring
 
-[The osu!mania score](/wiki/Gameplay/Score/osu!mania) is capped at 1 million and consists of two parts, each contributing 50% of total score:
+[Score in osu!mania](/wiki/Gameplay/Score/osu!mania) is capped at 1 million and consists of two parts, each contributing 50% of the total score:
 
-1. Base score, which is [judgement](/wiki/Gameplay/Judgement/osu!mania)-centered. Judgement determines an object's base scoring value (MAX, 300, 200, 100, 50, or 0 in case of a miss).
-2. Bonus score, which is based on judgement and a floating bonus multiplier, which increases with a rainbow 300 or 300, and decreases with a 200 or below.
+1. Base score, which is [judgement](/wiki/Gameplay/Judgement/osu!mania)-centred. Judgement determines a hit object's base scoring value (MAX, 300, 200, 100, 50, or 0 in case of a miss).
+2. Bonus score, which is based on judgement and a floating bonus multiplier, which increases when getting a 300 or rainbow 300, and decreases with a 200 or below.
 
 In addition, score also has the following components:
 

--- a/wiki/Game_mode/osu!mania/en.md
+++ b/wiki/Game_mode/osu!mania/en.md
@@ -189,7 +189,7 @@ The **[05 March 2015 (2015-03-05) update](https://osu.ppy.sh/home/changelog)** g
 [Score in osu!mania](/wiki/Gameplay/Score/osu!mania) is capped at 1 million and consists of two parts, each contributing 50% of the total score:
 
 1. Base score, which is [judgement](/wiki/Gameplay/Judgement/osu!mania)-centred. Judgement determines a hit object's base scoring value (MAX, 300, 200, 100, 50, or 0 in case of a miss).
-2. Bonus score, which is based on judgement and a floating bonus multiplier, which increases when getting a 300 or rainbow 300, and decreases with a 200 or below.
+2. Bonus score, which is based on judgement and a floating bonus multiplier, which increases when getting a MAX or a 300, and decreases with a 200 or below.
 
 In addition, score also has the following components:
 

--- a/wiki/Game_mode/osu!mania/en.md
+++ b/wiki/Game_mode/osu!mania/en.md
@@ -186,133 +186,17 @@ The **[05 March 2015 (2015-03-05) update](https://osu.ppy.sh/home/changelog)** g
 
 ## Scoring
 
-*Scoring values can be found in [osu!mania scoring system](/wiki/Score/osu!mania).*
+[The osu!mania score](/wiki/Gameplay/Score/osu!mania) is capped at 1 million and consists of two parts, each contributing 50% of total score:
 
-Scoring section details all the intricacies of scoring, including mathematical formula.
+1. Base score, which is [judgement](/wiki/Gameplay/Judgement/osu!mania)-centered. Judgement determines an object's base scoring value (MAX, 300, 200, 100, 50, or 0 in case of a miss).
+2. Bonus score, which is based on judgement and a floating bonus multiplier, which increases with a rainbow 300 or 300, and decreases with a 200 or below.
 
-### Grades
+In addition, score also has the following components:
 
-| Grade | Condition |
-| :-: | :-- |
-| SS | 100% Accuracy (only MAX and/or 300). |
-| S | Over 95% Accuracy (an 'S' rank is possible even with several misses, like in *osu!catch*). |
-| A | Over 90% Accuracy. |
-| B | Over 80% Accuracy. |
-| C | Over 70% Accuracy. |
-| D | Anything else. |
+- [Accuracy](/wiki/Gameplay/Accuracy#osu!mania) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) shows how many objects were hit in a row. It has no effect on total score and may be [broken](/wiki/Glossary/Combobreak) by a miss.
 
-It is possible to obtain SSH or SH ranks (silver S or SS) with [Hidden](/wiki/Game_modifier/Hidden)/[Fade In](/wiki/Game_modifier/Fade_In) or [Flashlight](/wiki/Game_modifier/Flashlight) mod.
-
-### Accuracy
-
-Accuracy is calculated similarly to [osu!](/wiki/Game_mode/osu!) in this mode.
-
-In other words: `Accuracy = Total points of hits / (Total number of hits * 300)`
-
-| Term | Formula |
-| :-: | :-- |
-| **Total points of hits** | `(Number of 50s * 50 + Number of 100s * 100 + Number of 200s * 200 + Number of 300s * 300 + Number of rainbow 300s * 300)` |
-| **Total number of hits** | `(Number of misses + Number of 50s + Number of 100s + Number of 200s + Number of 300s + Number of rainbow 300s)` |
-
-Note that MAX (or rainbow 300) and 300 are both worth the maximum for calculating accuracy, despite a MAX being worth more in terms of score than a 300.
-
-### Score
-
-Each beatmap has the same maximum total score of 1 million (1,000,000).
-
-The score is given in two parts, base score and bonus score, each contributing 50% of total score.
-
-- Base score is based on hit judgement.
-  - A rainbow 300 is worth a bit more than 300.
-- Bonus score is based on hit judgement and a floating bonus multiplier.
-  - The multiplier increases with a rainbow 300 or 300, while it decreases with a 200 or below.
-  - The better judgement, the more multiplier increase/less punishment.
-    - There's an upper limit for the multiplier.
-
-The score given by each note is calculated with the following formula:
-
-```
-Score = BaseScore + BonusScore
-
-BaseScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitValue / 320)
-
-BonusScore = (MaxScore * ModMultiplier * 0.5 / TotalNotes) * (HitBonusValue * Sqrt(Bonus) / 320)
-Bonus = Bonus before this hit + HitBonus - HitPunishment / ModDivider
-Bonus is limited to [0, 100], initially 100.
-
-MaxScore = 1 000 000
-ModMultiplier = The score multiplier of the selected mods (difficulty reduction and/or nK)
-ModDivider = The punishment divider of the selected mods (difficulty increase)
-
-Judgement  HitValue  HitBonusValue  HitBonus  HitPunishment
-   MAX       320          32            2
-   300       300          32            1
-   200       200          16                        8
-   100       100           8                       24
-    50        50           4                       44
-  Miss         0           0                        ∞
-
-       Mod  ModMultiplier  ModDivider
-      Easy       0.5
-    NoFail       0.5
-  HalfTime       0.5
-  HardRock                    1.08
-DoubleTime                     1.1
- NightCore                     1.1
-    FadeIn                    1.06
-    Hidden                    1.06
-Flashlight                    1.06
-```
-
-### Hit objects judgement
-
-**Notes:**
-
-- MAX (rainbow 300), 300, 200, 100 or 50 from a note depending on timing of hit.
-- A Miss given when missing a note or hit it way too early.
-
-**Hold notes:**
-
-- The judgement for hold notes depends on both starting hold and ending release points.
-- Keep holding till end of note, with initial and final with perfect timing: MAX
-- Keep holding till end of note, without releasing the note: 200
-- Do a *NG* and not recover the hold note: Miss
-- Do a *NG* and even hold back the note: 50
-
-NG: *Not Good*, a term in *StepMania/DDR*, which happens when the hold note was released during hold timing.
-
-### Score/Combo Multiplier
-
-**The following each add a point to the score/combo multiplier:**
-
-- Completing the note with correct key.
-- Holding the hold note with correct key.
-
-**The following will reset the score multiplier to zero:**
-
-- Not completing the note.
-- Releasing the hold note during the hold period.
-
-**The following will not increase or reset the score multiplier:**
-
-- Releasing the hold note on the ending note of the hold.
-
-## Health bar
-
-The system used to calculate health gain is complicated so it will not be explained in detail. It all revolves around the HP difficulty setting which can only be set by the mapper itself.
-
-**The following will result in health recovery:**
-
-- Getting Rainbow 300, 300, or 200.
-- Holding the hold note with correct key.
-
-**The following will result in health loss:**
-
-- Getting 50 or Miss.
-
-**The following will reserve health in the health bar:**
-
-- None.
+After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!mania), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!mania/en.md
+++ b/wiki/Game_mode/osu!mania/en.md
@@ -196,7 +196,7 @@ In addition, score also has the following components:
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!mania) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) shows how many objects were hit in a row. It has no effect on total score and may be [broken](/wiki/Glossary/Combobreak) by a miss.
 
-After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!mania), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy.
+After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!mania), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!mania/es.md
+++ b/wiki/Game_mode/osu!mania/es.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
 ---
 
 # osu!mania

--- a/wiki/Game_mode/osu!mania/fr.md
+++ b/wiki/Game_mode/osu!mania/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
+---
+
 # osu!mania
 
 *[Cliquez pour retourner à la page des Modes de Jeu](/wiki/Game_mode).*

--- a/wiki/Game_mode/osu!taiko/en.md
+++ b/wiki/Game_mode/osu!taiko/en.md
@@ -82,11 +82,11 @@ If [Relax](/wiki/Game_modifier/Relax) mod was used, the score judgement only acc
 
 ## Scoring
 
-[The osu!taiko score](/wiki/Gameplay/Score/osu!taiko) is a weighted sum of all hit objects' values. It depends on the following:
+[Score in osu!taiko](/wiki/Gameplay/Score/osu!taiko) is a weighted sum of multiple components of gameplay. It depends on the following:
 
-- [Judgement](/wiki/Gameplay/Judgement/osu!taiko) determines an object's base scoring value (300, 100, or 0 in case of a miss). The value of regular and large notes depends on hit timing; every other hit object's base value is constant.
+- [Judgement](/wiki/Gameplay/Judgement/osu!taiko) determines a hit object's base scoring value (300, 100, or 0 in case of a miss). The value of regular and large notes depends on hit timing, while every other object's base value is constant.
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!taiko) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
-- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, the score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
 - [Kiai time](/wiki/Kiai_time): in osu!taiko, active kiai time increases score gain by 20%, just as it does in the original *Taiko no Tatsujin* series.
 
 In addition to score boost, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass the beatmap.

--- a/wiki/Game_mode/osu!taiko/en.md
+++ b/wiki/Game_mode/osu!taiko/en.md
@@ -91,7 +91,7 @@ If [Relax](/wiki/Game_modifier/Relax) mod was used, the score judgement only acc
 
 In addition to score boost, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass the beatmap.
 
-After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!taiko), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 100s, and misses.
+After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!taiko), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on the amount of 300s, 100s, and misses.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!taiko/en.md
+++ b/wiki/Game_mode/osu!taiko/en.md
@@ -89,7 +89,7 @@ If [Relax](/wiki/Game_modifier/Relax) mod was used, the score judgement only acc
 - [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, the score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
 - [Kiai time](/wiki/Kiai_time): in osu!taiko, active kiai time increases score gain by 20%, just as it does in the original *Taiko no Tatsujin* series.
 
-In addition to score boost, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass the beatmap.
+In addition to giving score, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass a beatmap.
 
 After completing a beatmap, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!taiko), a short accuracy assessment in the form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on the amount of 300s, 100s, and misses.
 

--- a/wiki/Game_mode/osu!taiko/en.md
+++ b/wiki/Game_mode/osu!taiko/en.md
@@ -86,7 +86,7 @@ If [Relax](/wiki/Game_modifier/Relax) mod was used, the score judgement only acc
 
 - [Judgement](/wiki/Gameplay/Judgement/osu!taiko) determines a hit object's base scoring value (300, 100, or 0 in case of a miss). The value of regular and large notes depends on hit timing, while every other object's base value is constant.
 - [Accuracy](/wiki/Gameplay/Accuracy#osu!taiko) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
-- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, the score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: clearing a hit object contributes more to the total score when combo is high and vice versa. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, the score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
 - [Kiai time](/wiki/Kiai_time): in osu!taiko, active kiai time increases score gain by 20%, just as it does in the original *Taiko no Tatsujin* series.
 
 In addition to giving score, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass a beatmap.

--- a/wiki/Game_mode/osu!taiko/en.md
+++ b/wiki/Game_mode/osu!taiko/en.md
@@ -82,137 +82,16 @@ If [Relax](/wiki/Game_modifier/Relax) mod was used, the score judgement only acc
 
 ## Scoring
 
-*Scoring values can be found in [osu!taiko scoring system](/wiki/Score/osu!taiko).*
+[The osu!taiko score](/wiki/Gameplay/Score/osu!taiko) is a weighted sum of all hit objects' values. It depends on the following:
 
-Scoring section details all the intricacies of scoring, including mathematical formula.
+- [Judgement](/wiki/Gameplay/Judgement/osu!taiko) determines an object's base scoring value (300, 100, or 0 in case of a miss). The value of regular and large notes depends on hit timing; every other hit object's base value is constant.
+- [Accuracy](/wiki/Gameplay/Accuracy#osu!taiko) depends on judgement and shows how precise hits are. Late or early key presses, as well as misses, decrease overall accuracy.
+- [Combo](/wiki/Gameplay/Combo_(score_multiplier)) is a score multiplier: the higher it is, the more the object contributes to the total score. Combo may be [broken](/wiki/Glossary/Combobreak) by a miss. In osu!taiko, score multiplier derived from combo is limited and doesn't affect total score as much as it does in osu! or osu!catch.
+- [Kiai time](/wiki/Kiai_time): in osu!taiko, active kiai time increases score gain by 20%, just as it does in the original *Taiko no Tatsujin* series.
 
-The scoring terms in osu!taiko use the same terms used in *Taiko no Tatsujin* as shown below:
+In addition to score boost, each cleared object fills a small part of the [health bar](/wiki/Glossary/Health_bar), which must be at least **50% full** for a player to pass the beatmap.
 
-- GREAT (良), or 300
-- GOOD  (可), or 100
-- MISS/BAD (不可), or Miss
-
-## Grading
-
-| Grade | Condition |
-| :-: | :-- |
-| SS | 100% Accuracy. |
-| S | Over 95% Accuracy (90+% GREATs, or less than 1 GOOD for every 10 notes). |
-| A | Over 90% Accuracy (80+% GREATs, or less than 1 GOOD for every 5 notes). |
-| B | Over 80% Accuracy (70+% GREATs, or less than 1 GOOD for every 3.33 notes). |
-
-## Accuracy
-
-The song accuracy is calculated by sum of all note accuracy divided by number of notes. A GREAT (良) counts as 100%, a GOOD (可) as 50% (half) and a MISS/BAD (不可) as 0% (which breaks the combo). Drumrolls and spinners do not influence the accuracy.
-
-In other words: `Accuracy = Total points of hits / (Total number of hits * 300)`
-
-| Term | Formula |
-| :-: | :-- |
-| **Total points of hits** | ((Misses \* 0) + (100s\[GOOD\] \* 0.5) + 300s\[GREAT\]) \* 300 |
-| **Total number of hits** | Misses + 100s\[GOOD\] + 300s\[GREAT\] |
-| **s** | Number of |
-
-Unlike osu! or osu!catch, a miss in Taiko will not reduce the score from maximum possible score greatly. Instead, constantan score is reduced per miss if each miss is separated by more than 100 combos (with the existence of shaker and large notes, score loss would be larger).
-
-For example, in a typical difficulty, breaking a combo in the middle of a song, without accounting for large notes and spinners, would result in a maximum loss of 44,000 points (to bring the combo back up to 100).
-
-### Score
-
-Each GREAT (excluding Kiai Time's 1.2x bonus) is worth *300 + RoundDown(Combo / 10)* times *n* up to a maximum of *300+10n* points, in which *n* depends on the difficulty rating of the song.
-
-Each *GOOD* gives half of the score as *GREAT* does, while zero score is given for *MISS/BAD*.
-
-Double score is given for *successful hit* on large notes (different from *Taiko no Tatsujin*, left and right drum must be hit at the same time very precisely in order to allow a successful hit of large notes).
-
-For yellow long notes (drumroll), 300 is given per hit in the small one while 600 per hit is given to the large one.
-
-For denden/shaker notes, each strike/shake gives 300 and finishing the denden/shaker gives score twice as much as a GREAT of the current combo.
-
-A typical value of *n* (4.5-5 star difficulties in old 5 star ratings system) is 80, which gives a maximum score of 1,100/2,200 at 100 combo and later combos. For 4 - 4.5 star difficulties, *n* is equal to 64 in which the maximum score per hit is 940/1,880. In the hardest case, *n* is equal to 96 in which the maximum score per hit is 1,260/2,520. There are lower value of *n* for even easier difficulties.
-
-Unlike [osu!](/wiki/Game_mode/osu!)/[osu!catch](/wiki/Game_mode/osu!catch), a miss in osu!taiko will not cause a *drastic* score difference from the maximum possible score (in osu!/osu!catch, score deviation damage from a miss grows *wider* the higher the maximum combo and especially breaking in around half combo of the maximum combo). Instead, a constant score of *n* (explained above) is reduced per miss if each miss is separated by more than 100 combos. With the existence of shaker and large notes, score loss would be larger.
-
-For example, in a typical difficulty (80), breaking a combo in the middle of a song without accounting for large notes and spinners, would result in a maximum loss of 44,000 points (to bring the combo back up to 100, all GREAT score value).
-
-Also unlike the other game modes, Kiai Time has an effect on scores because it refers to the *"Go-Go Time"* in *Taiko no Tatsujin*. While Kiai Time is active, the drum in the upper left changes animation, the playfield has a background gradient and the hit area gains a fire graphic around it. Additionally, all hit notes gain a 1.2x score multiplier, long yellow notes (drumroll) included, except for hits on a denden/shaker (the final hit is still multiplied).
-
-In short: `Score = {ScoreValue + [min(RoundDown(Combo / 10), 10) * RoundDown(taiko score multiplier * raw mod multiplier)]} * Kiai Time`
-
-| Term | Meaning |
-| :-: | :-- |
-| **ScoreValue** | The Score Value gained from the hit (300/600, 150/300, or 0/0). |
-| **Combo** | (Combo before this hit - 1) or 0; whichever is higher |
-| **taiko score multiplier** | \[Depends on difficulty rating\] Possible values are: 32, 48, 64, 80, 96 |
-| **raw mod multiplier** | The *raw* multiplier of the selected mods (shown multipliers are usually rounded up) |
-| **RoundDown** | Round down this value to a whole number instead, removing all the decimal values. |
-| **min(x, y)** | Always pick the lowest value between *x* or *y*. |
-| **Kiai Time** | If Kiai Time was active, this value is 1.2. Otherwise, the value is 1.0. |
-
-**Exceptions:**
-
-- Each successful drumroll hit gives a constant GREAT Score Value (300/600 for small/large drumroll respectively) with Kiai Time bonus only.
-- Each denden hits/shaker shakes gives a constant GREAT Score Value (300) without Kiai Time bonus except for last denden hit/shaker shake, which gives a large GREAT Score Value (600) with current combo multiplier.
-
-### Hit objects judgement
-
-**Small/Large Notes:**
-
-- *GREAT* given if drummed inside the judgement circle perfectly with correct colour.
-- *GOOD* given if drummed slightly away from the judgement circle with correct colour.
-- *MISS/BAD* given if drummed too early, too late, missed the judgement circle, or drummed the wrong colour.
-
-**Drumroll:**
-
-- Constant 300/600 score with Kiai Time bonus when available given per small notes drummed successfully in the drumroll with any colour.
-- No score given when drummed on the gap of the small notes.
-- No *MISS/BAD* for not doing the drumroll as per *Taiko no Tatsujin* style.
-
-**Denden/Shaker:**
-
-- Constant 300 score given per hit/shake until completed.
-- *GREAT* given on the last hit/shake.
-- *MISS/BAD* damage given (not considered a miss) if failed to complete the Denden/Shaker successfully.
-
-### Score/Combo Multiplier
-
-**The following each add a point to the score/combo multiplier:**
-
-- Getting *GREAT* or *GOOD* on small/large notes.
-
-**The following will reset the score multiplier to zero:**
-
-- Getting *MISS/BAD* on small/large notes
-
-**The following will not increase or reset the score multiplier:**
-
-- Doing the drumroll.
-- Not doing the drumroll.
-- Completing the Denden/Shaker
-- Not completing the Denden/Shaker
-
-## Health bar
-
-The system used to calculate health gain is complicated so it will not be explained in detail. It all revolves around the HP difficulty setting which can only be set by the mapper itself.
-
-**Note:** The health bar must be at least **50% full** to pass the beatmap.
-
-**The following will result in health recovery:**
-
-- Getting *GREAT* or *GOOD* on small/large notes.
-
-**The following will result in health loss:**
-
-- Getting *MISS/BAD* on small/large notes
-- Not completing the Denden/Shaker
-
-**The following does nothing to the health bar:**
-
-- Doing the drumroll.
-- Not doing the drumroll.
-- Completing the Denden/Shaker
-
-**Note:** It is entirely possible for a beatmap to *never pass by design* due to the beatmap containing drumrolls and/or dendens/shakers only.
+After the beatmap is over, the score is assigned a [grade](/wiki/Gameplay/Grade#osu!taiko), a short accuracy assessment in form of a single letter. A golden or silver SS denotes 100% accuracy, and everything else, from S to D, depends on amount of 300s, 100s, and misses.
 
 ## Skinning
 

--- a/wiki/Game_mode/osu!taiko/fr.md
+++ b/wiki/Game_mode/osu!taiko/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 2dccc07cb4759a455196482e5f00383834f9813b
+---
+
 # osu!taiko
 
 ![Gameplay d'osu!taiko](/wiki/shared/taiko-gameplay.jpg "Interface osu!taiko")


### PR DESCRIPTION
part of #6431. every article's `Scoring` section is replaced by a short summary. since #6470 and #6476, individual sections reside in:

- `Score`: https://github.com/ppy/osu-wiki/tree/master/wiki/Gameplay/Score
- `Grades`: https://github.com/ppy/osu-wiki/tree/master/wiki/Gameplay/Grade
- `Accuracy`: https://github.com/ppy/osu-wiki/tree/master/wiki/Gameplay/Accuracy
- `Hit object judgement`: https://github.com/ppy/osu-wiki/tree/master/wiki/Gameplay/Judgement
- `Combo multiplier`: https://github.com/ppy/osu-wiki/tree/master/wiki/Gameplay/Combo_(score_multiplier)
- `Health bar`: https://github.com/ppy/osu-wiki/tree/master/wiki/Beatmapping/Health (don't ask)

nothing of value should have been lost, nonetheless, **please check my changes carefully**.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
