### PR TITLE
Fix incorrect tags in `MWC/2022_4K`

### DIFF
--- a/wiki/Tournaments/MWC/2022_4K/en.md
+++ b/wiki/Tournaments/MWC/2022_4K/en.md
@@ -1,6 +1,6 @@
 ---
 tags:
-  - MWC
+  - MWC2022
   - MWC 2022
   - MWC4K 2022
   - MWC 4K 2022


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

@yobrevelc reported that couldn't find this tournament by searching "MWC2022".  
compared with last few years (2021 , 2020 , 2019).the following things are different:
1. `MWC` tag added
2. `MWC[year]` tag removed.
so this PR comes out, to consist with last years tags.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
