### PR TITLE
Update `o!tFAC #1` contest article

### DIFF
--- a/wiki/Contests/o!tFAC/1/en.md
+++ b/wiki/Contests/o!tFAC/1/en.md
@@ -39,7 +39,7 @@ The osu!taiko Featured Artist Cup #1 was run by various community members.
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 4 months of osu!supporter, Ranked status¹,  Unique profile badge (unconfirmed) |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 4 months of osu!supporter, Ranked status¹,  Unique profile badge |
 | ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 3 months of osu!supporter |
 | ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 2 months of osu!supporter |
 

--- a/wiki/Contests/o!tFAC/1/en.md
+++ b/wiki/Contests/o!tFAC/1/en.md
@@ -39,7 +39,7 @@ The osu!taiko Featured Artist Cup #1 was run by various community members.
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 4 months of osu!supporter, Ranked status¹,  Unique profile badge |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 4 months of osu!supporter, Ranked status¹, unique profile badge |
 | ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 3 months of osu!supporter |
 | ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 2 months of osu!supporter |
 


### PR DESCRIPTION
Badge was confirmed and delivered to the [winner](https://osu.ppy.sh/users/14184157), removing the `(unconfirmed)` mark from prizes now.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

