### PR TITLE
Fix various links across the wiki

### DIFF
--- a/wiki/Community/en.md
+++ b/wiki/Community/en.md
@@ -20,7 +20,7 @@ This page lists ways for people from all around osu! to get in touch with each o
 
 ## Initiatives
 
-- [osu! community meetings](/wiki/Community/osu!_Community_Meetings)
+- [osu! community meetings](/wiki/Community/osu!_community_meetings)
 - [Video series](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/fr.md
+++ b/wiki/Community/fr.md
@@ -20,7 +20,7 @@ Cette page répertorie les moyens par lesquels les utilisateurs de tout le site 
 
 ## Initiatives
 
-- [osu! community meetings](/wiki/Community/osu!_Community_Meetings)
+- [osu! community meetings](/wiki/Community/osu!_community_meetings)
 - [Séries vidéo](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/id.md
+++ b/wiki/Community/id.md
@@ -20,7 +20,7 @@ Berikut ini merupakan daftar artikel yang membahas seputar cara komunikasi yang 
 
 ## Inisiatif
 
-- [Pertemuan komunitas osu!](/wiki/Community/osu!_Community_Meetings)
+- [Pertemuan komunitas osu!](/wiki/Community/osu!_community_meetings)
 - [Serial video](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/zh-tw.md
+++ b/wiki/Community/zh-tw.md
@@ -23,7 +23,7 @@ no_native_review: true
 
 ## 企劃
 
-- [osu! 社群會議](/wiki/Community/osu!_Community_Meetings)
+- [osu! 社群會議](/wiki/Community/osu!_community_meetings)
 - [影片系列](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Guides/Videos_from_YouTube/fr.md
+++ b/wiki/Guides/Videos_from_YouTube/fr.md
@@ -33,6 +33,6 @@ youtube-dl -f bestvideo <video link>
 
 ## Supprimer les pistes audio
 
-*Page principale : [Compression des fichiers](/wiki/Guides/Compressing_Files)*
+*Page principale : [Compression des fichiers](/wiki/Guides/Compressing_files)*
 
 Après avoir téléchargé la vidéo, vous pouvez la charger dans la beatmap comme vous le feriez normalement via l'[onglet design](/wiki/Beatmap_editor/Design) dans l'[éditeur de beatmap](/wiki/Beatmap_editor). Cependant, non seulement la vidéo contiendra des pistes audio qui ne seront pas utilisées et prendront de la place supplémentaire, mais les [critères de classement](/wiki/Ranking_Criteria#Video-and-background) de la beatmap interdisent les vidéos avec des pistes audio car elles ne sont pas utilisées. Voir [compression des fichiers](/wiki/Guides/Compressing_files) pour savoir comment supprimer l'audio de la vidéo.

--- a/wiki/Guides/fr.md
+++ b/wiki/Guides/fr.md
@@ -16,7 +16,7 @@ Vous trouverez ci-dessous une liste triée des guides créés par les membres de
 - [Changement de l'artiste ou du titre](Changing_the_Artist_or_Title)
 - [Modification du texte du titre](/wiki/Beatmap/Title_Text#changer-le-texte-du-titre)
 - [Informations sur les collaborations](Collab_Information)
-- [Compression de fichiers](Compressing_Files)
+- [Compression de fichiers](Compressing_files)
 - [Bibliothèque de hitsounds personnalisés](Custom_Hitsound_Library)
 - [Remplacement d'échantillons personnalisés](Custom_Sample_Overrides)
 - [Comment chronométrer les chansons](How_to_Time_Songs)
@@ -24,7 +24,7 @@ Vous trouverez ci-dessous une liste triée des guides créés par les membres de
 - [Guide de mapping osu!mania](osu!mania_Mapping_Guide)
 - [Réglage du décalage sur le bon rythme](Setting_the_Offset_on_the_Correct_Beat)
 - [Démarrage d'un projet de création de beatmap](Starting_a_Beatmap_Project)
-- [Vidéos de YouTube](Videos_from_Youtube)
+- [Vidéos de YouTube](Videos_from_YouTube)
 
 ## Modding
 

--- a/wiki/Guides/id.md
+++ b/wiki/Guides/id.md
@@ -20,7 +20,7 @@ Berikut adalah daftar berbagai panduan yang telah dibuat oleh anggota-anggota ko
 - [Panduan Mapping osu!mania](osu!mania_Mapping_Guide)
 - [Mengatur offset dengan ketukan yang tepat](Setting_the_Offset_on_the_Correct_Beat)
 - [Menambahkan hitsound khusus](Using_custom_hitsounds)
-- [Video dari YouTube](Videos_from_Youtube)
+- [Video dari YouTube](Videos_from_YouTube)
 
 ## Modding
 

--- a/wiki/Guides/ja.md
+++ b/wiki/Guides/ja.md
@@ -17,7 +17,7 @@ outdated_since: acdcb1efbd3ac94eef628b095b78cbacfcdac000
 - [アーティストまたはタイトルの変更](Changing_the_Artist_or_Title)
 - [タイトルテキストの変更](/wiki/Beatmap/Title_Text#changing-title-text)
 - [コラボ情報](Collab_Information)
-- [ファイルを圧縮する](Compressing_Files)
+- [ファイルを圧縮する](Compressing_files)
 - [カスタムヒットサウンドライブラリ](Custom_Hitsound_Library)
 - [カスタムサンプルオーバーライド](Custom_Sample_Overrides)
 - [曲の時間を計る方法](How_to_Time_Songs)
@@ -25,7 +25,7 @@ outdated_since: acdcb1efbd3ac94eef628b095b78cbacfcdac000
 - [osu!mania マッピングガイド](osu!mania_Mapping_Guide)
 - [正しいビートのオフセットを設定](Setting_the_Offset_on_the_Correct_Beat)
 - [ビートマッププロジェクトの開始](Starting_a_Beatmap_Project)
-- [YouTubeの動画](Videos_from_Youtube)
+- [YouTubeの動画](Videos_from_YouTube)
 
 ## Modding
 

--- a/wiki/Guides/pt-br.md
+++ b/wiki/Guides/pt-br.md
@@ -17,7 +17,7 @@ Abaixo se encontra uma lista ordenada de guias criados por membros da comunidade
 - [Mudando o Artista ou Título](Changing_the_Artist_or_Title)
 - [Mudando o texto do Título](/wiki/Beatmap/Title_Text#changing-title-text)
 - [Informação de Collab](Collab_Information)
-- [Compactando Arquivos](Compressing_Files)
+- [Compactando Arquivos](Compressing_files)
 - [Biblioteca de Hitsound Customizado](Custom_Hitsound_Library)
 - [Sobreposição de Amostra Customizado](Custom_Sample_Overrides)
 - [Como Fazer o Timing de Músicas](How_to_Time_Songs)
@@ -25,7 +25,7 @@ Abaixo se encontra uma lista ordenada de guias criados por membros da comunidade
 - [Guia de Mapping de osu!mania](osu!mania_Mapping_Guide)
 - [Pondo o Offset na Batida Correta](Setting_the_Offset_on_the_Correct_Beat)
 - [Começando um Projeto de Beatmap](Starting_a_Beatmap_Project)
-- [Vídeos do YouTube](Videos_from_Youtube)
+- [Vídeos do YouTube](Videos_from_YouTube)
 
 ## Modding
 

--- a/wiki/Guides/tr.md
+++ b/wiki/Guides/tr.md
@@ -16,7 +16,7 @@ Aşağıda osu!community üyeleri tarafından yaratılmış; pek çoğu osu!foru
 - [Sanatçı ya da Başlık Adı Değiştirme](Changing_the_Artist_or_Title)
 - [Başlık Metnini Değiştirme](/wiki/Beatmap/Title_Text#changing-title-text)
 - [Collab Bilgisi](Collab_Information)
-- [Dosyaları Sıkıştırmak](Compressing_Files)
+- [Dosyaları Sıkıştırmak](Compressing_files)
 - [Özel Vuruş Sesi Kütüphanesi](Custom_Hitsound_Library)
 - [Özel Ses Seti Bindirmeleri](Custom_Sample_Overrides)
 - [Şarkılar Naısl Zamanlanır](How_to_Time_Songs)
@@ -24,7 +24,7 @@ Aşağıda osu!community üyeleri tarafından yaratılmış; pek çoğu osu!foru
 - [osu!mania Map Yapım Kılavuzu](osu!mania_Mapping_Guide)
 - [Ofseti Doğru Vuruşa Ayarlamak](Setting_the_Offset_on_the_Correct_Beat)
 - [Bir Beatmap Projesi Başlatmak](Starting_a_Beatmap_Project)
-- [YouTube'dan Videolar](Videos_from_Youtube)
+- [YouTube'dan Videolar](Videos_from_YouTube)
 
 ## Modlama
 

--- a/wiki/Main_Page/cs.md
+++ b/wiki/Main_Page/cs.md
@@ -134,7 +134,7 @@ Stejně jako téměř všechno tady, osu! wiki je psána a udržována dobrovoln
 
 [Historie osu!](/wiki/History_of_osu!) • [Historie osu! wiki](/wiki/History_of_osu!/osu!_wiki) • [Časová osa mapování a úprav](/wiki/Mapping_and_Modding_Timeline) • [April Fools](/wiki/History_of_osu!/April_Fools)
 
-[Obsah](/wiki/Sitemap) • [Jak přispět?](/wiki/osu!_wiki/Contribution_guide) • [Kritéria pro návrh článku](/wiki/Article_Styling_Criteria) • [Kritéria pro návrh zpráv](/wiki/News_Styling_Criteria)
+[Obsah](/wiki/Sitemap) • [Jak přispět?](/wiki/osu!_wiki/Contribution_guide) • [Kritéria pro návrh článku](/wiki/Article_styling_criteria) • [Kritéria pro návrh zpráv](/wiki/News_Styling_Criteria)
 
 </div>
 </div>

--- a/wiki/Rules/de.md
+++ b/wiki/Rules/de.md
@@ -45,7 +45,7 @@ Diese Regeln beziehen sich ausschließlich auf Beatmaps, die über das [Beatmap 
 1. **Stelle sicher, dass du die Berechtigung hast, jeden Inhalt in deiner Beatmap zu verwenden.** Das umschließt Lieder, Videos, Hitsounds, Bilder oder andere Inhalte, die nicht von dir direkt selbst erstellt wurden. Solltest du dir unsicher sein, wo du frei nutzbare Inhalte finden kannst, kannst du die Bibliothek von Liedern unserer [Featured Artists](https://osu.ppy.sh/beatmaps/artists/) durchsuchen. Dort findest du Musik die zu 100% für die Benutzung in osu! lizensiert ist. Achte außerdem auf die [Regeln für die Inhaltsverwendung](Content_Usage_Guidelines).
 2. **Komm in [Beatmapdiskussionen](/wiki/Beatmap_Discussion) nicht vom Thema ab.** Die Threads und Diskussionen gelten der Beatmap und sonst nichts. Wenn du ein Problem mit etwas hast, was sich nicht direkt auf die Beatmap bezieht, dann veröffentliche es stattdessen im richtigen Forum.
 3. **Plagiiere oder stehle nicht die Arbeit anderer Nutzer.** Lade keine Inhalte anderer Nutzer ohne deren expliziten Erlaubnis hoch, einschließlich Skins und Guest Difficulties.
-4. **Folge den [Regeln für Liedinhalte](/wiki/Song_Content_Rules) und den [Empfehlungen für visuelle Inhalte](/wiki/Rules/Visual_Content_Considerations).**
+4. **Folge den [Regeln für Liedinhalte](Song_Content_Rules) und den [Empfehlungen für visuelle Inhalte](Visual_Content_Considerations).**
 
 ## Was passiert, wenn ich diese Regeln breche?
 

--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -1081,7 +1081,7 @@
 "licencing":                   "Rules/Content_Usage_Guidelines"
 "licensing":                   "Rules/Content_Usage_Guidelines"
 "explicit":                    "Rules/Explicit_Content"
-"song_content_rules":          "Rules/Song_content_rules"
+"song_content_rules":          "Rules/Song_Content_Rules"
 "scr":                         "Rules/Song_Content_Rules"
 "song_content":                "Rules/Song_Content_Rules"
 "songs_content":               "Rules/Song_Content_Rules"


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

Fixes casing on various links, while also fixing links that incur more than one redirect

Specifically, this intends to fix most errors, that might have been missed in https://github.com/ppy/osu-wiki/pull/6641, as reported by the new and shiny [wikilink checker](https://github.com/Walavouchey/osu-wiki-tools/blob/master/find-broken-wikilinks.py) when set to check all files

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] `SKIP_OUTDATED_CHECK`