### PR TITLE
Use correct hash for `outdated_since` in a few articles

### DIFF
--- a/wiki/Storyboard/Scripting/Audio/de.md
+++ b/wiki/Storyboard/Scripting/Audio/de.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Storyboard Audio

--- a/wiki/Storyboard/Scripting/Audio/fr.md
+++ b/wiki/Storyboard/Scripting/Audio/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Échantillons audio d'un storyboard

--- a/wiki/Storyboard/Scripting/Audio/ja.md
+++ b/wiki/Storyboard/Scripting/Audio/ja.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # 音について

--- a/wiki/Storyboard/Scripting/Audio/pt-br.md
+++ b/wiki/Storyboard/Scripting/Audio/pt-br.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Áudio de Storyboard

--- a/wiki/Storyboard/Scripting/Cheat_Sheet/fr.md
+++ b/wiki/Storyboard/Scripting/Cheat_Sheet/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Aide-mémoire sur le scénario d'un storyboard

--- a/wiki/Storyboard/Scripting/Commands/fr.md
+++ b/wiki/Storyboard/Scripting/Commands/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Commandes de script d'un storyboard

--- a/wiki/Storyboard/Scripting/Objects/fr.md
+++ b/wiki/Storyboard/Scripting/Objects/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: aecdfe5275d693cac9f3d610277e56531f81c58c
+outdated_since: 3edcc9733800c0e9221a2032eede25009608e79d
 ---
 
 # Objets d'un storyboard


### PR DESCRIPTION
(invalidated in <https://github.com/ppy/osu-wiki/pull/7376>)

`SKIP_OUTDATED_CHECK`