### PR TITLE
Make remaining translations use identifier-based links to `Help centre`

### DIFF
--- a/wiki/Help_centre/Tournament_bans/id.md
+++ b/wiki/Help_centre/Tournament_bans/id.md
@@ -14,7 +14,7 @@ Kami menjatuhkan larangan turnamen kepada para pemain yang terbukti melakukan pe
 
 Sebagai contoh, kami tidak membenarkan tindakan para pemain yang menulis atau menggambar simbol/ujaran kebencian (seperti logo swastika) dalam bentuk apapun dengan *cursor smoke* mereka pada pertandingan yang disiarkan secara langsung.
 
-Di samping itu, para pengguna yang sebelumnya di-*restrict* baru akan dapat [kembali mengikuti turnamen setelah minimal 1 tahun](/wiki/Help_centre/Account_restrictions#penyebab-penyebab-umum-restriction-dan-masa-cooldown-nya-masing-masing) terhitung dari tanggal pemulihan akun mereka (yang dapat berlaku lebih apabila dirasa perlu oleh [account support team](/wiki/People/The_Team/Account_support_team)).
+Di samping itu, para pengguna yang sebelumnya di-*restrict* baru akan dapat [kembali mengikuti turnamen setelah minimal 1 tahun](/wiki/Help_centre/Account_restrictions#reasons) terhitung dari tanggal pemulihan akun mereka (yang dapat berlaku lebih apabila dirasa perlu oleh [account support team](/wiki/People/The_Team/Account_support_team)).
 
 ## Hal-hal apa saja yang dapat membuat seseorang dijatuhi larangan turnamen secara permanen? {#why-permanent}
 

--- a/wiki/Help_centre/Tournament_bans/id.md
+++ b/wiki/Help_centre/Tournament_bans/id.md
@@ -8,7 +8,7 @@ Larangan turnamen seringkali tidak dijatuhkan sebagai suatu hukuman yang terpisa
 
 Berhubung turnamen merupakan hal yang serius, seluruh hukuman larangan turnamen yang dijatuhkan akan ditegakkan secara tegas tanpa dapat dinegosiasikan lebih lanjut.
 
-## Hal-hal apa saja yang dapat membuat seseorang dijatuhi larangan turnamen secara sementara?
+## Hal-hal apa saja yang dapat membuat seseorang dijatuhi larangan turnamen secara sementara? {#why-temporary}
 
 Kami menjatuhkan larangan turnamen kepada para pemain yang terbukti melakukan pelanggaran berat terhadap [peraturan komunitas](/wiki/Rules) yang berlaku dalam ruang lingkup [turnamen yang didukung secara resmi](/wiki/Tournaments/Official_support) secara umum, bahkan apabila pelanggaran tersebut tidak memengaruhi hasil turnamen yang ada sekalipun.
 
@@ -16,7 +16,7 @@ Sebagai contoh, kami tidak membenarkan tindakan para pemain yang menulis atau me
 
 Di samping itu, para pengguna yang sebelumnya di-*restrict* baru akan dapat [kembali mengikuti turnamen setelah minimal 1 tahun](/wiki/Help_centre/Account_restrictions#penyebab-penyebab-umum-restriction-dan-masa-cooldown-nya-masing-masing) terhitung dari tanggal pemulihan akun mereka (yang dapat berlaku lebih apabila dirasa perlu oleh [account support team](/wiki/People/The_Team/Account_support_team)).
 
-## Hal-hal apa saja yang dapat membuat seseorang dijatuhi larangan turnamen secara permanen?
+## Hal-hal apa saja yang dapat membuat seseorang dijatuhi larangan turnamen secara permanen? {#why-permanent}
 
 Kami menjatuhkan larangan turnamen secara permanen kepada para pemain yang terbukti menggunakan program ilegal apapun ataupun memperoleh keuntungan secara tidak adil dalam bentuk apapun dalam turnamen yang didukung secara resmi. Di samping itu, kami juga menjatuhkan hukuman ini kepada mereka yang tertangkap tangan melakukan tindak pelecehan yang tidak dapat ditoleransi lagi.
 
@@ -30,19 +30,19 @@ Untuk lebih jelasnya, berikut merupakan berbagai hal yang dapat membuat seseoran
 - Menyalahgunakan posisi panitia untuk memberikan keuntungan kepada pihak tertentu (seperti memanipulasi jadwal, mengubah komposisi tim, ataupun mendiskualifikasi peserta tertentu secara sepihak)
 - Mengkoordinir gerakan tertentu yang bertujuan untuk menghujat serta melecehkan pemain/panitia dalam kerangka perlakuan yang tidak lagi dapat dipandang sebagai kritik
 
-## Apakah saya dapat mengajukan banding terhadap larangan turnamen saya?
+## Apakah saya dapat mengajukan banding terhadap larangan turnamen saya? {#appeal}
 
 Baik itu sementara ataupun permanen, **kamu tidak dapat mengajukan banding terhadap larangan turnamen yang kamu terima**.
 
 Dalam situasi khusus, [account support team](/wiki/People/The_Team/Account_support_team) kami dapat meninjau ulang kasus tertentu yang memang tim kami rasa perlu untuk diselidiki lebih lanjut dan menyesuaikan masa hukuman yang dijatuhkan.
 
-## Apa yang dapat saya lakukan selagi saya berada dalam masa larangan?
+## Apa yang dapat saya lakukan selagi saya berada dalam masa larangan? {#while-banned}
 
 Kamu dapat tetap berpartisipasi pada turnamen komunitas yang tidak berstatus resmi dan tidak melibatkan proses penyaringan peserta (*screening*) selama panitia turnamen yang bersangkutan berkenan dengan keikutsertaanmu.
 
 Meskipun demikian, terlepas dari apakah turnamen tersebut resmi atau tidak, kami berhak untuk menyediakan informasi seputar status larangan turnamenmu kepada panitia turnamen apabila diminta.
 
-## Alasan umum larangan turnamen beserta durasinya
+## Alasan umum larangan turnamen beserta durasinya {#reasons}
 
 | Alasan larangan turnamen | Durasi | Catatan |
 | :-- | :-- | :-- |

--- a/wiki/People/The_Team/Account_support_team/ru.md
+++ b/wiki/People/The_Team/Account_support_team/ru.md
@@ -31,8 +31,8 @@ tags:
   - Удаление карт;
   - Удаление комментариев или форумных постов.
 - Добровольное [признание в нарушении правил](/wiki/Reporting_bad_behaviour/Handling_foul_play#как-можно-попросить-о-разбане?).
-- [Потеря доступа к почте](/wiki/Help_centre/Account#доступ-к-аккаунту), привязанной к аккаунту osu!, или утрата самого аккаунта.
-- [Незначительные изменения ника](/wiki/Help_centre/Account#смена-ника) (или откат уже сделанных).
+- [Потеря доступа к почте](/wiki/Help_centre/Account#sign-in), привязанной к аккаунту osu!, или утрата самого аккаунта.
+- [Незначительные изменения ника](/wiki/Help_centre/Account#change-username) (или откат уже сделанных).
 - Регистрация [бот-аккаунта](/wiki/Bot_account).
 
 ### [support@ppy.sh](mailto:support@ppy.sh)
@@ -41,8 +41,8 @@ tags:
 
 - Жалобы на поведение модератора.
 - Жалобы на модератора, не соблюдающего [Кодекс поведения волонтёра](/wiki/Contributor_Code_of_Conduct).
-- [Проблемы с оплатой](/wiki/Help_centre/Account#саппортер) заказов из [osu!store](https://osu.ppy.sh/store/listing).
-- Технические проблемы, которые не удалось или нельзя решить через [форум техподдержки](https://osu.ppy.sh/community/forums/5), например, [проблемы с подключением](/wiki/Help_centre/Client#online).
+- [Проблемы с оплатой](/wiki/Help_centre/Account#supporter) заказов из [osu!store](https://osu.ppy.sh/store/listing).
+- Технические проблемы, которые не удалось или нельзя решить через [форум техподдержки](https://osu.ppy.sh/community/forums/5), например, [проблемы с подключением](/wiki/Help_centre/Client#online-features).
 
 ### [privacy@ppy.sh](mailto:privacy@ppy.sh)
 


### PR DESCRIPTION
a follow-up to #7505 (two translations were merged when it was still pending)