### PR TITLE
Update `Coffee Hispanic: Mocha`'s prize listing

### DIFF
--- a/wiki/Tournaments/CH/CHM_1/en.md
+++ b/wiki/Tournaments/CH/CHM_1/en.md
@@ -34,9 +34,9 @@ The **Coffee Hispanic: Mocha** (***CH:M***) was a double-elimination 1v1 osu! to
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 100 USD, physical trophy, exclusive custom-made keyboard (courtesy of [LotusPro](https://twitter.com/Lotusmech)), unique profile badge, commemorative banner |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | Physical trophy, exclusive custom-made keypad (courtesy of [LotusPro](https://twitter.com/Lotusmech)), commemorative banner |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | Physical trophy, exclusive custom-made keypad (courtesy of [LotusPro](https://twitter.com/Lotusmech)), commemorative banner |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 100 USD, physical trophy, [One by Wacom](http://www.wacom.com/en-id/products/pen-tablets/one-by-wacom) graphic tablet, unique profile badge, commemorative banner |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | Physical trophy, commemorative banner |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | Physical trophy, commemorative banner |
 
 ![](img/badge.png "Coffee Hispanic: Mocha winner badge")
 


### PR DESCRIPTION
okay so Vaf (the tournament's organizer) contacted me earlier shortly after #6950 was merged and he pointed out that apparently their old sponsor (the one that was listed on the forum thread) never sent them anything so ultimately they ended up with a completely different prizes instead for the winners of the tournament :

![image](https://user-images.githubusercontent.com/36564236/156831049-3922779e-f351-405a-90bc-9b11edbaac3f.png)

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)