### PR TITLE
Add `.osu-wiki-bin.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # prevent accidental addition of files from local remark runs
 node_modules/
+
+# virtual python environment for local ci runs
 .venv/
+
+# used by https://github.com/cl8n/osu-wiki-bin for api keys
+.osu-wiki-bin.json


### PR DESCRIPTION
There have been a few instances of people who use https://github.com/cl8n/osu-wiki-bin committing the `.osu-wiki-bin.json` file in pull requests