### PR TITLE
Add osu! Talk Event article

### DIFF
--- a/wiki/Community/en.md
+++ b/wiki/Community/en.md
@@ -21,6 +21,7 @@ This page lists ways for people from all around osu! to get in touch with each o
 ## Initiatives
 
 - [osu! community meetings](/wiki/Community/osu!_community_meetings)
+- [osu! Talk Event](/wiki/Community/osu!_Talk_Event)
 - [Video series](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/fr.md
+++ b/wiki/Community/fr.md
@@ -21,6 +21,7 @@ Cette page répertorie les moyens par lesquels les utilisateurs de tout le site 
 ## Initiatives
 
 - [osu! community meetings](/wiki/Community/osu!_community_meetings)
+- [osu! Talk Event](/wiki/Community/osu!_Talk_Event)
 - [Séries vidéo](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/id.md
+++ b/wiki/Community/id.md
@@ -21,6 +21,7 @@ Berikut ini merupakan daftar artikel yang membahas seputar cara komunikasi yang 
 ## Inisiatif
 
 - [Pertemuan komunitas osu!](/wiki/Community/osu!_community_meetings)
+- [osu! Talk Event](/wiki/Community/osu!_Talk_Event)
 - [Serial video](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)

--- a/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
+++ b/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
@@ -5,6 +5,8 @@ tags:
 
 # osu! Talk Event: Overcoming Obstacles
 
+![osu! Talk Event banner](/wiki/shared/news/2022-05-19-osu-talk-event-overcoming-obstacles/ote-newspost-banner.png)
+
 The **osu! Talk Event** is an event organised by osu! University where different people hold talks about various topics. This is the first iteration of the event with the theme of "overcoming obstacles".
 
 Speakers hold their talks in a Stage channel on the [osu!dev Discord server](/wiki/Community/osu!dev_Discord_server). During the event, thread channels will be opened in the `#community-meetings` channel for discussion.

--- a/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
+++ b/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - osu! University
+---
+
+# osu! Talk Event: Overcoming Obstacles
+
+The **osu! Talk Event** is an event organised by osu! University where different people hold talks about various topics. This is the first iteration of the event with the theme of "overcoming obstacles".
+
+Speakers hold their talks in a Stage channel on the [osu!dev Discord server](/wiki/Community/osu!dev_Discord_server). During the event, thread channels will be opened in the `#community-meetings` channel for discussion.
+
+The talks are also livestreamed on [osu! University's Twitch channel](https://twitch.tv/osuuniversity) and recordings of each talk will be available in [osu! University's YouTube channel](https://www.youtube.com/c/osuuniversity).
+
+To participate as a speaker in a future iteration of the event, or recommend someone who would be fit to give a talk, fill out the [speaker nomination form](https://forms.gle/HCD6ac8JwURGh8zx8).
+
+## Event information
+
+- **The event will last 3 days total**, from May 20 - 22, 2022.
+- **The speaker will use a Discord stage channel** in the [osu!dev Discord server](https://discord.gg/ppy) to give their talk.
+- **Talks will be less than 18 minutes long.** This is the maximum allowed length, not a goal to aim for—even a 3-minute talk can have massive impact.
+- The stories shared do not necessarily have to be about osu!, but because this is an osu!-related event, speakers are recommended to try connecting their story or the lesson behind it to osu! in some way.
+
+## Links
+
+- [Forum thread](https://osu.ppy.sh/community/forums/topics/1574152)
+- [Announcement news post](https://osu.ppy.sh/home/news/2022-05-19-osu-talk-event-overcoming-obstacles)
+- [osu!dev Discord server](/wiki/Community/osu!dev_Discord_server)
+- [osu! University Discord server](https://discord.gg/QubdHdnBVg)
+- [osu! University's Twitch channel](https://twitch.tv/osuuniversity)
+- [osu! University's YouTube channel](https://www.youtube.com/c/osuuniversity)
+- [Speaker nomination form](https://forms.gle/HCD6ac8JwURGh8zx8)
+
+## Schedule
+
+### Friday, May 20, 2022
+
+[Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976723460766187570)
+
+| Time (UTC) | Speaker | Title |
+| :-: | :-- | :-- |
+| 21:30 | [PandaPasBo](https://osu.ppy.sh/users/10262231) | "Why expectation ruins your skill in osu" |
+| 22:00 | [xootynator](https://osu.ppy.sh/users/3717598) | "xooty's left hand training" |
+| 22:30 | [Likean00b](https://osu.ppy.sh/users/4860447) | "When tournaments become a hindrance" |
+| 23:00 | [MakiDonalds](https://osu.ppy.sh/users/11610772) | "Break your walls before they break you" |
+
+### Saturday, May 21, 2022
+
+[Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976724758722924574)
+
+| Time (UTC) | Speaker | Title |
+| :-: | :-- | :-- |
+| 11:00 | [IryN](https://osu.ppy.sh/users/17909384) | "Being hardstuck" |
+| 13:00 | [Axiqn](https://osu.ppy.sh/users/21130016) | "Focusing on weaknesses" |
+| 13:30 | [UserAlsoExists](https://osu.ppy.sh/users/19036931) | "The "play less" meta" |
+| 14:30 | [-Liability](https://osu.ppy.sh/users/12260184) | "Doubting yourself" |
+| 15:00 | [Astral52](https://osu.ppy.sh/users/11936432) | "Opening the mind to have fun: How to build a less toxic mentality" |
+
+### Sunday, May 22, 2022
+
+[Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976725279126982656)
+
+| Time (UTC) | Speaker | Title |
+| :-: | :-- | :-- |
+| 18:00 | [cristi2708](https://osu.ppy.sh/users/7552300) | "A perspective on switches and tapping techinques" |
+| 18:30 | [PruceStrats](https://osu.ppy.sh/users/16518886) | "Overcoming adversity in daily life" |
+| 19:00 | [-TunaSliders-](https://osu.ppy.sh/users/15420104) | "Using ideas from osu! to view life differently" |
+| 19:30 | [WaifuMaterial](https://osu.ppy.sh/users/14592606) | "Overcoming social anxiety" |
+| 20:00 | [chiv](https://osu.ppy.sh/users/6701656) | "The problematic state of osu! tournaments" |

--- a/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
+++ b/wiki/Community/osu!_Talk_Event/Overcoming_Obstacles/en.md
@@ -38,33 +38,33 @@ To participate as a speaker in a future iteration of the event, or recommend som
 
 [Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976723460766187570)
 
-| Time (UTC) | Speaker | Title |
-| :-: | :-- | :-- |
-| 21:30 | [PandaPasBo](https://osu.ppy.sh/users/10262231) | "Why expectation ruins your skill in osu" |
-| 22:00 | [xootynator](https://osu.ppy.sh/users/3717598) | "xooty's left hand training" |
-| 22:30 | [Likean00b](https://osu.ppy.sh/users/4860447) | "When tournaments become a hindrance" |
-| 23:00 | [MakiDonalds](https://osu.ppy.sh/users/11610772) | "Break your walls before they break you" |
+| Time (UTC) | Speaker | Title | VOD |
+| :-: | :-- | :-- | :-- |
+| 21:30 | [PandaPasBo](https://osu.ppy.sh/users/10262231) | "Why expectation ruins your skill in osu" | [#1](https://www.youtube.com/watch?v=ES-gjqgu0i8) |
+| 22:00 | [xootynator](https://osu.ppy.sh/users/3717598) | "xooty's left hand training" | [#1](https://www.youtube.com/watch?v=vkEw7YF_8fA) |
+| 22:30 | [Likean00b](https://osu.ppy.sh/users/4860447) | "When tournaments become a hindrance" | [#1](https://www.youtube.com/watch?v=Ll5itEiaZko) |
+| 23:00 | [MakiDonalds](https://osu.ppy.sh/users/11610772) | "Break your walls before they break you" | [#1](https://www.youtube.com/watch?v=NU6JRqGrEGg) |
 
 ### Saturday, May 21, 2022
 
 [Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976724758722924574)
 
-| Time (UTC) | Speaker | Title |
-| :-: | :-- | :-- |
-| 11:00 | [IryN](https://osu.ppy.sh/users/17909384) | "Being hardstuck" |
-| 13:00 | [Axiqn](https://osu.ppy.sh/users/21130016) | "Focusing on weaknesses" |
-| 13:30 | [UserAlsoExists](https://osu.ppy.sh/users/19036931) | "The "play less" meta" |
-| 14:30 | [-Liability](https://osu.ppy.sh/users/12260184) | "Doubting yourself" |
-| 15:00 | [Astral52](https://osu.ppy.sh/users/11936432) | "Opening the mind to have fun: How to build a less toxic mentality" |
+| Time (UTC) | Speaker | Title | VOD |
+| :-: | :-- | :-- | :-- |
+| 11:00 | [IryN](https://osu.ppy.sh/users/17909384) | "Being hardstuck" |  |
+| 13:00 | [Axiqn](https://osu.ppy.sh/users/21130016) | "Focusing on weaknesses" |  |
+| 13:30 | [UserAlsoExists](https://osu.ppy.sh/users/19036931) | "The "play less" meta" |  |
+| 14:30 | [-Liability](https://osu.ppy.sh/users/12260184) | "Doubting yourself" |  |
+| 15:00 | [Astral52](https://osu.ppy.sh/users/11936432) | "Opening the mind to have fun: How to build a less toxic mentality" |  |
 
 ### Sunday, May 22, 2022
 
 [Sign up for this event on Discord to be notified when it starts](https://discord.gg/z62bbJHA?event=976725279126982656)
 
-| Time (UTC) | Speaker | Title |
-| :-: | :-- | :-- |
-| 18:00 | [cristi2708](https://osu.ppy.sh/users/7552300) | "A perspective on switches and tapping techinques" |
-| 18:30 | [PruceStrats](https://osu.ppy.sh/users/16518886) | "Overcoming adversity in daily life" |
-| 19:00 | [-TunaSliders-](https://osu.ppy.sh/users/15420104) | "Using ideas from osu! to view life differently" |
-| 19:30 | [WaifuMaterial](https://osu.ppy.sh/users/14592606) | "Overcoming social anxiety" |
-| 20:00 | [chiv](https://osu.ppy.sh/users/6701656) | "The problematic state of osu! tournaments" |
+| Time (UTC) | Speaker | Title | VOD |
+| :-: | :-- | :-- | :-- |
+| 18:00 | [cristi2708](https://osu.ppy.sh/users/7552300) | "A perspective on switches and tapping techinques" |  |
+| 18:30 | [PruceStrats](https://osu.ppy.sh/users/16518886) | "Overcoming adversity in daily life" |  |
+| 19:00 | [-TunaSliders-](https://osu.ppy.sh/users/15420104) | "Using ideas from osu! to view life differently" |  |
+| 19:30 | [WaifuMaterial](https://osu.ppy.sh/users/14592606) | "Overcoming social anxiety" |  |
+| 20:00 | [chiv](https://osu.ppy.sh/users/6701656) | "The problematic state of osu! tournaments" |  |

--- a/wiki/Community/osu!_Talk_Event/en.md
+++ b/wiki/Community/osu!_Talk_Event/en.md
@@ -1,0 +1,25 @@
+---
+tags:
+  - osu! University
+---
+
+# osu! Talk Event
+
+The **osu! Talk Event** is an event organised by osu! University where different people hold talks about various topics.
+
+Speakers hold their talks in a Stage channel on the [osu!dev Discord server](/wiki/Community/osu!dev_Discord_server). During the event, thread channels will be opened in the `#community-meetings` channel for discussion.
+
+The talks are also livestreamed on [osu! University's Twitch channel](https://twitch.tv/osuuniversity) and recordings of each talk will be available in [osu! University's YouTube channel](https://www.youtube.com/c/osuuniversity).
+
+To participate as a speaker in one of these talks, or recommend someone who would be fit to give a talk, fill out the [speaker nomination form](https://forms.gle/HCD6ac8JwURGh8zx8).
+
+## Iterations
+
+- [osu! Talk Event: Overcoming Obstacles](Overcoming_Obstacles)
+
+## Links
+
+- [osu!dev Discord server](/wiki/Community/osu!dev_Discord_server)
+- [osu! University Discord server](https://discord.gg/QubdHdnBVg)
+- [osu! University's Twitch channel](https://twitch.tv/osuuniversity)
+- [osu! University's YouTube channel](https://www.youtube.com/c/osuuniversity)

--- a/wiki/Community/zh-tw.md
+++ b/wiki/Community/zh-tw.md
@@ -24,6 +24,7 @@ no_native_review: true
 ## 企劃
 
 - [osu! 社群會議](/wiki/Community/osu!_community_meetings)
+- [osu! Talk Event](/wiki/Community/osu!_Talk_Event)
 - [影片系列](/wiki/Community/Video_series)
   - [osu!academy](/wiki/Community/Video_series/osu!academy)
   - [osu!mapping](/wiki/Community/Video_series/osu!mapping)


### PR DESCRIPTION
Slightly unsure of the formatting and what information to include where (mainly the index page). I was about to put everything in one article but then remembered this was just the first iteration of the event.

I'll most likely remove the discord event links when the event concludes

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)