### PR TITLE
Add rule to ASC disallowing translation of footnote identifiers

### DIFF
--- a/wiki/Article_styling_criteria/Formatting/de.md
+++ b/wiki/Article_styling_criteria/Formatting/de.md
@@ -1,3 +1,8 @@
+---
+outdated_since: f5cbe6d8793eeb5aeec9376259b23bdbdbc1e84b
+outdated_translation: true
+---
+
 # Formatierung
 
 *Für die Schriftstandards, siehe: [Artikelgestaltungskriterien/Schrift](../Writing)*

--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -811,9 +811,11 @@ The following is an example of what a table should look like:
 
 Footnotes are short notes located at the end of the page. They are used for citing sources, or providing background information that would otherwise disrupt the flow of the article. Footnotes may contain text formatting and links.
 
-In the osu! wiki, footnotes are implemented using special syntax (`[^identifier]`). Footnotes can use any identifier, but they will automatically be rendered as superscripts with increasing numbers in order of their first appearance. The footnotes themselves must be placed in a separate second-level heading at the end of the article. Depending on the content, the heading used may be `References`, `Notes`, or `Notes and references`.
+In the osu! wiki, footnotes are implemented using special syntax (`[^identifier]`). Footnotes can use any identifier, but they will automatically be rendered as superscripts with increasing numbers in order of their first appearance. Translations must not modify identifiers of footnotes.
 
 Footnote references are placed directly after the words, phrases, or sentences they explain, with no space in between. These references must be placed after punctuation, except for parentheses, when they pertain to the contents inside, and dashes.<!-- Taken from https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Punctuation_and_footnotes -->
+
+The footnotes themselves must be placed in a separate second-level heading at the end of the article. Depending on the content, the heading used may be `References`, `Notes`, or `Notes and references`.
 
 Correct usage examples:
 

--- a/wiki/Article_styling_criteria/Formatting/fr.md
+++ b/wiki/Article_styling_criteria/Formatting/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_since: f5cbe6d8793eeb5aeec9376259b23bdbdbc1e84b
+outdated_translation: true
+---
+
 # Mise en forme
 
 *Pour les normes de rédaction, voir : [Critères de mise en forme d'article/Rédaction](../Writing)*\


### PR DESCRIPTION
Walavouchey suggested this, just makes it slightly easier to edit and review translations. all existing articles follow this rule already