### PR TITLE
Use GitHub annotations for remark-lint output

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm install
 
       - name: run remark on changed files
-        run: bash scripts/ci/run_remark.sh ${{ github.sha }} ${{ github.sha }}
+        run: bash scripts/ci/run_remark.sh --github-action ${{ github.sha }}
 
       - name: set up Python
         uses: actions/setup-python@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "remark-lint-osu-links": "github:cl8n/remark-lint-osu-links",
                 "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
                 "remark-preset-lint-markdown-style-guide": "5.1.2",
+                "vfile-reporter-github-action": "^1.0.0",
                 "vfile-reporter-position": "github:TicClick/vfile-reporter-position#update-vfile-message-v3"
             }
         },
@@ -4173,6 +4174,11 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/vfile-reporter-github-action": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-1.0.0.tgz",
+            "integrity": "sha512-q3Q8iuH7jSrFixDkeWuc4TjfZ9ZRfn29JO8EmEeoBu9+kV+kMpbVrkLyk4DLD3va1OK4+P8Ho6r8fSUIIgdZEA=="
+        },
         "node_modules/vfile-reporter-position": {
             "version": "1.0.0",
             "resolved": "git+ssh://git@github.com/TicClick/vfile-reporter-position.git#7a7a2949a5d215fcbd1f2fc30b0b8c26194ee830",
@@ -7230,6 +7236,11 @@
                     "integrity": "sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA=="
                 }
             }
+        },
+        "vfile-reporter-github-action": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-1.0.0.tgz",
+            "integrity": "sha512-q3Q8iuH7jSrFixDkeWuc4TjfZ9ZRfn29JO8EmEeoBu9+kV+kMpbVrkLyk4DLD3va1OK4+P8Ho6r8fSUIIgdZEA=="
         },
         "vfile-reporter-position": {
             "version": "git+ssh://git@github.com/TicClick/vfile-reporter-position.git#7a7a2949a5d215fcbd1f2fc30b0b8c26194ee830",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "remark-lint-osu-links": "github:cl8n/remark-lint-osu-links",
         "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
         "remark-preset-lint-markdown-style-guide": "5.1.2",
+        "vfile-reporter-github-action": "^1.0.0",
         "vfile-reporter-position": "github:TicClick/vfile-reporter-position#update-vfile-message-v3"
     }
 }


### PR DESCRIPTION
rewrote the remark wrapper along the way

some examples at <https://github.com/cl8n/osu-wiki/pull/5/files#diff-96b8f45fb84fb906fe4921166395d11d11abb05c5a4ff44269e9ff14014ccde4>
