### PR TITLE
Ignore `no-heading-punctuation` lint rule for artist/song titles

### DIFF
--- a/news/2018-03-20-featured-artist-track-updates.md
+++ b/news/2018-03-20-featured-artist-track-updates.md
@@ -32,6 +32,8 @@ We've got **three** new tracks lined up from IAHN in his classic electronic styl
     <source src="https://assets.ppy.sh/artists/3/previews/387.mp3" type="audio/mpeg">
 </audio>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ## yuki.
 
 **Two** brand new, osu! exclusive tracks arrive with this update from yuki. [Check out his Featured Artist listing for more details and links to the beatmap files for the new tracks!](https://osu.ppy.sh/beatmaps/artists/4)

--- a/news/2019-03-07-new-featured-artist-imperial-circus-dead-decadence.md
+++ b/news/2019-03-07-new-featured-artist-imperial-circus-dead-decadence.md
@@ -22,6 +22,8 @@ But naturally, don't take our word for it! Here's a few samples of just a snippe
     <source src="https://assets.ppy.sh/artists/35/previews/854.mp3" type="audio/mpeg">
 </audio>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### Hai shita Shoujo Wa, Haiyoru Konton To Kaikousu.
 
 <audio controls>

--- a/news/2019-11-27-new-featured-artist-goreshit.md
+++ b/news/2019-11-27-new-featured-artist-goreshit.md
@@ -16,6 +16,8 @@ Dialling industrial-fused breakcore up to the maximum, we're certain that we're 
 
 Check out a sample of what's available below:
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### there are no angels here.
 
 <audio controls>

--- a/news/2020-09-04-new-featured-artist-updates-september-2020.md
+++ b/news/2020-09-04-new-featured-artist-updates-september-2020.md
@@ -112,6 +112,8 @@ With an anime sound comparable only to [*\*namirin*](https://osu.ppy.sh/beatmaps
 
 **UNDEAD CORPORATION**'s latest release, **Face the Fate**, is a collaboration with [*HONE YOUR SENSE*](http://www.honeyoursense.com/) — another artist in the Japanese metal scene! While we can't control fate, we're *pretty certain* you'll see more from UNDEAD CORPORATION on osu! in the future.
 
+<!-- lint ignore no-heading-punctuation -->
+
 ## [yuki.](https://osu.ppy.sh/beatmaps/artists/4)
 
 [![](https://assets.ppy.sh/artists/4/header.jpg)](https://osu.ppy.sh/beatmaps/artists/4)

--- a/news/2021-02-20-new-featured-artist-nora2r.md
+++ b/news/2021-02-20-new-featured-artist-nora2r.md
@@ -20,6 +20,8 @@ We've gathered **16** tracks from the boss of bass, including the song most appr
     </video>
 </div>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### nora2r - B.B.K.K.B.K.K.
 
 Play through [the mapset above](https://osu.ppy.sh/beatmapsets/1372554) by [Nozhomi](https://osu.ppy.sh/users/2716981) or this [older mapset](https://osu.ppy.sh/beatmapsets/153920) by rezoons.

--- a/news/2021-05-22-new-featured-artist-yukitani.md
+++ b/news/2021-05-22-new-featured-artist-yukitani.md
@@ -20,6 +20,8 @@ Older generations of osu! players might already be well-versed with **yukitani**
     </video>
 </div>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### Amusing Reflection Rag.
 
 Check out [this new osu!taiko showcase beatmap](https://osu.ppy.sh/beatmapsets/1436446) hosted by [Reficul](https://osu.ppy.sh/users/1506011) of the Mappers' Guild!

--- a/news/2021-07-17-new-featured-artist-michael-cera-palin.md
+++ b/news/2021-07-17-new-featured-artist-michael-cera-palin.md
@@ -34,6 +34,8 @@ Check out [the map from the video above](https://osu.ppy.sh/beatmapsets/1275141)
     <source src="https://assets.ppy.sh/artists/182/Growing Pains/Michael%20Cera%20Palin%20-%20Laughing%20Makes%20It%20Worse.mp3" type="audio/mpeg">
 </audio>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### Go Home. Play Music. Feel Better.
 
 <audio controls>

--- a/news/2021-07-21-new-featured-artist-aoi.md
+++ b/news/2021-07-21-new-featured-artist-aoi.md
@@ -36,6 +36,8 @@ Bash your keys to [this osu!taiko map](https://osu.ppy.sh/beatmapsets/1488148) h
     <source src="https://assets.ppy.sh/artists/183/Songs/Aoi%20vs.%20siqlo%20-%20Hacktivism.mp3" type="audio/mpeg">
 </audio>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### Aoi - c.s.q.n.
 
 Try out [another osu!taiko map](https://osu.ppy.sh/beatmapsets/1492454) hosted by [DakeDekaane](https://osu.ppy.sh/users/1425253)!

--- a/news/2022-01-08-new-featured-artist-dgk.md
+++ b/news/2022-01-08-new-featured-artist-dgk.md
@@ -22,6 +22,8 @@ See what the hype's all about by watching a replay of [this straight-slider-focu
     </video>
 </div>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### nx.
 
 Try [the beatmap from the video above](https://osu.ppy.sh/beatmapsets/1667057) hosted by [-Sylvari](https://osu.ppy.sh/users/3493804)!

--- a/news/2022-07-02-featured-artist-track-updates-summer-2022.md
+++ b/news/2022-07-02-featured-artist-track-updates-summer-2022.md
@@ -157,6 +157,8 @@ While not a World Cup tiebreaker, [Valley of Voices](https://osu.ppy.sh/beatmaps
     <source src="https://assets.ppy.sh/artists/203/Songs/Lundy%20-%20axelnaught%20~l%27execution%20de%20la%20reine~.mp3" type="audio/mpeg">
 </audio>
 
+<!-- lint ignore no-heading-punctuation -->
+
 ### Lundy - not to pop your bubble...
 
 <audio controls>


### PR DESCRIPTION
ignore these cases individually for now, disabling the rule for all news posts is probably too broad
