### PR TITLE
Fix backwards markdown links in `Gameplay/Score`

### DIFF
--- a/wiki/Gameplay/Score/en.md
+++ b/wiki/Gameplay/Score/en.md
@@ -14,10 +14,10 @@ ScoreV1 is the colloquial name for the original, default scoring system in osu!.
 
 For detailed descriptions of how ScoreV1 works in each game mode, see:
 
-- [ScoreV1/osu!](osu!)
-- [ScoreV1/osu!taiko](osu!taiko)
-- [ScoreV1/osu!catch](osu!catch)
-- [ScoreV1/osu!mania](osu!mania)
+- [osu!](ScoreV1/osu!)
+- [osu!taiko](ScoreV1/osu!taiko)
+- [osu!catch](ScoreV1/osu!catch)
+- [osu!mania](ScoreV1/osu!mania)
 
 ## ScoreV2
 


### PR DESCRIPTION
They were not supposed to look like this:

![image](https://user-images.githubusercontent.com/20418176/174433203-471d6f0c-6ee0-44d6-887e-c5d5764f6608.png)

Oops.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
