### PR TITLE
Fix incorrect heading level in the `Tournaments` index page and sort flags references in `Tournaments/o!BAM/1`

### DIFF
--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -201,7 +201,7 @@ Unofficial tournaments/competitions hosted by the communities.
 | [osu! Asia Oceania Tournament](o!AOT/1) | 2019-07-26 | 2019-09-22 | 進撃のバブルティー | 黃建智 | 과로사 |
 | [osu! Asia Oceania Tournament 2](o!AOT/2) | 2020-07-03 | 2020-08-16 | Floating up | PUPU | :peepolaughpoint: |
 
-### osu! Battle Archive Malaysia
+#### osu! Battle Archive Malaysia
 
 | Name | Start | End | ![Gold crown][GCrown] | ![Silver crown][SCrown] | ![Bronze crown][BCrown] |
 | :-- | :-- | :-- | :-- | :-- | :-- |

--- a/wiki/Tournaments/o!BAM/1/en.md
+++ b/wiki/Tournaments/o!BAM/1/en.md
@@ -573,7 +573,7 @@ Wednesday, 15 September 2021:
    - Playing a FreeMod pick without any mods activated is not allowed.
 7. The results of each match and any other relevant information regarding the match will be posted on the Discord server after the match has been concluded by the responsible referees.
 
+[flag_FR]: /wiki/shared/flag/FR.gif "France"
 [flag_MY]: /wiki/shared/flag/MY.gif "Malaysia"
 [flag_SG]: /wiki/shared/flag/SG.gif "Singapore"
 [flag_VN]: /wiki/shared/flag/VN.gif "Vietnam"
-[flag_FR]: /wiki/shared/flag/FR.gif "France"


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Small thing missed during review of https://github.com/ppy/osu-wiki/pull/6706