### PR TITLE
Add missing flag image reference

### DIFF
--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -734,6 +734,7 @@ Unofficial tournaments/competitions hosted by the communities.
 [flag_NL]: /wiki/shared/flag/NL.gif "Netherlands"
 [flag_NO]: /wiki/shared/flag/NO.gif "Norway"
 [flag_NZ]: /wiki/shared/flag/NZ.gif "New Zealand"
+[flag_PE]: /wiki/shared/flag/PE.gif "Peru"
 [flag_PH]: /wiki/shared/flag/PH.gif "Philippines"
 [flag_PL]: /wiki/shared/flag/PL.gif "Poland"
 [flag_PT]: /wiki/shared/flag/PT.gif "Portugal"


### PR DESCRIPTION
This somehow wasn't caught by ci in https://github.com/ppy/osu-wiki/pull/6911 (remark should've caught this)

[ci run in question](https://github.com/ppy/osu-wiki/runs/5270480954?check_suite_focus=true).

![image](https://user-images.githubusercontent.com/36758269/154909835-e0ec217a-1d06-4642-900e-820136a87066.png)

Looks like it ran on commit 222d8d0254d94c5f893aa0d7610d2c9cb414969d (and not the latest commit of the pr), which appears to be a bogus merge commit i can't find neither on ppy/osu-web or notchxu/osu-web. could have to do with making the pr from master, very unsure.