### PR TITLE
Fix commit hash validation not working in the outdated checker

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,9 +15,25 @@ jobs:
     name: changed files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
+      - name: sparse checkout
+        shell: bash
+        run: |
+          # repository url, utilising provided github credentials
+          REPOSITORY="https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git"
+          # merge commit ref name (with refs/heads/ stripped out)
+          BRANCH="${GITHUB_REF/#refs\/heads\//}"
+
+          git version
+          # clone without blobs; don't checkout to avoid fetching them anyway
+          git clone --filter=blob:none --no-checkout ${REPOSITORY} .
+          git config --local gc.auto 0
+
+          # set up sparse checkout
+          git sparse-checkout set --no-cone '**/*.md' '**/.remark*' '**/*.json' '**/*.yaml' 'scripts' 'wiki/**/*'
+
+          # fetch the merge commit ref
+          git -c protocol.version=2 fetch --no-tags --prune --progress --depth=2 origin +${GITHUB_SHA}:refs/remotes/origin/${BRANCH}
+          git checkout --progress --force -B $BRANCH refs/remotes/origin/$BRANCH
 
       - name: inspect binary file sizes
         shell: bash


### PR DESCRIPTION
This reverts commit 179fe2eab37b7cad431f1a00b3695df63d94c5d9.

this broke the commit hash check in the outdated checker which uses git-show to check if the hash is valid

actions/checkout@v3 must be doing the checkout slightly differently than what we used to have, but i haven't looked into it that much

[test branch](https://github.com/Walavouchey/osu-wiki/pull/26)

noticed this in https://github.com/ppy/osu-wiki/pull/7682