### PR TITLE
Expand on main menu banner image requirements

### DIFF
--- a/wiki/Tournaments/Official_support/de.md
+++ b/wiki/Tournaments/Official_support/de.md
@@ -4,6 +4,8 @@ tags:
   - badges
   - badged
   - Abzeichen
+outdated_since: 6913d0808f4e9fa9e5f4c9d17cd3cd9158be3d3e
+outdated_translation: true
 ---
 
 # Offizielle Turnierunterstützung

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -152,11 +152,16 @@ Long-running community tournaments may qualify for in-game main-menu banner supp
 If you satisfy the above criteria, you may make a request for main-menu banner support by sending an email to [tournaments@ppy.sh](mailto:tournaments@ppy.sh). The banner image must adhere to the following standards:
 
 - The submitted file must be a **PNG**.
-- The dimensions must be **1500x256px**.
-  - All banner images will be treated as `2x`, meaning that they will be exported at 50% scale by us into a `1x` image. Design your images appropriately to ensure things are legible at half size.
+- Width must be no larger than **1000px**. Using smaller widths is fine.
+- Height must always be **180px**. Smaller values are NOT fine.
+- All banner images will be treated as `2x`, meaning that they will be exported at 50% scale by us into a `1x` image. Design your images appropriately to ensure things are legible at half size. Users will see either image depending on their chosen client resolution.
 - It must clearly display the logo, motif, AND name of your tournament, plus any information about the ongoing stage or section that is being advertised.
 - It must be cleanly designed with an emphasis on being mostly transparent and relatively unobtrusive visually.
 - It must not include any sort of sponsorship or promote anything besides the tournament.
+
+You may find the following template helpful:
+
+![](https://assets.ppy.sh/media/mainmenu_template.png)
 
 Please consult the following examples of acceptable banner designs:
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -3,6 +3,8 @@ tags:
   - badge
   - badges
   - badged
+outdated_since: 6913d0808f4e9fa9e5f4c9d17cd3cd9158be3d3e
+outdated_translation: true
 ---
 
 # Official tournament support

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -3,8 +3,6 @@ tags:
   - badge
   - badges
   - badged
-outdated_since: 6913d0808f4e9fa9e5f4c9d17cd3cd9158be3d3e
-outdated_translation: true
 ---
 
 # Official tournament support

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -161,9 +161,7 @@ If you satisfy the above criteria, you may make a request for main-menu banner s
 - It must be cleanly designed with an emphasis on being mostly transparent and relatively unobtrusive visually.
 - It must not include any sort of sponsorship or promote anything besides the tournament.
 
-You may find the following template helpful:
-
-![](https://assets.ppy.sh/media/mainmenu_template.png)
+[Download a template image for main menu banners here.](https://assets.ppy.sh/media/mainmenu_template.png)
 
 Please consult the following examples of acceptable banner designs:
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -153,8 +153,8 @@ If you satisfy the above criteria, you may make a request for main-menu banner s
 
 - The submitted file must be a **PNG**.
 - Width must be no larger than **1000px**. Using smaller widths is fine.
-- Height must always be **180px**. Smaller values are NOT fine.
-- All banner images will be treated as `2x`, meaning that they will be exported at 50% scale by us into a `1x` image. Design your images appropriately to ensure things are legible at half size. Users will see either image depending on their chosen client resolution.
+- Height must always be **180px**. Other values are NOT fine.
+- All banner images will be treated as `2x`, meaning that they will be exported at 50% scale into a `1x` image. Design your images appropriately to ensure things are legible at half size. Users will see either image depending on their chosen client resolution.
 - It must clearly display the logo, motif, AND name of your tournament, plus any information about the ongoing stage or section that is being advertised.
 - It must be cleanly designed with an emphasis on being mostly transparent and relatively unobtrusive visually.
 - It must not include any sort of sponsorship or promote anything besides the tournament.

--- a/wiki/Tournaments/Official_support/fr.md
+++ b/wiki/Tournaments/Official_support/fr.md
@@ -3,6 +3,8 @@ tags:
   - badge
   - badges
   - badged
+outdated_since: 6913d0808f4e9fa9e5f4c9d17cd3cd9158be3d3e
+outdated_translation: true
 ---
 
 # Support aux tournois officiels


### PR DESCRIPTION
A fairly simple change to bring the article up to the standards we actually use (as there's a LOT of manual resizing going on at our end), including a helpful design template by ChillierPear.