### PR TITLE
Improve triangles Beatmapping Contest newspost readability

### DIFF
--- a/news/2022-05-31-triangles.md
+++ b/news/2022-05-31-triangles.md
@@ -16,21 +16,30 @@ Mappers and storyboarders unite in osu!'s newest contest: **triangles**!
 
 **triangles** is a mapping and storyboarding contest using osu!(lazer)'s theme song, and the winning submission will be **bundled with all new installations of osu!(lazer)** (along with other cool prizes!).
 
-There's a lot to explain. Let's dive in.
+To participate in this contest, you'll need to get a **team of 2-5 mappers/storyboarders** to create a **triangle-themed** beatmap set to the track *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*, plus a **triangle-themed** storyboard following a few limitations laid out in the Rules below.
 
-## Teams
+There's a lot to explain, so let's dive straight in.
 
-To participate in this contest, you need a **team of 2-5 mappers/storyboarders** to create:
+## Rules
 
-- A **triangle-themed** beatmap spread...
-  - of the song *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*
-  - following the [ranking criteria](/wiki/Ranking_Criteria) 
-  - with **FIVE DIFFICULTIES TOTAL**: Easy, Normal, Hard, Insane, and Expert
-- A **triangle-themed** storyboard...
-  - with a `.osb` file no greater than **1 MB**. This is to ensure the storyboard is well optimised and doesn't take too long to parse and load into the game.
-- A full submission no greater than **10 MB**.
+Surprising absolutely nobody, this contest has RULES:
 
-**Submit your team name and member list to [this form](https://docs.google.com/forms/d/e/1FAIpQLSeExd07kLYqp-Mx-lM7Wwxii_qidSUasAlMi3HUHUsdfVSUyg/viewform?usp=sf_link).** Once confirmed, your team will be published on the [*triangles* contest wiki page](/wiki/Contests/triangles_Beatmapping_Contest)!
+- **Submission must include the following:**
+  - A beatmap spread of *cYsmix - triangles* with **FIVE DIFFICULTIES TOTAL**: Easy, Normal, Hard, Insane, and Expert. [Download the beatmap template here!](https://assets.ppy.sh/artists/2/Songs/cYsmix%20-%20triangles.osz)
+  - A storyboard with a `.osb` file no greater than **1 MB**. This may sound small to some, but many storyboards have been made in the past with filesizes far smaller than this. Consider it part of the challenge, and make sure to make full use of loops and triggers!
+- **Submission must be no greater than 10 MB.** While not required, we recommend designs that use simple shapes, keep resources to a minimum, and align with lazer's approach to UI design.
+- **Submission must be in `.osz` format.**
+- **Beatmaps must be in *osu!* game mode only.** Comparing beatmaps of different modes in a judging scenario is unfortunately not realistic.
+- **Beatmaps should abide by the [ranking criteria](/wiki/Ranking_Criteria).** While we can be forgiving for mistakes, submissions that could not be ranked without major changes will be disqualified.
+- **Team name and members must be confirmed through [this form](https://docs.google.com/forms/d/e/1FAIpQLSeExd07kLYqp-Mx-lM7Wwxii_qidSUasAlMi3HUHUsdfVSUyg/viewform?usp=sf_link).**
+  - If your country does not support Google Forms, [send pishifat a message](https://osu.ppy.sh/community/chat?sendto=3178418).
+  - Teams must have 2-5 members.
+- **Submissions must not be publicly revealed until after the judging phase ends.**
+- **Submissions must not be Qualified until after the community vote ends.**
+
+Once you've read these rules and have assembled a team of fellow creator-compatriots **submit your team name and member list to [this form](https://docs.google.com/forms/d/e/1FAIpQLSeExd07kLYqp-Mx-lM7Wwxii_qidSUasAlMi3HUHUsdfVSUyg/viewform?usp=sf_link).** 
+
+Once confirmed, your team will be published on the [*triangles* contest wiki page](/wiki/Contests/triangles_Beatmapping_Contest)!
 
 Unlike last year's [A Labour of Love](https://osu.ppy.sh/home/news/2020-11-30-a-labour-of-love) contest, entries this time around will remain **anonymous** during the judging phase. This means you should **NOT** upload your submission to BSS or share details about it until *after* judging is completed.
 
@@ -103,23 +112,6 @@ Players have a chance to earn something too! Once the playlists are closed, whoe
 Once *everything above* is finalized, we'll announce the results in a **livestream showcase of the finalists** with commentary from some of the judges!
 
 In case one team wins multiple categories, we'll combine their profile badges accordingly. Sorry profile badge collectors, you only receive one.
-
-## Rules
-
-Surprising absolutely nobody, this contest has RULES:
-
-- **Submission must include the following:**
-  - A beatmap spread of *cYsmix - triangles* with **FIVE DIFFICULTIES TOTAL**: Easy, Normal, Hard, Insane, and Expert. [Download the beatmap template here!](https://assets.ppy.sh/artists/2/Songs/cYsmix%20-%20triangles.osz)
-  - A storyboard with a `.osb` file no greater than **1 MB**. This may sound small to some, but many storyboards have been made in the past with filesizes far smaller than this. Consider it part of the challenge, and make sure to make full use of loops and triggers!
-- **Submission must be no greater than 10 MB.** While not required, we recommend designs that use simple shapes, keep resources to a minimum, and align with lazer's approach to UI design.
-- **Submission must be in `.osz` format.**
-- **Beatmaps must be in *osu!* game mode only.** Comparing beatmaps of different modes in a judging scenario is unfortunately not realistic.
-- **Beatmaps should abide by the [ranking criteria](/wiki/Ranking_Criteria).** While we can be forgiving for mistakes, submissions that could not be ranked without major changes will be disqualified.
-- **Team name and members must be confirmed through [this form](https://docs.google.com/forms/d/e/1FAIpQLSeExd07kLYqp-Mx-lM7Wwxii_qidSUasAlMi3HUHUsdfVSUyg/viewform?usp=sf_link).**
-  - If your country does not support Google Forms, [send pishifat a message](https://osu.ppy.sh/community/chat?sendto=3178418).
-  - Teams must have 2-5 members.
-- **Submissions must not be publicly revealed until after the judging phase ends.**
-- **Submissions must not be Qualified until after the community vote ends.**
 
 ---
 

--- a/news/2022-05-31-triangles.md
+++ b/news/2022-05-31-triangles.md
@@ -16,7 +16,7 @@ Mappers and storyboarders unite in osu!'s newest contest: **triangles**!
 
 **triangles** is a mapping and storyboarding contest using osu!(lazer)'s theme song, and the winning submission will be **bundled with all new installations of osu!(lazer)** (along with other cool prizes!).
 
-To participate in this contest, you'll need to form a **team of 2-5 mappers/storyboarders** to create a **triangle-themed** beatmap set to the track *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*, plus a **triangle-themed** storyboard following a few limitations laid out in the Rules below.
+To participate in this contest, you'll need to form a **team of 2-5 mappers/storyboarders** to create a **triangle-themed** beatmap set to the track *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*, plus a **triangle-themed** storyboard following a few limitations laid out in the rules below.
 
 There's a lot to explain, so let's dive straight in.
 

--- a/news/2022-05-31-triangles.md
+++ b/news/2022-05-31-triangles.md
@@ -16,7 +16,7 @@ Mappers and storyboarders unite in osu!'s newest contest: **triangles**!
 
 **triangles** is a mapping and storyboarding contest using osu!(lazer)'s theme song, and the winning submission will be **bundled with all new installations of osu!(lazer)** (along with other cool prizes!).
 
-To participate in this contest, you'll need to get a **team of 2-5 mappers/storyboarders** to create a **triangle-themed** beatmap set to the track *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*, plus a **triangle-themed** storyboard following a few limitations laid out in the Rules below.
+To participate in this contest, you'll need to form a **team of 2-5 mappers/storyboarders** to create a **triangle-themed** beatmap set to the track *[cYsmix](https://osu.ppy.sh/beatmaps/artists/2) - triangles*, plus a **triangle-themed** storyboard following a few limitations laid out in the Rules below.
 
 There's a lot to explain, so let's dive straight in.
 


### PR DESCRIPTION
Removes duplicate mentions of the rules and the team submission link to hopefully streamline readability somewhat.