### PR TITLE
Remove extraneous "UTC" in OTE news post tables

### DIFF
--- a/news/2022-05-19-osu-talk-event-overcoming-obstacles.md
+++ b/news/2022-05-19-osu-talk-event-overcoming-obstacles.md
@@ -36,11 +36,11 @@ Below is the talk schedule for the event, including the speaker's username and t
 
 | Time (UTC) | Speaker | Title |
 | :-: | :-- | :-- |
-| 11:00 UTC | [IryN](https://osu.ppy.sh/users/17909384) | "Being hardstuck" |
-| 13:00 UTC | [Axiqn](https://osu.ppy.sh/users/21130016) | "Focusing on weaknesses" |
-| 13:30 UTC | [UserAlsoExists](https://osu.ppy.sh/users/19036931) | "The "play less" meta" |
-| 14:30 UTC | [-Liability](https://osu.ppy.sh/users/12260184) | "Doubting yourself" |
-| 15:00 UTC | [Astral52](https://osu.ppy.sh/users/11936432) | "Opening the mind to have fun: How to build a less toxic mentality" |
+| 11:00 | [IryN](https://osu.ppy.sh/users/17909384) | "Being hardstuck" |
+| 13:00 | [Axiqn](https://osu.ppy.sh/users/21130016) | "Focusing on weaknesses" |
+| 13:30 | [UserAlsoExists](https://osu.ppy.sh/users/19036931) | "The "play less" meta" |
+| 14:30 | [-Liability](https://osu.ppy.sh/users/12260184) | "Doubting yourself" |
+| 15:00 | [Astral52](https://osu.ppy.sh/users/11936432) | "Opening the mind to have fun: How to build a less toxic mentality" |
 
 ### Sunday, May 22, 2022
 
@@ -48,11 +48,11 @@ Below is the talk schedule for the event, including the speaker's username and t
 
 | Time (UTC) | Speaker | Title |
 | :-: | :-- | :-- |
-| 18:00 UTC | [cristi2708](https://osu.ppy.sh/users/7552300) | "A perspective on switches and tapping techinques" |
-| 18:30 UTC | [PruceStrats](https://osu.ppy.sh/users/16518886) | "Overcoming adversity in daily life" |
-| 19:00 UTC | [-TunaSliders-](https://osu.ppy.sh/users/15420104) | "Using ideas from osu! to view life differently" |
-| 19:30 UTC | [WaifuMaterial](https://osu.ppy.sh/users/14592606) | "Overcoming social anxiety" |
-| 20:00 UTC | [chiv](https://osu.ppy.sh/users/6701656) | "The problematic state of osu! tournaments" |
+| 18:00 | [cristi2708](https://osu.ppy.sh/users/7552300) | "A perspective on switches and tapping techinques" |
+| 18:30 | [PruceStrats](https://osu.ppy.sh/users/16518886) | "Overcoming adversity in daily life" |
+| 19:00 | [-TunaSliders-](https://osu.ppy.sh/users/15420104) | "Using ideas from osu! to view life differently" |
+| 19:30 | [WaifuMaterial](https://osu.ppy.sh/users/14592606) | "Overcoming social anxiety" |
+| 20:00 | [chiv](https://osu.ppy.sh/users/6701656) | "The problematic state of osu! tournaments" |
 
 ---
 


### PR DESCRIPTION
i apparently didn't check for such a thing