### PR TITLE
[FR] Add `People\The_Team\Nomination_Assessment_Team\Evaluations`

### DIFF
--- a/wiki/People/The_Team/Nomination_Assessment_Team/Evaluations/fr.md
+++ b/wiki/People/The_Team/Nomination_Assessment_Team/Evaluations/fr.md
@@ -1,0 +1,83 @@
+## Évaluations des Beatmap Nominator
+
+Les évaluations de ceux qui demandent à devenir [Beatmap Nominator](/wiki/People/The_Team/Beatmap_Nominators) (*BN*) ainsi que des Beatmap Nominators actuels sont effectuées par les membres de la [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (*NAT*). Ces évaluations suivent un format défini afin de garantir que chaque candidature et chaque nominateur seront examinés régulièrement. Toutes les évaluations ont lieu sur le [site web de la NAT](https://bn.mappersguild.com/).
+
+Chaque évaluation comporte deux phases : *individuelle* et *groupe*. Ces phases diffèrent dans les détails de leur fonctionnement pour les applications ou les évaluations régulières des BN et seront détaillées ci-dessous.
+
+Trois membres de la NAT sont affectés à chaque évaluation, mais d'autres membres peuvent se joindre à la conversation pendant la phase de groupe si certains éléments de l'évaluation nécessitent une discussion plus approfondie sur des points sur lesquels les membres de la NAT initialement affectés ne peuvent parvenir à un consensus.
+
+Si un membre de la NAT est indisponible ou ne peut pas effectuer l'évaluation qui lui a été assignée, sa tâche peut être réassignée de manière aléatoire à un autre membre de la NAT à partir du site web de la NAT.
+
+Les références à Discord dans cet article se rapportent au serveur Discord des BN, dont l'accès est limité aux membres de la BN, de la NAT, de la GMT et aux anciens membres pour l'organisation, la discussion et la socialisation du groupe.
+
+## Applications des Beatmap Nominator
+
+Chaque demande soumise au site web de la NAT qui passe le [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) sera examinée par les membres de la NAT afin de déterminer si le candidat peut ou non entrer dans le groupe des Beatmap Nominators. Pour plus d'informations sur la façon de postuler, consultez la page [Devenir un Beatmap Nominator](/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator).
+
+### Processus
+
+Lorsqu'un utilisateur postule pour devenir un BN, la NAT sera notifié via le bot Discord "bnsite" dans leur canal Discord respectif. La notification comprendra le nom et le résultat du test du candidat, ainsi que les membres du NAT qui ont été affectés à la demande.
+
+Les membres de la NAT peuvent ensuite examiner la demande complète sur le site web de la NAT, qui comprend toutes les informations que le candidat a soumises, ses résultats d'examen, ainsi qu'un historique des évaluations antérieures si l'utilisateur a fait une demande ou a été un BN auparavant.
+
+L'évaluation est divisée en deux phases : *individuelle* et *groupe*.
+
+### La phase individuelle
+
+La phase individuelle a une date limite de 7 jours après que le candidat ait envoyé sa candidature, et est remplie individuellement par chaque membre de la NAT assigné. Chaque membre de la NAT soumettra son évaluation du modding et des candidatures des candidats, afin de déterminer s'ils répondent aux [critères de base](/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator#basic-criteria) pour devenir un BN. Pendant cette phase, ils ne discutent pas de leurs conclusions entre eux afin de se forger pleinement une opinion individuelle sur la candidature.
+
+Une fois que trois membres de la NAT auront soumis leurs évaluations individuelles, la demande passera automatiquement à la phase de groupe sur le site web de la NAT.
+
+### Phase de groupe
+
+La phase de groupe a une date limite de 14 jours après que le candidat ait envoyé sa demande. Au cours de la phase de groupe, les membres de la NAT peuvent lire les évaluations des autres membres et discuter davantage si nécessaire pour parvenir à un consensus final. Une fois le consensus atteint, ils publient le résultat sur le site web de la NAT et rédigent le retour d'évaluation final pour le candidat. 
+
+Dans le cas de [candidatures échouées](/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator#failed-applications), le NAT déterminera également la durée du cooldown de l'utilisateur avant qu'il puisse postuler à nouveau. Le délai de réflexion standard est de 90 jours à partir de la date de la demande, mais la durée peut être réduite pour les candidats ayant relativement peu de problèmes à résoudre avant de devenir un Beatmap Nominator. Dans ce cas, les conditions de réduction du délai d'attente seront indiquées dans le feedback envoyé aux candidats.
+
+Une fois que le consensus est atteint et que les commentaires sont rédigés, les membres de la NAT les examinent afin d'affiner l'exactitude et la clarté des commentaires pour le candidat. Ils envoient ensuite le feedback au candidat, après quoi l'évaluation sera archivée pour référence future. Le feedback lui-même sera envoyé par le [mappersguild bot](https://osu.ppy.sh/users/23648635) comme un message dans le chat d'osu!.
+
+## Évaluations actuelles des Beatmap Nominator
+
+Chaque BN est examiné régulièrement par les membres de la NAT.
+
+Pour les nominateurs en [probation](/wiki/People/The_Team/Beatmap_Nominators#probationary-beatmap-nominators), ou qui ont reçu un avertissement d'[activité](/wiki/People/The_Team/Beatmap_Nominators/Rules#activity), leur prochaine évaluation sera programmée environ 1 mois après avoir été mis en probation ou avoir reçu leur avertissement.
+
+Pour les Beatmap Nominators sans avertissements récents, leurs évaluations seront programmées tous les 3 mois.
+
+La durée entre les évaluations est automatiquement programmée par le [site web de la NAT](https://bn.mappersguild.com/). Toutefois, s'il existe une raison importante de s'inquiéter des performances d'un BN à une date antérieure, les membres de la NAT peuvent également programmer manuellement une évaluation pour qu'elle ait lieu plus tôt que d'habitude.
+
+Tout comme les candidatures, les évaluations actuelles des BN sont attribuées de manière aléatoire à 3 membres de la NAT et seront annoncées dans les salons textuels Discord de la NAT du mode concerné.
+
+### Phase individuelle
+
+La phase individuelle sera affichée sur le site web des BN deux semaines avant l'échéance, ce qui permettra aux membres de la NAT de savoir quelles évaluations sont à venir afin de les aider à gérer leur charge de travail de manière appropriée. Au cours de la phase individuelle, les membres de la NAT peuvent soumettre leurs évaluations sur la performance du Beatmap Nominator. Ces évaluations tiendront compte des nominations du BN, des éventuelles réinitialisations de nominations qui ont eu lieu sur leurs nominations, ainsi que de le modding globale du BN sur un échantillon de leurs beatmaps nominées. Les membres de la NAT vérifieront également si le BN respecte les [règles pour les Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators/Rules) et les [attentes](/wiki/People/The_Team/Beatmap_Nominators/Expectations) de manière appropriée.
+
+### Phase de groupe
+
+Après que trois membres de la NAT aient soumis leurs évaluations, l'évaluation passera à la phase de groupe. Au cours de la phase de groupe, les membres de la NAT discuteront de leurs évaluations entre eux, parviendront à un consensus et rédigeront des commentaires sur l'évaluation. Les résultats et les commentaires varieront en fonction du BN. S'il s'avère qu'un BN ne répond pas aux normes, il peut recevoir un avertissement ou être placé en probation, selon la gravité du problème. 
+
+Une fois le feedback écrit et vérifié, il sera envoyé et accompagnera tout changement de groupe nécessaire si le BN est déplacé des Beatmap Nominator probatoire aux Beatmap Nominator complets, ou vice versa. Le feedback sera envoyé par le [mappersguild bot](https://osu.ppy.sh/users/23648635) comme un message dans le chat d'osu!
+
+Les avertissements et la mise à l'épreuve dus à des performances médiocres en tant que Beatmap Nominator à part entière sont effectifs pendant environ un an. Si un BN a des problèmes récurrents après avoir été averti ou mis à l'épreuve récemment, il peut être exclus des Beatmap Nominators lors de futures évaluations.
+
+## Évaluations spéciales
+
+### Activité
+
+L'activité de chaque Beatmap Nominator est vérifiée automatiquement par le site web de la NAT le 1er de chaque mois. S'il s'avère que certains nominateurs ne remplissent pas les conditions d'activité, ils seront signalés et affichés dans le salon textuel NAT de leur mode respectif pour que les membres de la NAT puissent les examiner par le robot Discord "bnsite". L'examen consistera notamment à vérifier si le BN a récemment publié un avis d'absence et à s'assurer que la vérification du site Web correspond bien au statut d'activité du BN.
+
+S'il s'avère que le BN ne respecte effectivement pas l'activité, il sera soit averti soit exclus en fonction de la gravité. Les Beatmap Nominator qui ont été exclus pour leur activité de cette manière peuvent postuler à nouveau dans 30 jours, à condition qu'ils aient au moins 8 mods pour montrer qu'ils sont redevenus actifs en tant que moddeurs.
+
+### Démissions
+
+Les Beatmap Nominators peuvent démissionner du groupe à tout moment via le site web de la NAT. Lorsque cela se produit, trois membres du NAT seront chargés d'évaluer le nominateur une dernière fois, afin de déterminer si la démission est en "bons" termes ou en termes "standard". Cette évaluation a un délai de 24 heures et est annoncée aux membres de la NAT dans leur salon textuel Discord respectif. Les Beatmap Nominators qui démissionnent en bons termes peuvent être en mesure de revenir rapidement au statut de BN à part entière s'ils choisissent de postuler à nouveau dans l'année qui suit leur démission. Ceux qui démissionnent dans des conditions normales devront commencer par une période de probation s'ils réussissent leur nouvelle candidature.
+
+En général, les évaluations en bons et moyens termes sont relativement simples. Les nominateurs qui n'ont pas été récemment avertis ou placés en probation, et qui n'étaient pas sur le point d'être avertis pour des problèmes, démissionneront généralement en bons termes. Le terme standard est généralement utilisé pour les nominateurs qui ont été récemment avertis, qui sont en probation ou qui étaient sur le point d'être avertis pour des problèmes lors de leur prochaine évaluation de BN actuel.
+
+Une fois qu'un consensus sur les conditions de démission aura été atteint, la NAT enverra au BN un message via le [mappersguild bot](https://osu.ppy.sh/users/23648635) l'informant de son statut et de la date à laquelle il pourra se représenter pour devenir un BN s'il le souhaite.
+
+### Évaluations fictives
+
+En plus des évaluations du BN par les membres du NAT, des évaluations fictives peuvent également être données aux Beatmap Nominators pour les évaluations de nouvelles demandes des BN. Dans les évaluations fictives, les nominateurs soumettront des évaluations individuelles en même temps que la NAT, mais cela ne déterminera pas le résultat final de la demande, à moins que les évaluateurs de la NAT ne puissent pas parvenir à leur propre consensus. Pour les évaluations fictives auxquelles ils ont participé, les nominateurs pourront lire les évaluations individuelles dans un format anonyme une fois la demande archivée.
+
+Les évaluations fictives permettent à la NAT de repérer les futurs membres de la NAT, ainsi qu'aux Beatmap Nominators de voir comment la NAT évalue les candidatures et d'en tirer des leçons si rejoindre la NAT à l'avenir est quelque chose qui les intéresse. En tant que tel, il n'y a aucune conséquence à ne pas les remplir.


### PR DESCRIPTION
Proposal to add the French translation of the wiki page `People\The_Team\Nomination_Assessment_Team\Evaluations`.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
- [ ] The changes have been approved on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)