### PR TITLE
Rewrite `ScoreV1/osu!` using ground truth information

### DIFF
--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -2,8 +2,7 @@
 
 *See also: [osu! judgement system](/wiki/Gameplay/Judgement/osu!)*
 
-In **ScoreV1**, each of the object types in osu! is scored slightly differently.
-However, the total score is a simple sum of points awarded for each individual object in the beatmap.
+In **ScoreV1**, each of the object types in osu! is scored slightly differently. However, the total score is a simple sum of points awarded for each individual object in the beatmap.
 
 The rules for scoring each individual object type are outlined in the sections below.
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -30,12 +30,12 @@ Note that game modifiers (like Hard Rock or Easy, which change circle size, for 
 
 ## Sliders
 
-Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider parts (namely, the slider head, slider end, slider ticks, and slider repeats) hit. This judgement is converted to a score value using the same method that hit circles use.
+Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider parts (namely, the slider head, slider tail, slider ticks, and slider repeats) hit. This judgement is converted to a score value using the same method that hit circles use.
 
 Additionally, elements of the slider grant score in an independent fashion:
 
 - Each slider tick hit grants 10 points.
-- Each slider repeat or slider end hit grants 30 points.
+- Each slider repeat or slider tail hit grants 30 points.
 
 The point values above are not affected by any bonuses or multipliers.
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -7,7 +7,7 @@ However, the total score is a simple sum of points awarded for each individual o
 
 The rules for scoring each individual object type are outlined in the sections below.
 
-### Hit circles
+## Hit circles
 
 Each hit circle is assigned a numerical point value using the formula below:
 
@@ -15,12 +15,12 @@ Each hit circle is assigned a numerical point value using the formula below:
 
 where:
 
-* The *hit value* is the numerical value of the hit circle judgement (50, 100, or 300).
-* The *combo multiplier* is equal to (combo before this hit - 1) or 0, whichever is higher.
-* The *difficulty multiplier* is a value specific to the beatmap being played. The exact formula to compute it is given in the next subsection.
-* The *mod multiplier* is the total multiplier of the set of active mods.
+- The *hit value* is the numerical value of the hit circle judgement (50, 100, or 300).
+- The *combo multiplier* is equal to (combo before this hit - 1) or 0, whichever is higher.
+- The *difficulty multiplier* is a value specific to the beatmap being played. The exact formula to compute it is given in the next subsection.
+- The *mod multiplier* is the total multiplier of the set of active mods.
 
-#### Difficulty multiplier
+### Difficulty multiplier
 
 The **difficulty multiplier** is equal to an older version of star rating for the beatmap being played. It can be calculated via the following formula:
 
@@ -28,7 +28,7 @@ The **difficulty multiplier** is equal to an older version of star rating for th
 
 Note that game modifiers (like Hard Rock or Easy, which change circle size, for instance) do not affect the difficulty multiplier, as the original values of the variables are always used in the formula above regardless of which mods are enabled.
 
-### Sliders
+## Sliders
 
 Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider ticks hit. This judgement is converted to a score value using the same method that hit circles use.
 
@@ -39,7 +39,7 @@ Additionally, elements of the slider grant score in an independent fashion:
 
 The point values above are not affected by any bonuses or multipliers.
 
-### Spinners
+## Spinners
 
 Each spinner as a whole produces a 50, 100, or 300 judgement, based on the ratio of rotations performed to rotations required to complete the spinner. This judgement is converted to a score value using the same method that hit circles use.
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -1,31 +1,51 @@
----
-needs_cleanup: true
----
-
-# osu! scoring system
+# ScoreV1 (osu!)
 
 *See also: [osu! judgement system](/wiki/Gameplay/Judgement/osu!)*
 
-The score given by each hit circle and end of a slider is calculated with the following formula:-
+In **ScoreV1**, each of the object types in osu! is scored slightly differently.
+However, the total score is a simple sum of points awarded for each individual object in the beatmap.
 
-`Score = Hit Value + (Hit Value * ((Combo multiplier * Difficulty multiplier * Mod multiplier) / 25))`
+The rules for scoring each individual object type are outlined in the sections below.
 
-| Term | Meaning |
-| :-: | :-- |
-| **Hit Value** | The hit circle judgement (50, 100 or 300), any slider ticks and spinner's bonus |
-| **Combo multiplier** | (Combo before this hit - 1) or 0; whichever is higher |
-| **Difficulty multiplier** | The difficulty setting for the beatmap (see next header) |
-| **Mod multiplier** | The multiplier of the selected mods |
+### Hit circles
 
-Additionally each slider start, end and repeat tick awards 30 points, each slider middle tick awards 10 points and each spin of a spinner awards 100 points.
+Each hit circle is assigned a numerical point value using the formula below:
 
-Additional bonus of 1,000 points given for each spin of a spinner after the spinner meter is full.
+`Score = Hit value * ((Combo multiplier * Difficulty multiplier * Mod multiplier) / 25)`
 
-## Difficulty multiplier
+where:
 
-The **Difficulty multiplier** equals the old star rating. It can be calculated via the following formula:
+* The *hit value* is the numerical value of the hit circle judgement (50, 100, or 300).
+* The *combo multiplier* is equal to (combo before this hit - 1) or 0, whichever is higher.
+* The *difficulty multiplier* is a value specific to the beatmap being played. The exact formula to compute it is given in the next subsection.
+* The *mod multiplier* is the total multiplier of the set of active mods.
 
-`Stars = Round((HP Drain + Circle Size + Overall Difficulty + Clamp(Hit object count / Drain time in seconds * 8, 0, 16)) / 38 * 5)`
+#### Difficulty multiplier
 
-Note that game modifiers (like Hard Rock/Easy) will not change the **Difficulty multiplier**.
-It will only account for original values only.
+The **difficulty multiplier** is equal to an older version of star rating for the beatmap being played. It can be calculated via the following formula:
+
+`Difficulty multiplier = Round((HP Drain + Circle Size + Overall Difficulty + Clamp(Hit object count / Drain time in seconds * 8, 0, 16)) / 38 * 5)`
+
+Note that game modifiers (like Hard Rock or Easy, which change circle size, for instance) do not affect the difficulty multiplier, as the original values of the variables are always used in the formula above regardless of which mods are enabled.
+
+### Sliders
+
+Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider ticks hit. This judgement is converted to a score value using the same method that hit circles use.
+
+Additionally, elements of the slider grant score in an independent fashion:
+
+- Each slider tick hit grants 10 points.
+- Each slider repeat or slider end hit grants 30 points.
+
+The point values above are not affected by any bonuses or multipliers.
+
+### Spinners
+
+Each spinner as a whole produces a 50, 100, or 300 judgement, based on the ratio of rotations performed to rotations required to complete the spinner. This judgement is converted to a score value using the same method that hit circles use.
+
+Additionally, the spinner grants bonus points:
+
+- Each full spin before the spinner is completed grants 100 points.
+- After the spinner is completed, full spins grant an additional 1,000 points, for a total of 1,100 points altogether per spin.
+
+The point values above are not affected by any bonuses or multipliers.

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -16,7 +16,7 @@ where:
 
 - The *hit value* is the numerical value of the hit circle judgement (50, 100, or 300).
 - The *combo multiplier* is equal to (combo before this hit - 1) or 0, whichever is higher.
-- The *difficulty multiplier* is a value specific to the beatmap being played. The exact formula to compute it is given in the next subsection.
+- The *difficulty multiplier* is a value specific to the beatmap being played. See the [below section](#difficulty-multiplier) for the exact formula to compute it.
 - The *mod multiplier* is the total multiplier of the set of active mods.
 
 ### Difficulty multiplier
@@ -29,22 +29,18 @@ Note that game modifiers (like Hard Rock or Easy, which change circle size, for 
 
 ## Sliders
 
-Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider parts (namely, the slider head, slider tail, slider ticks, and slider repeats) hit. This judgement is converted to a score value using the same method that hit circles use.
+Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider parts hit (namely, the slider head, slider tail, slider ticks, and slider repeats). This judgement is converted to a score value using the same method that hit circles use.
 
-Additionally, elements of the slider grant score in an independent fashion:
+Additionally, elements of the slider grant score in an independent fashion, unaffected by any bonuses or multipliers:
 
 - Each slider tick hit grants 10 points.
 - Each slider repeat or slider tail hit grants 30 points.
-
-The point values above are not affected by any bonuses or multipliers.
 
 ## Spinners
 
 Each spinner as a whole produces a 50, 100, or 300 judgement, based on the ratio of rotations performed to rotations required to complete the spinner. This judgement is converted to a score value using the same method that hit circles use.
 
-Additionally, the spinner grants bonus points:
+The spinner also grants additional bonus points, unaffected by any other bonuses or multipliers:
 
 - Each full spin before the spinner is completed grants 100 points.
 - After the spinner is completed, full spins grant an additional 1,000 points, for a total of 1,100 points altogether per spin.
-
-The point values above are not affected by any bonuses or multipliers.

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -11,7 +11,7 @@ The rules for scoring each individual object type are outlined in the sections b
 
 Each hit circle is assigned a numerical point value using the formula below:
 
-`Score = Hit value * ((Combo multiplier * Difficulty multiplier * Mod multiplier) / 25)`
+`Score = Hit value * (1 + (Combo multiplier * Difficulty multiplier * Mod multiplier / 25))`
 
 where:
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/en.md
@@ -30,7 +30,7 @@ Note that game modifiers (like Hard Rock or Easy, which change circle size, for 
 
 ## Sliders
 
-Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider ticks hit. This judgement is converted to a score value using the same method that hit circles use.
+Each slider as a whole produces a 50, 100, or 300 judgement, based on the proportion of slider parts (namely, the slider head, slider end, slider ticks, and slider repeats) hit. This judgement is converted to a score value using the same method that hit circles use.
 
 Additionally, elements of the slider grant score in an independent fashion:
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!/fr.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 9808129dbb76e6901c616fbad561dccb292b60f3
+---
+
 # Système de notation d'osu!
 
 *Voir également : [Système de jugement d'osu!](/wiki/Gameplay/Judgement/osu!)*


### PR DESCRIPTION
- Closes #2528
- Step forward in #2026 (1/4)

The contents were not as wrong as the original issue described them, because things improved along the way (e.g. in e5e1f8f8909d6037c207a8ac906898e59b2d0a4b). That said, there were still some half-truths and inaccuracies in the old version.

I've opted for a full rewrite using a bit of a different structure to make describing the algorithm easier. This is going to get much worse when it comes to taiko, for instance, as there's a lot of object type specific logic there. Interested in opinions about how well this style holds up.

Information was cross-checked against source and also verified empirically to a degree. If there's anything unclear in the wording I used please let me know - describing complex formulas and algorithms tends to get messy and imprecise when done in natural language.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)