### PR TITLE
Update schedules, rules for `TWC 2022`

### DIFF
--- a/wiki/Tournaments/TWC/2022/en.md
+++ b/wiki/Tournaments/TWC/2022/en.md
@@ -338,7 +338,7 @@ Qualifier results:
    - "Lag spikes" are not considered a valid reason to nullify a beatmap.
    - If a rematch happens, the original roster for each team during that particular beatmap must remain the same. If that is not possible, e.g. by virtue of a technical issue, both teams will be allowed to swap rosters.
    - This rule is not to be abused. Referees may veto a rematch request if they find that this is the case.
-9. Disconnects within 30 seconds or 25% of the beatmap length (whichever happens first) can be rematched, at the referee's discretion, as long as it's clearly communicated in the chatroom.
+9. Disconnects within 30 seconds or 25% of the beatmap length (whichever happens first) can be rematched, at the referee's discretion, as long as it is clearly communicated in the chatroom.
 10. If a player disconnects, their scores will not be counted towards their team's total, unless adequate proof of said score is provided. The following are considered as acceptable proof:
     - Player point-of-view live stream snippets (commonly referred to as "clips" or "VODs"). The entirety of the play, along with the results screen must be clearly visible along with the affected player's score.
     - Replay files of the play, taken directly from the "Local scores" tab on the affected player's client (the timestamps must exactly match the time at which the game took place, as seen on the multiplayer lobby link).
@@ -442,7 +442,7 @@ Qualifier results:
 7. The FreeMod bracket will have FreeMod activated, and the No Fail mod will be enforced. Each player may pick Hidden, Hard Rock or Hidden + Hard Rock.
    - When playing a FreeMod map, at least one player of each team must use a mod.
    - Both teams must select the No Fail mod in addition to their chosen mod combination.
-   - Players must select different mod combinations. Using only Hidden, Hard Rock, or Hidden + Hard Rock for both players at the same time is not allowed. No Fail will not be counted as a mod (e.g. a No Fail + Hidden and Hidden mod combination will be considered as just Hidden for both players).
+   - Players must select different mod combinations. Using only Hidden, Hard Rock, or Hidden + Hard Rock for both players at the same time is not allowed. No Fail will not be counted as a mod (e.g. two players using No Fail + Hidden and Hidden will be considered as using the same mod combination).
 8. The tiebreaker will be played with FreeMod activated, but will not follow the FreeMod bracket rules: players do not need to have a mod activated and are allowed to select the same mod combination. Both teams must select the No Fail mod.
 9. The size of the NoMod bracket will be 3 for the Qualifiers, 4 for the Round of 32 and Round of 16, 5 for the Quarterfinals and Semifinals, and 6 for the Finals and Grand Finals.
 10. The size of the [Hidden](/wiki/Game_modifier/Hidden), [Hard Rock](/wiki/Game_modifier/Hard_Rock) and [Double Time](/wiki/Game_modifier/Double_Time) brackets will be 2 for all stages.

--- a/wiki/Tournaments/TWC/2022/en.md
+++ b/wiki/Tournaments/TWC/2022/en.md
@@ -95,33 +95,49 @@ The osu!taiko World Cup 2022 is run by various community members.
 | ![][flag_US] | **United States** | **[general chicken](https://osu.ppy.sh/users/8050850)**, [R J](https://osu.ppy.sh/users/6490509), [AuroraPhasmata](https://osu.ppy.sh/users/13664116), [Miniature Lamp](https://osu.ppy.sh/users/9821194), [ChurroChef](https://osu.ppy.sh/users/9258564), [cheese salad](https://osu.ppy.sh/users/6349821) |
 | ![][flag_VN] | **Vietnam** | **[davidminh0111](https://osu.ppy.sh/users/9623142)**, [AkiraPlayz](https://osu.ppy.sh/users/16039831), [crazynt\_ngu](https://osu.ppy.sh/users/7844013), [JackTVN](https://osu.ppy.sh/users/12510704), [njshift1](https://osu.ppy.sh/users/16688499) |
 
-## Match schedule: Round of 16
+## Match schedule: Quarterfinals
 
-### Saturday, March 26, 2022
+### Saturday, April 2, 2022
 
-| Team A | | | Team B | Match time | Local time A | Local time B |
-| --: | --: | :-- | :-- | :-: | :-: | :-: |
-| New Zealand | ![][flag_NZ] | ![][flag_PH] | Philippines | Mar 26 (Sat) 11:00 UTC | Mar 26 (Sat) 23:00 UTC+12 | Mar 26 (Sat) 19:00 UTC+8 |
-| Portugal | ![][flag_PT] | ![][flag_SG] | Singapore | Mar 26 (Sat) 13:00 UTC | Mar 26 (Sat) 13:00 UTC | Mar 26 (Sat) 21:00 UTC+8 |
-| Netherlands | ![][flag_NL] | ![][flag_CH] | Switzerland | Mar 26 (Sat) 14:00 UTC | Mar 26 (Sat) 15:00 UTC+1 | Mar 26 (Sat) 15:00 UTC+1 |
-| Czech Republic | ![][flag_CZ] | ![][flag_AR] | Argentina | Mar 26 (Sat) 16:00 UTC | Mar 26 (Sat) 17:00 UTC+1 | Mar 26 (Sat) 13:00 UTC-3 |
-| Costa Rica | ![][flag_CR] | ![][flag_TR] | Turkey | Mar 26 (Sat) 17:00 UTC | Mar 26 (Sat) 11:00 UTC-6 | Mar 26 (Sat) 20:00 UTC+3 |
-| Germany | ![][flag_DE] | ![][flag_FR] | France | Mar 26 (Sat) 17:00 UTC | Mar 26 (Sat) 18:00 UTC+1 | Mar 26 (Sat) 18:00 UTC+1 |
-| Mexico | ![][flag_MX] | ![][flag_IT] | Italy | Mar 26 (Sat) 20:00 UTC | Mar 26 (Sat) 14:00 UTC-6 | Mar 26 (Sat) 21:00 UTC+1 |
+| Team A | | | Team B | Match time | Local time A | Local time B | |
+| --: | --: | :-- | :-- | :-: | :-: | :-: | :-: |
+| Malaysia | ![][flag_MY] | ![][flag_NZ] | New Zealand | Apr 2 (Sat) 08:00 UTC | Apr 2 (Sat) 16:00 UTC+8 | Apr 2 (Sat) 20:00 UTC+12 | ² |
+| Taiwan | ![][flag_TW] | ![][flag_CN] | China | Apr 2 (Sat) 10:00 UTC | Apr 2 (Sat) 18:00 UTC+8 | Apr 2 (Sat) 18:00 UTC+8 | ² |
+| Finland | ![][flag_FI] | ![][flag_TR] | Turkey | Apr 2 (Sat) 12:00 UTC | Apr 2 (Sat) 14:00 UTC+2 | Apr 2 (Sat) 15:00 UTC+3 | ² |
+| Chile | ![][flag_CL] | ![][flag_SG] | Singapore | Apr 2 (Sat) 14:00 UTC | Apr 2 (Sat) 11:00 UTC-3 | Apr 2 (Sat) 22:00 UTC+8 | ² |
+| Brazil | ![][flag_BR] | ![][flag_RU] | Russian Federation | Apr 2 (Sat) 15:30 UTC | Apr 2 (Sat) 12:30 UTC-3 | Apr 2 (Sat) 18:30 UTC+3 | ² |
+| France | ![][flag_FR] | ![][flag_CH] | Switzerland | Apr 2 (Sat) 17:00 UTC | Apr 2 (Sat) 18:00 UTC+1 | Apr 2 (Sat) 18:00 UTC+1 | ² |
+| United States | ![][flag_US] | ![][flag_IT] | Italy | Apr 2 (Sat) 18:30 UTC | Apr 2 (Sat) 13:30 UTC-5 | Apr 2 (Sat) 19:30 UTC+1 | ² |
+| Canada | ![][flag_CA] | ![][flag_AR] | Argentina | Apr 2 (Sat) 20:00 UTC | Apr 2 (Sat) 15:00 UTC-5 | Apr 2 (Sat) 17:00 UTC-3 | ² |
 
-### Sunday, March 27, 2022
+### Sunday, April 3, 2022
 
-| Team A | | | Team B | Match time | Local time A | Local time B |
-| --: | --: | :-- | :-- | :-: | :-: | :-: |
-| United States | ![][flag_US] | ![][flag_AU] | Australia | Mar 27 (Sun) 03:00 UTC | Mar 26 (Sat) 22:00 UTC-5 | Mar 27 (Sun) 13:00 UTC+10 |
-| Hong Kong | ![][flag_HK] | ![][flag_MY] | Malaysia | Mar 27 (Sun) 12:00 UTC | Mar 27 (Sun) 20:00 UTC+8 | Mar 27 (Sun) 20:00 UTC+8 |
-| South Korea | ![][flag_KR] | ![][flag_FI] | Finland | Mar 27 (Sun) 12:00 UTC | Mar 27 (Sun) 21:00 UTC+9 | Mar 27 (Sun) 14:00 UTC+2 |
-| Poland | ![][flag_PL] | ![][flag_RU] | Russian Federation | Mar 27 (Sun) 13:00 UTC | Mar 27 (Sun) 14:00 UTC+1 | Mar 27 (Sun) 16:00 UTC+3 |
-| Taiwan | ![][flag_TW] | ![][flag_ID] | Indonesia | Mar 27 (Sun) 13:00 UTC | Mar 27 (Sun) 21:00 UTC+8 | Mar 27 (Sun) 20:00 UTC+7 |
-| Colombia | ![][flag_CO] | ![][flag_CN] | China | Mar 27 (Sun) 14:00 UTC | Mar 27 (Sun) 09:00 UTC-5 | Mar 27 (Sun) 22:00 UTC+8 |
-| Japan | ![][flag_JP] | ![][flag_CL] | Chile | Mar 27 (Sun) 14:00 UTC | Mar 27 (Sun) 23:00 UTC+9 | Mar 27 (Sun) 11:00 UTC-3 |
-| Brazil | ![][flag_BR] | ![][flag_GB] | United Kingdom | Mar 27 (Sun) 15:00 UTC | Mar 27 (Sun) 12:00 UTC-3 | Mar 27 (Sun) 15:00 UTC |
-| Canada | ![][flag_CA] | ![][flag_SE] | Sweden | Mar 27 (Sun) 16:00 UTC | Mar 27 (Sun) 11:00 UTC-5 | Mar 27 (Sun) 17:00 UTC+1 |
+| Team A | | | Team B | Match time | Local time A | Local time B | |
+| --: | --: | :-- | :-- | :-: | :-: | :-: | :-: |
+| United States | ![][flag_US] | ![][flag_MY] | Malaysia | Apr 3 (Sun) 03:00 UTC | Apr 2 (Sat) 22:00 UTC-5 | Apr 3 (Sun) 11:00 UTC+8 | ³ |
+| United States | ![][flag_US] | ![][flag_NZ] | New Zealand | Apr 3 (Sun) 03:00 UTC | Apr 2 (Sat) 22:00 UTC-5 | Apr 3 (Sun) 15:00 UTC+12 | ³ |
+| Canada | ![][flag_CA] | ![][flag_SG] | Singapore | Apr 3 (Sun) 04:00 UTC | Apr 2 (Sat) 23:00 UTC-5 | Apr 3 (Sun) 12:00 UTC+8 | ³ |
+| Hong Kong | ![][flag_HK] | ![][flag_AU] | Australia | Apr 3 (Sun) 08:00 UTC | Apr 3 (Sun) 16:00 UTC+8 | Apr 3 (Sun) 18:00 UTC+10 | ¹ |
+| Italy | ![][flag_IT] | ![][flag_MY] | Malaysia | Apr 3 (Sun) 10:00 UTC | Apr 3 (Sun) 11:00 UTC+1 | Apr 3 (Sun) 18:00 UTC+8 | ³ |
+| Italy | ![][flag_IT] | ![][flag_NZ] | New Zealand | Apr 3 (Sun) 10:00 UTC | Apr 3 (Sun) 11:00 UTC+1 | Apr 3 (Sun) 22:00 UTC+12 | ³ |
+| Japan | ![][flag_JP] | ![][flag_SE] | Sweden | Apr 3 (Sun) 10:00 UTC | Apr 3 (Sun) 19:00 UTC+9 | Apr 3 (Sun) 11:00 UTC+1 | ¹ |
+| South Korea | ![][flag_KR] | ![][flag_GB] | United Kingdom | Apr 3 (Sun) 11:30 UTC | Apr 3 (Sun) 20:30 UTC+9 | Apr 3 (Sun) 11:30 UTC | ¹ |
+| Taiwan | ![][flag_TW] | ![][flag_FR] | France | Apr 3 (Sun) 13:00 UTC | Apr 3 (Sun) 21:00 UTC+8 | Apr 3 (Sun) 14:00 UTC+1 | ³ |
+| Taiwan | ![][flag_TW] | ![][flag_CH] | Switzerland | Apr 3 (Sun) 13:00 UTC | Apr 3 (Sun) 21:00 UTC+8 | Apr 3 (Sun) 14:00 UTC+1 | ³ |
+| China | ![][flag_CN] | ![][flag_FR] | France | Apr 3 (Sun) 13:00 UTC | Apr 3 (Sun) 21:00 UTC+8 | Apr 3 (Sun) 14:00 UTC+1 | ³ |
+| China | ![][flag_CN] | ![][flag_CH] | Switzerland | Apr 3 (Sun) 13:00 UTC | Apr 3 (Sun) 21:00 UTC+8 | Apr 3 (Sun) 14:00 UTC+1 | ³ |
+| Brazil | ![][flag_BR] | ![][flag_FI] | Finland | Apr 3 (Sun) 14:00 UTC | Apr 3 (Sun) 11:00 UTC-3 | Apr 3 (Sun) 16:00 UTC+2 | ³ |
+| Brazil | ![][flag_BR] | ![][flag_TR] | Turkey | Apr 3 (Sun) 14:00 UTC | Apr 3 (Sun) 11:00 UTC-3 | Apr 3 (Sun) 17:00 UTC+3 | ³ |
+| Russian Federation | ![][flag_RU] | ![][flag_FI] | Finland | Apr 3 (Sun) 14:00 UTC | Apr 3 (Sun) 17:00 UTC+3 | Apr 3 (Sun) 16:00 UTC+2 | ³ |
+| Russian Federation | ![][flag_RU] | ![][flag_TR] | Turkey | Apr 3 (Sun) 14:00 UTC | Apr 3 (Sun) 17:00 UTC+3 | Apr 3 (Sun) 17:00 UTC+3 | ³ |
+| Argentina | ![][flag_AR] | ![][flag_SG] | Singapore | Apr 3 (Sun) 15:00 UTC | Apr 3 (Sun) 12:00 UTC-3 | Apr 3 (Sun) 23:00 UTC+8 | ³ |
+| Germany | ![][flag_DE] | ![][flag_ID] | Indonesia | Apr 3 (Sun) 15:30 UTC | Apr 3 (Sun) 16:30 UTC+1 | Apr 3 (Sun) 22:30 UTC+7 | ¹ |
+| Canada | ![][flag_CA] | ![][flag_CL] | Chile | Apr 3 (Sun) 17:00 UTC | Apr 3 (Sun) 12:00 UTC-5 | Apr 3 (Sun) 14:00 UTC-3 | ³ |
+| Argentina | ![][flag_AR] | ![][flag_CL] | Chile | Apr 3 (Sun) 17:00 UTC | Apr 3 (Sun) 14:00 UTC-3 | Apr 3 (Sun) 14:00 UTC-3 | ³ |
+
+¹ Winners bracket match\
+² Losers bracket match\
+³ Potential match: final matchup depends on the results of ²
 
 ## Mappools
 
@@ -196,6 +212,36 @@ The osu!taiko World Cup 2022 is run by various community members.
   1. [seatrus - O (KTYN) \[Infinity\]](https://osu.ppy.sh/beatmapsets/1712976#taiko/3500185)
 
 ## Match results
+
+### Round of 16
+
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/19vfkfIEnt0dhqC2cXuCvDSwhvFAeSbw5i_ZAw2l1CtA/edit?rm=minimal).
+
+Saturday, March 26, 2022
+
+| Team A | | | Team B | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **New Zealand** ![][flag_NZ] | **5** | 2 | ![][flag_PH] Philippines | [#1](https://osu.ppy.sh/community/matches/99114582) |
+| Portugal ![][flag_PT] | 4 | **5** | ![][flag_SG] **Singapore** | [#1](https://osu.ppy.sh/community/matches/99117585) |
+| Netherlands ![][flag_NL] | 1 | **5** | ![][flag_CH] **Switzerland** | [#1](https://osu.ppy.sh/community/matches/99119714) |
+| Czech Republic ![][flag_CZ] | 0 | **5** | ![][flag_AR] **Argentina** | [#1](https://osu.ppy.sh/community/matches/99123857) |
+| Costa Rica ![][flag_CR] | 0 | **5** | ![][flag_TR] **Turkey** | [#1](https://osu.ppy.sh/community/matches/99125955) |
+| **Germany** ![][flag_DE] | **5** | 3 | ![][flag_FR] France | [#1](https://osu.ppy.sh/community/matches/99126137) |
+| Mexico ![][flag_MX] | 0 | **5** | ![][flag_IT] **Italy** | [#1](https://osu.ppy.sh/community/matches/99132507) |
+
+Sunday, March 27, 2022
+
+| Team A | | | Team B | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| United States ![][flag_US] | 4 | **5** | ![][flag_AU] **Australia** | [#1](https://osu.ppy.sh/community/matches/99144573) |
+| **Hong Kong** ![][flag_HK] | **5** | 1 | ![][flag_MY] Malaysia | [#1](https://osu.ppy.sh/community/matches/99155883) |
+| **South Korea** ![][flag_KR] | **5** | 0 | ![][flag_FI] Finland | [#1](https://osu.ppy.sh/community/matches/99155889) |
+| Poland ![][flag_PL] | 3 | **5** | ![][flag_RU] **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/99157397) |
+| Taiwan ![][flag_TW] | 4 | **5** | ![][flag_ID] **Indonesia** | [#1](https://osu.ppy.sh/community/matches/99157464) |
+| Colombia ![][flag_CO] | 0 | **5** | ![][flag_CN] **China** | [#1](https://osu.ppy.sh/community/matches/99159135) |
+| **Japan** ![][flag_JP] | **5** | 0 | ![][flag_CL] Chile | [#1](https://osu.ppy.sh/community/matches/99159159) |
+| Brazil ![][flag_BR] | 4 | **5** | ![][flag_GB] **United Kingdom** | [#1](https://osu.ppy.sh/community/matches/99161154) |
+| Canada ![][flag_CA] | 4 | **5** | ![][flag_SE] **Sweden** | [#1](https://osu.ppy.sh/community/matches/99163168) |
 
 ### Round of 32
 

--- a/wiki/Tournaments/TWC/2022/en.md
+++ b/wiki/Tournaments/TWC/2022/en.md
@@ -284,17 +284,16 @@ Qualifier results:
 3. The maps for each round will be announced by the mapset selectors on the Sunday before the actual matches take place. Only these will be used during the respective matches.
 4. The match schedule will be settled by the Tournament Management (see above).
 5. If no referee is available at match time, the match will be postponed.
-6. Failed players' scores do not get added to the team score.
-7. Use of the Visual Settings to alter background dim or disable beatmap elements like storyboards and skins are allowed.
+6. Use of the Visual Settings to alter background dim or disable beatmap elements like storyboards and skins are allowed.
    - Custom skin elements must not be used to alter core gameplay elements or mechanics.
-8. If the beatmap ends in a draw, the game will be nullified.
+7. If the beatmap ends in a draw, the game will be nullified.
    - If a game is nullified, the beatmap will be replayed.
-9. Teams may ask for a rematch if a team member encounters technical difficulties while playing.
+8. Teams may ask for a rematch if a team member encounters technical difficulties while playing.
    - "Lag spikes" are not considered a valid reason to nullify a beatmap.
    - If a rematch happens, the original roster for each team during that particular beatmap must remain the same. If that is not possible, e.g. by virtue of a technical issue, both teams will be allowed to swap rosters.
    - This rule is not to be abused. Referees may veto a rematch request if they find that this is the case.
-10. Disconnects within 30 seconds or 25% of the beatmap length (whichever happens first) can be rematched, at the referee's discretion, as long as it's clearly communicated in the chatroom.
-11. If a player disconnects, their scores will not be counted towards their team's total, unless adequate proof of said score is provided. The following are considered as acceptable proof:
+9. Disconnects within 30 seconds or 25% of the beatmap length (whichever happens first) can be rematched, at the referee's discretion, as long as it's clearly communicated in the chatroom.
+10. If a player disconnects, their scores will not be counted towards their team's total, unless adequate proof of said score is provided. The following are considered as acceptable proof:
     - Player point-of-view live stream snippets (commonly referred to as "clips" or "VODs"). The entirety of the play, along with the results screen must be clearly visible along with the affected player's score.
     - Replay files of the play, taken directly from the "Local scores" tab on the affected player's client (the timestamps must exactly match the time at which the game took place, as seen on the multiplayer lobby link).
     - Screenshots from other players taken directly in-game that show the affected player's score.
@@ -302,24 +301,24 @@ Qualifier results:
       - Screenshots taken in-game at the time of disconnection may be accepted. Note that this method does not provide a one-to-one representation of that player's score. Using this method is not encouraged and it may be denied at the referee's discretion if the information provided is not sufficient to identify the player/score.
       - All screenshots **MUST** be taken using the game itself (using `Shift` + `F12`), that is, they must be hosted on the `https://osu.ppy.sh/` domain. Any other form of screenshot will be denied.
     - Player scores may be derived from the official stream as a last resort, in cases where the match is streamed.
-12. If less than the minimum amount of required players are present at match time, the match can be postponed for up to 10 minutes. If after this period there are still not enough players for either team, a *win by default* will be declared for the side with the most members present.
+11. If less than the minimum amount of required players are present at match time, the match can be postponed for up to 10 minutes. If after this period there are still not enough players for either team, a *win by default* will be declared for the side with the most members present.
     - The minimum amount of required players is the amount of players needed to play a beatmap without any vacant spots in the lobby (i.e. 2 participants must be present for the match to begin).
-13. If a player disconnects between beatmaps and the team cannot provide a substitute, the match can be delayed for up to 10 minutes (limited to once per team, per match).
-14. Exchanging players between games is allowed without limitations.
-15. **The minimum size for a team is 3 players, and the maximum is 6.**
-16. Players are expected to keep the match running fluently and without delays. Excessive match delays from the players' side may result in penalties being applied at the referee's discretion. Disrupting the match by foul play, insulting or provoking other players or staff, delaying the match, or other deliberate inappropriate misbehaviour are strictly prohibited, and will be punished accordingly.
-17. All players and staff must be treated with respect. Instructions from the referees and the Tournament Management are to be followed. Decisions labelled as final are not to be objected.
-18. The multiplayer chatrooms underlie the [osu! community rules](/wiki/Rules). All chat rules apply to the multiplayer chatrooms, too.
+12. If a player disconnects between beatmaps and the team cannot provide a substitute, the match can be delayed for up to 10 minutes (limited to once per team, per match).
+13. Exchanging players between games is allowed without limitations.
+14. **The minimum size for a team is 3 players, and the maximum is 6.**
+15. Players are expected to keep the match running fluently and without delays. Excessive match delays from the players' side may result in penalties being applied at the referee's discretion. Disrupting the match by foul play, insulting or provoking other players or staff, delaying the match, or other deliberate inappropriate misbehaviour are strictly prohibited, and will be punished accordingly.
+16. All players and staff must be treated with respect. Instructions from the referees and the Tournament Management are to be followed. Decisions labelled as final are not to be objected.
+17. The multiplayer chatrooms underlie the [osu! community rules](/wiki/Rules). All chat rules apply to the multiplayer chatrooms, too.
     - Breaking the chat rules may result in a silence. Silenced players cannot participate in multiplayer matches and must be exchanged for the duration of the punishment.
-19. Penalties for violating the tournament rules include, but are not limited to:
+18. Penalties for violating the tournament rules include, but are not limited to:
     - Exclusion of specific players for one beatmap.
     - Exclusion of specific players for an entire match.
     - Declaring the match as forfeited, or as a win by default for the other team.
     - Disqualification from the entire tournament.
     - Disqualification from the current and future official tournaments, until appealed.
-20. Referees may allow, at their discretion, lower or higher tolerances for timers.
-21. The Tournament Management may request liveplays or recordings of individual players or teams at any point.
-22. The Tournament Management reserves the right to modify these rules at any moment. Any such changes will be announced in advance.
+19. Referees may allow, at their discretion, lower or higher tolerances for timers.
+20. The Tournament Management may request liveplays or recordings of individual players or teams at any point.
+21. The Tournament Management reserves the right to modify these rules at any moment. Any such changes will be announced in advance.
 
 ### Tournament registration
 
@@ -393,12 +392,12 @@ Qualifier results:
 3. The Qualifiers Stage mappool will consist of 10 maps, Round of 32 and Round of 16 will consist of 14 maps, Quarterfinals and Semifinals will consist of 15 maps, and the Finals and Grand Finals mappools will consist of 16 maps.
 4. Every mappool, except for the Qualifier stage, will contain a tiebreaker beatmap. It will only be played in case of a tie in the scoreline in the best of system, e.g. the scoreline is 4-4 and the match is best of 9, the tiebreaker shall be played.
 5. The NoMod bracket will be played with the [No Fail](/wiki/Game_modifier/No_Fail) mod activated.
-6. The Hidden, Hard Rock and Double Time brackets will be played with the respective mods activated.
-7. The FreeMod bracket will have FreeMod activated. Each player may pick Hidden, Hard Rock or Hidden + Hard Rock.
+6. The Hidden, Hard Rock and Double Time brackets will be played with the respective mods activated along with the No Fail mod.
+7. The FreeMod bracket will have FreeMod activated, and the No Fail mod will be enforced. Each player may pick Hidden, Hard Rock or Hidden + Hard Rock.
    - When playing a FreeMod map, at least one player of each team must use a mod.
-   - Players must select different mod combinations. Using only Hidden, Hard Rock, or Hidden + Hard Rock for both players at the same time is not allowed.
-8. The tiebreaker will be played under FreeMod conditions.
-   - While playing the tiebreaker, players do not need to have a mod activated and are allowed to select the same mod combinations.
+   - Both teams must select the No Fail mod in addition to their chosen mod combination.
+   - Players must select different mod combinations. Using only Hidden, Hard Rock, or Hidden + Hard Rock for both players at the same time is not allowed. No Fail will not be counted as a mod (e.g. a No Fail + Hidden and Hidden mod combination will be considered as just Hidden for both players).
+8. The tiebreaker will be played with FreeMod activated, but will not follow the FreeMod bracket rules: players do not need to have a mod activated and are allowed to select the same mod combination. Both teams must select the No Fail mod.
 9. The size of the NoMod bracket will be 3 for the Qualifiers, 4 for the Round of 32 and Round of 16, 5 for the Quarterfinals and Semifinals, and 6 for the Finals and Grand Finals.
 10. The size of the [Hidden](/wiki/Game_modifier/Hidden), [Hard Rock](/wiki/Game_modifier/Hard_Rock) and [Double Time](/wiki/Game_modifier/Double_Time) brackets will be 2 for all stages.
 11. The size of the FreeMod brackets will be 3 for all stages minus the Qualifiers, which will have 1 FreeMod map.


### PR DESCRIPTION
Clarifies that the No Fail mod should be used for FreeMod/Tiebreaker maps. Also adds the Quarterfinals schedule, pool to come at a later date (waiting on one map to be uploaded).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)