### PR TITLE
[DE] Fix link in `Account support team`

### DIFF
--- a/wiki/People/The_Team/Account_support_team/de.md
+++ b/wiki/People/The_Team/Account_support_team/de.md
@@ -27,7 +27,7 @@ Du solltest das Team zu Account-bezogenen Themen kontaktieren, über die du kein
   - Entfernung von Profilinhalten;
   - Entfernung von Beatmaps;
   - Entfernung von Forumsbeiträgen und Kommentaren.
-- Fälle von Fehlverhalten, die du [gestehen möchtest](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play#was-kann-ich-tun-wenn-ich-die-regeln-gebrochen-habe?).
+- Fälle von Fehlverhalten, die du [gestehen möchtest](/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play#was-kann-ich-tun,-wenn-ich-die-regeln-gebrochen-habe?).
 - [Verlust des Zugriffs auf die E-Mail](/wiki/Help_Centre/Installation_and_registration#wo-registriere-ich-mich-für-osu!?), die mit deinem osu!-Account verbunden ist oder, wenn dein Account gestohlen wurde.
 - [Rücksetzungen des Benutzernamens und Rechtschreibfehlerkorrekturen](/wiki/Help_Centre/Account#namensänderungen).
 - [Registrierungen von Bot-Accounts](/wiki/Bot_account).

--- a/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play/de.md
+++ b/wiki/Reporting_Bad_Behaviour/Handling_Foul_Play/de.md
@@ -76,7 +76,7 @@ Das Support-Team erwartet, dass Nutzer ihre vergangenen Verstöße auflisten und
 
 *Es wird vermutlich einige Zeit dauern, auf deine Beschwerde zu antworten, aber keine Beschwerden werden ignoriert.*
 
-## Was kann ich tun, wenn ich die Regeln gebrochen habe? {#was-kann-ich-tun-wenn-ich-die-regeln-gebrochen-habe?}
+## Was kann ich tun, wenn ich die Regeln gebrochen habe?
 
 Wenn du gegen die Regeln verstoßen hast und dies bereinigen möchtest, wende dich bitte an [accounts@ppy.sh](mailto:accounts@ppy.sh) und erkläre, was du getan hast. Ehrlichkeit wird sehr wertgeschätzt und das wird wahrscheinlich nicht in einer permanenten Strafe enden.
 


### PR DESCRIPTION
Third time's a charme...

The original link probably didn't work because one letter was uppercase. My second try didn't work either because custom identifiers (`{#id}`) don't support special characters like question marks. The change can be found in #6655 .

I'm reverting back now to the first try but with everything in lowercase.

[Here](https://discord.com/channels/188630481301012481/218677502141399041/928347613634392145) is the discussion on Discord regarding my issue, in case anyone wants to read it.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

