### PR TITLE
Add missing streamer profile on `Perak osu! Tournament 2022`

### DIFF
--- a/wiki/Tournaments/POT/2022/en.md
+++ b/wiki/Tournaments/POT/2022/en.md
@@ -41,8 +41,8 @@ The PERAK osu! Tournament 2022 was run by various Indonesian osu! community memb
 | Supervisor | ![][flag_ID] [Bisma404](https://osu.ppy.sh/users/7171896), ![][flag_ID] [Jevlyn](https://osu.ppy.sh/users/28585681) |
 | Mappool selector | ![][flag_ID] [Splacten](https://osu.ppy.sh/users/10018405), ![][flag_ID] [Larzz](https://osu.ppy.sh/users/10483670) |
 | Playtester | ![][flag_ID] [phizh](https://osu.ppy.sh/users/4569302), ![][flag_ID] [Kuro Fuyusaki](https://osu.ppy.sh/users/2667496) |
-| Streamer | ![][flag_ID] [Victim\_Crasher](https://osu.ppy.sh/users/2084869), ![][flag_ID] [Tix](https://osu.ppy.sh/users/11421465) |
-| Commentator | ![][flag_ID] [Victim\_Crasher](https://osu.ppy.sh/users/2084869), ![][flag_ID] [Tix](https://osu.ppy.sh/users/11421465), ![][flag_ID] [nasje](https://osu.ppy.sh/users/7579498), ![][flag_ID] [eucharistica](https://osu.ppy.sh/users/28736472) |
+| Streamer | ![][flag_ID] [Victim\_Crasher](https://osu.ppy.sh/users/2084869), ![][flag_ID] [Tix](https://osu.ppy.sh/users/11421465), ![][flag_ID] [kilgo](https://osu.ppy.sh/users/9692053) |
+| Commentator | ![][flag_ID] [Victim\_Crasher](https://osu.ppy.sh/users/2084869), ![][flag_ID] [Tix](https://osu.ppy.sh/users/11421465), ![][flag_ID] [kilgo](https://osu.ppy.sh/users/9692053), ![][flag_ID] [nasje](https://osu.ppy.sh/users/7579498), ![][flag_ID] [eucharistica](https://osu.ppy.sh/users/28736472) |
 | Referee | ![][flag_ID] [kilgo](https://osu.ppy.sh/users/9692053), ![][flag_ID] [Romizzz](https://osu.ppy.sh/users/6154769) |
 | Graphic designer | ![][flag_ID] [Kizito Hiro](https://osu.ppy.sh/users/2263272) |
 | Wiki editor | ![][flag_ID] [Niva](https://osu.ppy.sh/users/197805) |


### PR DESCRIPTION
was just told that i missed a name from the list of streamers/commentators in the tournament whoops

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
