### PR TITLE
Fix the `outdated_since` tag in `Gameplay` and `Judgement` translations

### DIFF
--- a/wiki/Gameplay/Judgement/fr.md
+++ b/wiki/Gameplay/Judgement/fr.md
@@ -1,7 +1,7 @@
 ---
 stub: true
 outdated: true
-outdated_since: 091042b514b2b47faad0d1031030cb1d43253f63
+outdated_since: 8a5f5265f6fa698fdea71e909684ba286ee85111
 ---
 
 # Jugement

--- a/wiki/Gameplay/fr.md
+++ b/wiki/Gameplay/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated: true
-outdated_since: 091042b514b2b47faad0d1031030cb1d43253f63
+outdated_since: 8a5f5265f6fa698fdea71e909684ba286ee85111
 ---
 
 # Gameplay

--- a/wiki/Gameplay/id.md
+++ b/wiki/Gameplay/id.md
@@ -1,6 +1,6 @@
 ---
 outdated: true
-outdated_since: 091042b514b2b47faad0d1031030cb1d43253f63
+outdated_since: 8a5f5265f6fa698fdea71e909684ba286ee85111
 ---
 
 # Gameplay


### PR DESCRIPTION
a follow-up to https://github.com/ppy/osu-wiki/pull/6742