### PR TITLE
Add 2022 section to `osu! rankings history`

### DIFF
--- a/wiki/History_of_osu!/Online_rankings/osu!/en.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!/en.md
@@ -266,7 +266,13 @@ While ![][flag_AU] [peppy](https://osu.ppy.sh/users/2) was assumed to be the fir
 | Player | From | To | Sources |
 | --: | :-- | :-- | :-- |
 | ![][flag_DE] [WhiteCat](https://osu.ppy.sh/users/4504101) | *2019-10-06* | 2021-04-08 | [\[1\]](https://web.archive.org/web/20191006200709/https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://ameobea.me/osutrack/user/whitecat/) [\[3\]](https://web.archive.org/web/20210119102542/https://old.reddit.com/r/osugame/comments/de8duf/whitecat_is_now_1_global_on_osustandard/) [\[4\]](https://web.archive.org/web/20210203170702if_/https://www.youtube.com/watch?v=Bx4R7lovF-0) |
-| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | 2021-04-08 | Present | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
+| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | 2021-04-08 | *Present* | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
+
+## 2022
+
+| Player | From | To | Sources |
+| --: | :-- | :-- | :-- |
+| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | *2021-04-08* | Present | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
 
 ## Number of reigns
 

--- a/wiki/History_of_osu!/Online_rankings/osu!/fr.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!/fr.md
@@ -13,6 +13,8 @@ tags:
   - classements
   - meilleur joueur
 no_native_review: true
+outdated: true
+outdated_since: af1924df8cfa9b43fa3f4cb2c4fb5935bf1b81d9
 ---
 
 # L'histoire des classements du mode osu!

--- a/wiki/History_of_osu!/Online_rankings/osu!/id.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!/id.md
@@ -12,6 +12,8 @@ tags:
   - peringkat #1
   - peringkat
   - pemain teratas
+outdated: true
+outdated_since: af1924df8cfa9b43fa3f4cb2c4fb5935bf1b81d9
 ---
 
 # Sejarah peringkat osu!


### PR DESCRIPTION
New year, new section!

mrekk/sakamata1 name is being left unchanged until the window for name reverts has passed. (See https://github.com/ppy/osu-wiki/pull/5863#issuecomment-882825742)

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
