### PR TITLE
Fix typos and prize arrangement in `Roundtable` article

### DIFF
--- a/wiki/Tournaments/The_Roundtable/1v1_double_elimination/en.md
+++ b/wiki/Tournaments/The_Roundtable/1v1_double_elimination/en.md
@@ -15,9 +15,9 @@ tags:
 
 | Placing | Prize(s) |
 | :-: | :-- |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 3rd place profile badge |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 2nd place profile badge |
 | ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 1st place profile badge |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 2nd place profile badge |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 3rd place profile badge |
 
 ## Participants
 
@@ -53,7 +53,7 @@ The matches will proceed as follows:
 
 - Two players will join a multiplayer room with supervision from an on-site tournament organizer.
 - When both players are in the room and ready, the match will start.
-- When the match stats, both users will `!roll` to determine the pick and ban order. The roll winner will choose either the pick order or the ban order, and roll loser will choose the remaining order. Bans will be done in ABBA order.
+- When the match starts, both users will `!roll` to determine the pick and ban order. The roll winner will choose either the pick order or the ban order, and roll loser will choose the remaining order. Bans will be done in ABBA order.
 - Each player bans a Tiebreaker with an on-site tournament organizer, and the remaining Tiebreaker is selected. If both players ban the same Tiebreaker, the tournament organizer will `!roll 2` to select the Tiebreaker.
 - Following the first map, the loser of the previous map will pick the next map until one player reaches the required amount of points to win the match.
 - If both players are at match point, the Tiebreaker will be played.

--- a/wiki/Tournaments/The_Roundtable/2v2_team_tandem_tournament/en.md
+++ b/wiki/Tournaments/The_Roundtable/2v2_team_tandem_tournament/en.md
@@ -50,6 +50,6 @@ The matches will proceed as follows:
 
 - Two teams will join a multiplayer room with supervision from an on-site tournament organizer.
 - When both teams are in the room and ready, the match will start.
-- When the match stats, both teams will `!roll` to determine the pick and ban order. The roll winner will choose either the pick order or the ban order, and roll loser will choose the remaining order. Bans will be done in ABBA order.
+- When the match starts, both teams will `!roll` to determine the pick and ban order. The roll winner will choose either the pick order or the ban order, and roll loser will choose the remaining order. Bans will be done in ABBA order.
 - Following the first map, the losing team of the previous map will pick the next map until one team reaches the required amount of points to win the match.
 - If both teams are at match point, the Tiebreaker will be played.


### PR DESCRIPTION
Should’ve done a more thorough review on the last PR, this fixes the blatant typos and some styling issues I find with article.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
