### PR TITLE
Disable CI workflow runs for the master branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,6 @@
 name: osu-wiki continuous integration
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
they're only redundant since all changes are run through them via pull requests anyway, and they pointlessly keep failing when they are skipped

[context](https://discord.com/channels/188630481301012481/218677502141399041/993418941454102619)