### PR TITLE
Update community meeting article

### DIFF
--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -41,6 +41,7 @@ Das erste osu! Community Meeting fand am 19. September 2021 statt. Alle Treffen 
 | 10 | [6. Februar 2022](https://youtu.be/xA4nbE8DM4s) | [Sitzungsnotizen](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Diverse Fragen aus der Community |
 | 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | - | Mod-Multiplikatoren und Score |
 | 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | - | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
+| 13 | [20. März 2022](https://youtu.be/2Cp9rm0rNPQ) | [Sitzungsnotizen](https://yui.tv/osu-community-meetings/2022-03-20) | Entwicklungs-Update, diverse Fragen aus der Community |
 
 ## Weiterführende Links
 

--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 38cfa4c8f690c8afc5c7d82cd790a1fc954bd796
+---
+
 # osu! Community Meetings
 
 Die **osu! Community Meetings** sind eine alle zwei Wochen stattfindende Diskussionsrunde, die vom [osu!-Team](/wiki/People/The_Team) veranstaltet wird. Das Hauptziel dieser Treffen ist es, jedem die Möglichkeit zu geben, direkt mit den Entwicklern und den für die Verwaltung der Community verantwortlichen Personen zu sprechen, um Probleme zur Diskussion zu stellen oder weitere Überlegungen einzubringen.

--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -39,8 +39,8 @@ Das erste osu! Community Meeting fand am 19. September 2021 statt. Alle Treffen 
 | 8 | [9. Januar 2022](https://youtu.be/JXgQ6YEDCGg) | [Sitzungsnotizen](https://docs.google.com/document/d/1wJtJ7Agnsci3Ujxk52-ajeXfSJEKO-RCXDZCSUHcQYY) | HP-Mechanik (Gesundheitsverlust), verschiedene Fragen aus der Community |
 | 9 | [22. Januar 2022](https://youtu.be/Prx0XzHl6-M) | [Sitzungsnotizen](https://docs.google.com/document/d/1W_97ttbAo1mHjUgTeU_IB5SQVeQztT-pRrwiyTfjTu4) | Diverse Fragen aus der Community, Entwicklungs-Update |
 | 10 | [6. Februar 2022](https://youtu.be/xA4nbE8DM4s) | [Sitzungsnotizen](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Diverse Fragen aus der Community |
-| 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | [Zusammenfassender Neswbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod-Multiplikatoren und Score |
-| 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | [Zusammenfassender Neswbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
+| 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | [Zusammenfassender Newsbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod-Multiplikatoren und Score |
+| 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | [Zusammenfassender Newsbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
 | 13 | [20. März 2022](https://youtu.be/2Cp9rm0rNPQ) | [Sitzungsnotizen](https://yui.tv/osu-community-meetings/2022-03-20) | Entwicklungs-Update, diverse Fragen aus der Community |
 
 ## Weiterführende Links

--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -41,7 +41,7 @@ Das erste osu! Community Meeting fand am 19. September 2021 statt. Alle Treffen 
 | 10 | [6. Februar 2022](https://youtu.be/xA4nbE8DM4s) | [Sitzungsnotizen](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Diverse Fragen aus der Community |
 | 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | [Zusammenfassender Newsbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod-Multiplikatoren und Score |
 | 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | [Zusammenfassender Newsbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
-| 13 | [20. März 2022](https://youtu.be/2Cp9rm0rNPQ) | [Sitzungsnotizen](https://yui.tv/osu-community-meetings/2022-03-20) | Entwicklungs-Update, diverse Fragen aus der Community |
+| 13 | [20. März 2022](https://youtu.be/2Cp9rm0rNPQ) | [Sitzungsnotizen](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Entwicklungs-Update, diverse Fragen aus der Community |
 
 ## Weiterführende Links
 

--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -1,8 +1,3 @@
----
-outdated: true
-outdated_since: 38cfa4c8f690c8afc5c7d82cd790a1fc954bd796
----
-
 # osu! Community Meetings
 
 Die **osu! Community Meetings** sind eine alle zwei Wochen stattfindende Diskussionsrunde, die vom [osu!-Team](/wiki/People/The_Team) veranstaltet wird. Das Hauptziel dieser Treffen ist es, jedem die Möglichkeit zu geben, direkt mit den Entwicklern und den für die Verwaltung der Community verantwortlichen Personen zu sprechen, um Probleme zur Diskussion zu stellen oder weitere Überlegungen einzubringen.
@@ -44,8 +39,8 @@ Das erste osu! Community Meeting fand am 19. September 2021 statt. Alle Treffen 
 | 8 | [9. Januar 2022](https://youtu.be/JXgQ6YEDCGg) | [Sitzungsnotizen](https://docs.google.com/document/d/1wJtJ7Agnsci3Ujxk52-ajeXfSJEKO-RCXDZCSUHcQYY) | HP-Mechanik (Gesundheitsverlust), verschiedene Fragen aus der Community |
 | 9 | [22. Januar 2022](https://youtu.be/Prx0XzHl6-M) | [Sitzungsnotizen](https://docs.google.com/document/d/1W_97ttbAo1mHjUgTeU_IB5SQVeQztT-pRrwiyTfjTu4) | Diverse Fragen aus der Community, Entwicklungs-Update |
 | 10 | [6. Februar 2022](https://youtu.be/xA4nbE8DM4s) | [Sitzungsnotizen](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Diverse Fragen aus der Community |
-| 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | - | Mod-Multiplikatoren und Score |
-| 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | - | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
+| 11 | [20. Februar 2022](https://youtu.be/d66pU5lsHvE) | [Zusammenfassender Neswbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod-Multiplikatoren und Score |
+| 12 | [6. März 2022](https://youtu.be/HimCHAnPCCY) | [Zusammenfassender Neswbeitrag](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Ranglisten, Cross-Kompatibilität und Vorbereitung auf die Veröffentlichung von osu!(lazer) |
 | 13 | [20. März 2022](https://youtu.be/2Cp9rm0rNPQ) | [Sitzungsnotizen](https://yui.tv/osu-community-meetings/2022-03-20) | Entwicklungs-Update, diverse Fragen aus der Community |
 
 ## Weiterführende Links

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -41,7 +41,7 @@ The first osu! community meeting was hosted on September 19, 2021. All meetings 
 | 10 | [February 6, 2022](https://youtu.be/xA4nbE8DM4s) | [Meeting notes](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Various community questions |
 | 11 | [February 20, 2022](https://youtu.be/d66pU5lsHvE) | [Summary news post](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod multipliers and score |
 | 12 | [March 6, 2022](https://youtu.be/HimCHAnPCCY) | [Summary news post](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Leaderboards, cross-compatibility, and preparing for the release of osu!(lazer) |
-| 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://yui.tv/osu-community-meetings/2022-03-20) | Development update, various community questions |
+| 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Development update, various community questions |
 
 ## Related links
 

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -41,6 +41,7 @@ The first osu! community meeting was hosted on September 19, 2021. All meetings 
 | 10 | [February 6, 2022](https://youtu.be/xA4nbE8DM4s) | [Meeting notes](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Various community questions |
 | 11 | [February 20, 2022](https://youtu.be/d66pU5lsHvE) | - | Mod multipliers and score |
 | 12 | [March 6, 2022](https://youtu.be/HimCHAnPCCY) | - | Leaderboards, cross-compatibility, and preparing for the release of osu!(lazer) |
+| 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://yui.tv/osu-community-meetings/2022-03-20) | Development update, various community questions |
 
 ## Related links
 

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -39,8 +39,8 @@ The first osu! community meeting was hosted on September 19, 2021. All meetings 
 | 8 | [January 9, 2022](https://youtu.be/JXgQ6YEDCGg) | [Meeting notes](https://docs.google.com/document/d/1wJtJ7Agnsci3Ujxk52-ajeXfSJEKO-RCXDZCSUHcQYY) | HP mechanics (health drain), various community questions |
 | 9 | [January 22, 2022](https://youtu.be/Prx0XzHl6-M) | [Meeting notes](https://docs.google.com/document/d/1W_97ttbAo1mHjUgTeU_IB5SQVeQztT-pRrwiyTfjTu4) | Various community questions, development update |
 | 10 | [February 6, 2022](https://youtu.be/xA4nbE8DM4s) | [Meeting notes](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Various community questions |
-| 11 | [February 20, 2022](https://youtu.be/d66pU5lsHvE) | - | Mod multipliers and score |
-| 12 | [March 6, 2022](https://youtu.be/HimCHAnPCCY) | - | Leaderboards, cross-compatibility, and preparing for the release of osu!(lazer) |
+| 11 | [February 20, 2022](https://youtu.be/d66pU5lsHvE) | [Summary news post](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Mod multipliers and score |
+| 12 | [March 6, 2022](https://youtu.be/HimCHAnPCCY) | [Summary news post](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Leaderboards, cross-compatibility, and preparing for the release of osu!(lazer) |
 | 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://yui.tv/osu-community-meetings/2022-03-20) | Development update, various community questions |
 
 ## Related links

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -1,8 +1,3 @@
----
-outdated: true
-outdated_since: 38cfa4c8f690c8afc5c7d82cd790a1fc954bd796
----
-
 # osu! community meetings
 
 Les **osu! community meetings** sont un groupe de discussion bimensuel organisé par l'[équipe d'osu!](/wiki/People/The_Team). L'objectif principal de ces meetings est de donner à chacun une chance de parler directement avec les développeurs et les personnes responsables de la gestion de la communauté pour soulever des questions à discuter ou à approfondir.
@@ -44,8 +39,8 @@ Le premier osu! community meeting a eu lieu le 19 septembre 2021. Tous les meeti
 | 8 | [9 janvier 2022](https://youtu.be/JXgQ6YEDCGg) | [Document de synthèse](https://docs.google.com/document/d/1wJtJ7Agnsci3Ujxk52-ajeXfSJEKO-RCXDZCSUHcQYY) | Mécanique des HP (drain de santé), questions diverses de la communauté |
 | 9 | [22 janvier 2022](https://youtu.be/Prx0XzHl6-M) | [Document de synthèse](https://docs.google.com/document/d/1W_97ttbAo1mHjUgTeU_IB5SQVeQztT-pRrwiyTfjTu4) | Questions diverses de la communauté, mise à jour concernant le développement |
 | 10 | [6 février 2022](https://youtu.be/xA4nbE8DM4s) | [Document de synthèse](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Questions diverses de la communauté |
-| 11 | [20 février 2022](https://youtu.be/d66pU5lsHvE) | - | Score et multiplicateurs de mods |
-| 12 | [6 mars 2022](https://youtu.be/HimCHAnPCCY) | - | Classements, compatibilité entre les clients, et préparation de la sortie d'osu!(lazer) |
+| 11 | [20 février 2022](https://youtu.be/d66pU5lsHvE) | [Article récapitulatif](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Score et multiplicateurs de mods |
+| 12 | [6 mars 2022](https://youtu.be/HimCHAnPCCY) | [Article récapitulatif](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) | Classements, compatibilité entre les clients, et préparation de la sortie d'osu!(lazer) |
 | 13 | [20 mars 2022](https://youtu.be/2Cp9rm0rNPQ) | [Document de synthèse](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Mise à jour concernant le développement, questions diverses de la communauté |
 
 ## Liens associés

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 38cfa4c8f690c8afc5c7d82cd790a1fc954bd796
+---
+
 # osu! community meetings
 
 Les **osu! community meetings** sont un groupe de discussion bimensuel organisé par l'[équipe d'osu!](/wiki/People/The_Team). L'objectif principal de ces meetings est de donner à chacun une chance de parler directement avec les développeurs et les personnes responsables de la gestion de la communauté pour soulever des questions à discuter ou à approfondir.

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -41,6 +41,7 @@ Le premier osu! community meeting a eu lieu le 19 septembre 2021. Tous les meeti
 | 10 | [6 février 2022](https://youtu.be/xA4nbE8DM4s) | [Document de synthèse](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Questions diverses de la communauté |
 | 11 | [20 février 2022](https://youtu.be/d66pU5lsHvE) | - | Score et multiplicateurs de mods |
 | 12 | [6 mars 2022](https://youtu.be/HimCHAnPCCY) | - | Classements, compatibilité entre les clients, et préparation de la sortie d'osu!(lazer) |
+| 13 | [20 mars 2022](https://youtu.be/2Cp9rm0rNPQ) | [Document de synthèse](https://yui.tv/osu-community-meetings/2022-03-20) | Mise à jour concernant le développement, questions diverses de la communauté |
 
 ## Liens associés
 

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -46,7 +46,7 @@ Le premier osu! community meeting a eu lieu le 19 septembre 2021. Tous les meeti
 | 10 | [6 février 2022](https://youtu.be/xA4nbE8DM4s) | [Document de synthèse](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Questions diverses de la communauté |
 | 11 | [20 février 2022](https://youtu.be/d66pU5lsHvE) | - | Score et multiplicateurs de mods |
 | 12 | [6 mars 2022](https://youtu.be/HimCHAnPCCY) | - | Classements, compatibilité entre les clients, et préparation de la sortie d'osu!(lazer) |
-| 13 | [20 mars 2022](https://youtu.be/2Cp9rm0rNPQ) | [Document de synthèse](https://yui.tv/osu-community-meetings/2022-03-20) | Mise à jour concernant le développement, questions diverses de la communauté |
+| 13 | [20 mars 2022](https://youtu.be/2Cp9rm0rNPQ) | [Document de synthèse](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Mise à jour concernant le développement, questions diverses de la communauté |
 
 ## Liens associés
 

--- a/wiki/Community/osu!_community_meetings/id.md
+++ b/wiki/Community/osu!_community_meetings/id.md
@@ -41,6 +41,7 @@ Pertemuan komunitas osu! pertama diadakan pada tanggal 19 September 2021. Adapun
 | 10 | [6 Februari 2022](https://youtu.be/xA4nbE8DM4s) | [Notulen pertemuan](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Berbagai pertanyaan dari para anggota komunitas |
 | 11 | [20 Februari 2022](https://youtu.be/d66pU5lsHvE) | - |  Pengali skor dan skor |
 | 12 | [6 Maret 2022](https://youtu.be/HimCHAnPCCY) | - |  |
+| 13 | [20 Maret 2022](https://youtu.be/2Cp9rm0rNPQ) | [Notulen pertemuan](https://yui.tv/osu-community-meetings/2022-03-20) | Berita-berita terkini seputar pengembangan osu! serta berbagai pertanyaan dari para anggota komunitas |
 
 ## Tautan terkait
 

--- a/wiki/Community/osu!_community_meetings/id.md
+++ b/wiki/Community/osu!_community_meetings/id.md
@@ -1,3 +1,8 @@
+---
+outdated: true
+outdated_since: 38cfa4c8f690c8afc5c7d82cd790a1fc954bd796
+---
+
 # Pertemuan komunitas osu!
 
 **Pertemuan komunitas osu!** merupakan sebuah panel diskusi yang diadakan oleh [tim inti osu!](/wiki/People/The_Team) setiap dua minggu sekali. Tujuan utama dari pertemuan ini adalah untuk memberikan kesempatan kepada seluruh pihak untuk dapat berbicara secara langsung dengan para pengembang serta orang-orang yang bertanggung jawab dalam mengatur komunitas mengenai berbagai hal yang dirasa perlu untuk dibahas dan dipertimbangkan lebih lanjut.

--- a/wiki/Community/osu!_community_meetings/id.md
+++ b/wiki/Community/osu!_community_meetings/id.md
@@ -46,7 +46,7 @@ Pertemuan komunitas osu! pertama diadakan pada tanggal 19 September 2021. Adapun
 | 10 | [6 Februari 2022](https://youtu.be/xA4nbE8DM4s) | [Notulen pertemuan](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | Berbagai pertanyaan dari para anggota komunitas |
 | 11 | [20 Februari 2022](https://youtu.be/d66pU5lsHvE) | - |  Pengali skor dan skor |
 | 12 | [6 Maret 2022](https://youtu.be/HimCHAnPCCY) | - |  |
-| 13 | [20 Maret 2022](https://youtu.be/2Cp9rm0rNPQ) | [Notulen pertemuan](https://yui.tv/osu-community-meetings/2022-03-20) | Berita-berita terkini seputar pengembangan osu! serta berbagai pertanyaan dari para anggota komunitas |
+| 13 | [20 Maret 2022](https://youtu.be/2Cp9rm0rNPQ) | [Notulen pertemuan](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Berita-berita terkini seputar pengembangan osu! serta berbagai pertanyaan dari para anggota komunitas |
 
 ## Tautan terkait
 

--- a/wiki/Community/osu!_community_meetings/zh-tw.md
+++ b/wiki/Community/osu!_community_meetings/zh-tw.md
@@ -51,6 +51,7 @@ Translation: *Note: If the above date has passed, the most recent date can be fo
 | 10 | [2022 年 2 月 6 號](https://youtu.be/xA4nbE8DM4s) | [筆記](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | 各類由社群提出的問題 |
 | 11 | [2022 年 2 月 20 號](https://youtu.be/d66pU5lsHvE) | - |  |
 | 12 | [2022 年 3 月 6 號](https://youtu.be/HimCHAnPCCY) | - |  |
+| 13 | [2022 年 3 月 20 號](https://youtu.be/2Cp9rm0rNPQ) | [筆記](https://yui.tv/osu-community-meetings/2022-03-20) | 開發最新進度、各類由社群提出的問題 |
 
 ## 相關連結
 

--- a/wiki/Community/osu!_community_meetings/zh-tw.md
+++ b/wiki/Community/osu!_community_meetings/zh-tw.md
@@ -51,7 +51,7 @@ Translation: *Note: If the above date has passed, the most recent date can be fo
 | 10 | [2022 年 2 月 6 號](https://youtu.be/xA4nbE8DM4s) | [筆記](https://docs.google.com/document/d/1IM8LlHTrU9aIBkS-WTfbpLrMMrq2eRgRl7EAo_chDYE) | 各類由社群提出的問題 |
 | 11 | [2022 年 2 月 20 號](https://youtu.be/d66pU5lsHvE) | - |  |
 | 12 | [2022 年 3 月 6 號](https://youtu.be/HimCHAnPCCY) | - |  |
-| 13 | [2022 年 3 月 20 號](https://youtu.be/2Cp9rm0rNPQ) | [筆記](https://yui.tv/osu-community-meetings/2022-03-20) | 開發最新進度、各類由社群提出的問題 |
+| 13 | [2022 年 3 月 20 號](https://youtu.be/2Cp9rm0rNPQ) | [筆記](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | 開發最新進度、各類由社群提出的問題 |
 
 ## 相關連結
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Translations have their agenda copied from previous rows, but they've still been outdated due to adding the news post link

I've put the notes at yui.tv, which is a simple web server I've spun up that doesn't do much else currently. I thought it was a better option than keeping the notes at notion.so (and it also cleans up the url). I usually don't like keeping up google docs, but if copying it over to one is better then that's fine too.