### PR TITLE
Remove mention of the next community meeting date and other clean-up

### DIFF
--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 0d867e97c5066c996407f9515953de3d351b596a
+---
+
 # osu! Community Meetings
 
 Die **osu! Community Meetings** sind eine alle zwei Wochen stattfindende Diskussionsrunde, die vom [osu!-Team](/wiki/People/The_Team) veranstaltet wird. Das Hauptziel dieser Treffen ist es, jedem die Möglichkeit zu geben, direkt mit den Entwicklern und den für die Verwaltung der Community verantwortlichen Personen zu sprechen, um Probleme zur Diskussion zu stellen oder weitere Überlegungen einzubringen.

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -2,25 +2,25 @@
 
 The **osu! community meetings** are a fortnightly discussion panel hosted by the [osu! team](/wiki/People/The_Team). The primary aim of these meetings is to give anyone a chance to speak directly with the developers and people responsible for managing the community to raise issues for discussion or further consideration.
 
-Long ago in the [game's distant past](https://twitter.com/ppy/status/1169256824052170755), the osu! team used to host regular community meetings where everyone was welcome to talk. With the scale of the game today, this is no longer feasible, but through Discord a queueing system of sorts has been implemented where questions can be addressed one at a time. If you are interested in asking questions, please make sure you've read through the FAQ listed below, just in case your question has already been asked and answered!
+Long ago in the [game's distant past](https://twitter.com/ppy/status/1169256824052170755), the osu! team used to host regular community meetings where everyone was welcome to talk. With the scale of the game today, this is no longer feasible, but through Discord a queueing system of sorts has been implemented where questions can be addressed one at a time.
+
+If you are interested in asking questions, please make sure you've read through the FAQ below, just in case your question has already been asked and answered!
 
 Currently, the osu! community meetings are being chaired by [peppy](https://osu.ppy.sh/users/2), [Ephemeral](https://osu.ppy.sh/users/102335), and [smoogipoo](https://osu.ppy.sh/users/1040328).
 
-Meetings are generally held every two weeks, with reminders announced on [peppy's Twitter](https://twitter.com/ppy) about a day beforehand.
-
-The next osu! community meeting date will be announced at a later date.
-
 ## Getting involved
 
-The osu! community meetings are currently hosted on a Discord Stage on the [osu!dev Discord](https://discord.gg/ppy), and simulcasted on [peppy's Twitch channel](https://www.twitch.tv/ppy). Each meeting is currently scheduled to last about an hour, taking place every other weekend. 
+The osu! community meetings are currently hosted on a Discord Stage on the [osu!dev Discord server](https://discord.gg/ppy), and simulcasted on [peppy's Twitch channel](https://www.twitch.tv/ppy). Each meeting is currently scheduled to last about an hour.
 
-Everyone is welcome to join! If you have a question or have something to add to the discussion, you can raise your hand on the Discord Stage to join the queue, or write a message on the relevant Discord thread if you are not comfortable speaking, which will be read out loud and answered. In addition, before asking a question, please observe the following guidelines:
+The meetings are generally held every other weekend, with reminders announced on [peppy's Twitter](https://twitter.com/ppy) about a day beforehand. To get notified about these meetings when they start, mark yourself as interested using the event posted on the [osu!dev Discord server](https://discord.gg/ppy).
+
+Everyone is welcome to join! If you have a question or have something to add to the discussion, you can raise your hand on the Discord Stage to join the queue, or write a message on the relevant Discord thread in the `#community-meetings` channel if you are not comfortable speaking, which will be read out loud and answered. In addition, before asking a question, please observe the following guidelines:
 
 - Plan your talking points ahead of time, and keep them as concise as possible.
 - Try to only bring up issues which affect the larger community, not just you. 
 - Verification on osu!dev is not necessary, but may increase your chances of being selected for questions during Q&A sessions.
 
-We aim to take no more than 5 minutes per question, so please understand that questions that have been answered before or that are especially generic may not be chosen for discussion.
+The aim is to take no more than 5 minutes per question, so please understand that previously answered or especially generic questions may be skipped.
 
 ## Archives
 

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -4,7 +4,7 @@ The **osu! community meetings** are a fortnightly discussion panel hosted by the
 
 Long ago in the [game's distant past](https://twitter.com/ppy/status/1169256824052170755), the osu! team used to host regular community meetings where everyone was welcome to talk. With the scale of the game today, this is no longer feasible, but through Discord a queueing system of sorts has been implemented where questions can be addressed one at a time.
 
-If you are interested in asking questions, please make sure you've read through the FAQ below, just in case your question has already been asked and answered!
+If you are interested in asking questions, please make sure you've read through the guidelines listed further down this page.
 
 Currently, the osu! community meetings are being chaired by [peppy](https://osu.ppy.sh/users/2), [Ephemeral](https://osu.ppy.sh/users/102335), and [smoogipoo](https://osu.ppy.sh/users/1040328).
 

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 0d867e97c5066c996407f9515953de3d351b596a
+---
+
 # osu! community meetings
 
 Les **osu! community meetings** sont un groupe de discussion bimensuel organisé par l'[équipe d'osu!](/wiki/People/The_Team). L'objectif principal de ces meetings est de donner à chacun une chance de parler directement avec les développeurs et les personnes responsables de la gestion de la communauté pour soulever des questions à discuter ou à approfondir.

--- a/wiki/Community/osu!_community_meetings/id.md
+++ b/wiki/Community/osu!_community_meetings/id.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 0d867e97c5066c996407f9515953de3d351b596a
+---
+
 # Pertemuan komunitas osu!
 
 **Pertemuan komunitas osu!** merupakan panel diskusi yang diadakan oleh [tim inti osu!](/wiki/People/The_Team) setiap dua minggu sekali. Tujuan utama dari pertemuan-pertemuan tersebut adalah untuk memberikan kesempatan kepada seluruh pihak untuk berbicara secara langsung dengan pengembang dan orang-orang yang bertanggung jawab dalam mengatur komunitas untuk membahas tentang suatu hal atau pertimbangan lebih lanjut.


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

updating live to the next date is no longer necessary since the introduction of the events feature on discord, which is faster to update (apart from twitter)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

this pr was done entirely on a phone using the github interface. 6/10 wouldn't do again