### PR TITLE
Minor formatting fix for `Tournaments/Official_support`

### DIFF
--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -17,7 +17,7 @@ Officially supported tournaments have access to:
 Community-run tournaments which abide by the following hard criteria are eligible for support:
 
 - The tournament series must run no more than four times per year.
-- The tournament must operate on a Round of 16 double-elimination format at a minimum, OR have at least 64 players (or 16 teams) participating. Larger scales and formats are permitted.
+- The tournament must operate on a Round of 16 double-elimination format at a minimum, **OR**, have at least 64 players (or 16 teams) participating. Larger scales and formats are permitted.
 - The tournament is organised and run by an *experienced team of accomplished and reputable staff**¹*** , **OR**, the tournament *has been run at least once before without receiving rewards*.
 - Staff members must not participate in the tournament themselves at any point, and registered players are unable to later assist as staff either. For our definition on "staff", please refer to the [FAQ](#what-is-considered-staff).
 - The forum thread for the tournament **MUST** contain a clearly visible link in a normal-sized font to the [tournament reports form](https://pif.ephemeral.ink/tournament-reports) as the very last content of the original post.


### PR DESCRIPTION
OR is now bold