### PR TITLE
Bump osu-wiki-tools to version `0.0.3`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
 yamllint==1.26.3
-osu-wiki-tools==0.0.2
+osu-wiki-tools==0.0.3


### PR DESCRIPTION
This release fixes some small issues

View the changes at: https://github.com/Walavouchey/osu-wiki-tools/compare/v0.0.2...v0.0.3

Notable changes in this version:

- Fix link fragment checking not being ignored properly in outdated translations
- Fix footnotes getting detected as reference-style links (found in https://github.com/ppy/osu-wiki/pull/7534)
- Print information on how to skip the check (SKIP_OUTDATED_CHECK) when there are errors

[Test branch](https://github.com/Walavouchey/osu-wiki/pull/24) 