### PR TITLE
Re-enable code ownership for the `Help centre` articles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 /news/                     @ppy/news-approval
 /wiki/Legal/**/en.md       @peppy @Ephemeralis
-/wiki/Help_Centre/**/en.md @peppy @Ephemeralis
+/wiki/Help_centre/**/en.md @peppy @Ephemeralis


### PR DESCRIPTION
found in https://github.com/ppy/osu-wiki/pull/7170, broken in https://github.com/ppy/osu-wiki/pull/6723. if anything, only Ephemeral has edited these since then, so no unattended edits were made