### PR TITLE
Change outdated term "iDevice" to "iOS device" in osu!stream article 

### DIFF
--- a/wiki/osu!stream/de.md
+++ b/wiki/osu!stream/de.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 5ec193cde80339dbf180e6dd622a35731c905556
+outdated_translation: true
+---
+
 # osu!stream
 
 ![](img/Os-Logo.jpg "Logo von osu!stream")

--- a/wiki/osu!stream/en.md
+++ b/wiki/osu!stream/en.md
@@ -33,7 +33,7 @@ Development for this version ended in 2020. For more information, read the [blog
   - If requested for Apple ID, key-in the Apple ID and the password.
 - Plug-in the iOS device to the device (that has osu!stream).
 - Transfer the osu!stream files using iTunes.
-- Unplug the iOS devicey and osu!stream can be played.
+- Unplug the iOS device and osu!stream can be played.
 
 ## Adding Beatmaps
 

--- a/wiki/osu!stream/en.md
+++ b/wiki/osu!stream/en.md
@@ -12,13 +12,13 @@ Development for this version ended in 2020. For more information, read the [blog
 
 ## Installation
 
-![](img/Os-Devices.jpg "osu!stream in iDevice")
+![](img/Os-Devices.jpg "osu!stream in iOS devices")
 
-### iDevice's App Store method (Suggested)
+### iOS' App Store method (Suggested)
 
-**Make sure the iDevice can connect to the Internet (either by Wi-Fi or 3G/4G).**
+**Make sure the iOS device can connect to the Internet (either by Wi-Fi or 3G/4G).**
 
-- Go to "App Store" from the iDevice
+- Go to "App Store" from the iOS device
 - Search for osu!stream
 - Press and install osu!stream
   - If prompted to key-in the Apple ID and the password, please do so.
@@ -31,13 +31,13 @@ Development for this version ended in 2020. For more information, read the [blog
 
 - Go to [this link and download it](http://itunes.apple.com/us/app/osu!stream/id436952197?ls=1&mt=8)
   - If requested for Apple ID, key-in the Apple ID and the password.
-- Plug-in the iDevice to the device (that has osu!stream).
+- Plug-in the iOS device to the device (that has osu!stream).
 - Transfer the osu!stream files using iTunes.
-- Unplug the iDevice and osu!stream can be played.
+- Unplug the iOS devicey and osu!stream can be played.
 
 ## Adding Beatmaps
 
-**Make sure the iDevice can connect to the Internet (either by Wi-Fi or 3G/4G).**
+**Make sure the iOS device can connect to the Internet (either by Wi-Fi or 3G/4G).**
 
 - Open osu!stream.
 - Press the osu! symbol and it should be directed to the main menu (or tutorial if first time)

--- a/wiki/osu!stream/en.md
+++ b/wiki/osu!stream/en.md
@@ -14,7 +14,7 @@ Development for this version ended in 2020. For more information, read the [blog
 
 ![](img/Os-Devices.jpg "osu!stream in iOS devices")
 
-### iOS' App Store method (Suggested)
+### iOS App Store method (suggested)
 
 **Make sure the iOS device can connect to the Internet (either by Wi-Fi or 3G/4G).**
 

--- a/wiki/osu!stream/fr.md
+++ b/wiki/osu!stream/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 5ec193cde80339dbf180e6dd622a35731c905556
+outdated_translation: true
+---
+
 # osu!stream
 
 ![](img/Os-Logo.jpg "logo d'osu!stream")


### PR DESCRIPTION
After further discussion on the #osu-wiki Discord channel, we figured it would be best to update the term "iDevice" into something more usual and clearer and agreed to use "iOS device(s)" instead.  

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)