### PR TITLE
[FR] Cleanup `Community\osu!dev_Discord_server`, `History_of_osu!\2014`, `2015`, `Online_rankings\osu!`, `osu!catch`, `osu!mania`, `osu!taiko`

### DIFF
--- a/wiki/Community/osu!dev_Discord_server/fr.md
+++ b/wiki/Community/osu!dev_Discord_server/fr.md
@@ -2,12 +2,11 @@
 tags:
   - development
   - développement
-no_native_review: true
 ---
 
 # Serveur Discord osu!dev
 
-**osu!dev** est le serveur [Discord](https://discordapp.com) officiel pour travailler sur les projets open-source et communautaires relatifs à osu!. C'est le lieu principal pour contribuer au développement d'osu! et entrer en contact avec [le staff d'osu!](/wiki/People/The_Team).
+**osu!dev** est le serveur [Discord](https://discordapp.com) officiel pour travailler sur les projets open-source et communautaires relatifs à osu!. C'est le lieu principal pour contribuer au développement d'osu! et entrer en contact avec [l'équipe d'osu!](/wiki/People/The_Team).
 
 Le lien d'invitation permanent est <https://discord.gg/ppy>.
 
@@ -31,7 +30,7 @@ Chaque partie du développement possède son propre canal de discussion :
 | [Beatmap Spotlights](/wiki/Beatmap_Spotlights) | `#osu-spotlights` |
 | [osu! wiki](https://github.com/ppy/osu-wiki) | `#osu-wiki` |
 | [Project Loved](/wiki/Community/Project_Loved) | `#osu-loved` |
-| [Official tournament support](/wiki/Tournaments/Official_support) | `#tournaments` |
+| [Support officiel des tournois](/wiki/Tournaments/Official_support) | `#tournaments` |
 | [osu! community meetings](/wiki/Community/osu!_community_meetings) | `#community-meetings` |
 | Discussions sur le [Modding](/wiki/Modding)/[Réunions de la NAT](/wiki/Modding/NAT_meetings) | `#modding` |
 | [Mappers' Guild](/wiki/Community/Mappers_Guild) | `#mappers-guild` |

--- a/wiki/History_of_osu!/2014/fr.md
+++ b/wiki/History_of_osu!/2014/fr.md
@@ -1,18 +1,14 @@
----
-no_native_review: true
----
-
 # L'histoire d'osu! en 2014
 
 ## Janvier
 
-L'ensemble du système des [points de performance (pp)](/wiki/Performance_points) a été complètement désactivé pour maintenance le 20 janvier 2014 en raison d'erreurs de calcul survenues au cours des mois précédents \[1\]. Cette désactivation a ensuite été suivie d'une annonce, le 26 janvier 2014, détaillant une refonte complète du système de pp, qui a été mise en service le lendemain \[2,3\]. Le nouveau système a été conçu et mis en œuvre par [Tom94](https://osu.ppy.sh/users/1857058) et visait à baser les scores de pp sur une nouvelle "valeur de difficulté" (distincte du [classement par étoiles](/wiki/Beatmapping/Star_rating)) qui était déterminée pour chaque combinaison de [beatmap](/wiki/Beatmap) et de [mod](/wiki/Game_modifier) dans le jeu \[1\]. En conséquence, l'ancien système de pp a été renommé "ppv1" et le nouveau système a été nommé "ppv2".
+L'ensemble du système des [points de performance (pp)](/wiki/Performance_points) a été complètement désactivé pour une maintenance le 20 janvier 2014 en raison d'erreurs de calcul survenues au cours des mois précédents \[1\]. Cette désactivation a ensuite été suivie d'une annonce, le 26 janvier 2014, détaillant une refonte complète du système de pp, qui a été mise en service le lendemain \[2,3\]. Le nouveau système a été conçu et mis en œuvre par [Tom94](https://osu.ppy.sh/users/1857058) et visait à baser les scores de pp sur une nouvelle "valeur de difficulté" (distincte du [star rating](/wiki/Beatmapping/Star_rating)) qui était déterminée pour chaque combinaison de [beatmap](/wiki/Beatmap) et de [mod](/wiki/Game_modifier) dans le jeu \[1\]. En conséquence, l'ancien système de pp a été renommé "ppv1" et le nouveau système a été nommé "ppv2".
 
 ## Mars
 
-Le 1er mars 2014, le système de points de performance remanié par Tom94 quelques mois auparavant était prêt à être mis en ligne pour [osu!taiko](/wiki/Game_mode/osu!taiko), [osu!catch](/wiki/Game_mode/osu!catch) et [osu!mania](/wiki/Game_mode/osu!mania) en tant que système de classement officiel pour ces modes, tout en rappelant que le système actuel n'était pas encore terminé à 100 % et qu'il fallait encore recueillir les commentaires des joueurs \[4\].
+Le 1er mars 2014, le système des points de performance remanié par Tom94 quelques mois auparavant était prêt à être mis en ligne pour [osu!taiko](/wiki/Game_mode/osu!taiko), [osu!catch](/wiki/Game_mode/osu!catch) et [osu!mania](/wiki/Game_mode/osu!mania) en tant que système de classement officiel pour ces modes, tout en rappelant que le système actuel n'était pas encore terminé à 100 % et qu'il fallait encore recueillir les commentaires des joueurs \[4\].
 
-Comme les éléments de [skinning](/wiki/Skinning) se sont développés, l'élément `playfield.jpg` a été déprécié et remplacé par un nouvel élément générique qui n'est pas modifiable. `playfield.jpg` était un élément qui permettait aux skinneurs d'utiliser n'importe quelle image comme arrière-plan par défaut d'une beatmap si aucune n'était fournie. Cette fonctionnalité a été apportée plus tard sous la forme de `menu-background.jpg`, qui modifiait à la fois l'écran principal et les fonds par défaut du champ de jeu \[5,6\].
+Comme les éléments de [skinning](/wiki/Skinning) se sont développés, l'élément `playfield.jpg` a été déprécié et remplacé par un nouvel élément générique qui n'est pas modifiable. `playfield.jpg` était un élément qui permettait aux skinneurs d'utiliser n'importe quelle image comme arrière-plan par défaut d'une beatmap si aucune n'était fournie. Cette fonctionnalité a été apportée plus tard sous la forme de `menu-background.jpg`, qui modifiait à la fois l'écran principal et les arrière-plan par défaut du terrain de jeu \[5,6\].
 
 ![](img/2014-03_01.jpg "Arrière-plan par défaut pour les beatmaps sans arrière-plan spécifié")
 
@@ -30,9 +26,9 @@ Le 21 août 2014, un [newspost](https://osu.ppy.sh/home/news/2014-08-21-restruct
 
 ## Octobre
 
-Le mois d'octobre a apporté une poignée de nouveaux ajouts au jeu de base, notamment un nouvel écran de connexion et un nouveau système de défilement dans [osu!mania](/wiki/Game_mode/osu!mania) basé sur le BPM de la beatmap, de nouvelles séquences d'intro et d'outro, et une chanson thème personnalisée qui devait être jouée au démarrage (par opposition à une beatmap aléatoire).
+Le mois d'octobre a apporté une poignée de nouveaux ajouts au jeu de base, notamment un nouvel écran de connexion et un nouveau système de défilement dans [osu!mania](/wiki/Game_mode/osu!mania) basé sur le BPM de la beatmap, de nouvelles séquences d'intro et d'outro, et une chanson de thème personnalisée qui devait être jouée au démarrage (par opposition à une beatmap aléatoire).
 
-De plus, [peppy](https://osu.ppy.sh/users/2) a également publié la version "osu!test" (désormais connue sous le nom de "Cutting Edge") pour tous les joueurs, et non plus seulement pour les [osu!supporters](https://osu.ppy.sh/home/support), afin de faciliter les efforts de débogage.
+De plus, [peppy](https://osu.ppy.sh/users/2) a également publié la version "osu!test" (désormais connue sous le nom de "Cutting Edge") pour tous les joueurs, et non plus seulement pour les [osu!supporter](https://osu.ppy.sh/home/support), afin de faciliter les efforts de débogage.
 
 ## Références
 

--- a/wiki/History_of_osu!/2015/fr.md
+++ b/wiki/History_of_osu!/2015/fr.md
@@ -4,7 +4,6 @@ tags:
   - 2015
   - legacy
   - histoire
-no_native_review: true
 ---
 
 # L'histoire d'osu! en 2015
@@ -21,39 +20,39 @@ Les tout premiers autocollants osu! Beatmap Blueprint ont été ajoutés à l'[o
 
 La prise en charge de la [télécommande Wii](https://en.wikipedia.org/wiki/Wii_Remote) a été ajoutée pour [osu!taiko](/wiki/Game_mode/osu!taiko) le 26 mars 2015 [[5]][r].
 
-Le 31 mars 2015, les [osu!coins](/wiki/History_of_osu!/April_Fools#osu!coins) ont été ajoutées comme monnaie de jeu pour osu! dans le cadre d'une blague de poisson d'avril. Ces pièces ont été créées pour parodier l'utilisation courante de la monnaie du jeu et des [microtransactions](https://en.wikipedia.org/wiki/Microtransaction) dans les jeux mobiles [free-to-play](https://fr.wikipedia.org/wiki/Free-to-play). Les pièces osu!ont été rapidement retirées le jour suivant.
+Le 31 mars 2015, les [osu!coins](/wiki/History_of_osu!/April_Fools#osu!coins) ont été ajoutées comme monnaie de jeu pour osu! dans le cadre d'une blague de poisson d'avril. Ces pièces ont été créées pour parodier l'utilisation courante de la monnaie du jeu et des [microtransactions](https://en.wikipedia.org/wiki/Microtransaction) dans les jeux mobiles [free-to-play](https://fr.wikipedia.org/wiki/Free-to-play). Les osu!coins ont été rapidement retirées le jour suivant.
 
 ## Avril
 
 Le canal `#balkan` a été réintroduite dans le jeu suite à une [demande de fonctionnalité](https://osu.ppy.sh/community/forums/topics/152009&start=0) le 2 avril 2015 [[6,7]][r].
 
-Le [mod Co-op](/wiki/Game_modifier/Co-op) est devenu un mod non classable le 6 avril 2015 [[8]][r].
+Le mod [Co-op](/wiki/Game_modifier/Co-op) est devenu un mod non classable le 6 avril 2015 [[8]][r].
 
-9K a été rendu classable après avoir reçu un support d'utilisation approprié dans l'éditeur le 30 avril 2015 [[9]][r].
+Le mod 9K a été rendu classable après avoir reçu un support d'utilisation approprié dans l'éditeur le 30 avril 2015 [[9]][r].
 
 ## Mai
 
-*Remarque : Le [post de forum](https://osu.ppy.sh/community/forums/topics/334994) qui annonçait la nouvelle du nouveau système de classement a été publié le 4 juin 2015, bien que l'ancien système ait en fait été entièrement déprécié le 1er mai 2015, et que la mise en œuvre complète du nouveau système devait encore être disponible pour le public à la fin de 2015.*
+*Remarque : Le [post de forum](https://osu.ppy.sh/community/forums/topics/334994) qui annonçait le nouveau système de classement a été publié le 4 juin 2015, bien que l'ancien système ait en fait été entièrement déprécié le 1er mai 2015, et que la mise en œuvre complète du nouveau système devait encore être disponible pour le public à la fin de l'année 2015.*
 
-L'ancien classement Beatmap Nominator (BN) a été entièrement déprécié le 1er mai 2015, et remplacé par un nouveau classement en temps réel. Ce nouveau classement a conservé l'objectif initial du précédent, bien qu'il soit axé sur le défi et la collaboration plutôt que sur la performance individuelle sur une période donnée. L'accueil du public à l'égard de ce nouveau changement a été globalement positif, même si de nombreux utilisateurs ont fait remarquer que le nouveau système était déroutant [[10,11]][r].
+L'ancien classement des Beatmap Nominator (BN) a été entièrement déprécié le 1er mai 2015, et remplacé par un nouveau classement en temps réel. Ce nouveau classement a conservé l'objectif initial du précédent, bien qu'il soit axé sur le défi et la collaboration plutôt que sur la performance individuelle sur une période donnée. L'accueil du public à l'égard de ce nouveau changement a été globalement positif, même si de nombreux utilisateurs ont fait remarquer que le nouveau système était déroutant [[10,11]][r].
 
 Parmi les changements et les annonces faites autour du classement des beatmaps, [un changement a été apporté au processus de classement](https://osu.ppy.sh/community/forums/topics/325973) le 5 mai 2015 qui a permis aux joueurs de contester les disqualifications faites par la Quality Assurance Team (QAT), en raison de l'absence de tout moyen de contester les problèmes que la QAT peut soulever. Le nouveau changement a permis de soumettre un formulaire en cas de litige, où une décision finale pourrait être prise concernant une beatmap et s'il elle est prête à être classée [[12]][r].
 
-La [chaîne YouTube osu!news](https://www.youtube.com/channel/UCZKQIqv9O2tddMNUMAxWaqQ) a téléchargé sa [première vidéo](https://www.youtube.com/watch?v=KQbudVxEjr8) au public le 8 mai 2015. La chaîne était gérée par différents membres de la communauté et visait à créer des vidéos sur les vitrines de skin, les tournois, le mapping, les concours et d'autres nouvelles de la communauté [[12,13]][r].
+La [chaîne YouTube osu!news](https://www.youtube.com/channel/UCZKQIqv9O2tddMNUMAxWaqQ) a téléchargé sa [première vidéo](https://www.youtube.com/watch?v=KQbudVxEjr8) au public le 8 mai 2015. La chaîne était gérée par différents membres de la communauté et visait à créer des vidéos sur les skins, les tournois, le mapping, les concours et d'autres nouvelles de la communauté [[12,13]][r].
 
-Le osu!keyboard (également connu sous le nom de "osu! 'nono' keyboard") a été ajouté à l'osu!store le 30 mai 2015, se détaillant pour environ 40 $ au lancement. Annoncés initialement dans un [tweet de peppy](https://twitter.com/ppy/status/603797988742336512) le 28 mai 2015, il n'y avait que 100 claviers disponibles au lancement, et ils ressemblaient plus à un pavé numérique qu'à un clavier de taille normale [[14,15]][r].
+Le osu!keyboard (également connu sous le nom de "osu! 'nono' keyboard") a été ajouté à l'osu!store le 30 mai 2015, pour environ 40 $ au lancement. Annoncés initialement dans un [tweet de peppy](https://twitter.com/ppy/status/603797988742336512) le 28 mai 2015, il n'y avait que 100 claviers disponibles au lancement, et ils ressemblaient plus à un pavé numérique qu'à un clavier de taille normale [[14,15]][r].
 
-![](img/osu-keyboard.jpg "Le osu! keyboard teasé dans un tweet de peppy")
+![](img/osu-keyboard.jpg "Le osu! keyboard tease dans un tweet de peppy")
 
 ## Juin
 
-La mise en œuvre du système de changement de nom d'utilisateur dans l'osu!store a été mise en ligne le 16 juin 2015, bien que la fonctionnalité complète du système n'ait pas été disponible avant le 18 juin 2015. Les changements ont fait en sorte que les joueurs devaient payer 4 dollars américains pour leur premier changement de nom, après quoi le prix doublerait à chaque achat successif avec un plafond à 100 dollars américains ; cependant, si un utilisateur achetait un [osu!supporter tag](https://osu.ppy.sh/home/support), alors son premier changement serait gratuit [[16,17,18,19]][r].
+La mise en œuvre du système de changement de nom d'utilisateur dans l'osu!store a été mise en ligne le 16 juin 2015, bien que la fonctionnalité complète du système n'ait pas été disponible avant le 18 juin 2015. Les changements ont fait en sorte que les joueurs devaient payer 4 dollars américains pour leur premier changement de nom, après quoi le prix doublerait à chaque achat successif avec un plafond à 100 dollars américains ; cependant, si un utilisateur achetait un tag [osu!supporter](https://osu.ppy.sh/home/support), alors son premier changement serait gratuit [[16,17,18,19]][r].
 
 La possibilité de voir à quoi ressemblerait un replay sans [mods](/wiki/Game_modifier) a été ajoutée le 23 juin 2015 suite à une [demande de fonctionnalité](https://osu.ppy.sh/community/forums/topics/97560), bien que le changement n'ait rendu les mods [Double Time](/wiki/Game_modifier/Double_Time), [Half Time](/wiki/Game_modifier/Half_Time) et [Flashlight](/wiki/Game_modifier/Flashlight) modifiables [[20]][r].
 
 ## Juillet
 
-Le 15 juillet 2015, il a été annoncé qu'une nouvelle équipe publique [Slack](https://slack.com/) a été créée dans le but de mieux communiquer avec les contributeurs publics. [peppy](https://osu.ppy.sh/users/2) avait initialement fait l'annonce sur son blog et avait expliqué que toute personne désireuse d'aider à tester des fonctionnalités de pointe, de contribuer à des ressources graphiques/sonores ou d'obtenir de l'aide pour travailler avec les services d'osu! pouvait venir rejoindre l'équipe et parler directement aux personnes des différentes [équipes d'osu!](/wiki/People/The_Team) [[21]][r].
+Le 15 juillet 2015, il a été annoncé qu'une nouvelle équipe publique [Slack](https://slack.com/) a été créée dans le but de mieux communiquer avec les contributeurs publics. [peppy](https://osu.ppy.sh/users/2) avait initialement fait l'annonce sur son blog et avait expliqué que toute personne désireuse d'aider à tester des fonctionnalités futures, de contribuer à des ressources graphiques/sonores ou d'obtenir de l'aide pour travailler avec les services d'osu! pouvait venir rejoindre l'équipe et parler directement aux personnes des différentes [équipes d'osu!](/wiki/People/The_Team) [[21]][r].
 
 *Note : Il y avait toujours une équipe Slack privée que l'équipe d'osu! utilisait pour les communications internes, qui n'était pas accessible ou visualisable par les utilisateurs extérieurs ; ces deux équipes étaient indépendantes l'une de l'autre.*
 
@@ -65,7 +64,7 @@ Les Chat Moderators ont été officiellement fusionnés dans la Global Moderatio
 
 ## Septembre
 
-L'ancien compteur d'images par seconde a été remplacé par un nouvel "affichage de rafraîchissement et de latence" le 2 septembre 2015. Ce nouvel affichage indiquait toujours le nombre d'images par seconde (FPS) en cours, mais la nouvelle modification faisait en sorte qu'il était masqué s'il dépassait 500 FPS. En outre, un nouveau compteur a été ajouté sous le compteur FPS, qui affiche exactement la latence introduite pendant le rendu des images (mesurée en millisecondes). Les images "bégayées" ou "abandonnées" sont affichées sous la forme de rectangles colorés à gauche du compteur afin de mieux visualiser la latence du rendu d'image que subit l'utilisateur [[26,27]][r].
+L'ancien compteur d'images par seconde a été remplacé par un nouvel "affichage de rafraîchissement et de latence" le 2 septembre 2015. Ce nouvel affichage indiquait toujours le nombre d'images par seconde (FPS) en cours, mais la nouvelle modification faisait en sorte qu'il était masqué s'il dépassait 500 FPS. En outre, un nouveau compteur a été ajouté sous le compteur de FPS, qui affiche exactement la latence introduite pendant le rendu des images (mesurée en millisecondes). Les images "bégayées" ou "abandonnées" sont affichées sous la forme de rectangles colorés à gauche du compteur afin de mieux visualiser la latence du rendu d'image que subit l'utilisateur [[26,27]][r].
 
 Le 26 septembre 2015, [cYsmix](http://cysmix.com/) est devenu l'un des premiers artistes officiels d'osu!. Ce partenariat a donné lieu à la création de trois titres réalisés spécifiquement pour osu! ainsi qu'à la création d'un concours de mapping utilisant ces titres. Les quatre titres sont les suivants :
 
@@ -73,11 +72,11 @@ Le 26 septembre 2015, [cYsmix](http://cysmix.com/) est devenu l'un des premiers 
 - ["House with Legs"](https://soundcloud.com/olemlanglie/cysmix-house-with-legs-osu)
 - ["Dovregubben's Hall (New Ver.)"](https://soundcloud.com/olemlanglie/cysmix-dovregubbens-hall-new-ver-osu)
 
-![](img/cysmix-album-cover-1.jpg "La couverture de l'album de cYsmix, la première publication de chansons officielles d'osu!")
+![](img/cysmix-album-cover-1.jpg "La couverture de l'album de cYsmix, la première publication de musiques officielles d'osu!")
 
 Chaque morceau avait son propre fichier [`.osz`](/wiki/osu!_File_Formats/Osz_(file_format)) pré-timé inclus avec lui et ont été publiés sur [cYsmix's SoundCloud](https://soundcloud.com/olemlanglie) le 28 septembre 2015.
 
-En plus de cela, un "open bounty" nommé "Mapping With Rewards" a été créé pour cet événement, qui permettait à quiconque de mapper l'une des musiques mentionnés ci-dessus, de le mettre dans un état classable, et si c'était assez impressionnant, cette personne recevrait un bounty pour cela. La récompense offerte à l'époque était la suivante : une chanson avec le client (pour une période limitée), 50 $ de crédit osu!store, 6 mois de tag supporter et un badge de profil unique. Ce bounty ouvert a été créé pour récompenser les joueurs pour la qualité de leurs beatmaps et pour célébrer les nouvelles musiques sans avoir à subir les inconvénients des concours de mapping traditionnels [[26]][r].
+En plus de cela, un "open bounty" nommé "Mapping With Rewards" a été créé pour cet événement, qui permettait à quiconque de mapper l'une des musiques mentionnés ci-dessus, de la faire classée, et si c'était assez impressionnant, cette personne recevrait un bounty pour cela. La récompense offerte à l'époque était la suivante : une musique avec le client (pour une période limitée), 50 $ de crédit osu!store, 6 mois de tag supporter et un badge de profil unique. Ce bounty ouvert a été créé pour récompenser les joueurs pour la qualité de leurs beatmaps et pour célébrer les nouvelles musiques sans avoir à subir les inconvénients des concours de mapping traditionnels [[26]][r].
 
 Cependant, malgré les [promesses de peppy sur son blog](https://blog.ppy.sh/post/132009865043/mapping-with-rewards-oct-2015), les résultats de Mapping With Rewards n'ont pas été publiés à la fin de l'année.
 
@@ -85,9 +84,9 @@ Cependant, malgré les [promesses de peppy sur son blog](https://blog.ppy.sh/pos
 
 Après des mois de travail, une migration complète du rendu graphique [DirectX](https://en.wikipedia.org/wiki/DirectX) vers [OpenGL](https://en.wikipedia.org/wiki/OpenGL) a été achevée et poussée à tous les utilisateurs sur les versions stables le 16 octobre 2015. Cependant, les utilisateurs qui n'ont pas pu exécuter la nouvelle mise à jour en raison de problèmes de compatibilité ont été basculés vers un nouvelle versions nommé "Stable (Fallback)", qui utilisait l'ancien rendu graphique DirectX. Cette version était destinée à être supportée en continu en parallèle de la version Stable jusqu'à ce que l'équipe d'osu! se sente suffisamment confiante dans la compatibilité du rendu OpenGL pour tous les utilisateurs [[28,29,30,31,32]][r].
 
-Un autre lot de chansons officielles d'osu! a été publié par cYsmix le 27 octobre 2015, avec un concours similaire de type "open-bounty" ouvert pour celui-ci également. Les trois chansons étaient ["Fright March"](https://soundcloud.com/olemlanglie/cysmix-fright-march-osu), ["Moonlight Sonata"](https://soundcloud.com/olemlanglie/cysmix-moonlight-sonata-osu), et ["Classic Pursuit"](https://soundcloud.com/olemlanglie/cysmix-classic-pursuit-osu) [[33,34]][r].
+Un autre lot de musiques officielles d'osu! a été publié par cYsmix le 27 octobre 2015, avec un concours similaire de type "open-bounty" ouvert pour celui-ci également. Les trois musiques étaient ["Fright March"](https://soundcloud.com/olemlanglie/cysmix-fright-march-osu), ["Moonlight Sonata"](https://soundcloud.com/olemlanglie/cysmix-moonlight-sonata-osu), et ["Classic Pursuit"](https://soundcloud.com/olemlanglie/cysmix-classic-pursuit-osu) [[33,34]][r].
 
-![](img/cysmix-album-cover-2.jpg "La couverture de l'album de la deuxième version des chansons officielles d'osu! de cYsmix.")
+![](img/cysmix-album-cover-2.jpg "La couverture de l'album de la deuxième version des musiques officielles d'osu! de cYsmix.")
 
 Tout comme le [concours Mapping with Rewards du mois précédent](#septembre), les résultats n'ont pas été publiés avant la fin de l'année.
 
@@ -111,19 +110,15 @@ La vérification obligatoire de l'email pour certaines actions sur le compte a c
 Quelques jours plus tard (19 novembre 2015), peppy a mis à jour les utilisateurs sur la situation dans [un autre billet de blog](https://blog.ppy.sh/post/133524244723/20151119), dans lequel il a développé la situation et gardé la même position :
 
 > Quelques mises à jour sur la sécurité des comptes :
-
 > - Je suis convaincu que le système d'osu! n'a pas été compromis.
 > - Tous les utilisateurs qui ont été ciblés jusqu'à présent ont utilisé le même mot de passe pendant plus de trois ans.
 > - Beaucoup ont utilisé un mot de passe très simple ou ont partagé le mot de passe avec d'autres services.
 > - Tous les utilisateurs compromis ont eu au moins un autre compte compromis dans le passé.
-
 > Néanmoins, je continue à prendre des mesures :
-
 > - J'ai élargi la liste des mots de passe courants et je réinitialise de force les mots de passe des utilisateurs qui les possèdent.
 > - Nous sommes en alerte et prêts à aider les utilisateurs qui rencontrent des difficultés.
 > - Nous avons mis en place des procédures pour les utilisateurs dont l'adresse e-mail n'est pas valide afin qu'ils puissent récupérer leur compte avec succès.
 > - Nous travaillons à l'ajout d'un support à deux facteurs (email pour l'instant) au client d'osu!. Cela devrait apparaître très bientôt.
-
 > Nous avons beaucoup de comptes à réinitialiser de force en raison de la faiblesse des mots de passe et, en raison d'un personnel d'assistance limité, nous échelonnerons le "déploiement" de ces réinitialisations au cours des prochaines semaines.
 
 — peppy, "20151119" [[40]][r]

--- a/wiki/History_of_osu!/Online_rankings/osu!/fr.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!/fr.md
@@ -12,18 +12,15 @@ tags:
   - rang #1
   - classements
   - meilleur joueur
-no_native_review: true
-outdated: true
-outdated_since: af1924df8cfa9b43fa3f4cb2c4fb5935bf1b81d9
 ---
 
 # L'histoire des classements du mode osu!
 
-Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/osu/performance) de [osu!](/wiki/Game_mode/osu!).
+Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/osu/performance) dans le mode [osu!](/wiki/Game_mode/osu!).
 
 Au fil des ans, trois systèmes différents ont été utilisés pour classer les joueurs :
 
-- [Ranked Score](/wiki/Gameplay/Score/Ranked_score) (6 octobre 2007 - 24 juillet 2012)
+- Le [score classé](/wiki/Gameplay/Score/Ranked_score) (6 octobre 2007 - 24 juillet 2012)
 - [ppv1](/wiki/Performance_points/ppv1) (24 juillet 2012 - 27 janvier 2014)
 - [ppv2](/wiki/Performance_points) (27 janvier 2014 - présent)
 
@@ -33,7 +30,7 @@ Alors que ![][flag_AU] [peppy](https://osu.ppy.sh/users/2) était supposé être
 
 ## 2007
 
-*Note : Pendant la période où le [Ranked Score](/wiki/Gameplay/Score/Ranked_score) était utilisé, le détenteur du rang 1 changeait fréquemment, donc les listes précédentes peuvent avoir une précision réduite. Des informations détaillées peuvent être trouvées sur la reconstruction estimée du classement mondial en Ranked Score, qui est disponible [ici](https://docs.google.com/spreadsheets/d/1fcFtTNim7hminC2LaMGwTBwa6_GIHU8Sz-wQ_eXymiE).*
+*Note : Pendant la période où le [score classé](/wiki/Gameplay/Score/Ranked_score) était utilisé, le détenteur du rang 1 changeait fréquemment, donc les listes précédentes peuvent avoir une précision réduite. Des informations détaillées peuvent être trouvées sur la reconstruction estimée du classement mondial en score classé, qui est disponible [ici](https://docs.google.com/spreadsheets/d/1fcFtTNim7hminC2LaMGwTBwa6_GIHU8Sz-wQ_eXymiE).*
 
 | Joueur | Du | Jusqu'au | Sources |
 | --: | :-- | :-- | :-- |
@@ -133,7 +130,7 @@ Alors que ![][flag_AU] [peppy](https://osu.ppy.sh/users/2) était supposé être
 
 ## 2012
 
-*Note : [ppv1](/wiki/Performance_points/ppv1) a entièrement remplacé Ranked Score le 24 juillet 2012.*
+*Note : [ppv1](/wiki/Performance_points/ppv1) a entièrement remplacé le score classé le 24 juillet 2012.*
 
 | Joueur | Du | Jusqu'au | Sources |
 | --: | :-- | :-- | :-- |
@@ -273,7 +270,13 @@ Alors que ![][flag_AU] [peppy](https://osu.ppy.sh/users/2) était supposé être
 | Joueur | Du | Jusqu'au | Sources |
 | --: | :-- | :-- | :-- |
 | ![][flag_DE] [WhiteCat](https://osu.ppy.sh/users/4504101) | *06/10/2019* | 08/04/2021 | [\[1\]](https://web.archive.org/web/20191006200709/https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://ameobea.me/osutrack/user/whitecat/) [\[3\]](https://web.archive.org/web/20210119102542/https://old.reddit.com/r/osugame/comments/de8duf/whitecat_is_now_1_global_on_osustandard/) [\[4\]](https://web.archive.org/web/20210203170702if_/https://www.youtube.com/watch?v=Bx4R7lovF-0) |
-| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | 08/04/2021 | Présent | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
+| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | 08/04/2021 | *Présent* | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
+
+## 2022
+
+| Joueur | Du | Jusqu'au | Sources |
+| --: | :-- | :-- | :-- |
+| ![][flag_AU] [mrekk](https://osu.ppy.sh/users/7562902) | *2021-04-08* | Present | [\[1\]](https://osu.ppy.sh/rankings/osu/performance) [\[2\]](https://osu.ppy.sh/users/7562902) [\[3\]](https://ameobea.me/osutrack/user/mrekk/) [\[4\]](https://old.reddit.com/r/osugame/comments/mmkaag/mrekk_is_now_1_surpassing_whitecat/) [\[5\]](https://osu.ppy.sh/scores/osu/3584256449") [\[6\]](https://www.reddit.com/r/osugame/comments/mmkajm/mrekk_colorsslash_colors_power_ni_omakasero/) [\[7\]](https://www.youtube.com/watch?v=xQLVNqfqaOE) |
 
 ## Nombre de règnes
 

--- a/wiki/History_of_osu!/Online_rankings/osu!catch/fr.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!catch/fr.md
@@ -13,9 +13,8 @@ tags:
   - rang #1
   - classements
   - meilleur joueur
-no_native_review: true
 ---
 
 # L'histoire des classements du mode osu!catch
 
-Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/fruits/performance) de [osu!catch](/wiki/Game_mode/osu!catch).
+Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/fruits/performance) du mode [osu!catch](/wiki/Game_mode/osu!catch).

--- a/wiki/History_of_osu!/Online_rankings/osu!mania/fr.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!mania/fr.md
@@ -13,9 +13,8 @@ tags:
   - rang #1
   - classements
   - meilleur joueur
-no_native_review: true
 ---
 
 # L'histoire des classements du mode osu!mania
 
-Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/mania/performance) de [osu!mania](/wiki/Game_mode/osu!mania).
+Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/mania/performance) du mode [osu!mania](/wiki/Game_mode/osu!mania).

--- a/wiki/History_of_osu!/Online_rankings/osu!taiko/fr.md
+++ b/wiki/History_of_osu!/Online_rankings/osu!taiko/fr.md
@@ -13,9 +13,8 @@ tags:
   - rang #1
   - classements
   - meilleur joueur
-no_native_review: true
 ---
 
 # L'histoire des classements du mode osu!taiko
 
-Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/taiko/performance) de [osu!taiko](/wiki/Game_mode/osu!taiko).
+Voici la liste des joueurs reconnus comme ayant atteint le rang 1 dans le [classement mondial](https://osu.ppy.sh/rankings/taiko/performance) du mode [osu!taiko](/wiki/Game_mode/osu!taiko).


### PR DESCRIPTION
Cleanup of the following wiki pages:

- `Community\osu!dev_Discord_server`
- `History_of_osu!\2014`
- `History_of_osu!\2015`
- `History_of_osu!\Online_rankings\osu!`
- `History_of_osu!\Online_rankings\osu!catch`
- `History_of_osu!\Online_rankings\osu!mania`
- `History_of_osu!\Online_rankings\osu!taiko`
- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)