### PR TITLE
Update `MWC/2022_7K` for the Finals week 

### DIFF
--- a/wiki/Tournaments/MWC/2022_7K/en.md
+++ b/wiki/Tournaments/MWC/2022_7K/en.md
@@ -118,6 +118,32 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 
 ## Mappools
 
+### Finals
+
+**[Download the mappack here (168 MB)](https://drive.google.com/uc?id=1_S2JNbi6CZOL3yXvdfpbfN18dCXwAKjo)**
+
+- Rice
+  1. [ROKINA - Kimi to bokueno sousouka (Jinjin) \[Requiem\]](https://osu.ppy.sh/beatmapsets/1666751#mania/3404149)
+  2. [Ariabl'eyeS - Sougetsu Oratorio (\_underjoy) \[Arcadia (cut)\]](https://osu.ppy.sh/beatmapsets/1693118#mania/3459764)
+  3. [sakuzyo - Toy's 3 minutes war (Kawawa) \[LF> Ludibrium PQ @195\]](https://osu.ppy.sh/beatmapsets/1692913#mania/3459366)
+  4. [Dz'Xa - EXTRAHAPPY (lenpai) \[:3 (250 bpm)\]](https://osu.ppy.sh/beatmapsets/1693251#mania/3460002)
+  5. [Junk - Life is PIANO (Evening) \[Life is COLABOO@136\]](https://osu.ppy.sh/beatmapsets/1692950#mania/3459426)
+  6. [USAO - Knight Rider (Camellia's "Knightstyle Razor-psy-harp" Remix) (Evening) \[En Garde+ (Evening's Nouveau Flip)\]](https://osu.ppy.sh/beatmapsets/1692951#mania/3459428)
+  7. [katagiri - Angel's Salad (Kawawa) \[Diet (MWC Edition)\]](https://osu.ppy.sh/beatmapsets/1692919#mania/3459379)
+- LN
+  1. [YOASOBI - Gunjou (\[Crz\]Emperor-) \[Blue\]](https://osu.ppy.sh/beatmapsets/1256369#mania/3397105)
+  2. [xi - Bad Elixir (Exyph) \[No Hope\]](https://osu.ppy.sh/beatmapsets/1240933#mania/2579737)
+  3. [NAGI\* - fractal (\[Crz\]Emperor-) \[underjoy vs Emperor-'s Fractal Universe\]](https://osu.ppy.sh/beatmapsets/1496315#mania/3397135)
+  4. [Mary - Alice in Reitouko (Leeju) \[Leeju's 7K Terni in Freezer (MWC cut. edit)\]](https://osu.ppy.sh/beatmapsets/1412771#mania/3459276)
+  5. [Tiara - Negai covered by Isekaijoucho (Kim\_GodSSI) \[Wish\]](https://osu.ppy.sh/beatmapsets/1692906#mania/3459342)
+- Hybrid
+  1. [Camellia - Kamah (Leeju) \[Leeju's 7K Syphoning Souls +\]](https://osu.ppy.sh/beatmapsets/1558744#mania/3459278)
+  2. [Noah - Break down (Wonki) \[Extra\]](https://osu.ppy.sh/beatmapsets/1450907#mania/2982951)
+  3. [sa10 - banana man (Jinjin) \[Bananamania (2022)\]](https://osu.ppy.sh/beatmapsets/543154#mania/3459405)
+- Tiebreaker
+  1. **[seatrus - DOOMSDAY THUNDERTEMPEST (paulkappa) \[FINAL LAP ONTO DISASTER\]](https://osu.ppy.sh/beatmapsets/1692926#mania/3459391)**
+
+
 ### Semifinals
 
 **[Download the mappack here (104 MB)](https://drive.google.com/uc?id=1zbZY8aEs_0rS-UHLjiWUQaxmNdVoXJR5)**
@@ -205,6 +231,8 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 ## Match results
 
 ### Semifinals
+
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1IFUI0PzZAgl8RRmfmHHmVrezL6qkCAaRM3ME5lKKrQQ/edit?rm=minimal).
 
 Saturday, February 5, 2022
 

--- a/wiki/Tournaments/MWC/2022_7K/en.md
+++ b/wiki/Tournaments/MWC/2022_7K/en.md
@@ -93,31 +93,24 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 | ![][flag_GB] | **United Kingdom** | **[Vygatron](https://osu.ppy.sh/users/3628783)**, [username1947](https://osu.ppy.sh/users/16162078), [Lelloq](https://osu.ppy.sh/users/8610776), [aid\_](https://osu.ppy.sh/users/12808079) |
 | ![][flag_US] | **United States** | **[Alter-](https://osu.ppy.sh/users/4980256)**, [Terni](https://osu.ppy.sh/users/3279570), [\[GS\]Teo](https://osu.ppy.sh/users/7081478), [RevVoJH](https://osu.ppy.sh/users/7286896) |
 
-## Match schedule: Semifinals
+## Match schedule: Finals
 
-### Saturday, February 5, 2022
-
-| Team A | | | Team B | Match time | Local time A | Local time B | |
-| --: | --: | :-- | :-- | :-: | :-: | :-: | :-: |
-| Indonesia | ![][flag_ID] | ![][flag_PL] | Poland | Feb 5 (Sat) 12:00 UTC | Feb 5 (Sat) 19:00 UTC+7 | Feb 5 (Sat) 13:00 UTC+1 | ² |
-| China | ![][flag_CN] | ![][flag_MY] | Malaysia | Feb 5 (Sat) 12:00 UTC | Feb 5 (Sat) 20:00 UTC+8 | Feb 5 (Sat) 20:00 UTC+8 | ¹ |
-| Japan | ![][flag_JP] | ![][flag_BR] | Brazil | Feb 5 (Sat) 14:00 UTC | Feb 5 (Sat) 23:00 UTC+9 | Feb 5 (Sat) 11:00 UTC-3 | ² |
-| Thailand | ![][flag_TH] | ![][flag_CL] | Chile | Feb 5 (Sat) 15:00 UTC | Feb 5 (Sat) 22:00 UTC+7 | Feb 5 (Sat) 12:00 UTC-3 | ² |
-| Canada | ![][flag_CA] | ![][flag_ES] | Spain | Feb 5 (Sat) 16:00 UTC | Feb 5 (Sat) 11:00 UTC-5 | Feb 5 (Sat) 17:00 UTC+1 | ² |
-
-### Sunday, February 6, 2022
+### Saturday, February 12, 2022
 
 | Team A | | | Team B | Match time | Local time A | Local time B | |
 | --: | --: | :-- | :-- | :-: | :-: | :-: | :-: |
-| Thailand | ![][flag_TH] | ![][flag_CA] | Canada | Feb 6 (Sun) 05:00 UTC | Feb 6 (Sun) 12:00 UTC+7 | Feb 6 (Sun) 00:00 UTC-5 | ³ |
-| South Korea | ![][flag_KR] | ![][flag_PH] | Philippines | Feb 6 (Sun) 10:00 UTC | Feb 6 (Sun) 19:00 UTC+9 | Feb 6 (Sun) 18:00 UTC+8 | ¹ |
-| Thailand | ![][flag_TH] | ![][flag_ES] | Spain | Feb 6 (Sun) 12:00 UTC | Feb 6 (Sun) 19:00 UTC+7 | Feb 6 (Sun) 13:00 UTC+1 | ³ |
-| Japan | ![][flag_JP] | ![][flag_ID] | Indonesia | Feb 6 (Sun) 14:00 UTC | Feb 6 (Sun) 23:00 UTC+9 | Feb 6 (Sun) 21:00 UTC+7 | ³ |
-| Japan | ![][flag_JP] | ![][flag_PL] | Poland | Feb 6 (Sun) 14:00 UTC | Feb 6 (Sun) 23:00 UTC+9 | Feb 6 (Sun) 15:00 UTC+1 | ³ |
-| Brazil | ![][flag_BR] | ![][flag_ID] | Indonesia | Feb 6 (Sun) 15:00 UTC | Feb 6 (Sun) 12:00 UTC-3 | Feb 6 (Sun) 22:00 UTC+7 | ³ |
-| Brazil | ![][flag_BR] | ![][flag_PL] | Poland | Feb 6 (Sun) 15:00 UTC | Feb 6 (Sun) 12:00 UTC-3 | Feb 6 (Sun) 16:00 UTC+1 | ³ |
-| Chile | ![][flag_CL] | ![][flag_CA] | Canada | Feb 6 (Sun) 18:00 UTC | Feb 6 (Sun) 15:00 UTC-3 | Feb 6 (Sun) 13:00 UTC-5 | ³ |
-| Chile | ![][flag_CL] | ![][flag_ES] | Spain | Feb 6 (Sun) 18:00 UTC | Feb 6 (Sun) 15:00 UTC-3 | Feb 6 (Sun) 19:00 UTC+1 | ³ |
+| Philippines | ![][flag_PH] | ![][flag_JP] | Japan | Feb 12 (Sat) 10:00 UTC | Feb 12 (Sat) 18:00 UTC+8 | Feb 12 (Sat) 19:00 UTC+9 | ² |
+| China | ![][flag_CN] | ![][flag_TH] | Thailand | Feb 12 (Sat) 11:30 UTC | Feb 12 (Sat) 19:30 UTC+8 | Feb 12 (Sat) 18:30 UTC+7 | ² |
+| Thailand | ![][flag_TH] | ![][flag_PH] | Philippines | Feb 12 (Sat) 13:00 UTC | Feb 12 (Sat) 20:00 UTC+7 | Feb 12 (Sat) 21:00 UTC+8 | ³ |
+| Thailand | ![][flag_TH] | ![][flag_JP] | Japan | Feb 12 (Sat) 13:00 UTC | Feb 12 (Sat) 20:00 UTC+7 | Feb 12 (Sat) 22:00 UTC+9 | ³ |
+
+### Sunday, February 13, 2022
+
+| Team A | | | Team B | Match time | Local time A | Local time B | |
+| --: | --: | :-- | :-- | :-: | :-: | :-: | :-: |
+| China | ![][flag_CN] | ![][flag_PH] | Philippines | Feb 13 (Sun) 10:00 UTC | Feb 13 (Sun) 18:00 UTC+8 | Feb 13 (Sun) 18:00 UTC+8 | ³ |
+| China | ![][flag_CN] | ![][flag_JP] | Japan | Feb 13 (Sun) 10:00 UTC | Feb 13 (Sun) 18:00 UTC+8 | Feb 13 (Sun) 19:00 UTC+9 | ³ |
+| South Korea | ![][flag_KR] | ![][flag_MY] | Malaysia | Feb 13 (Sun) 11:30 UTC | Feb 13 (Sun) 20:30 UTC+9 | Feb 13 (Sun) 19:30 UTC+8 | ¹ |
 
 ¹ Winners bracket match\
 ² Losers bracket match\
@@ -210,6 +203,26 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 8. [technoplanet - Intuition (Evening) \[Stage 8: Advent of Colour\]](https://osu.ppy.sh/beatmapsets/1670397#mania/3411676)
 
 ## Match results
+
+### Semifinals
+
+Saturday, February 5, 2022
+
+| Team A | | | Team B | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **Indonesia** ![][flag_ID] | **7** | 2 | ![][flag_PL] Poland | [#1](https://osu.ppy.sh/community/matches/97417859) |
+| China ![][flag_CN] | 2 | **7** | ![][flag_MY] **Malaysia** | [#1](https://osu.ppy.sh/community/matches/97417959) |
+| **Japan** ![][flag_JP] | **7** | 3 | ![][flag_BR] Brazil | [#1](https://osu.ppy.sh/community/matches/97421449) |
+| **Thailand** ![][flag_TH] | **7** | 1 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/97423673) |
+| Canada ![][flag_CA] | 4 | **7** | ![][flag_ES] **Spain** | [#1](https://osu.ppy.sh/community/matches/97426048) |
+
+Sunday, February 6, 2022
+
+| Team A | | | Team B | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **South Korea** ![][flag_KR] | **7** | 6 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/97459939) |
+| **Thailand** ![][flag_TH] | **7** | 0 | ![][flag_ES] Spain | [#1](https://osu.ppy.sh/community/matches/97462885) |
+| **Japan** ![][flag_JP] | **7** | 3 | ![][flag_ID] Indonesia | [#1](https://osu.ppy.sh/community/matches/97466272) |
 
 ### Quarterfinals
 

--- a/wiki/Tournaments/MWC/2022_7K/en.md
+++ b/wiki/Tournaments/MWC/2022_7K/en.md
@@ -143,7 +143,6 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 - Tiebreaker
   1. **[seatrus - DOOMSDAY THUNDERTEMPEST (paulkappa) \[FINAL LAP ONTO DISASTER\]](https://osu.ppy.sh/beatmapsets/1692926#mania/3459391)**
 
-
 ### Semifinals
 
 **[Download the mappack here (104 MB)](https://drive.google.com/uc?id=1zbZY8aEs_0rS-UHLjiWUQaxmNdVoXJR5)**

--- a/wiki/Tournaments/MWC/2022_7K/en.md
+++ b/wiki/Tournaments/MWC/2022_7K/en.md
@@ -123,71 +123,71 @@ The osu!mania 7K 2022 is run by the osu! team and various community members.
 **[Download the mappack here (104 MB)](https://drive.google.com/uc?id=1zbZY8aEs_0rS-UHLjiWUQaxmNdVoXJR5)**
 
 - Rice
-  1. [modama/hugepulse - Swim in the sea of quarks (MapleSyrup-) \[\[7K\] Creation 1.15x\]](https://osu.ppy.sh/beatmapsets/1687220#mania/3448226)
+  1. [modama/hugepulse - Swim in the sea of quarks (MapleSyrup-) \[Creation 1.15x\]](https://osu.ppy.sh/beatmapsets/1687220#mania/3448226)
   2. [TUYU - Shuuten no Saki ga Aru to suru naraba (Leeju) \[Leeju's 7K Afterlife +\]](https://osu.ppy.sh/beatmapsets/1603565#mania/3448143)
-  3. [ikaruga\_nex - ReviXy (TakJun) \[\[7K\] ETJun\]](https://osu.ppy.sh/beatmapsets/1489038#mania/3393667)
-  4. [polysha - Jasmine Tea Girl (Evening) \[\[7K\] Shimmer+@130\]](https://osu.ppy.sh/beatmapsets/1687214#mania/3448213)
-  5. [Camellia - Electromagnetic Stealth Girl Born In Philadelphia (paradoxus\_) \[\[7K\] para & wawa collab (no LN)\]](https://osu.ppy.sh/beatmapsets/1544574#mania/3441781)
-  6. [Takanashi Kiara - SPARKS (Remuring) \[\[7K\] KFP\]](https://osu.ppy.sh/beatmapsets/1601721#mania/3270989)
-  7. [Igorrr - Robert (Jinjin) \[\[7K\] dieu\]](https://osu.ppy.sh/beatmapsets/1687197#mania/3448178)
+  3. [ikaruga\_nex - ReviXy (TakJun) \[ETJun\]](https://osu.ppy.sh/beatmapsets/1489038#mania/3393667)
+  4. [polysha - Jasmine Tea Girl (Evening) \[Shimmer+@130\]](https://osu.ppy.sh/beatmapsets/1687214#mania/3448213)
+  5. [Camellia - Electromagnetic Stealth Girl Born In Philadelphia (paradoxus\_) \[para & wawa collab (no LN)\]](https://osu.ppy.sh/beatmapsets/1544574#mania/3441781)
+  6. [Takanashi Kiara - SPARKS (Remuring) \[KFP\]](https://osu.ppy.sh/beatmapsets/1601721#mania/3270989)
+  7. [Igorrr - Robert (Jinjin) \[dieu\]](https://osu.ppy.sh/beatmapsets/1687197#mania/3448178)
 - LN
-  1. [Aethoro - Snowy (\_underjoy) \[\[7K\] Icicles\]](https://osu.ppy.sh/beatmapsets/1687222#mania/3448230)
-  2. [Kijibato - w / WWW (feat. Hoshimiya Toto) (\_underjoy) \[\[7K\] Flexo123's GO FUN?\]](https://osu.ppy.sh/beatmapsets/1687225#mania/3448238)
-  3. [SHK - Violet Perfume (Wilben\_Chan) \[\[7K\] Nightmare (edit)\]](https://osu.ppy.sh/beatmapsets/1371078#mania/3440839)
-  4. [GFRIEND - Time for the moon night (Jinjin) \[\[7K\] ByeolBit\]](https://osu.ppy.sh/beatmapsets/1674163#mania/3419908)
-  5. [La+ Darknesss - God-ish (MapleSyrup-) \[\[7K\] Fool-ish Obsesssion\]](https://osu.ppy.sh/beatmapsets/1687218#mania/3448224)
+  1. [Aethoro - Snowy (\_underjoy) \[Icicles\]](https://osu.ppy.sh/beatmapsets/1687222#mania/3448230)
+  2. [Kijibato - w / WWW (feat. Hoshimiya Toto) (\_underjoy) \[Flexo123's GO FUN?\]](https://osu.ppy.sh/beatmapsets/1687225#mania/3448238)
+  3. [SHK - Violet Perfume (Wilben\_Chan) \[Nightmare (edit)\]](https://osu.ppy.sh/beatmapsets/1371078#mania/3440839)
+  4. [GFRIEND - Time for the moon night (Jinjin) \[ByeolBit\]](https://osu.ppy.sh/beatmapsets/1674163#mania/3419908)
+  5. [La+ Darknesss - God-ish (MapleSyrup-) \[Fool-ish Obsesssion\]](https://osu.ppy.sh/beatmapsets/1687218#mania/3448224)
 - Hybrid
-  1. [Akhuta - Nigra Ludia (Wilben\_Chan) \[\[7K\] Nightmare\]](https://osu.ppy.sh/beatmapsets/1034341#mania/2162574)
-  2. [AZKi - Fake.Fake.Fake (\_Reimu) \[\[7K\] Aqua.M.T\]](https://osu.ppy.sh/beatmapsets/984170#mania/2059275)
-  3. [Camellia feat. Nana Takahashi - Mushi no Sumu Tokoro -Ugomeki wa nao fukamaru (Remuring) \[\[7K\] Corruption (MWC Edit)\]](https://osu.ppy.sh/beatmapsets/1276561#mania/3448223)
+  1. [Akhuta - Nigra Ludia (Wilben\_Chan) \[Nightmare\]](https://osu.ppy.sh/beatmapsets/1034341#mania/2162574)
+  2. [AZKi - Fake.Fake.Fake (\_Reimu) \[Aqua.M.T\]](https://osu.ppy.sh/beatmapsets/984170#mania/2059275)
+  3. [Camellia feat. Nana Takahashi - Mushi no Sumu Tokoro -Ugomeki wa nao fukamaru (Remuring) \[Corruption (MWC Edit)\]](https://osu.ppy.sh/beatmapsets/1276561#mania/3448223)
 - Tiebreaker
-  1. **[Camellia - Newspapers for Magicians (Blocko) \[\[7K\] The Daily Prophet\]](https://osu.ppy.sh/beatmapsets/1645306#mania/3448228)**
+  1. **[Camellia - Newspapers for Magicians (Blocko) \[The Daily Prophet\]](https://osu.ppy.sh/beatmapsets/1645306#mania/3448228)**
 
 ### Quarterfinals
 
 **[Download the mappack here (109 MB)](https://drive.google.com/uc?id=1JhpOSJ2m2jt1XHeuvM71hqZBBiZvy_Kz)**
 
 - Rice
-  1. [USAO - Phalanx (Evening) \[\[7K\] SKY\_PIERCER.tar.gz\]](https://osu.ppy.sh/beatmapsets/1681593#mania/3435340)
-  2. [ck - Carnation (ck remix) (TakJun) \[\[7K\] CarnationJun\]](https://osu.ppy.sh/beatmapsets/1638338#mania/3354720)
-  3. [nmk - Shoujo ga Mita Nippon no Hara Fuukei -Spell Music Mix- (qodtjr) \[\[7K\] Alice\]](https://osu.ppy.sh/beatmapsets/1089000#mania/2276927)
-  4. [naotyu- - L99 (hoo9030) \[\[7K\] EX Challenge \[0.95x Rate\]\]](https://osu.ppy.sh/beatmapsets/1427458#mania/2940516)
-  5. [Pop'n Masters - Popperz Chronicle (lenpai) \[\[7K\] Another\]](https://osu.ppy.sh/beatmapsets/1509343#mania/3432698)
-  6. [The Flashbulb - Kirlian Shores (tyrcs) \[\[7K\] Beside the Sea +\]](https://osu.ppy.sh/beatmapsets/1084086#mania/3383148)
+  1. [USAO - Phalanx (Evening) \[SKY\_PIERCER.tar.gz\]](https://osu.ppy.sh/beatmapsets/1681593#mania/3435340)
+  2. [ck - Carnation (ck remix) (TakJun) \[CarnationJun\]](https://osu.ppy.sh/beatmapsets/1638338#mania/3354720)
+  3. [nmk - Shoujo ga Mita Nippon no Hara Fuukei -Spell Music Mix- (qodtjr) \[Alice\]](https://osu.ppy.sh/beatmapsets/1089000#mania/2276927)
+  4. [naotyu- - L99 (hoo9030) \[EX Challenge \[0.95x Rate\]\]](https://osu.ppy.sh/beatmapsets/1427458#mania/2940516)
+  5. [Pop'n Masters - Popperz Chronicle (lenpai) \[Another\]](https://osu.ppy.sh/beatmapsets/1509343#mania/3432698)
+  6. [The Flashbulb - Kirlian Shores (tyrcs) \[Beside the Sea +\]](https://osu.ppy.sh/beatmapsets/1084086#mania/3383148)
 - LN
-  1. [Jamie Christopherson - Island Village (X\_Devil) \[\[7K\] LineageII: Talking Island Village\]](https://osu.ppy.sh/beatmapsets/1054940#mania/2204243)
+  1. [Jamie Christopherson - Island Village (X\_Devil) \[LineageII: Talking Island Village\]](https://osu.ppy.sh/beatmapsets/1054940#mania/2204243)
   2. [Lime - 8bit Voyager (Leeju) \[Leeju's 7K Journey\]](https://osu.ppy.sh/beatmapsets/1656843#mania/3381798)
-  3. [Jay Chou - Mojito (Wilben\_Chan) \[\[7K\] Sweet Love\]](https://osu.ppy.sh/beatmapsets/1557864#mania/3182371)
-  4. [ryo(supercell) - Love is War (Mwk Remix) (Chenut BS) \[\[7K\] LOVE DECLARATION\]](https://osu.ppy.sh/beatmapsets/1046089#mania/3431581)
+  3. [Jay Chou - Mojito (Wilben\_Chan) \[Sweet Love\]](https://osu.ppy.sh/beatmapsets/1557864#mania/3182371)
+  4. [ryo(supercell) - Love is War (Mwk Remix) (Chenut BS) \[LOVE DECLARATION\]](https://osu.ppy.sh/beatmapsets/1046089#mania/3431581)
 - Hybrid
-  1. [Holo Bass - Power Stance (MapleSyrup-) \[\[7K\] Domination 1.05x\]](https://osu.ppy.sh/beatmapsets/1681558#mania/3435273)
-  2. [Linear ring - Enchanted love (qodtjr) \[\[7K\] Blind\]](https://osu.ppy.sh/beatmapsets/1486478#mania/3047946)
-  3. [Liquid Tension Experiment - The Passage of Time (Davvy) \[\[7K\] Samsara\]](https://osu.ppy.sh/beatmapsets/1360458#mania/2815242)
+  1. [Holo Bass - Power Stance (MapleSyrup-) \[Domination 1.05x\]](https://osu.ppy.sh/beatmapsets/1681558#mania/3435273)
+  2. [Linear ring - Enchanted love (qodtjr) \[Blind\]](https://osu.ppy.sh/beatmapsets/1486478#mania/3047946)
+  3. [Liquid Tension Experiment - The Passage of Time (Davvy) \[Samsara\]](https://osu.ppy.sh/beatmapsets/1360458#mania/2815242)
 - Tiebreaker
-  1. **[Silentroom - Nhelv (Evening) \[\[7K\] Divergence & Convergence (MWC Edit)\]](https://osu.ppy.sh/beatmapsets/1681594#mania/3435342)**
+  1. **[Silentroom - Nhelv (Evening) \[Divergence & Convergence (MWC Edit)\]](https://osu.ppy.sh/beatmapsets/1681594#mania/3435342)**
 
 ### Round of 16
 
 **[Download the mappack here (89 MB)](https://drive.google.com/uc?id=1uc1oILMX9J7dw1huWo3Kd3r31qROfIRm)**
 
 - Rice
-  1. [Laur - Attractor Dimension (Wonki) \[\[7K\] Insane\]](https://osu.ppy.sh/beatmapsets/1587984#mania/3243265)
-  2. [cosMo@bousouP - Oceanus (\_Kobii) \[\[7K\] Insane \[210bpm\]\]](https://osu.ppy.sh/beatmapsets/1676381#mania/3424741)
-  3. [Mr.T - electro peaceful(8bit) (qodtjr) \[\[7K\] Notes of Peace\]](https://osu.ppy.sh/beatmapsets/707059#mania/1494875)
-  4. [sakuzyo - Lost Memory (DaDarkDragon) \[\[7K\] Memories \[1,1x Rate\]\]](https://osu.ppy.sh/beatmapsets/1312121#mania/2719418)
-  5. [BEMANI Sound Team "Power Of Nature" - Tadoru Kimi wo Koete (guden) \[\[7K\] Wayfarer\]](https://osu.ppy.sh/beatmapsets/1539977#mania/3148168)
-  6. [TAKU INOUE & Hoshimachi Suisei - Sanji Juunihun (Evening) \[\[7K\] CHANGE THE WORLD (EDIT)\]](https://osu.ppy.sh/beatmapsets/1676465#mania/3424887)
+  1. [Laur - Attractor Dimension (Wonki) \[Insane\]](https://osu.ppy.sh/beatmapsets/1587984#mania/3243265)
+  2. [cosMo@bousouP - Oceanus (\_Kobii) \[Insane \[210bpm\]\]](https://osu.ppy.sh/beatmapsets/1676381#mania/3424741)
+  3. [Mr.T - electro peaceful(8bit) (qodtjr) \[Notes of Peace\]](https://osu.ppy.sh/beatmapsets/707059#mania/1494875)
+  4. [sakuzyo - Lost Memory (DaDarkDragon) \[Memories \[1,1x Rate\]\]](https://osu.ppy.sh/beatmapsets/1312121#mania/2719418)
+  5. [BEMANI Sound Team "Power Of Nature" - Tadoru Kimi wo Koete (guden) \[Wayfarer\]](https://osu.ppy.sh/beatmapsets/1539977#mania/3148168)
+  6. [TAKU INOUE & Hoshimachi Suisei - Sanji Juunihun (Evening) \[CHANGE THE WORLD (EDIT)\]](https://osu.ppy.sh/beatmapsets/1676465#mania/3424887)
 - LN
-  1. [M2U - Yoake no Uta feat. Dazbee (SurfChu85) \[\[7K\] Daybreak\]](https://osu.ppy.sh/beatmapsets/1477099#mania/3030679)
-  2. [dj TAKA feat. Erika Mochizuki - MOON (paulkappa) \[\[7K\] Slave of Sadness\]](https://osu.ppy.sh/beatmapsets/1666530#mania/3402422)
-  3. [Yuki Kajiura - Himeboshi (\_underjoy) \[\[7K\] Tranquility\]](https://osu.ppy.sh/beatmapsets/1069926#mania/3424740)
-  4. [Crush - OHIO (JuHaa) \[\[7K\] HIOH!\]](https://osu.ppy.sh/beatmapsets/1566789#mania/3199120)
+  1. [M2U - Yoake no Uta feat. Dazbee (SurfChu85) \[Daybreak\]](https://osu.ppy.sh/beatmapsets/1477099#mania/3030679)
+  2. [dj TAKA feat. Erika Mochizuki - MOON (paulkappa) \[Slave of Sadness\]](https://osu.ppy.sh/beatmapsets/1666530#mania/3402422)
+  3. [Yuki Kajiura - Himeboshi (\_underjoy) \[Tranquility\]](https://osu.ppy.sh/beatmapsets/1069926#mania/3424740)
+  4. [Crush - OHIO (JuHaa) \[HIOH!\]](https://osu.ppy.sh/beatmapsets/1566789#mania/3199120)
 - Hybrid
   1. [Camellia vs. Tsukasa Kaminose - Gunkyouzouteki Soseiriron (\_Stan) \[Imi\[7\]ation // 7K\]](https://osu.ppy.sh/beatmapsets/1262927#mania/2687659)
-  2. [Cuvelia - Tenkuu no Yoake (AncuL) \[\[7K\] Imaginary\]](https://osu.ppy.sh/beatmapsets/630583#mania/1331170)
-  3. [M2U - White Rose (JuHaa) \[\[7K\] White picture\]](https://osu.ppy.sh/beatmapsets/1514154#mania/3099963)
+  2. [Cuvelia - Tenkuu no Yoake (AncuL) \[Imaginary\]](https://osu.ppy.sh/beatmapsets/630583#mania/1331170)
+  3. [M2U - White Rose (JuHaa) \[White picture\]](https://osu.ppy.sh/beatmapsets/1514154#mania/3099963)
 - Tiebreaker
-  1. **[Nekomata Gekidan - envidia (Umo-) \[\[7K\] Envy\]](https://osu.ppy.sh/beatmapsets/1330328#mania/2756301)**
+  1. **[Nekomata Gekidan - envidia (Umo-) \[Envy\]](https://osu.ppy.sh/beatmapsets/1330328#mania/2756301)**
 
 ### Qualifiers
 


### PR DESCRIPTION
Adds the Semifinals results/stats as well as the mappool for the Finals week along with its schedule. Also removes the 7K prefix some beatmap difficulties had since that's an osu-web prefix that isn't part of the original difficulty name.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)