### PR TITLE
Add clause about unsolicited PMs in `Bot account`

### DIFF
--- a/wiki/Bot_account/en.md
+++ b/wiki/Bot_account/en.md
@@ -20,7 +20,7 @@ The main difference between personal accounts and bot accounts is in the rate li
 - Personal accounts can send 10 messages every 5 seconds
 - Bot accounts can send 300 messages every 60 seconds
 
-These rate limits only apply to private messages, `#multiplayer`, and `#spectator`. Bot accounts are not allowed to send messages in other channels. In addition to this, they should not send unsolicited private messages.
+These rate limits only apply to private messages, `#multiplayer`, and `#spectator`. Bot accounts are not allowed to send messages in other channels, nor any unsolicited private messages.
 
 ## Creating a bot account
 
@@ -35,6 +35,7 @@ Before considering a request, the support team requires that the bot meets these
 - The bot is used by at least 50 unique users every month
 - The bot respects the personal account rate limits
 - The bot does not send any messages in public channels
+- The bot does not send any unsolicited private messages
 - The bot is helpful to a wide audience in the osu! community
 
 ### Filing a request

--- a/wiki/Bot_account/en.md
+++ b/wiki/Bot_account/en.md
@@ -20,7 +20,7 @@ The main difference between personal accounts and bot accounts is in the rate li
 - Personal accounts can send 10 messages every 5 seconds
 - Bot accounts can send 300 messages every 60 seconds
 
-These rate limits only apply to private messages, `#multiplayer`, and `#spectator`. Bot accounts are not allowed to send messages in other channels.
+These rate limits only apply to private messages, `#multiplayer`, and `#spectator`. Bot accounts are not allowed to send messages in other channels. In addition to this, they should not send unsolicited private messages.
 
 ## Creating a bot account
 

--- a/wiki/Bot_account/es.md
+++ b/wiki/Bot_account/es.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot

--- a/wiki/Bot_account/fr.md
+++ b/wiki/Bot_account/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot

--- a/wiki/Bot_account/id.md
+++ b/wiki/Bot_account/id.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot

--- a/wiki/Bot_account/ru.md
+++ b/wiki/Bot_account/ru.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot

--- a/wiki/Bot_account/tr.md
+++ b/wiki/Bot_account/tr.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot

--- a/wiki/Bot_account/zh.md
+++ b/wiki/Bot_account/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated: true
+outdated_since: 421d351504f7f02cbe916b63fc6120b24fce0c3a
 tags:
   - bot accounts
   - chat bot


### PR DESCRIPTION
Per internal discussion, this PR clarifies that bots should not send unsolicited private messages.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
