### PR TITLE
Clarify conditions for scorebar-ki.png et al

### DIFF
--- a/wiki/Skinning/Interface/en.md
+++ b/wiki/Skinning/Interface/en.md
@@ -1159,6 +1159,7 @@ Notes:
 - This element represents the "passing" zone.
 - This element is not used in [osu!mania](/wiki/Game_mode/osu!mania).
 - Y-position at 16; x-position is placed at the end of the cropped `scorebar-colour.png`
+- A `scorebar-colour.png` is required for this element to appear.
 
 ---
 
@@ -1176,6 +1177,7 @@ Notes:
 - this element represents the "warning" zone
 - This element is not used in [osu!mania](/wiki/Game_mode/osu!mania)
 - Y-position at 16; x-position is placed at the end of the cropped `scorebar-colour.png`
+- A `scorebar-colour.png` is required for this element to appear.
 
 ---
 
@@ -1193,6 +1195,7 @@ Notes:
 - This element represents the "critical" zone.
 - This element is not used in [osu!mania](/wiki/Game_mode/osu!mania)
 - Y-position at 16; x-position is placed at the end of the cropped `scorebar-colour.png`
+- A `scorebar-colour.png` is required for this element to appear.
 
 ---
 

--- a/wiki/Skinning/Interface/fr.md
+++ b/wiki/Skinning/Interface/fr.md
@@ -1160,6 +1160,7 @@ Notes :
 - Cet élément représente la zone de "dépassement".
 - Cet élément n'est pas utilisé dans [osu!mania](/wiki/Game_mode/osu!mania).
 - Position Y à 16 ; la position x est placée à la fin de `scorebar-colour.png` recadrée.
+- Un fichier `scorebar-colour.png` est nécessaire pour que cet élément apparaisse.
 
 ---
 
@@ -1177,6 +1178,7 @@ Notes :
 - cet élément représente la zone "d'alerte".
 - Cet élément n'est pas utilisé dans [osu!mania](/wiki/Game_mode/osu!mania).
 - Position Y à 16 ; la position x est placée à la fin de la `scorebar-colour.png` recadrée.
+- Un fichier `scorebar-colour.png` est nécessaire pour que cet élément apparaisse.
 
 ---
 
@@ -1194,6 +1196,7 @@ Notes :
 - Cet élément représente la zone "critique".
 - Cet élément n'est pas utilisé dans [osu!mania](/wiki/Game_mode/osu!mania).
 - Position Y à 16 ; la position x est placée à la fin de la `scorebar-colour.png` recadrée.
+- Un fichier `scorebar-colour.png` est nécessaire pour que cet élément apparaisse.
 
 ---
 


### PR DESCRIPTION
The wiki isn't clear about `scorebar-colour.png` being required for `scorebar-ki.png`, `scorebar-kidanger.png` and `scorebar-kidanger2.png` to appear, as indicated in [this](https://osu.ppy.sh/community/forums/topics/1494293?n=9) forum reply.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)