### PR TITLE
Add final member of the osu!taiko pp committee

### DIFF
--- a/wiki/People/Performance_Points_Committee/en.md
+++ b/wiki/People/Performance_Points_Committee/en.md
@@ -11,7 +11,7 @@ The osu! panel was first announced to the public through the [November 2021 *Per
 
 The osu!mania panel was formed 22 April 2022 in response to [another community survey regarding performance points and star rating in osu!taiko and osu!mania](https://osu.ppy.sh/home/news/2022-01-14-taiko-mania-pp-sr-survey) held earlier that year, as well as in anticipation of a surge in active development effort, starting with [a change in difficulty calculation for hold note releases in osu!mania](https://github.com/ppy/osu/pull/17913).
 
-The osu!taiko panel was formed on 1 May 2022 in response to the same survey as above, with [plans for major changes to the star rating algorithm](https://docs.google.com/document/d/1Z5GC4DMqOVzeIERMSK3qpQaqjq-sVnhbuoxAwy9qxDs/edit).
+The osu!taiko panel was formed on 1 May 2022 in response to the same survey as above, with [major changes to the star rating algorithm](https://docs.google.com/document/d/1Z5GC4DMqOVzeIERMSK3qpQaqjq-sVnhbuoxAwy9qxDs/edit).
 
 ## Members
 
@@ -29,6 +29,7 @@ The osu!taiko panel was formed on 1 May 2022 in response to the same survey as a
 | osu! profile | GitHub profile |
 | :-- | :-- |
 | ::{ flag=AU }:: [-Lawtron-](https://osu.ppy.sh/users/11475208) | [Lawtrohux](https://github.com/Lawtrohux) |
+| ::{ flag=GB }:: [Horiiizon](https://osu.ppy.sh/users/8071438) | [Horiiizons](https://github.com/Horiiizons) |
 | ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718) | [mangomizer](https://github.com/mangomizer) |
 | ::{ flag=MY }:: [vun](https://osu.ppy.sh/users/6932501) | [vunyunt](https://github.com/vunyunt) |
 

--- a/wiki/People/Performance_Points_Committee/fr.md
+++ b/wiki/People/Performance_Points_Committee/fr.md
@@ -32,6 +32,7 @@ Le panel du mode osu!taiko a été formé le 1er mai 2022 en réponse au même s
 | Profil osu! | Profil GitHub |
 | :-- | :-- |
 | ::{ flag=AU }:: [-Lawtron-](https://osu.ppy.sh/users/11475208) | [Lawtrohux](https://github.com/Lawtrohux) |
+| ::{ flag=GB }:: [Horiiizon](https://osu.ppy.sh/users/8071438) | [Horiiizons](https://github.com/Horiiizons) |
 | ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718) | [mangomizer](https://github.com/mangomizer) |
 | ::{ flag=MY }:: [vun](https://osu.ppy.sh/users/6932501) | [vunyunt](https://github.com/vunyunt) |
 

--- a/wiki/People/Performance_Points_Committee/fr.md
+++ b/wiki/People/Performance_Points_Committee/fr.md
@@ -2,6 +2,8 @@
 tags:
   - pp committee
   - comité des pp
+outdated_since: ead5b487acab4f9c7446891b3f88f92e152db8c1
+outdated_translation: true
 ---
 
 # Comité des points de performance

--- a/wiki/People/Performance_Points_Committee/ru.md
+++ b/wiki/People/Performance_Points_Committee/ru.md
@@ -33,6 +33,7 @@ outdated_translation: true
 | Профиль osu! | Профиль GitHub |
 | :-- | :-- |
 | ::{ flag=AU }:: [-Lawtron-](https://osu.ppy.sh/users/11475208) | [Lawtrohux](https://github.com/Lawtrohux) |
+| ::{ flag=GB }:: [Horiiizon](https://osu.ppy.sh/users/8071438) | [Horiiizons](https://github.com/Horiiizons) |
 | ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718) | [mangomizer](https://github.com/mangomizer) |
 | ::{ flag=MY }:: [vun](https://osu.ppy.sh/users/6932501) | [vunyunt](https://github.com/vunyunt) |
 

--- a/wiki/People/Performance_Points_Committee/ru.md
+++ b/wiki/People/Performance_Points_Committee/ru.md
@@ -3,6 +3,8 @@ tags:
   - pp committee
   - комитет по пп
   - пп комитет
+outdated_since: ead5b487acab4f9c7446891b3f88f92e152db8c1
+outdated_translation: true
 ---
 
 # Комитет по очкам производительности


### PR DESCRIPTION
This adds the final member of the osu!taiko pp committee, and changes the wording as active changes are now implemented.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

`SKIP_OUTDATED_CHECK`