### PR TITLE
Fix consistency on terms used (users/players)

### DIFF
--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -183,6 +183,8 @@ We have historically had issues where unscrupulous organisers have geared tourna
 
 No. Players who have been eliminated from the tournament/contest may not be enlisted as staff or assist in any organisational capacity with the sole exception of setting replays for mappool showcases. They can, however, be enlisted as a helper.
 
+### If a user has not yet played any matches, can they join the staff? {#no-play-join-staff}
+
 A registrant who has passed screening but has not been scheduled for any matches **AND** has not participated in any gameplay (including qualifiers) is not yet considered a player/participant of the tournament, and may therefore still be enlisted as staff.
 
 ### What should I do if a player in my tournament gets restricted? {#player-restriction}

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -107,8 +107,9 @@ For team-based tournaments, the expected format is:
 
 ```csv
 User1,Team1,1234567
-User2,Team2,1234567
-User3,Team3,1234567
+User2,Team1,1234567
+User3,Team2,1234567
+User4,Team2,1234567
 ```
 
 Once screening concludes, the account support team will provide a list of any users who failed screening and are not considered eligible for tournament play, without providing specific reasoning. Individual users who are unhappy with their screening outcome should be told to consult [accounts@ppy.sh](mailto:accounts@ppy.sh) via email.

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -8,7 +8,7 @@ This article was last updated on January 9, 2022. For any queries and clarificat
 
 Officially supported tournaments have access to:
 
-- A dedicated [screening process](#tournament-screening) to prevent players with serious integrity infringements (cheating, multi-accounting, tournament bans) from playing.
+- A dedicated [screening process](#tournament-screening) to prevent users with serious integrity infringements (cheating, multi-accounting, tournament bans) from playing.
 - [Profile badge prizes](#profile-badges) for first-place winners.
 - Potential consideration for a [main-menu banner advertisement](#requesting-main-menu-banner-support) during major matches
 
@@ -19,10 +19,10 @@ Community-run tournaments which abide by the following hard criteria are eligibl
 - The tournament series must run no more than four times per year.
 - The tournament must operate on a Round of 16 double-elimination format at a minimum, **OR**, have at least 64 players (or 16 teams) participating. Larger scales and formats are permitted.
 - The tournament is organised and run by an *experienced team of accomplished and reputable staff**¹*** , **OR**, the tournament *has been run at least once before without receiving rewards*.
-- Staff members must not participate in the tournament themselves at any point, and registered players are unable to later assist as staff either. For our definition on "staff", please refer to the [FAQ](#what-is-considered-staff).
+- Staff members must not participate in the tournament themselves at any point, and players are unable to later assist as staff either. For our definition on "staff", please refer to the [FAQ](#what-is-considered-staff).
 - The forum thread for the tournament **MUST** contain a clearly visible link in a normal-sized font to the [tournament reports form](https://pif.ephemeral.ink/tournament-reports) as the very last content of the original post.
   - `https://pif.ephemeral.ink/tournament-reports`
-  - This report form is overseen by the [Tournament Committee](/wiki/People/Tournament_Committee). We encourage all users—participants and staff alike—to make use of this form where necessary. 
+  - This report form is overseen by the [Tournament Committee](/wiki/People/Tournament_Committee). We encourage all users—players and staff alike—to make use of this form where necessary. 
 
 **¹**: An "experienced" staff member is loosely defined as someone who has contributed significantly to the successful running of at least **three** badge-receiving tournaments beforehand, or has been a part of an official World Cup volunteer team for any game mode. This may vary at the discretion of the account support team.
 
@@ -40,7 +40,7 @@ If your tournament satisfies the [eligibility criteria](#eligibility), you can m
   - Previous iterations of the same tournament series (only where applicable).
 - Separate lists for:
   - The staff and helpers involved in running the tournament (see [FAQ](#what-is-considered-staff)).
-  - All players who have registered for the tournament (see [tournament screening](#tournament-screening)).
+  - The users who have registered to participate in the tournament (see [tournament screening](#tournament-screening)).
 
 Once we receive your request, the account support team will return a list of users who are ineligible to participate in tournaments. Please allow ample time for a response. We will try our best to handle all requests within a week, but we occasionally have large spikes in workload that can make this impossible.
 
@@ -61,8 +61,8 @@ In addition, all promotional material or any services associated with a tourname
 
 **The tournament must also abide by the following practices throughout:**
 
-- All players must be screened by the account support team before play commences**²**. See [tournament screening](#tournament-screening) for more details.
-- If a player satisfies the sign-up criteria (if any), the tournament must not prevent players who pass the screening from participating without both ample evidence presented publicly against them and the approval of the account support team.
+- All registrants must be screened by the account support team before play commences**²**. See [tournament screening](#tournament-screening) for more details.
+- If a user satisfies the sign-up criteria (if any), the tournament must not prevent those who pass the screening from participating without both ample evidence presented publicly against them and the approval of the account support team.
   - This includes preventing users who are perceived to be "sandbagging" from play. Should an organiser have valid concerns about the presence of such players affecting the competitive integrity of their tournament, they may raise the issue to the [Tournament Committee](/wiki/People/Tournament_Committee) for a case-by-case review using the [tournament reports form](https://pif.ephemeral.ink/tournament-reports).
 - A dedicated referee must be present during every match. Players cannot "self-ref". 
 - All multiplayer matches relevant to the tournament must be created with the `!mp make` command, so that they do not expire. The results must be recorded and made publicly available on the original tournament forum post in a clear and accessible format.
@@ -79,7 +79,7 @@ Once the tournament has concluded, the tournament organisers will need to submit
 
 Tournament organisers are expected to ensure that their tournaments run smoothly and with minimal disruption where possible.
 
-Users under an active tournament ban are expected to disclose their tournament ban status to any officially supported tournament they intend to help with. They may be enlisted as [helpers](#what-is-considered-staff) at the host's discretion, but we encourage careful consideration of such choices as said individuals have already infringed upon the rules once (or more). They may not act as [staff](#what-is-considered-staff) UNLESS the host requests an exemption for them when sending in the player list for screening. The account support team will then assess these on a case-by-case basis with the user's history in mind.
+Users under an active tournament ban are expected to disclose their tournament ban status to any officially supported tournament they intend to help with. They may be enlisted as [helpers](#what-is-considered-staff) at the host's discretion, but we encourage careful consideration of such choices as said individuals have already infringed upon the rules once (or more). They may not act as [staff](#what-is-considered-staff) UNLESS the host requests an exemption for them when sending in their initial request for support. The account support team will then assess these on a case-by-case basis with the user's history in mind.
 
 ### Players
 
@@ -91,28 +91,27 @@ At the account support team's discretion, offending players may be issued timed 
 
 ### Tournament screening
 
-A major part of being an officially supported tournament is access to the screening process. Similar to the "security checks" undertaken by all World Cup players, screening helps prevent people with recent serious infringements or tournament bans from disrupting play.
+A major part of being an officially supported tournament is access to the screening process. Similar to the "security checks" undertaken by all World Cup players, screening helps prevent users with recent serious infringements or tournament bans from disrupting play.
 
-Tournament organisers will be expected to provide a comma-separated list (or spreadsheet) including player usernames and user IDs. If the tournament is team-based, this list must reflect the grouping of players in their teams of play, complete with any team name or other identifying marker.
+Tournament organisers will be expected to provide a comma-separated list (or spreadsheet) including usernames and user IDs. If the tournament is team-based, this list must reflect the grouping of users in their teams of play, complete with any team name or other identifying marker.
 
 The comma-separated list should look like this:
 
 ```csv
-Player1,1234567
-Player2,1234567
-Player3,1234567
+User1,1234567
+User2,1234567
+User3,1234567
 ```
 
 For team-based tournaments, the expected format is:
 
 ```csv
-Player1,Team1,1234567
-Player2,Team1,1234567
-Player3,Team2,1234567
-Player4,Team2,1234567
+User1,Team1,1234567
+User2,Team2,1234567
+User3,Team3,1234567
 ```
 
-Once screening concludes, the account support team will provide a list of any players from your tournament who failed screening and are not considered eligible for tournament play, without providing specific reasoning. Individual players who are unhappy with their screening outcome should be told to consult [accounts@ppy.sh](mailto:accounts@ppy.sh) via email.
+Once screening concludes, the account support team will provide a list of any users who failed screening and are not considered eligible for tournament play, without providing specific reasoning. Individual users who are unhappy with their screening outcome should be told to consult [accounts@ppy.sh](mailto:accounts@ppy.sh) via email.
 
 **Allowing users that have failed screening to play in your tournament will result in an immediate withdrawal of support and will result in future requests for support to be denied.**
 
@@ -181,7 +180,9 @@ We have historically had issues where unscrupulous organisers have geared tourna
 
 ### Can a player who has been eliminated from play in my tournament join the staff after the fact and not cause problems? {#player-join-staff}
 
-No. Participants who have been eliminated from the tournament/contest may not be enlisted as staff or assist in any organisational capacity **with the sole exception** of setting replays for mappool showcases. They can, however, be enlisted as a helper.
+No. Players who have been eliminated from the tournament/contest may not be enlisted as staff or assist in any organisational capacity with the sole exception of setting replays for mappool showcases. They can, however, be enlisted as a helper.
+
+A user who has not participated in any gameplay (including qualifiers) **AND** has not been scheduled for any matches does not qualify as a player/participant in our eyes, and therefore may be enlisted as staff (they have not been "eliminated" per se).
 
 ### What should I do if a player in my tournament gets restricted? {#player-restriction}
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -182,7 +182,7 @@ We have historically had issues where unscrupulous organisers have geared tourna
 
 No. Players who have been eliminated from the tournament/contest may not be enlisted as staff or assist in any organisational capacity with the sole exception of setting replays for mappool showcases. They can, however, be enlisted as a helper.
 
-A user who has not participated in any gameplay (including qualifiers) **AND** has not been scheduled for any matches does not qualify as a player/participant in our eyes, and therefore may be enlisted as staff (they have not been "eliminated" per se).
+A user who has passed screening but has not participated in any gameplay (including qualifiers) **AND** has not been scheduled for any matches does not qualify as a player/participant in our eyes, and therefore may be enlisted as staff (they have not been "eliminated" per se).
 
 ### What should I do if a player in my tournament gets restricted? {#player-restriction}
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -183,7 +183,7 @@ We have historically had issues where unscrupulous organisers have geared tourna
 
 No. Players who have been eliminated from the tournament/contest may not be enlisted as staff or assist in any organisational capacity with the sole exception of setting replays for mappool showcases. They can, however, be enlisted as a helper.
 
-A user who has passed screening but has not participated in any gameplay (including qualifiers) **AND** has not been scheduled for any matches does not qualify as a player/participant in our eyes, and therefore may be enlisted as staff (they have not been "eliminated" per se).
+A registrant who has passed screening but has not been scheduled for any matches **AND** has not participated in any gameplay (including qualifiers) is not yet considered a player/participant of the tournament, and may therefore still be enlisted as staff.
 
 ### What should I do if a player in my tournament gets restricted? {#player-restriction}
 


### PR DESCRIPTION
Add consistency to the use of "Users" and "players/participants"

user = user
player/participant = a user who is confirmed playing in the tournament.