### PR TITLE
Make the wikilink ci check skippable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,15 @@ jobs:
           python .github/scripts/ci/run_yamllint.py --config .yamllint.yaml
 
       - name: find broken wikilinks
+        shell: bash
+        env:
+          PULL_REQUEST_TAG: 'SKIP_WIKILINK_CHECK'
         run: |
+          if ${{ contains(github.event.pull_request.body, env.PULL_REQUEST_TAG) }}; then
+            echo "::notice::Broken wikilink check suppressed ($PULL_REQUEST_TAG tag found in the pull request)"
+            exit 0
+          fi
+
           ARTICLES=$( git diff --diff-filter=d --name-only ${{ github.sha }}^ ${{ github.sha }} "wiki/**/*.md" "news/*.md" )
           python .github/scripts/ci/find_broken_wikilinks.py --target $ARTICLES
 


### PR DESCRIPTION
While some refactoring is being done on the wikilink checker, although close to being done, I'm pushing this quick change of making it skippable in the meantime while I'm finding time to work on it.

An occurrence of `SKIP_WIKILINK_CHECK` in the pr description will cause the check to abort, just like the outdated articles check.

The goal is that once the wikilink checker is done, it'll check all articles by default (and be suppressible by a pr desc tag), as I've discussed with @TicClick

For now, this is required to merge https://github.com/ppy/osu-wiki/pull/6686, containing an edge case where the link specifies locale, though I'm still not sure what the correct way of handling it would be. See [this discussion](https://github.com/ppy/osu-wiki/pull/6686#discussion_r780698222) if you're curious.

[Test pr](https://github.com/Walavouchey/osu-wiki/pull/17), see the two runs on the last commit