### PR TITLE
[FR] Add notes on translations where the article is outdated, but the translation is up to date

### DIFF
--- a/wiki/Game_modifier/Score_multiplier/fr.md
+++ b/wiki/Game_modifier/Score_multiplier/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated: true
+outdated: true # À jour par rapport à `en.md`
 stub: true
 tags:
   - score multiplier

--- a/wiki/Gameplay/Replay/fr.md
+++ b/wiki/Gameplay/Replay/fr.md
@@ -1,5 +1,5 @@
 ---
-needs_cleanup: true
+needs_cleanup: true # À jour par rapport à `en.md`
 outdated: true
 ---
 

--- a/wiki/Guides/How_to_Time_Songs/fr.md
+++ b/wiki/Guides/How_to_Time_Songs/fr.md
@@ -1,5 +1,5 @@
 ---
-needs_cleanup: true
+needs_cleanup: true # À jour par rapport à `en.md`
 ---
 
 <!-- TODO: some outdated info and this could be simplified a lot. it's a pretty long read for what you get -->

--- a/wiki/History_of_osu!/2018/fr.md
+++ b/wiki/History_of_osu!/2018/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated: true
+outdated: true # À jour par rapport à `en.md`
 ---
 
 # L'histoire d'osu! en 2018

--- a/wiki/History_of_osu!/fr.md
+++ b/wiki/History_of_osu!/fr.md
@@ -1,5 +1,5 @@
 ---
-oudated: true
+outdated: true
 ---
 
 # L'histoire d'osu!

--- a/wiki/History_of_osu!/osu!_wiki/fr.md
+++ b/wiki/History_of_osu!/osu!_wiki/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated: true
+outdated: true # À jour par rapport à `en.md`
 ---
 
 # L'histoire de l'osu! wiki

--- a/wiki/Tournament_drawings/fr.md
+++ b/wiki/Tournament_drawings/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated: true
+outdated: true # À jour par rapport à `en.md`
 ---
 
 # Tournament drawings


### PR DESCRIPTION
Since we are close to finishing our updates, we decided to put a small note next to the `outdated` tag stating that the articles are up to date with the English version.

Since the idea of adding a new tag has been mentioned on the Discord and in the issues, I don't know if I can add the new tag by myself, so until that is put in place, we are putting up notes to help us.