### PR TITLE
Replace links in `Guides\Tablet_Purchase`

### DIFF
--- a/wiki/Guides/Tablet_Purchase/en.md
+++ b/wiki/Guides/Tablet_Purchase/en.md
@@ -50,7 +50,7 @@ At the time of writing there are three versions of the Bamboo, all confusingly u
 
 ![](img/gen3.jpg "Third generation Bamboo (Connect, Capture, Create - Connect shown)")
 
-You'll want to stay away from either of the Bamboo Touch tablets, they do not feature pen input, they're just multitouch trackpads for your computer. Frankly, [Apple did it better](https://apple.com/magictrackpad).
+You'll want to stay away from either of the Bamboo Touch tablets, they do not feature pen input, they're just multitouch trackpads for your computer. Frankly, [Apple did it better](https://www.apple.com/shop/product/MK2D3AM/A/magic-trackpad).
 
 The other Bamboo models come in two sizes, basically small and large. For the second generation, Bamboo Touch, Pen, and Pen and Touch were the "small" ones, whereas the Fun and Craft were the "large" ones. For the third generation, the Connect and Capture are the "small", whereas the Create is the "large".
 
@@ -81,7 +81,7 @@ Here are some links to purchase the latest models.
 - [Amazon - One by Wacom Tablet (small version) (CTL472)](https://www.amazon.com/dp/B07S1RR3FR)
 - [Amazon - Wacom Bamboo Splash Pen Tablet (CTL471)](https://a.co/fCXqteP)
 - [Amazon - Wacom Bamboo Capture Pen and Touch Tablet (CTH470)](https://a.co/b4GpKXt)
-- [Huion - HUION H430P (4096)](https://huiontablet.com/all-products/graphic-tablets/huion-h430p-4096.html)
+- [Huion - HUION H430P (4096)](https://store.huion.com/products/inspiroy-h430p)
   - [Amazon - Huion Inspiroy H430P Graphics Drawing Tablet for OSU](https://a.co/6uDGhXL)
 
 ## Conclusion

--- a/wiki/Guides/Tablet_Purchase/fr.md
+++ b/wiki/Guides/Tablet_Purchase/fr.md
@@ -50,7 +50,7 @@ Au moment de la rédaction de ce guide, il existe trois versions de la Bamboo, t
 
 ![](img/gen3.jpg "Bamboo troisième génération (Connect, Capture, Create - Connect présenté)")
 
-Il est préférable d'éviter l'une ou l'autre des tablettes Bamboo Touch, car elles ne sont pas dotées d'un stylet et ne sont que des trackpads multitouch pour votre ordinateur. Franchement, [Apple à fait mieux](https://apple.com/magictrackpad).
+Il est préférable d'éviter l'une ou l'autre des tablettes Bamboo Touch, car elles ne sont pas dotées d'un stylet et ne sont que des trackpads multitouch pour votre ordinateur. Franchement, [Apple à fait mieux](https://www.apple.com/shop/product/MK2D3AM/A/magic-trackpad).
 
 Les autres modèles Bamboo sont disponibles en deux tailles, en principe petite et grande. Pour la deuxième génération, les Bamboo Touch, Pen, et Pen and Touch étaient les "petites", tandis que les Fun et Craft étaient les "grandes". Pour la troisième génération, les modèles Connect et Capture sont les "petits", tandis que le modèle Create est le "grand".
 
@@ -81,7 +81,7 @@ Voici quelques liens pour acheter les derniers modèles :
 - [Amazon - One by Wacom Tablet (small version) (CTL472)](https://www.amazon.com/dp/B07S1RR3FR)
 - [Amazon - Wacom Bamboo Splash Pen Tablet (CTL471)](https://a.co/fCXqteP)
 - [Amazon - Wacom Bamboo Capture Pen and Touch Tablet (CTH470)](https://a.co/b4GpKXt)
-- [Huion - HUION H430P (4096)](https://huiontablet.com/all-products/graphic-tablets/huion-h430p-4096.html)
+- [Huion - HUION H430P (4096)](https://store.huion.com/products/inspiroy-h430p)
   - [Amazon - Huion Inspiroy H430P Graphics Drawing Tablet for OSU](https://a.co/6uDGhXL)
 
 ## Conclusion


### PR DESCRIPTION
While working on the translation, I've noticed that some links in this article are outdated. For example, the link for Huion redirects to their store page. If anyone wants to take a look for themselves, here are the old links:
- [https://apple.com/magictrackpad](https://apple.com/magictrackpad)
- [https://huiontablet.com/all-products/graphic-tablets/huion-h430p-4096.html](https://huiontablet.com/all-products/graphic-tablets/huion-h430p-4096.html)

And here are the new ones that I found for replacement:
- [https://www.apple.com/shop/product/MK2D3AM/A/magic-trackpad](https://www.apple.com/shop/product/MK2D3AM/A/magic-trackpad)
- [https://store.huion.com/products/inspiroy-h430p](https://store.huion.com/products/inspiroy-h430p)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
