### PR TITLE
Fix gitignore entry for osu-wiki-bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 # virtual python environment for local ci runs
 .venv/
 
-# used by https://github.com/cl8n/osu-wiki-bin for api keys
-.osu-wiki-bin.json
+# used by https://github.com/cl8n/osu-wiki-bin
+/.osu-wiki-bin*


### PR DESCRIPTION
there's a folder by this name too, and have been some other files in the past. this is the entry from my local `exclude`, I didn't realise there was a line in .gitignore
