### PR TITLE
Fix wrong name `Osu! Tatake! Ouendan`

### DIFF
--- a/wiki/Disambiguation/Ouendan/de.md
+++ b/wiki/Disambiguation/Ouendan/de.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 ---
 
 # Ouendan (Begriffsabgrenzung)

--- a/wiki/Disambiguation/Ouendan/en.md
+++ b/wiki/Disambiguation/Ouendan/en.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 ---
 
 # Ouendan (disambiguation)

--- a/wiki/Disambiguation/Ouendan/es.md
+++ b/wiki/Disambiguation/Ouendan/es.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 no_native_review: true
 ---
 

--- a/wiki/Disambiguation/Ouendan/fr.md
+++ b/wiki/Disambiguation/Ouendan/fr.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 ---
 
 # Ouendan

--- a/wiki/Disambiguation/Ouendan/id.md
+++ b/wiki/Disambiguation/Ouendan/id.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 ---
 
 # Ouendan (disambiguasi)

--- a/wiki/Disambiguation/Ouendan/th.md
+++ b/wiki/Disambiguation/Ouendan/th.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - Osu! Tatake! Ouendan
+  - Osu! Tatakae! Ouendan
 outdated: true
 outdated_since: 9eb0beb9e4e5381f34f66673a296fc77e685014e
 ---

--- a/wiki/Game_modifier/Hidden/fr.md
+++ b/wiki/Game_modifier/Hidden/fr.md
@@ -70,7 +70,7 @@ Dans le mode [osu!mania](/wiki/Game_mode/osu!mania), le mod Hidden fonctionne co
 
 ## Le saviez-vous ?
 
-- Le mod Hidden est apparu pour la première fois dans Ouendan 2, qui était le deuxième jeu DS japonais de la série [Osu! Tatake! Ouendan](https://fr.wikipedia.org/wiki/Osu!_Tatakae!_%C5%8Cendan) (la série dont osu! s'inspire).
+- Le mod Hidden est apparu pour la première fois dans Ouendan 2, qui était le deuxième jeu DS japonais de la série [Osu! Tatakae! Ouendan](https://fr.wikipedia.org/wiki/Osu!_Tatakae!_%C5%8Cendan) (la série dont osu! s'inspire).
 - Si une beatmap est passée avec un grade S ou SS avec le mod Hidden activé, la beatmap attribuera la variante argentée du grade à la place.
 - Par défaut, dans [osu!](/wiki/Game_mode/osu!) le [approach circle](/wiki/Hit_object/Approach_circle) du premier [objet](/wiki/Hit_object) sera temporairement visible au début d'une beatmap afin d'aider les joueurs à mieux évaluer le moment où ils doivent toucher l'objet en question. Ceci peut être désactivé dans les options sous `Gameplay`.
 - Dans le mode osu!mania, le mod Hidden est une variante du mod [Fade In](/wiki/Game_modifier/Fade_In).

--- a/wiki/Game_modifier/Hidden/id.md
+++ b/wiki/Game_modifier/Hidden/id.md
@@ -68,7 +68,7 @@ Pada [osu!mania](/wiki/Game_mode/osu!mania), mod Hidden berfungsi sebagai semaca
 
 ## Trivia
 
-- Mod Hidden pertama kali muncul di Ouendan 2, yang merupakan permainan DS Jepang kedua pada seri [Osu! Tatake! Ouendan](/wiki/Disambiguation/Ouendan) (seri awal yang menginspirasikan osu!).
+- Mod Hidden pertama kali muncul di Ouendan 2, yang merupakan permainan DS Jepang kedua pada seri [Osu! Tatakae! Ouendan](/wiki/Disambiguation/Ouendan) (seri awal yang menginspirasikan osu!).
 - Bila pemain berhasil lolos melewati sebuah beatmap dengan nilai S atau SS menggunakan mod Hidden, pemain akan diberikan nilai variasi perak.
 - Pada [osu!](/wiki/Game_mode/osu!), [approach circle](/wiki/Hit_object/Approach_circle) dari [hit object](/wiki/Hit_object) yang pertama secara default akan muncul untuk sementara pada awal map untuk membantu pemain memperkirakan kapan harus menekan hit object selanjutnya. Perlakuan ini bisa dimatikan di menu `Options`, di bawah `Gameplay`.
 - Pada osu!mania, mod Hidden adalah sebuah variasi dari mod [Fade In](/wiki/Game_modifier/Fade_In).


### PR DESCRIPTION
Some articles use `Tatake!` instead of `Tatakae!` for the game `Osu! Tatakae! Ouendan`.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
