### PR TITLE
Switch headings *General* and *Mouse* in `Client\Keyboard_shortcuts`

### DIFF
--- a/wiki/Client/Keyboard_shortcuts/en.md
+++ b/wiki/Client/Keyboard_shortcuts/en.md
@@ -190,13 +190,6 @@ These shortcuts work anywhere within the beatmap editor:
 
 ### Compose
 
-#### Mouse
-
-| Shortcut | Action |
-| :-- | :-- |
-| `Double Click` | On circles or slider ends to jump to the object's position in the timeline from any point in the song. (osu!, osu!taiko, osu!catch) |
-| `Right Click` | Toggle new combo (when placing new hit objects) or delete object (when selecting). |
-
 #### General
 
 | Shortcut | Action |
@@ -215,6 +208,13 @@ These shortcuts work anywhere within the beatmap editor:
 | `1`, `2`, or `3` | Switch between placement/selection mode: select, circle, and hold respectively (osu!mania). |
 | `Ctrl` + `Alt` + `Mouse Wheel Up/Down` | Switch between placement/selection modes. |
 | `Ctrl` + `Shift` + `A` | Open [AiMod](/wiki/Client/Beatmap_editor/AiMod). |
+
+#### Mouse
+
+| Shortcut | Action |
+| :-- | :-- |
+| `Double Click` | On circles or slider ends to jump to the object's position in the timeline from any point in the song. (osu!, osu!taiko, osu!catch) |
+| `Right Click` | Toggle new combo (when placing new hit objects) or delete object (when selecting). |
 
 #### Playfield
 

--- a/wiki/Client/Keyboard_shortcuts/fr.md
+++ b/wiki/Client/Keyboard_shortcuts/fr.md
@@ -192,13 +192,6 @@ Ces raccourcis fonctionnent partout dans l'éditeur de beatmaps :
 
 ### Compose
 
-#### Souris
-
-| Raccourci | Action |
-| :-- | :-- |
-| `Double Click` | Sur les cercles ou les extrémités du slider pour sauter à la position de l'objet dans la timeline à partir de n'importe quel point de la musique. (osu!, osu!taiko, osu!catch) |
-| `Right Click` | Active/Désactive un nouveau combo (lors du placement de nouveaux objets) ou supprime un objet (lors de la sélection). |
-
 #### Général
 
 | Raccourci | Action |
@@ -217,6 +210,13 @@ Ces raccourcis fonctionnent partout dans l'éditeur de beatmaps :
 | `1`, `2`, ou `3` | Passe du mode placement/sélection : sélection, cercle et hold respectivement (osu!mania). |
 | `Ctrl` + `Alt` + `Mouse Wheel Up/Down` | Active/Désactive entre les modes de placement/sélection. |
 | `Ctrl` + `Shift` + `A` | Ouvre [AiMod](/wiki/Client/Beatmap_editor/AiMod). |
+
+#### Souris
+
+| Raccourci | Action |
+| :-- | :-- |
+| `Double Click` | Sur les cercles ou les extrémités du slider pour sauter à la position de l'objet dans la timeline à partir de n'importe quel point de la musique. (osu!, osu!taiko, osu!catch) |
+| `Right Click` | Active/Désactive un nouveau combo (lors du placement de nouveaux objets) ou supprime un objet (lors de la sélection). |
 
 #### Terrain de jeu
 

--- a/wiki/Client/Keyboard_shortcuts/id.md
+++ b/wiki/Client/Keyboard_shortcuts/id.md
@@ -191,13 +191,6 @@ Tombol-tombol *shortcut* berikut dapat digunakan pada jendela, menu, atau tab be
 
 ### Tab Compose
 
-#### Mouse
-
-| Tombol *shortcut* | Fungsi |
-| :-- | :-- |
-| `Klik Kiri` dua kali | Berpindah secara cepat ke posisi objek yang dipilih. (osu!, osu!taiko, dan osu!catch) |
-| `Klik Kanan` | Mengaktifkan/menonaktifkan penerapan New Combo (pada saat hendak menempatkan objek baru) atau menghapus objek (pada saat memilih objek). |
-
 #### Umum
 
 | Tombol *shortcut* | Fungsi |
@@ -216,6 +209,13 @@ Tombol-tombol *shortcut* berikut dapat digunakan pada jendela, menu, atau tab be
 | `1`, `2`, atau `3` | Mengaktifkan mode Select, Circle, dan Hold (osu!mania). |
 | `Ctrl` + `Alt` + `Roda Mouse ke Atas/Bawah` | Mengubah mode pemilihan/penempatan objek yang aktif. |
 | `Ctrl` + `Shift` + `A` | Membuka jendela [AiMod](/wiki/Client/Beatmap_editor/AiMod). |
+
+#### Mouse
+
+| Tombol *shortcut* | Fungsi |
+| :-- | :-- |
+| `Klik Kiri` dua kali | Berpindah secara cepat ke posisi objek yang dipilih. (osu!, osu!taiko, dan osu!catch) |
+| `Klik Kanan` | Mengaktifkan/menonaktifkan penerapan New Combo (pada saat hendak menempatkan objek baru) atau menghapus objek (pada saat memilih objek). |
 
 #### Playfield
 

--- a/wiki/Client/Keyboard_shortcuts/tr.md
+++ b/wiki/Client/Keyboard_shortcuts/tr.md
@@ -190,13 +190,6 @@ Bu kısayollar beatmap düzenleyicinin her yerinde çalışır:
 
 ### Oluştur
 
-#### Fare
-
-| Kısayol | Eylem |
-| :-- | :-- |
-| `Çift Tık` | Dairelerin veya slider sonlarının üzerine şarkının herhangi bir yerinden objenin zaman çizgisindeki konumuna atla. (osu!, osu!taiko, osu!catch) |
-| `Sağ Tık` | Yeni kombo dizisine geç (yeni vuruş objesi yerleştirirken) ya da objeyi sil (seçerken). |
-
 #### Genel
 
 | Kısayol | Eylem |
@@ -215,6 +208,13 @@ Bu kısayollar beatmap düzenleyicinin her yerinde çalışır:
 | `1`, `2`, veya `3` | Sırasıyla seçim, circle, hold yerleştirme/seçim modları arasında geçiş yap (osu!mania). |
 | `Ctrl` + `Alt` + `Fare Tekerleği Yukarı/Aşağı` | Yerleştirme/seçim modları arasında geçiş yap. |
 | `Ctrl` + `Shift` + `A` | [AiMod](/wiki/Client/Beatmap_editor/AiMod)'u aç. |
+
+#### Fare
+
+| Kısayol | Eylem |
+| :-- | :-- |
+| `Çift Tık` | Dairelerin veya slider sonlarının üzerine şarkının herhangi bir yerinden objenin zaman çizgisindeki konumuna atla. (osu!, osu!taiko, osu!catch) |
+| `Sağ Tık` | Yeni kombo dizisine geç (yeni vuruş objesi yerleştirirken) ya da objeyi sil (seçerken). |
 
 #### Oyun alanı
 


### PR DESCRIPTION
Moves the heading *Mouse* below the heading *General*, so *General* is the first heading in this section. This order seems more plausible to me.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
