### PR TITLE
[FR] Cleanup `Client\Options`

### DIFF
--- a/wiki/Client/Options/fr.md
+++ b/wiki/Client/Options/fr.md
@@ -41,10 +41,10 @@ Si vous cliquez sur le bouton `Connecté en tant que {nom d'utilisateur}`, il af
 
 | Nom | Description | Type |
 | :-- | :-- | :-- |
-| `1. Consulter le profil` | Consultez votre profil sur le site web. | Bouton |
-| `2. Se déconnecter` | Se déconnectez du client. | Bouton |
-| `3. Changer d'avatar` | Change votre photo de profil (cela vous redirigera vers le site web). | Bouton |
-| `4. Fermer` | Ferme cette boîte de dialogue. Vous pouvez également appuyer sur `Esc`. | Bouton |
+| `1. Consulter le profil` | Consulter votre profil sur le site web. | Bouton |
+| `2. Se déconnecter` | Se déconnecter du client. | Bouton |
+| `3. Changer d'avatar` | Changer votre photo de profil (cela vous redirigera vers le site web). | Bouton |
+| `4. Fermer` | Fermer cette boîte de dialogue. Vous pouvez également appuyer sur `Esc`. | Bouton |
 
 Vous pouvez accéder à ce menu en cliquant sur votre carte de joueur lorsqu'elle est disponible.
 
@@ -72,7 +72,7 @@ Si vous ouvrez la liste déroulante pour le `Canal de mise à jour`, les options
 | :-- | :-- |
 | `Stable` | Version publique stable. |
 | `Bêta` | Version de développement - obtient les nouvelles fonctionnalités plus tôt, mais peut comporter des bugs. |
-| `Expérimental` | Version de développement - obtient les nouvelles fonctionnalités encore plus tôt, mais peut être significativement remplis de bugs. |
+| `Expérimental` | Version de développement - obtient les nouvelles fonctionnalités encore plus tôt, mais peut comporter encore plus de bugs. |
 
 ## Graphismes
 
@@ -105,7 +105,7 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | `Optimal` | Limite le client à huit fois la fréquence de rafraîchissement de votre moniteur, plafonnant à 960 FPS. |
 | `Illimité (en jeu)` | Limite le client à la fréquence de rafraîchissement de votre moniteur. Voir l'explication ci-dessous pour plus de détails. |
 
-- Explication sur le `VSync` : En termes simples, l'utilisation de VSync oblige le jeu à attendre le chargement complet de l'image avant de l'afficher.
+- Explication sur la `VSync` : En termes simples, l'utilisation de la VSync oblige le jeu à attendre le chargement complet de l'image avant de l'afficher.
   - Vous pouvez l'utiliser si vous constatez un certain "déchirement" (lorsque la partie inférieure du jeu est en retard sur la partie supérieure du jeu).
   - Malgré ce qui a été dit plus haut, cela peut provoquer un certain décalage ou des ralentissements car le client doit attendre le chargement de chaque image.
 - Explication sur `Illimité (en jeu)` : L'illimité ne s'applique que lorsque vous jouez une beatmap.
@@ -130,10 +130,10 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Sliders progressifs` | Les sliders vont "serpenter" depuis leur position de départ. | Case à cocher | `Activé` |
-| `Vidéo d'arrière-plan` | Autorise la lecture de la vidéo d'arrière-plan de la beatmap pendant le jeu (peut être désactivé sur chaque beatmap indépendamment). | Case à cocher | `Activé` |
+| `Vidéo d'arrière-plan` | Autorise la lecture de la vidéo d'arrière-plan de la beatmap lorsque vous jouez (peut être désactivé sur chaque beatmap indépendamment). | Case à cocher | `Activé` |
 | `Storyboards` | Permet de lire les storyboards des beatmaps (peut être désactivé sur chaque beatmap indépendamment). | Case à cocher | `Activé` |
-| `"Combo bursts"` | Permettre aux combo bursts de s'afficher lorsqu'on atteint une étape d'un combo. | Case à cocher | `Désactivé` |
-| `Lueurs de fond` | Affiche une lueur subtile derrière chaque explosion de coup. Ne désactive pas la lueur pendant le Kiai Time. | Case à cocher | `Activé` |
+| `"Combo bursts"` | Permet aux combo bursts de s'afficher lorsqu'on atteint un palier de combo. | Case à cocher | `Désactivé` |
+| `Lueurs de fond` | Affiche une lueur subtile derrière chaque cercle cliqué. Ne désactive pas la lueur pendant le Kiai Time. | Case à cocher | `Activé` |
 | `Effets spéciaux` | Affiche, graphiquement parlant, des effets de type concert. Cette fonction est automatiquement désactivée si votre ordinateur ne peut pas la gérer. | Case à cocher | `Désactivé` |
 | `Filtre adoucissant` | Ajuste les shaders pour être moins flashy. Ceci activera automatiquement `Effets spéciaux`. | Case à cocher | `Activé` |
 | `Captures d'écran :` | Définit le format du fichier de capture d'écran. | Liste déroulante | `JPEG (plus léger)` |
@@ -143,7 +143,7 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Neige` | Affiche les effets de neige sur le menu principal (activé de force pendant l'hiver). | Case à cocher | `Désactivé` |
-| `Parallaxe` | Affiche une légère parallaxe lors de la navigation dans les menus du jeu (n'est pas activé en jeu). | Case à cocher | `Activé` |
+| `Parallaxe` | Affiche une légère parallaxe lors de la navigation dans les menus du jeu (ne fonctionne pas pendant une beatmap). | Case à cocher | `Activé` |
 | `Trucs et astuces` | Affiche un conseil chaque fois que vous visitez le menu principal. (Les conseils ne sont pas affichés dans la version Cutting Edge). | Case à cocher | `Activé` |
 | `Voix d'accueil` | Joue les sons "welcome" et "see ya" à l'ouverture et à la fermeture du jeu respectivement. | Case à cocher | `Activé` |
 | `Thème musical d'osu! au démarrage` | Si cette option est activée, la musique du thème principal sera jouée après l'ouverture du client. Une fois la musique changée, vous ne pouvez pas la rejouer tant que le client n'a pas été redémarré. | Case à cocher | `Activé` |
@@ -175,7 +175,7 @@ Cette section concerne les paramètres qui affectent la jouabilité.
 
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
-| `Assombrir l'arrière-plan` | Ajuste le niveau d'assombrissement appliqué à l'arrière-plan et au storyboard pendant le jeu (peut être réglé sur chaque beatmap indépendamment). | Curseur | `80%` |
+| `Assombrir l'arrière-plan` | Ajuste le niveau d'assombrissement appliqué à l'arrière-plan et au storyboard lorsque vous jouez (peut être réglé sur chaque beatmap indépendamment). | Curseur | `80%` |
 | `Don't change dim level during breaks` | Désactive l'éclaircissement du niveau d'obscurité pendant les pauses, rendant l'arrière-plan toujours invisible. | Case à cocher | `Désactivé` |
 | `Barre de progression` | Configure l'endroit et le mode d'affichage de la barre de progression de la musique. Voir ci-dessous pour plus de détails. | Liste déroulante | `En haut à droite (disque)` |
 | `Indicateur de performance` | Configure le compteur de précision apparaissant sous la beatmap. Notez qu'osu!catch utilisera toujours le paramètre `Couleur`. | Liste déroulante | `Précision` |
@@ -268,7 +268,7 @@ Cette section traite des questions relatives aux skins.
 | `Toujours utiliser le curseur du skin choisi` | Favorise le curseur du skin actuelle sur tous les curseurs fournis par les beatmaps. | Case à cocher | `Désactivé` |
 | `Taille du curseur` | Ajuste la taille du curseur. | Curseur | `1x` |
 | `Ajustement automatique de la taille du curseur` | Ajuste automatiquement la taille du curseur en fonction de la taille de l'approach circle d'une beatmap. | Case à cocher | `Désactivé` |
-| `Colorer les sliderballs en fonction de la couleur des sliders` | Les sliderballs utiliseront la couleur actuelle du combo (généralement transparente). Nécessite le support du skin. | Case à cocher | `Activé` |
+| `Colorer les sliderballs en fonction de la couleur des sliders` | Les sliderballs utiliseront la couleur actuelle du combo (généralement transparente). Nécessite la prise en charge du skin. | Case à cocher | `Activé` |
 
 ## Contrôles
 
@@ -285,11 +285,11 @@ Cette section traite des périphériques d'entrée.
 | `Faire correspondre la zone active de la tablette à la fenêtre d'osu!` | Limite les périphériques d'entrée à un positionnement absolu (par exemple, les tablettes à stylet) à la seule fenêtre du client. | Case à cocher | `Désactivé` |
 | `Confirmer le curseur :` | Empêche le curseur de la souris de quitter la fenêtre du client. Voir ci-dessous pour plus de détails. | Liste déroulante | `Seulement en plein écran` |
 | `Molette de la souris désactivée pendant les parties` | Désactive la molette de la souris pendant le jeu. L'utilisation de la molette de la souris peut modifier la valeur du volume principal. | Case à cocher | `Désactivé` |
-| `Boutons de la souris désactivés pendant les parties` | Désactive les boutons de la souris pendant le jeu. Ceci est utile pour les utilisateurs de claviers. | Case à cocher | `Désactivé` |
-| `Visualiser les clics` | Montre un effet d'ondulation subtile lorsque vous cliquez avec votre périphérique d'entré. | Case à cocher | `Désactivé` |
+| `Boutons de la souris désactivés pendant les parties` | Désactive les boutons de la souris lorsque vous jouez. Ceci est utile pour les utilisateurs de claviers. | Case à cocher | `Désactivé` |
+| `Visualiser les clics` | Montre un effet d'ondulation subtile lorsque vous cliquez avec votre périphérique d'entrée. | Case à cocher | `Désactivé` |
 
 - Lorsque `Contourner le pilote du dispositif de pointage` est activé, il affichera le nombre de rapports qu'il reçoit par seconde et la latence en millisecondes.
-- L'effet d'ondulation du curseur peut être déclenché en appuyant sur `M1` et `M2` pendant le jeu.
+- L'effet d'ondulation du curseur peut être déclenché en appuyant sur `M1` et `M2` lorsque vous jouez.
 
 ---
 
@@ -363,9 +363,9 @@ Cette section concerne le tchat, les spectateurs, le multi, et osu!direct.
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Discord Rich Presence` | Fournit des [données de présence riches à Discord](/wiki/Guides/Discord_Rich_Presence). | Case à cocher | `Activé` |
-| `Intégrer au status Yahoo! Messenger` | Votre messager Yahoo! affichera la musique que vous êtes en train de lire ou d'écouter. Ce paramètre doit être défini sur le site Web. | Case à cocher | `Désactivé` |
-| `Intégrer au messages perso MSN` | Votre Windows Live Messenger affichera la musique que vous êtes en train de jouer ou d'écouter. | Case à cocher | `Désactivé` |
-| `Téléchargements osu!direct automatiques` | Pour les [osu!supporter](/wiki/osu!supporter) uniquement. Lorsque vous êtes spectateur ou en multijoueur, la beatmap sera téléchargé automatiquement. | Case à cocher | `Activé` |
+| `Intégrer au statut Yahoo! Messenger` | Votre Yahoo! Messenger affichera la musique que vous êtes en train de jouer ou d'écouter. Ce paramètre doit être défini sur le site Web. | Case à cocher | `Désactivé` |
+| `Intégrer au message perso MSN` | Votre Windows Live Messenger affichera la musique que vous êtes en train de jouer ou d'écouter. | Case à cocher | `Désactivé` |
+| `Téléchargements osu!direct automatiques` | Pour les [osu!supporter](/wiki/osu!supporter) uniquement. Lorsque vous êtes spectateur ou en multijoueur, la beatmap sera téléchargée automatiquement. | Case à cocher | `Activé` |
 | `Ne pas télécharger les vidéos` | Pour les [osu!supporter](/wiki/osu!supporter) uniquement. Les téléchargements d'osu!direct seront limités aux versions non-vidéo des beatmaps. | Case à cocher | `Désactivé` |
 
 ### Tchat
@@ -427,5 +427,5 @@ b{YYYY}{MM}{DD}.{revision}{type}
 
 - L'ancien écran d'options était un véritable écran avec des onglets, des boutons et un fond bleu pâle foncé.
 - L'ancien écran d'options comportait également un écran de sélection du skin qui vous permet également de prévisualiser la lecture en direct d'une beatmap dans osu!
-  - Après que l'écran des options a été déplacé vers une barre latérale, cet écran était toujours accessible en ouvrant un fichier skin.
+  - Après que l'écran des options ait été transformé en barre latérale, cet écran était toujours accessible en ouvrant un fichier skin.
   - Cet accès a été supprimé par la suite après l'apparition des aperçus de skins et des fonctions d'aperçu en direct.

--- a/wiki/Client/Options/fr.md
+++ b/wiki/Client/Options/fr.md
@@ -1,12 +1,8 @@
----
-no_native_review: true
----
-
 # Options
 
 ![Menu des options](img/options_basic-FR.jpg "Menu des options \(barre latérale à gauche\)")
 
-Dans le menu principal, cliquez sur `Options` ou appuyez sur `O` (ou appuyez sur `Ctrl` + `O` qui fonctionne dans presque tous les écrans) pour accéder à la barre latérale des options et changer les options disponibles dans osu!. Une fois que le menu des options est ouvert, vous pouvez taper pour rechercher un paramètre spécifique. Le texte de la barre de recherche se mettra à trembler si la requête de recherche n'a aucun résultat.
+Dans le menu principal, cliquez sur `Options` ou appuyez sur `O` (ou appuyez sur `Ctrl` + `O` qui fonctionne dans presque tous les écrans) pour accéder à la barre latérale des options et changer les options disponibles dans osu!. Une fois que le menu des options est ouvert, vous pouvez saisir du texte pour rechercher un paramètre spécifique. Le texte de la barre de recherche se mettra à trembler si la requête de recherche n'a aucun résultat.
 
 Lorsqu'un paramètre ayant une valeur par défaut est modifié, la barre verticale grise à gauche devient jaune pour ce paramètre. En cliquant sur cette barre, la valeur sera réinitialisée à sa valeur par défaut.
 
@@ -14,11 +10,11 @@ Lorsqu'un paramètre ayant une valeur par défaut est modifié, la barre vertica
 
 ![Icône de la section Général](img/general-FR.jpg "Icône de la section Général")
 
-Cette section concerne votre compte, les paramètres linguistiques et les mises à jour d'osu!
+Cette section concerne votre compte, les paramètres de langues et les mises à jour d'osu!
 
 ### Connexion
 
-Si vous n'êtes pas connecté au client, le menu des options s'ouvrira automatiquement au démarrage, vous invitant à vous connecter. Vous pouvez ignorer cette demande en appuyant sur `Esc`, en cliquant sur le bouton retour, ou en naviguant vers l'écran de sélection des beatmaps. Si vous ne vous connectez pas, le client vous marquera comme "Invité" et vous ne pourrez pas récupérer les scores en ligne, soumettre des scores ou jouer en [Multi](/wiki/Multi).
+Si vous n'êtes pas connecté au client, le menu des options s'ouvrira automatiquement au démarrage, vous invitant à vous connecter. Vous pouvez ignorer cette demande en appuyant sur `Esc`, en cliquant sur le bouton retour, ou en naviguant vers l'écran de sélection des beatmaps. Si vous ne vous connectez pas, le client vous marquera comme "Invité" et vous ne pourrez pas récupérer les scores en ligne, envoyer des scores ou jouer en [multijoueur](/wiki/Multi).
 
 Si vous êtes un invité, ces options seront affichées :
 
@@ -41,13 +37,13 @@ Si vous êtes connecté, vous verrez :
 
 ---
 
-Si vous cliquez sur l'invite `Connecté en tant que {nom d'utilisateur}`, il affichera un menu avec les boutons suivants :
+Si vous cliquez sur le bouton `Connecté en tant que {nom d'utilisateur}`, il affichera un menu avec les boutons suivants :
 
 | Nom | Description | Type |
 | :-- | :-- | :-- |
 | `1. Consulter le profil` | Consultez votre profil sur le site web. | Bouton |
-| `2. Se déconnecter` | Se déconnecter du client. | Bouton |
-| `3. Changer d'avatar` | Changez votre photo de profil (cela vous redirigera vers le site web). | Bouton |
+| `2. Se déconnecter` | Se déconnectez du client. | Bouton |
+| `3. Changer d'avatar` | Change votre photo de profil (cela vous redirigera vers le site web). | Bouton |
 | `4. Fermer` | Ferme cette boîte de dialogue. Vous pouvez également appuyer sur `Esc`. | Bouton |
 
 Vous pouvez accéder à ce menu en cliquant sur votre carte de joueur lorsqu'elle est disponible.
@@ -56,7 +52,7 @@ Vous pouvez accéder à ce menu en cliquant sur votre carte de joueur lorsqu'ell
 
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
-| `Sélection de la langue :` | Affichez une liste de langues à sélectionner. | Liste déroulante |  |
+| `Sélection de la langue :` | Affiche une liste des langues à sélectionner. | Liste déroulante |  |
 | `Métadonnées des maps dans leur langue d'origine dès que possible` | Dans l'écran de sélection des beatmaps, les beatmaps affichent leurs métadonnées originales ou non traduites, si elles sont disponibles. | Case à cocher | `Désactivé` |
 | `Appliquer la police de caractère Tahoma dans le chat` | Utilise l'ancienne police (Tahoma) au lieu de la police actuelle (Aller) dans la [console de tchat](/wiki/Client/Interface/Chat_console). | Case à cocher | `Désactivé` |
 
@@ -64,9 +60,9 @@ Vous pouvez accéder à ce menu en cliquant sur votre carte de joueur lorsqu'ell
 
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
-| `Canal de mise à jour :` | Affichez la liste des versions que vous souhaitez utiliser. | Liste déroulante | `Stable` |
+| `Canal de mise à jour :` | Affiche la liste des versions que vous souhaitez utiliser. | Liste déroulante | `Stable` |
 | `osu! est à jour !` | Cliquez sur ce bouton pour forcer le client à vérifier à nouveau les mises à jour et à les télécharger, le cas échéant. | Bouton |  |
-| `Ouvrir le dossier d'osu!` | Ouvrez le dossier local d'osu!, qui contient vos skins, vos beatmaps, etc. | Bouton |  |
+| `Ouvrir le dossier d'osu!` | Ouvre le dossier local d'osu!, qui contient vos skins, vos beatmaps, etc. | Bouton |  |
 
 ---
 
@@ -76,13 +72,13 @@ Si vous ouvrez la liste déroulante pour le `Canal de mise à jour`, les options
 | :-- | :-- |
 | `Stable` | Version publique stable. |
 | `Bêta` | Version de développement - obtient les nouvelles fonctionnalités plus tôt, mais peut comporter des bugs. |
-| `Expérimental` | Version de développement - obtient les nouvelles fonctionnalités encore plus tôt, mais peut être significativement plus buggué. |
+| `Expérimental` | Version de développement - obtient les nouvelles fonctionnalités encore plus tôt, mais peut être significativement remplis de bugs. |
 
 ## Graphismes
 
 ![Icône de la section Graphismes](img/graphics-FR.jpg "Icône de la section Graphismes")
 
-Cette section concerne l'apparence de votre client , les parties de l'interface et les paramètres vidéo.
+Cette section concerne l'apparence de votre client, les sections de l'interface et les paramètres vidéo.
 
 ### Moteur de rendu
 
@@ -109,7 +105,7 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | `Optimal` | Limite le client à huit fois la fréquence de rafraîchissement de votre moniteur, plafonnant à 960 FPS. |
 | `Illimité (en jeu)` | Limite le client à la fréquence de rafraîchissement de votre moniteur. Voir l'explication ci-dessous pour plus de détails. |
 
-- Explication sur `VSync` : En termes simples, l'utilisation de VSync oblige le jeu à attendre le chargement complet de l'image avant de l'afficher.
+- Explication sur le `VSync` : En termes simples, l'utilisation de VSync oblige le jeu à attendre le chargement complet de l'image avant de l'afficher.
   - Vous pouvez l'utiliser si vous constatez un certain "déchirement" (lorsque la partie inférieure du jeu est en retard sur la partie supérieure du jeu).
   - Malgré ce qui a été dit plus haut, cela peut provoquer un certain décalage ou des ralentissements car le client doit attendre le chargement de chaque image.
 - Explication sur `Illimité (en jeu)` : L'illimité ne s'applique que lorsque vous jouez une beatmap.
@@ -134,11 +130,11 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Sliders progressifs` | Les sliders vont "serpenter" depuis leur position de départ. | Case à cocher | `Activé` |
-| `Vidéo d'arrière-plan` | Autorise la lecture de la vidéo de fond de la beatmap pendant le jeu (peut être désactivé par beatmap). | Case à cocher | `Activé` |
-| `Storyboards` | Permet de lire les storyboards des beatmaps (peut être désactivé par beatmap). | Case à cocher | `Activé` |
-| `"Combo bursts"` | Permettre aux combo bursts de s'afficher lorsqu'on atteint une étape de combo. | Case à cocher | `Désactivé` |
-| `Lueurs de fond` | Affiche une lueur subtile derrière chaque explosion de coup. Ne désactive pas l'éclairage pendant le Kiai Time. | Case à cocher | `Activé` |
-| `Effets spéciaux` | Affiche, graphiquement parlant, des effets de type concert. Cette fonction peut être automatiquement désactivée si votre ordinateur ne peut pas la gérer. | Case à cocher | `Désactivé` |
+| `Vidéo d'arrière-plan` | Autorise la lecture de la vidéo d'arrière-plan de la beatmap pendant le jeu (peut être désactivé sur chaque beatmap indépendamment). | Case à cocher | `Activé` |
+| `Storyboards` | Permet de lire les storyboards des beatmaps (peut être désactivé sur chaque beatmap indépendamment). | Case à cocher | `Activé` |
+| `"Combo bursts"` | Permettre aux combo bursts de s'afficher lorsqu'on atteint une étape d'un combo. | Case à cocher | `Désactivé` |
+| `Lueurs de fond` | Affiche une lueur subtile derrière chaque explosion de coup. Ne désactive pas la lueur pendant le Kiai Time. | Case à cocher | `Activé` |
+| `Effets spéciaux` | Affiche, graphiquement parlant, des effets de type concert. Cette fonction est automatiquement désactivée si votre ordinateur ne peut pas la gérer. | Case à cocher | `Désactivé` |
 | `Filtre adoucissant` | Ajuste les shaders pour être moins flashy. Ceci activera automatiquement `Effets spéciaux`. | Case à cocher | `Activé` |
 | `Captures d'écran :` | Définit le format du fichier de capture d'écran. | Liste déroulante | `JPEG (plus léger)` |
 
@@ -147,11 +143,11 @@ Si vous ouvrez la liste déroulante pour `Images par seconde :`, vous serez pré
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Neige` | Affiche les effets de neige sur le menu principal (activé de force pendant l'hiver). | Case à cocher | `Désactivé` |
-| `Parallaxe` | Affiche une légère parallaxe lors de la navigation dans les menus du jeu (pas pendant le jeu). | Case à cocher | `Activé` |
+| `Parallaxe` | Affiche une légère parallaxe lors de la navigation dans les menus du jeu (n'est pas activé en jeu). | Case à cocher | `Activé` |
 | `Trucs et astuces` | Affiche un conseil chaque fois que vous visitez le menu principal. (Les conseils ne sont pas affichés dans la version Cutting Edge). | Case à cocher | `Activé` |
 | `Voix d'accueil` | Joue les sons "welcome" et "see ya" à l'ouverture et à la fermeture du jeu respectivement. | Case à cocher | `Activé` |
-| `Thème musical d'osu! au démarrage` | Si cette option est activée, la chanson du thème principal sera jouée après l'ouverture du client. Une fois la chanson changée, vous ne pouvez pas la rejouer tant que le client n'a pas été redémarré. | Case à cocher | `Activé` |
-| `Seasonal backgrounds` | Utilise les gagnants des concours de fanarts comme fond dans le menu principal (et pour les beatmaps sans images de fond). Les images défilent lorsque la chanson est changée. | Liste déroulante | `Sometimes` |
+| `Thème musical d'osu! au démarrage` | Si cette option est activée, la musique du thème principal sera jouée après l'ouverture du client. Une fois la musique changée, vous ne pouvez pas la rejouer tant que le client n'a pas été redémarré. | Case à cocher | `Activé` |
+| `Seasonal backgrounds` | Utilise les arrière-plans gagnants des concours de fanarts comme arrière-plan dans le menu principal (et pour les beatmaps sans arrière-plan). Les images défilent lorsque la musique est changée. | Liste déroulante | `Sometimes` |
 
 ---
 
@@ -159,8 +155,8 @@ Si vous ouvrez la liste déroulante `Seasonal backgrounds`, les options suivante
 
 | Nom | Description |
 | :-- | :-- |
-| `Sometimes` | Vous verrez des fonds saisonniers pendant quelques semaines au début de chaque saison. L'équipe d'osu!dev choisira le moment où ils seront supprimés et remplacés par des arrière-plans plus simples auxquels vous êtes habitués. |
-| `Never` | Vous ne verrez jamais de fonds saisonniers, et les valeurs par défaut seront utilisées dans tous les cas. |
+| `Sometimes` | Vous verrez des arrière-plans saisonniers pendant quelques semaines au début de chaque saison. L'équipe d'osu!dev choisira le moment où ils seront supprimés et remplacés par des arrière-plans plus simples auxquels vous êtes habitués. |
+| `Never` | Vous ne verrez jamais d'arrière-plans saisonniers, et les valeurs par défaut seront utilisées dans tous les cas. |
 | `Always` | Vous disposerez toujours des arrière-plans de la saison en cours. |
 
 ### Menu de sélection des beatmaps
@@ -179,15 +175,15 @@ Cette section concerne les paramètres qui affectent la jouabilité.
 
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
-| `Assombrir l'arrière-plan` | Ajuste le niveau de gradation appliqué à l'arrière-plan et au storyboard pendant le jeu (peut être réglé par beatmap). | Curseur | `80%` |
-| `Don't change dim level during breaks` | Désactive l'éclaircissement du niveau d'obscurité pendant les pauses, rendant l'arrière-plan jamais visible. | Case à cocher | `Désactivé` |
-| `Barre de progression` | Configure l'endroit et le mode d'affichage de la barre de progression de la chanson. Voir ci-dessous pour plus de détails. | Liste déroulante | `En haut à droite (disque)` |
-| `Indicateur de performance` | Configure le compteur de précision apparaissant sous la beatmap. Notez que osu!catch utilisera toujours le paramètre `Couleur`. | Liste déroulante | `Précision` |
-| `Taille de l'indicateur` | Configure la taille de l'indicateur de score. | Slider | `1x` |
+| `Assombrir l'arrière-plan` | Ajuste le niveau d'assombrissement appliqué à l'arrière-plan et au storyboard pendant le jeu (peut être réglé sur chaque beatmap indépendamment). | Curseur | `80%` |
+| `Don't change dim level during breaks` | Désactive l'éclaircissement du niveau d'obscurité pendant les pauses, rendant l'arrière-plan toujours invisible. | Case à cocher | `Désactivé` |
+| `Barre de progression` | Configure l'endroit et le mode d'affichage de la barre de progression de la musique. Voir ci-dessous pour plus de détails. | Liste déroulante | `En haut à droite (disque)` |
+| `Indicateur de performance` | Configure le compteur de précision apparaissant sous la beatmap. Notez qu'osu!catch utilisera toujours le paramètre `Couleur`. | Liste déroulante | `Précision` |
+| `Taille de l'indicateur` | Configure la taille de l'indicateur de score. | Curseur | `1x` |
 | `Touches du jeu toujours affichées` | Affiche la superposition de l'état des touches, même pendant un jeu normal. | Case à cocher | `Désactivé` |
-| `Affiche le cercle d'approche du premier élément en Hidden` | Lorsque vous jouez avec le mod "hidden", ne montre que le cercle d'approche de la première note. | Case à cocher | `Activé` |
+| `Affiche le cercle d'approche du premier élément en Hidden` | Lorsque vous jouez avec le mod Hidden, ne montre que le cercle d'approche de la première note. | Case à cocher | `Activé` |
 | `Vitesse de défilement osu!mania basées sur le BPM` | Ajuste la vitesse de défilement d'osu!mania en fonction du BPM de la beatmap. | Case à cocher | `Désactivé` |
-| `Se souvenir des vitesses de défilement sur chaque map osu!mania` | Se souvient de la vitesse de défilement que vous aviez définie par beatmap. | Case à cocher | `Désactivé` |
+| `Se souvenir des vitesses de défilement sur chaque map osu!mania` | Se souvient de la vitesse de défilement que vous aviez définie sur chaque beatmap indépendamment. | Case à cocher | `Désactivé` |
 
 ---
 
@@ -195,10 +191,10 @@ Si vous ouvrez la liste déroulante pour `Barre de progression`, les options sui
 
 | Nom | Description |
 | :-- | :-- |
-| `En haut à droite (disque)` | Utilise un diagramme circulaire pour montrer la durée restante avant la fin de la chanson. Ceci est vu à gauche de la précision. |
-| `En haut à droite (barre)` | Utilise une courte barre horizontale pour afficher le temps restant avant la fin de la chanson. Elle est affichée sous le score mais au-dessus de la précision. |
-| `En bas à droite` | Utilise une courte barre horizontale pour afficher le temps restant avant la fin de la chanson. Elle est visible dans le coin inférieur droit. |
-| `En bas (large)` | Utilise une longue barre horizontale pour afficher le temps restant avant la fin de la chanson. Elle est visible en bas. |
+| `En haut à droite (disque)` | Utilise un diagramme circulaire pour montrer la durée restante avant la fin de la musique. Ceci est vu à gauche de la précision. |
+| `En haut à droite (barre)` | Utilise une courte barre horizontale pour afficher le temps restant avant la fin de la musique. Elle est affichée sous le score mais au-dessus de la précision. |
+| `En bas à droite` | Utilise une courte barre horizontale pour afficher le temps restant avant la fin de la musique. Elle est visible dans le coin inférieur droit. |
+| `En bas (large)` | Utilise une longue barre horizontale pour afficher le temps restant avant la fin de la musique. Elle est visible tout en bas. |
 
 ---
 
@@ -248,8 +244,8 @@ Le volume principal, le volume de la musique et le volume des effets peuvent êt
 | `Décalage audio` | Le décalage (en millisecondes) que toutes les beatmaps utiliseront (en plus du décalage local). | Curseur | `0ms` |
 | `Démarrer l'assistant` | Ouvre l'assistant de décalage. | Bouton |  |
 
-- Pour plus de détails sur l'assistant de décalage, voir [Offset Wizard](/wiki/Client/Options/Offset_Wizard).
-- Pour plus de détails sur l'utilisation de l'assistant de décalage, voir [How to use Offset Wizard](/wiki/Guides/How_to_Use_the_Offset_Wizard).
+- Pour plus de détails sur l'assistant de décalage, voir [Assistant de décalage](/wiki/Client/Options/Offset_Wizard).
+- Pour plus de détails sur l'utilisation de l'assistant de décalage, voir [Comment utiliser l'assistant de décalage](/wiki/Guides/How_to_Use_the_Offset_Wizard).
 
 ## Skin
 
@@ -262,15 +258,15 @@ Cette section traite des questions relatives aux skins.
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Image de l'échantillon du skin` | Affiche divers éléments de gameplay du skin sélectionné. Cliquez pour faire défiler les différents ensembles d'éléments. | Bouton |  |
-| `Skin actuel :` | Change le skin. Les éléments du menu déroulant sont basés sur ce qui se trouve dans le dossier `osu!/Skins`. (Les noms sont basés sur le nom du dossier). | Liste déroulante | `Default` |
-| `Voir le skin dans une partie fictive` | Prévisualise le skin en jouant une beatmap aléatoire avec le mod auto. Le mode de jeu est déterminé par ce qui a été choisi dans le menu de sélection des beatmaps. | Bouton |  |
+| `Skin actuel :` | Change le skin. Les éléments du menu déroulant sont basés sur ce qui se trouve dans le dossier `osu!/Skins`. (Les noms sont basés sur les noms des dossiers). | Liste déroulante | `Default` |
+| `Voir le skin dans une partie fictive` | Prévisualise le skin en jouant une beatmap aléatoire avec le mod Auto. Le mode de jeu est déterminé par ce qui a été choisi dans le menu de sélection des beatmaps. | Bouton |  |
 | `Ouvrir le dossier du skin` | Ouvre le dossier du skin sélectionné. | Bouton |  |
 | `Exporter en .osk` | Exporte le skin actuel sous la forme d'un fichier `.osk` à partager. Une fois que votre client a terminé l'exportation, il ouvrira le répertoire contenant le fichier `.osk`. | Bouton |  |
 | `Ignorer les skins intégrés aux beatmaps` | Favorise le skin sélectionné par rapport au skin inclus dans les beatmaps. Ceci n'inclut pas les hitsounds (voir l'option suivante ci-dessous). | Case à cocher | `Désactivé` |
 | `Activer les bruitages du skin choisi` | Utilise toujours les hitsounds du skin sélectionné au lieu des hitsounds inclus dans les beatmaps. | Case à cocher | `Activé` |
 | `Toujours utiliser le skin Taiko (mode Taiko)` | Utilise les éléments de skin spécifiques à osu!taiko, s'ils sont fournis par le skin sélectionné. Voir [Skinning/osu!taiko](/wiki/Skinning/osu!taiko) pour plus de détails. | Case à cocher | `Désactivé` |
 | `Toujours utiliser le curseur du skin choisi` | Favorise le curseur du skin actuelle sur tous les curseurs fournis par les beatmaps. | Case à cocher | `Désactivé` |
-| `Taille du curseur` | Ajuste la taille du curseur. | Slider | `1x` |
+| `Taille du curseur` | Ajuste la taille du curseur. | Curseur | `1x` |
 | `Ajustement automatique de la taille du curseur` | Ajuste automatiquement la taille du curseur en fonction de la taille de l'approach circle d'une beatmap. | Case à cocher | `Désactivé` |
 | `Colorer les sliderballs en fonction de la couleur des sliders` | Les sliderballs utiliseront la couleur actuelle du combo (généralement transparente). Nécessite le support du skin. | Case à cocher | `Activé` |
 
@@ -289,8 +285,8 @@ Cette section traite des périphériques d'entrée.
 | `Faire correspondre la zone active de la tablette à la fenêtre d'osu!` | Limite les périphériques d'entrée à un positionnement absolu (par exemple, les tablettes à stylet) à la seule fenêtre du client. | Case à cocher | `Désactivé` |
 | `Confirmer le curseur :` | Empêche le curseur de la souris de quitter la fenêtre du client. Voir ci-dessous pour plus de détails. | Liste déroulante | `Seulement en plein écran` |
 | `Molette de la souris désactivée pendant les parties` | Désactive la molette de la souris pendant le jeu. L'utilisation de la molette de la souris peut modifier la valeur du volume principal. | Case à cocher | `Désactivé` |
-| `Boutons de la souris désactivés pendant les parties` | Désactive les boutons de la souris pendant le jeu. Ceci est utile pour les utilisateurs de clavier. | Case à cocher | `Désactivé` |
-| `Visualiser les clics` | Montre un effet d'ondulation subtil lorsque vous cliquez sur la souris. | Case à cocher | `Désactivé` |
+| `Boutons de la souris désactivés pendant les parties` | Désactive les boutons de la souris pendant le jeu. Ceci est utile pour les utilisateurs de claviers. | Case à cocher | `Désactivé` |
+| `Visualiser les clics` | Montre un effet d'ondulation subtile lorsque vous cliquez avec votre périphérique d'entré. | Case à cocher | `Désactivé` |
 
 - Lorsque `Contourner le pilote du dispositif de pointage` est activé, il affichera le nombre de rapports qu'il reçoit par seconde et la latence en millisecondes.
 - L'effet d'ondulation du curseur peut être déclenché en appuyant sur `M1` et `M2` pendant le jeu.
@@ -301,16 +297,16 @@ Si vous ouvrez la liste déroulante pour `Confirmer le curseur :`, les options s
 
 | Nom | Description |
 | :-- | :-- |
-| `Jamais` | N'empêche jamais la souris de quitter le client. |
-| `Seulement en plein écran` | Empêche seulement la souris de quitter le client en plein écran (cela inclut également le `Letterboxing`). |
-| `Toujours` | Empêche toujours la souris de quitter le client, quelle que soit la résolution. |
+| `Jamais` | N'empêche jamais le curseur de quitter le client. |
+| `Seulement en plein écran` | Empêche seulement le curseur de quitter le client en plein écran (cela inclut également le `Letterboxing`). |
+| `Toujours` | Empêche toujours le curseur de quitter le client, quelle que soit la résolution. |
 
 ### Clavier
 
 | Nom | Description | Type |
 | :-- | :-- | :-- |
 | `Configurer les touches` | Affiche une boîte de dialogue qui vous permet de voir ou de modifier la configuration des touches du clavier. Voir [Configuration des touches](/wiki/Client/Options/Keyboard_bindings) pour plus de détails. | Bouton |
-| `Paramètres osu!mania` | Affiche une boîte de dialogue qui vous permet de voir ou de modifier la configuration des touches pour osu!mania. Voir [osu!mania layout](/wiki/Game_mode/osu!mania) pour plus de détails. | Bouton |
+| `Paramètres osu!mania` | Affiche une boîte de dialogue qui vous permet de voir ou de modifier la configuration des touches pour osu!mania. Voir [Configuration des touches sous osu!mania](/wiki/Game_mode/osu!mania) pour plus de détails. | Bouton |
 
 ### Divers
 
@@ -334,7 +330,7 @@ Ces options n'ont d'effet que lorsque vous travaillez dans l'éditeur de beatmap
 | `Vidéos` | Lit la vidéo d'arrière-plan de la beatmap dans l'éditeur. | Case à cocher | `Désactivé` |
 | `Toujours utiliser le skin par défaut` | Utilise le skin par défaut d'osu! dans l'éditeur malgré les paramètres du skin actuel. | Case à cocher | `Désactivé` |
 | `Sliders progressifs` | Active les sliders progressifs dans l'éditeur. | Case à cocher | `Activé` |
-| `Animations des élements comme dans le jeu` | Active l'animations des élements dans l'éditeur. | Case à cocher | `Désactivé` |
+| `Animations des éléments comme dans le jeu` | Active l'animations des éléments dans l'éditeur. | Case à cocher | `Désactivé` |
 | `"Follow points"` | Active les follow points dans l'éditeur. | Case à cocher | `Activé` |
 | `Empilage des notes` | Empile les cercles comme en jeu. | Case à cocher | `Activé` |
 
@@ -367,12 +363,12 @@ Cette section concerne le tchat, les spectateurs, le multi, et osu!direct.
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
 | `Discord Rich Presence` | Fournit des [données de présence riches à Discord](/wiki/Guides/Discord_Rich_Presence). | Case à cocher | `Activé` |
-| `Intégrer au status Yahoo! Messenger` | Votre messager Yahoo ! affichera la chanson que vous êtes en train de lire ou d'écouter. Ce paramètre doit être défini sur le site Web. | Case à cocher | `Désactivé` |
-| `Intégrer au messages perso MSN` | Votre Windows Live Messenger affichera la chanson que vous êtes en train de jouer ou d'écouter. | Case à cocher | `Désactivé` |
+| `Intégrer au status Yahoo! Messenger` | Votre messager Yahoo! affichera la musique que vous êtes en train de lire ou d'écouter. Ce paramètre doit être défini sur le site Web. | Case à cocher | `Désactivé` |
+| `Intégrer au messages perso MSN` | Votre Windows Live Messenger affichera la musique que vous êtes en train de jouer ou d'écouter. | Case à cocher | `Désactivé` |
 | `Téléchargements osu!direct automatiques` | Pour les [osu!supporter](/wiki/osu!supporter) uniquement. Lorsque vous êtes spectateur ou en multijoueur, la beatmap sera téléchargé automatiquement. | Case à cocher | `Activé` |
 | `Ne pas télécharger les vidéos` | Pour les [osu!supporter](/wiki/osu!supporter) uniquement. Les téléchargements d'osu!direct seront limités aux versions non-vidéo des beatmaps. | Case à cocher | `Désactivé` |
 
-### Chat
+### Tchat
 
 | Nom | Description | Type | Par défaut |
 | :-- | :-- | :-- | :-- |
@@ -406,7 +402,7 @@ En bas, le numéro de la version s'affiche. En cliquant dessus, vous ouvrirez [l
 
 Voir quelle version de build le client a actuellement et quel type de mises à jour de build le client reçoit. En cliquant sur ce lien, vous serez dirigé vers les notes de version en utilisant votre navigateur préféré.
 
-Les builds sont versionnés en utilisant ce schéma :
+Les builds utilisant ce schéma afin de connaître différentes informations :
 
 ```
 b{YYYY}{MM}{DD}.{revision}{type}
@@ -425,11 +421,11 @@ b{YYYY}{MM}{DD}.{revision}{type}
 - Si vous saisissez un nom d'utilisateur mais laissez la zone de texte du mot de passe vide, osu! utilisera ce nom lors de la sauvegarde locale du score.
 - L'ouverture de la barre latérale des options déclenchera automatiquement la fonction de `osu! est à jour !` (il commencera à vérifier les mises à jour).
 - L'option `Seasonal backgrounds` a été ajoutée après que des commentaires positifs aient été donnés à l'équipe osu!dev.
-  - Plus de détails : [modification du fond du menu principal](https://osu.ppy.sh/community/forums/topics/606931)
+  - Plus de détails : [main menu background changes](https://osu.ppy.sh/community/forums/topics/606931)
 
 ### Histoire
 
 - L'ancien écran d'options était un véritable écran avec des onglets, des boutons et un fond bleu pâle foncé.
-- L'ancien écran d'options comportait également un écran de sélection de skin qui vous permet également de prévisualiser la lecture en direct d'une beatmap dans osu!
+- L'ancien écran d'options comportait également un écran de sélection du skin qui vous permet également de prévisualiser la lecture en direct d'une beatmap dans osu!
   - Après que l'écran des options a été déplacé vers une barre latérale, cet écran était toujours accessible en ouvrant un fichier skin.
   - Cet accès a été supprimé par la suite après l'apparition des aperçus de skins et des fonctions d'aperçu en direct.

--- a/wiki/Client/Options/fr.md
+++ b/wiki/Client/Options/fr.md
@@ -331,7 +331,7 @@ Ces options n'ont d'effet que lorsque vous travaillez dans l'éditeur de beatmap
 | `Toujours utiliser le skin par défaut` | Utilise le skin par défaut d'osu! dans l'éditeur malgré les paramètres du skin actuel. | Case à cocher | `Désactivé` |
 | `Sliders progressifs` | Active les sliders progressifs dans l'éditeur. | Case à cocher | `Activé` |
 | `Animations des éléments comme dans le jeu` | Active l'animations des éléments dans l'éditeur. | Case à cocher | `Désactivé` |
-| `"Follow points"` | Active les follow points dans l'éditeur. | Case à cocher | `Activé` |
+| `Follow points` | Active les follow points dans l'éditeur. | Case à cocher | `Activé` |
 | `Empilage des notes` | Empile les cercles comme en jeu. | Case à cocher | `Activé` |
 
 Ces options peuvent être écrasées manuellement en utilisant le menu `Affichage` dans l'éditeur de beatmaps.


### PR DESCRIPTION
Proposal to cleanup the French translation of the wiki page `Client\Options`.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)