### PR TITLE
[DE] Update `Main_Page`, various styling changes across the wiki

### DIFF
--- a/wiki/Community/osu!dev_Discord_server/de.md
+++ b/wiki/Community/osu!dev_Discord_server/de.md
@@ -30,7 +30,7 @@ Jedes Projekt wird in seinem dafür vorgesehenen Kanal diskutiert:
 | [Beatmap Spotlights](/wiki/Beatmap_Spotlights) | `#osu-spotlights` |
 | [osu!-Wiki](https://github.com/ppy/osu-wiki) | `#osu-wiki` |
 | [Project Loved](/wiki/Community/Project_Loved) | `#osu-loved` |
-| [Offizielle Wettbewerbsunterstützung](/wiki/Tournaments/Official_support) | `#tournaments` |
+| [Offizielle Turnierunterstützung](/wiki/Tournaments/Official_support) | `#tournaments` |
 | [osu! Community Meetings](/wiki/Community/osu!_community_meetings) | `#community-meetings` |
 | [Modding](/wiki/Modding) Diskussionen und [NAT Meetings](/wiki/Modding/NAT_meetings) | `#modding` |
 | [Mappers' Guild](/wiki/Community/Mappers_Guild) | `#mappers-guild` |

--- a/wiki/Help_centre/Account/de.md
+++ b/wiki/Help_centre/Account/de.md
@@ -53,15 +53,15 @@ In Situationen, in denen wir uns sicher sind, dass Schummelei oder Fehlverhalten
 
 Siehe *[Einschränkungen des Accounts](/wiki/Help_centre/Account_restrictions)* für mehr Informationen über Accounteinschränkungen und das Beschwerdeverfahren.
 
-## Wettbewerbssperre
+## Turniersperre
 
-### Was ist eine Wettbewerbssperre?
+### Was ist eine Turniersperre?
 
-Wettbewerbssperren sind, wie der Name beschreibt, ein Verbot der Teilnahme an allen offiziell unterstützten Wettbewerben.
+Turniersperren sind, wie der Name beschreibt, ein Verbot der Teilnahme an allen offiziell unterstützten Turnieren.
 
-Ein Benutzer kann eine Wettbewerbssperre für einen Bruch der osu!-Communityregeln während eines Turnierspiels bekommen, abhängig von dem Schweregrad des Verstoßes. Beispiele für solches Fehlverhalten sind unter anderem das Erlangen eines unfairen Vorteils in offiziell unterstützten Wettbewerben, jemanden beleidigen, der an einem Turnier teilnimmt, oder die absichtliche Störung des Turnierablaufs.
+Ein Benutzer kann eine Turniersperre für einen Bruch der osu!-Communityregeln während eines Turnierspiels bekommen, abhängig von dem Schweregrad des Verstoßes. Beispiele für solches Fehlverhalten sind unter anderem das Erlangen eines unfairen Vorteils in offiziell unterstützten Turnieren, jemanden beleidigen, der an einem Turnier teilnimmt, oder die absichtliche Störung des Turnierablaufs.
 
-Die meisten Wettbewerbssperren haben eine festgelegte Dauer, variierend von 3 Monaten bis zu einem Jahr und mehr. Einige Sperren können dauerhaft sein. Unabhängig von der Dauer der Sperre sind alle Turniersperren **final** und können nicht angefochtet werden, wie es bei Einschränkungen der Fall ist.
+Die meisten Turniersperren haben eine festgelegte Dauer, variierend von 3 Monaten bis zu einem Jahr und mehr. Einige Sperren können dauerhaft sein. Unabhängig von der Dauer der Sperre sind alle Turniersperren **final** und können nicht angefochtet werden, wie es bei Einschränkungen der Fall ist.
 
 ## Anmeldung
 

--- a/wiki/Main_Page/de.md
+++ b/wiki/Main_Page/de.md
@@ -1,6 +1,4 @@
 ---
-outdated: true
-outdated_since: 9b7428d718587f9fea31c773261ec4b724b52ac2
 layout: main_page
 ---
 
@@ -113,7 +111,7 @@ osu! würde nicht ohne die Hilfe von vielen Menschen existieren, die in der Entw
 
 [Das Team](/wiki/People/The_Team): [Entwickler](/wiki/People/The_Team/Developers) • [Global Moderation Team](/wiki/People/The_Team/Global_Moderation_Team) • [Support Team](/wiki/People/The_Team/Support_Team) • [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) • [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) • [osu! Alumni](/wiki/People/The_Team/osu!_Alumni) • [Project Loved Team](/wiki/People/The_Team/Project_Loved_Team)
 
-[Community-Mitwirkende](/wiki/People/Community_Contributors) • [Benutzer mit besonderen Titeln](/wiki/People/Users_with_unique_titles)
+[Community-Mitwirkende](/wiki/People/Community_Contributors) • [Benutzer mit besonderen Titeln](/wiki/People/Users_with_unique_titles) • [Turnierkomitee](/wiki/People/Tournament_Committee) • [Performance-Punkte-Komitee](/wiki/People/Performance_Points_Committee)
 
 </div>
 <div class="wiki-main-page-panel">

--- a/wiki/People/Community_Contributors/de.md
+++ b/wiki/People/Community_Contributors/de.md
@@ -20,7 +20,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_CN] [Ballance](https://osu.ppy.sh/users/165946) | Gestaltung der [Achievements](/wiki/Medals). |
 | ![][flag_US] [akrolsmir](https://osu.ppy.sh/users/576800) | Entwickler und Aufrechthaltung des [AIBat](https://osu.ppy.sh/community/forums/topics/55305), dem bekanntesten Drittanbietertool für Beatmap-Modding, das heute von den meisten Benutzern in der Community verwendet wird. |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Ausgezeichnete Arbeit im Testen von Features und bei der Fehlerbehebung sowie Entwicklung verschiedener Funktionen für Mapper und Modder. |
-| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisieren vieler offiziellen Wettbewerbe (unter anderem dem OWC). |
+| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisieren vieler offiziellen Turnier (unter anderem dem OWC). |
 | ![][flag_US] [Blazevoir](https://osu.ppy.sh/users/120265) | Wahnsinnige Moderationserfolge (entspricht etwa 6 Mitarbeitern) und fast alleinige Moderation von `#osu` während der Spitzenzeiten (9k+ Nutzer). |
 | ![][flag_PL] [Piotrekol](https://osu.ppy.sh/users/304520) | Entwicklung und Pflege von [osu!stats](https://osustats.ppy.sh/) und einer Reihe nützlicher Werkzeuge für Beatmapping, Modding und allgemeines Spielen. |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) | Herausragende Leistungen beim Testen von Bugfixes/Features und bei der Bearbeitung von Support-Anfragen der Benutzer. |
@@ -90,13 +90,13 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | Benutzer | Beiträge |
 | :-- | :-- |
 | ![][flag_DE] [OnosakiHito](https://osu.ppy.sh/users/290128) | Herausragende Arbeit bei der Gründung der frühen osu!taiko-Community, mehrjährige Tätigkeit im BAT/QAT |
-| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Herausragende Beiträge zur osu!catch-Community, Überarbeitung der Ranking-Kriterien und Wettbewerben |
-| ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Herausragende Beiträge zu zahlreichen Medienprojekten, Wettbewerben und eine langjährige Zugehörigkeit zum GMT |
+| ![][flag_ES] [Deif](https://osu.ppy.sh/users/318565) | Herausragende Beiträge zur osu!catch-Community, Überarbeitung der Ranking-Kriterien und Turnieren |
+| ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Herausragende Beiträge zu zahlreichen Medienprojekten, Turnieren und eine langjährige Zugehörigkeit zum GMT |
 | ![][flag_US] [Garven](https://osu.ppy.sh/users/244216) | Jahrelange engagierte Arbeit für das BVT/QAT und immenser Beitrag zur Überarbeitung der Ranking-Kriterien |
 | ![][flag_DE] [Mao](https://osu.ppy.sh/users/2204515) | Jahrelanges Engagement für das BAT/QAT, maßgebliche Beteiligung an der Überarbeitung der Ranking-Kriterien und am Beatmap Nominator Test Management |
 | ![][flag_CH] [Irreversible](https://osu.ppy.sh/users/1287964) | Engagierter Beitrag zum BAT/QAT über unzählige Jahre hinweg |
-| ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) | Hunderte von Stunden an Statistiken und Analysen zu den Wettbewerben des World Cup |
-| ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973) | Herausragende Präsenz als Schiedsrichter bei Dutzenden Community-Wettbewerben |
+| ![][flag_DE] [Nwolf](https://osu.ppy.sh/users/1910766) | Hunderte von Stunden an Statistiken und Analysen zu den Turnieren des World Cup |
+| ![][flag_GB] [Yazzehh](https://osu.ppy.sh/users/7068973) | Herausragende Präsenz als Schiedsrichter bei Dutzenden Community-Turnieren |
 | ![][flag_CA] [Evrien](https://osu.ppy.sh/users/791660) | Hervorragende Leistungen bei Castings, Kommentierungen und ereignisbezogenen Berichten/Rückblicken |
 | ![][flag_DE] [Tom94](https://osu.ppy.sh/users/1857058) | Der Kopf hinter zahllosen Verbesserungen von osu!, von pp, zu einer neu geschriebenen Grafik-Engine, über Star-Rating und mehr! |
 | ![][flag_CA] [DrabWeb](https://osu.ppy.sh/users/6946022) | Herausragender Beitrag zum osu!(lazer)-Projekt |
@@ -119,7 +119,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | Benutzer | Beiträge |
 | :-- | :-- |
 | ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | World Cup Organisation & Gastgeber der osu! Coffee Hour |
-| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Herausragender Beitrag zur Organisation des World Cups und anderer Wettbewerbe |
+| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Herausragender Beitrag zur Organisation des World Cups und anderer Turniere |
 | ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | Herausragender Beitrag als Mitglied des GMTs und osu!-Wiki-Teams |
 | ![][flag_US] [clayton](https://osu.ppy.sh/users/3666350) | Hervorragende Beiträge in vielen Projekten und Bereichen |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | Hervorragende Arbeit bei Spielersupport und Problemlösung |
@@ -127,7 +127,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_SE] [Naxess](https://osu.ppy.sh/users/8129817) | Entwickler zahlreicher Tools, die sich als integraler Bestandteil des modernen Ranking-Zyklus erwiesen haben |
 | ![][flag_HU] [Kurokami](https://osu.ppy.sh/users/260933) | Herausragender Beitrag zum Beatmap-Spotlights-Projekt |
 | ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | Herausragender Beitrag in zahlreichen Projekten und Bereichen |
-| ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) | Hervorragender Beitrag zum GMT und zur Aufrechterhaltung von Wettbewerben |
+| ![][flag_FR] [shARPII](https://osu.ppy.sh/users/776257) | Hervorragender Beitrag zum GMT und zur Aufrechterhaltung von Turnieren |
 | ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Project Loved Teamleiter |
 | ![][flag_CA] [Kaifin](https://osu.ppy.sh/users/2596942) | Frühzeitige Unterstützung und Organisation des Project Loved |
 | ![][flag_US] [Zak](https://osu.ppy.sh/users/1375955) | Project Loved Captain (osu!catch) |
@@ -150,8 +150,8 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 
 | Benutzer | Beiträge |
 | :-- | :-- |
-| ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406) | Herausragende Beiträge zu Community-Angelegenheiten, Veranstaltungen und Wettbewerben |
-| ![][flag_SG] [hehe](https://osu.ppy.sh/users/2123087) | Herausragende Beiträge zur Mapping-Szene, zu Veranstaltungen und Wettbewerben |
+| ![][flag_CA] [VINXIS](https://osu.ppy.sh/users/4323406) | Herausragende Beiträge zu Community-Angelegenheiten, Veranstaltungen und Turnieren |
+| ![][flag_SG] [hehe](https://osu.ppy.sh/users/2123087) | Herausragende Beiträge zur Mapping-Szene, zu Veranstaltungen und Turnieren |
 | ![][flag_US] [Noffy](https://osu.ppy.sh/users/1541323) | Herausragende Beiträge zur Mapping-, Modding- und Metadaten-Szene |
 | ![][flag_SG] [Shoegazer](https://osu.ppy.sh/users/2520707) | Herausragende Beiträge zum Spielmodus osu!mania |
 | ![][flag_GB] [JBHyperion](https://osu.ppy.sh/users/4879508) | Herausragende Beiträge zum Spielmodus osu!catch und zum Management |
@@ -163,9 +163,9 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_GB] [Doomsday](https://osu.ppy.sh/users/18983) | Herausragende, unermüdliche Beiträge für die osu!-Community im Allgemeinen |
 | ![][flag_AT] [Omgforz](https://osu.ppy.sh/users/578943) | Herausragende Beiträge zum osu! World Cup |
 | ![][flag_AU] [Kano](https://osu.ppy.sh/users/3036203) | Herausragende Beiträge zum osu! World Cup |
-| ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992) | Herausragende Beiträge zur osu!mania-Wettbewerbsszene |
-| ![][flag_DE] [Junihuhn](https://osu.ppy.sh/users/4182339) | Herausragende Beiträge für die osu! World Cups & Wettbewerbsszene |
-| ![][flag_NL] [Sartan](https://osu.ppy.sh/users/4100941) | Herausragende Beiträge zur osu!catch Wettbewerbsszene |
+| ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992) | Herausragende Beiträge zur osu!mania-Turnierszene |
+| ![][flag_DE] [Junihuhn](https://osu.ppy.sh/users/4182339) | Herausragende Beiträge für die osu! World Cups & Turnierszene |
+| ![][flag_NL] [Sartan](https://osu.ppy.sh/users/4100941) | Herausragende Beiträge zur osu!catch Turnierszene |
 | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533) | Herausragende Beiträge zur Community-Moderation |
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) | Herausragende, unermüdliche Unterstützung und Hilfe für Spieler |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | Herausragende, unermüdliche Unterstützung und Hilfe für Spieler |
@@ -186,7 +186,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_PL] [spaceman_atlas](https://osu.ppy.sh/users/3035836) | Herausragende Beiträge zur Entwicklung von osu! durch viele Projekte |
 | ![][flag_DE] [RockRoller](https://osu.ppy.sh/users/8388854) | Herausragende Beiträge zur Skinning- und Moderationsszene von osu! |
 | ![][flag_US] [I Must Decrease](https://osu.ppy.sh/users/2773526) | Herausragende Beiträge zur Wartung und Entwicklung des Scorings |
-| ![][flag_US] [this1neguy](https://osu.ppy.sh/users/1797189) | Herausragende Beiträge zu den World Cups und Community-Wettbewerben |
+| ![][flag_US] [this1neguy](https://osu.ppy.sh/users/1797189) | Herausragende Beiträge zu den World Cups und Community-Turnieren |
 
 [flag_AR]: /wiki/shared/flag/AR.gif "Argentinien"
 [flag_AT]: /wiki/shared/flag/AT.gif "Österreich"

--- a/wiki/People/Community_Contributors/de.md
+++ b/wiki/People/Community_Contributors/de.md
@@ -20,7 +20,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_CN] [Ballance](https://osu.ppy.sh/users/165946) | Gestaltung der [Achievements](/wiki/Medals). |
 | ![][flag_US] [akrolsmir](https://osu.ppy.sh/users/576800) | Entwickler und Aufrechthaltung des [AIBat](https://osu.ppy.sh/community/forums/topics/55305), dem bekanntesten Drittanbietertool für Beatmap-Modding, das heute von den meisten Benutzern in der Community verwendet wird. |
 | ![][flag_NL] [statementreply](https://osu.ppy.sh/users/126198) | Ausgezeichnete Arbeit im Testen von Features und bei der Fehlerbehebung sowie Entwicklung verschiedener Funktionen für Mapper und Modder. |
-| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisieren vieler offiziellen Turnier (unter anderem dem OWC). |
+| ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Organisieren vieler offizieller Turniere (unter anderem dem OWC). |
 | ![][flag_US] [Blazevoir](https://osu.ppy.sh/users/120265) | Wahnsinnige Moderationserfolge (entspricht etwa 6 Mitarbeitern) und fast alleinige Moderation von `#osu` während der Spitzenzeiten (9k+ Nutzer). |
 | ![][flag_PL] [Piotrekol](https://osu.ppy.sh/users/304520) | Entwicklung und Pflege von [osu!stats](https://osustats.ppy.sh/) und einer Reihe nützlicher Werkzeuge für Beatmapping, Modding und allgemeines Spielen. |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) | Herausragende Leistungen beim Testen von Bugfixes/Features und bei der Bearbeitung von Support-Anfragen der Benutzer. |
@@ -165,7 +165,7 @@ Nicht zu verwechseln mit [osu! Alumni](/wiki/People/The_Team/osu!_Alumni), die f
 | ![][flag_AU] [Kano](https://osu.ppy.sh/users/3036203) | Herausragende Beiträge zum osu! World Cup |
 | ![][flag_US] [Halogen-](https://osu.ppy.sh/users/169992) | Herausragende Beiträge zur osu!mania-Turnierszene |
 | ![][flag_DE] [Junihuhn](https://osu.ppy.sh/users/4182339) | Herausragende Beiträge für die osu! World Cups & Turnierszene |
-| ![][flag_NL] [Sartan](https://osu.ppy.sh/users/4100941) | Herausragende Beiträge zur osu!catch Turnierszene |
+| ![][flag_NL] [Sartan](https://osu.ppy.sh/users/4100941) | Herausragende Beiträge zur osu!catch-Turnierszene |
 | ![][flag_RU] [Kobold84](https://osu.ppy.sh/users/3227533) | Herausragende Beiträge zur Community-Moderation |
 | ![][flag_US] [Death](https://osu.ppy.sh/users/3242450) | Herausragende, unermüdliche Unterstützung und Hilfe für Spieler |
 | ![][flag_US] [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) | Herausragende, unermüdliche Unterstützung und Hilfe für Spieler |

--- a/wiki/People/The_Team/Global_Moderation_Team/de.md
+++ b/wiki/People/The_Team/Global_Moderation_Team/de.md
@@ -61,10 +61,10 @@ Die [Seite für das globale Moderationsteam](https://osu.ppy.sh/groups/4) listet
 | ![][flag_HU] [[ Another ]](https://osu.ppy.sh/users/3416573) | Ungarisch | Chat-Moderation |
 | ![][flag_CH] [\[ryuu\]](https://osu.ppy.sh/users/5698467) | Russisch | Chat-Moderation |
 | ![][flag_US] [abraker](https://osu.ppy.sh/users/4635891) |  | Forum-Moderation |
-| ![][flag_CA] [Azer](https://osu.ppy.sh/users/2155578) |  | Verwaltung von Wettbewerben |
+| ![][flag_CA] [Azer](https://osu.ppy.sh/users/2155578) |  | Verwaltung von Turnieren |
 | ![][flag_MY] [bibitaru](https://osu.ppy.sh/users/4482419) | Chinesisch, Malaiisch | Chat-Moderation |
 | ![][flag_US] [Chaos](https://osu.ppy.sh/users/2628870) |  | Chat-Moderation |
-| ![][flag_US] [ChillierPear](https://osu.ppy.sh/users/9501251) | Schwedisch, Spanisch | Chat-Moderation, Verwaltung von Wettbewerben |
+| ![][flag_US] [ChillierPear](https://osu.ppy.sh/users/9501251) | Schwedisch, Spanisch | Chat-Moderation, Verwaltung von Turnieren |
 | ![][flag_GB] [chromb](https://osu.ppy.sh/users/10238680) |  | Chat-Moderation |
 | ![][flag_KR] [Civil oath](https://osu.ppy.sh/users/3216107) | Koreanisch, Japanisch | Chat-Moderation |
 | ![][flag_TR] [Coldrod](https://osu.ppy.sh/users/9065991) | Türkisch | Chat-Moderation |
@@ -85,10 +85,10 @@ Die [Seite für das globale Moderationsteam](https://osu.ppy.sh/groups/4) listet
 | ![][flag_JP] [KSHR](https://osu.ppy.sh/users/409957) | Japanisch | Chat-Moderation |
 | ![][flag_RU] [Kyubey](https://osu.ppy.sh/users/2195646) | Russisch | Chat-Moderation |
 | ![][flag_FI] [Laurakko](https://osu.ppy.sh/users/7253731) | Finnisch | Chat-Moderation |
-| ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | Portugiesisch, Spanisch | Chat-Moderation, Verwaltung von Wettbewerben |
+| ![][flag_BR] [LeoFLT](https://osu.ppy.sh/users/3668779) | Portugiesisch, Spanisch | Chat-Moderation, Verwaltung von Turnieren |
 | ![][flag_DE] [Loctav](https://osu.ppy.sh/users/71366) | Deutsch | Moderation der Mapping-/Modding-Community |
 | ![][flag_TW] [Loneight](https://osu.ppy.sh/users/663131) | Chinesisch | Chat-Moderation |
-| ![][flag_GB] [mangomizer](https://osu.ppy.sh/users/1893718) | Kantonesisch, Chinesisch | Verwaltung von Wettbewerben |
+| ![][flag_GB] [mangomizer](https://osu.ppy.sh/users/1893718) | Kantonesisch, Chinesisch | Verwaltung von Turnieren |
 | ![][flag_BR] [Maot](https://osu.ppy.sh/users/3914271) | Portugiesisch | Moderation der Mapping-/Modding-Community |
 | ![][flag_NO] [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu!-Entwicklung |
 | ![][flag_RU] [Kudou Chitose](https://osu.ppy.sh/users/9936528) | Russisch | Chat-Moderation |
@@ -102,7 +102,7 @@ Die [Seite für das globale Moderationsteam](https://osu.ppy.sh/groups/4) listet
 | ![][flag_DE] [OnosakiHito](https://osu.ppy.sh/users/290128) | Deutsch, Serbisch | Chat-Moderation, Moderation der Mapping-/Modding-Community |
 | ![][flag___] [osu!team](https://osu.ppy.sh/users/4341397) |  | Offizielle Präsenz des Teams |
 | ![][flag_PH] [Osu Tatakae Ouendan](https://osu.ppy.sh/users/594210) | Philippinisch | Chat-Moderation |
-| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | Deutsch | Verwaltung von Wettbewerben |
+| ![][flag_DE] [p3n](https://osu.ppy.sh/users/123703) | Deutsch | Verwaltung von Turnieren |
 | ![][flag_FR] [Pachiru](https://osu.ppy.sh/users/2850983) | Französisch, etwas Spanisch | Chat-Moderation |
 | ![][flag_PT] [Pereira006](https://osu.ppy.sh/users/537344) | Portugiesisch | Chat-Moderation |
 | ![][flag_HK] [Petal](https://osu.ppy.sh/users/7354729) | Kantonesisch, Chinesisch | Chat-Moderation |

--- a/wiki/People/The_Team/Support_Team/de.md
+++ b/wiki/People/The_Team/Support_Team/de.md
@@ -2,7 +2,7 @@
 
 *Für ein Team, welches Accounts verwaltet, siehe: [Account-Support-Team](/wiki/People/The_Team/Account_support_team)*
 
-Das **Support-Team** (auch bekannt als **Support Team Redux**) besteht aus Mitgliedern der osu!-Belegschaft, die für die Moderation von bestimmten Subforen im Forum zuständig sind: [Entwicklung](https://osu.ppy.sh/community/forums/2), [Spielverlauf & Rankings](https://osu.ppy.sh/community/forums/13) (ausgenommen [Wettbewerbe](https://osu.ppy.sh/community/forums/55) und [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4), und [Hilfe](https://osu.ppy.sh/community/forums/5).
+Das **Support-Team** (auch bekannt als **Support Team Redux**) besteht aus Mitgliedern der osu!-Belegschaft, die für die Moderation von bestimmten Subforen im Forum zuständig sind: [Entwicklung](https://osu.ppy.sh/community/forums/2), [Spielverlauf & Rankings](https://osu.ppy.sh/community/forums/13) (ausgenommen [Turniere](https://osu.ppy.sh/community/forums/55) und [Mapping Techniques](https://osu.ppy.sh/community/forums/61)), [Skinning](https://osu.ppy.sh/community/forums/15), [Feature Requests](https://osu.ppy.sh/community/forums/4), und [Hilfe](https://osu.ppy.sh/community/forums/5).
 
 ## Rollen und Verantwortlichkeiten
 

--- a/wiki/People/The_Team/de.md
+++ b/wiki/People/The_Team/de.md
@@ -34,7 +34,7 @@ Die unten aufgeführten Personen bilden den Kern des **osu!-Teams** und sind hau
 | ![][flag_FR] [Shiro](https://osu.ppy.sh/users/113005) | Allgemeiner Hausmeister |
 | ![][flag_AU] [smoogipoo](https://osu.ppy.sh/users/1040328) | osu!-Entwickler, osu!mania-Liebhaber, Fehlerbeseitiger |
 | ![][flag_US] [Toy](https://osu.ppy.sh/users/2757689) | Project Loved Manager, Community-Berater, Featured Artist Kontaktaufnahme |
-| ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Allgemeiner Hausmeister, Wettbewerbs-Assistent |
+| ![][flag_ES] [Trosk-](https://osu.ppy.sh/users/3469385) | Allgemeiner Hausmeister, Turnierassistent |
 | ![][flag_AU] [Zallius](https://osu.ppy.sh/users/55) | Gefährdete Art |
 
 Darüber hinaus ist das [Account-Support-Team](Account_support_team) da, um bei den Dingen zu helfen, die außerhalb der Reichweite liegen.
@@ -62,7 +62,7 @@ Die folgenden Benutzergruppen bestehen aus Mitgliedern der osu!-Community, die h
 | ![][flag_NZ] [deadbeat](https://osu.ppy.sh/users/128370) | Organisator und Administrator des World Cups |
 | ![][flag_US] [Derekku](https://osu.ppy.sh/users/91341) | Allgemeiner Hausmeister, Community-Manager |
 | ![][flag_NZ] [Echo](https://osu.ppy.sh/users/431) | osu!-Entwickler, Entwickler von IRC-Integration für In-Game-Chat, Wartung der Website. [Blog](http://blog.echo.sh/) |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | osu! Coffee Hour Gastgeber, World Cup Streamer, Wettbewerbsorganisator |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | osu! Coffee Hour Gastgeber, World Cup Streamer, Turnierorganisator |
 | ![][flag_NL] [Intermezzo](https://osu.ppy.sh/users/136842) | osu! Entwickler, Entwickler von osz2 und p2p Backend |
 | ![][flag_US] Jim | Ursprünglicher Website-Designer, Hosting-Provider in den Anfangstagen. [Brave New Games](http://www.bravegamer.com/) |
 | ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Organisator und Administrator des World Cups |

--- a/wiki/People/The_Team/osu!_Alumni/de.md
+++ b/wiki/People/The_Team/osu!_Alumni/de.md
@@ -86,7 +86,7 @@ Die [osu! Alumni Gruppenseite](https://osu.ppy.sh/groups/16) listet alle Mitglie
 | ![][flag_JP] [Guy](https://osu.ppy.sh/users/91738) | BAT, Chat-Moderator, QAT |
 | ![][flag_RU] [h3k1ru](https://osu.ppy.sh/users/291211) | GMT |
 | ![][flag_NL] [happy30](https://osu.ppy.sh/users/27767) | BAT |
-| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Verwaltung von Wettbewerben |
+| ![][flag_US] [HappyStick](https://osu.ppy.sh/users/256802) | Verwaltung von Turnieren |
 | ![][flag_MY] [HeatKai](https://osu.ppy.sh/users/332555) | BAT, Chat-Moderator |
 | ![][flag_TR] [heyronii](https://osu.ppy.sh/users/5642779) | GMT |
 | ![][flag_ID] [Hinsvar](https://osu.ppy.sh/users/1249323) | GMT |
@@ -103,7 +103,7 @@ Die [osu! Alumni Gruppenseite](https://osu.ppy.sh/groups/16) listet alle Mitglie
 | ![][flag_US] [James2250](https://osu.ppy.sh/users/16978) | GMT |
 | ![][flag_GB] [jericho2442](https://osu.ppy.sh/users/88904) | BAT |
 | ![][flag_CA] [jonathanlfj](https://osu.ppy.sh/users/270377) | BAT |
-| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Verwaltung von Wettbewerben |
+| ![][flag_AR] [juankristal](https://osu.ppy.sh/users/443656) | Verwaltung von Turnieren |
 | ![][flag_MX] [Kai](https://osu.ppy.sh/users/4537) | BAT |
 | ![][flag_CA] [karterfreak](https://osu.ppy.sh/users/1031958) | GMT, osu!media-Erstellung |
 | ![][flag_KR] [Kawayi Rika](https://osu.ppy.sh/users/596298) | BAT |
@@ -225,7 +225,7 @@ Die [osu! Alumni Gruppenseite](https://osu.ppy.sh/groups/16) listet alle Mitglie
 | ![][flag_NL] [Uni](https://osu.ppy.sh/users/617106) | GMT |
 | ![][flag_BE] [VeilStar](https://osu.ppy.sh/users/4255720) | GMT, Support-Team |
 | ![][flag_PH] [vytalibus](https://osu.ppy.sh/users/10028) | BAT |
-| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | GMT, Verwaltung von Wettbewerben |
+| ![][flag_CL] [WalterToro](https://osu.ppy.sh/users/5281416) | GMT, Verwaltung von Turnieren |
 | ![][flag_KR] [Where](https://osu.ppy.sh/users/549172) | GMT |
 | ![][flag_US] [whymeman](https://osu.ppy.sh/users/51994) | GMT |
 | ![][flag_ID] [Winshley](https://osu.ppy.sh/users/864895) | Chat-Moderator |


### PR DESCRIPTION
- Updates main page
- Turnier --> Wettbewerb
    - There is a difference between `Contest` and `Tournament`. They have been used interchangeably before in the German wiki. This PR changes usages of `Wettbewerb` to `Turnier` if the original article uses `tournament`. This word distinction is also documented in the new *translation for common terms* section of the German ASC.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
