### PR TITLE
[FR] Updated `osu!stream` wording to match the en version

### DIFF
--- a/wiki/osu!stream/fr.md
+++ b/wiki/osu!stream/fr.md
@@ -17,13 +17,13 @@ Le développement de cette version s'est terminé en 2020. Pour plus d'informati
 
 ## Installation
 
-![](img/Os-Devices.jpg "osu!stream dans iDevice")
+![](img/Os-Devices.jpg "osu!stream dans les appareils iOS")
 
-### Méthode de l'App Store de l'iDevice (recommandé)
+### Méthode de l'App Store iOS (recommandé)
 
-**Assurez-vous que l'iDevice peut se connecter à Internet (soit par Wi-Fi, soit par 3G/4G).**
+**Assurez-vous que l'appareil iOS peut se connecter à Internet (soit par Wi-Fi, soit par 3G/4G).**
 
-- Allez sur l'"App Store" depuis votre iDevice.
+- Allez sur l'"App Store" depuis votre appareil iOS.
 - Recherchez osu!stream
 - Appuyez et installez osu!stream
   - Si vous êtes invité à saisir votre identifiant Apple et votre mot de passe, faites-le.
@@ -36,13 +36,13 @@ Le développement de cette version s'est terminé en 2020. Pour plus d'informati
 
 - Allez sur [ce lien](http://itunes.apple.com/us/app/osu!stream/id436952197?ls=1&mt=8) et téléchargez osu!stream
   - Si l'on vous demande votre identifiant Apple, saisissez votre identifiant Apple et votre mot de passe.
-- Branchez l'iDevice sur l'appareil (qui a osu!stream).
+- Branchez l'appareil iOS sur l'appareil (qui a osu!stream).
 - Transférez les fichiers osu!stream en utilisant iTunes.
-- Débranchez l'iDevice et osu!stream pourra être lancé.
+- Débranchez l'appareil iOS et osu!stream pourra être lancé.
 
 ## Ajouter des beatmaps
 
-**Assurez-vous que l'iDevice peut se connecter à Internet (soit par Wi-Fi, soit par 3G/4G).**
+**Assurez-vous que l'appareil iOS peut se connecter à Internet (soit par Wi-Fi, soit par 3G/4G).**
 
 - Ouvrez osu!stream.
 - Appuyez sur le symbole d'osu! et vous devriez être redirigé vers le menu principal (ou le tutoriel si c'est la première fois).


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)

Replaced `iDevice` by `appareil iOS` to match the english version, i was thinking of making more changes as some anglicisms like `tels que des hold circles et des connected beats` sound weird to me but i assume they're intentional so i left them in.