### PR TITLE
[DE] Mark `Guides/Custom_Sample_Overrides` as outdated translation

### DIFF
--- a/wiki/Guides/Custom_Sample_Overrides/de.md
+++ b/wiki/Guides/Custom_Sample_Overrides/de.md
@@ -1,3 +1,7 @@
+---
+outdated_translation: true
+---
+
 # Custom Sample Overrides
 
 ## Sample Format


### PR DESCRIPTION
While randomly coming across this article, I discovered that it heavily differentiates from the English original. For example, the `Notes` as well as the `Related articles` section is missing entirely. The article also uses the formal `Sie` form of address instead of the informal `du`, but this is just a side note.

| English | German |
| :-: | :-: |
| ![en](https://user-images.githubusercontent.com/50201659/173923111-dd634aa3-91d9-477e-8f23-04606d40a19a.JPG) | ![de](https://user-images.githubusercontent.com/50201659/173923130-b46baa99-bf85-4a49-bc2b-f277453ac68f.JPG) |
