### PR TITLE
Use Markdown-powered anchors in older newsposts

### DIFF
--- a/news/2017-04-15-osuweekly-100.md
+++ b/news/2017-04-15-osuweekly-100.md
@@ -18,7 +18,7 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 - [Scorewatch](#score)
 - [Taiko World Cup](#twc-2017-week-5-summary---finals-week-1---with-magnomizer)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB"/>
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **Woah there peppy, you haven't caught your breath since [starting up the osu!dev blog again](https://blog.ppy.sh/back-in-business!/)!** A flurry of updates made to the osu!lazer client saw the long awaited revival of the osu!dev blog last week. To say that signs of life have been emerging from the well established outlet of development news would be an understatement of massive proportions. Ever since the 9th of April, a new post has been made every day. If you want to prevent yourself from being hopelessly behind on the times, I recommend you go check out the new jekyll powered blog before it's too late!
 
@@ -32,7 +32,7 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 
 **Voting for the [spring osu!fan art contest](https://osu.ppy.sh/home/news/2017-04-11-spring-fan-art-contest-voting-now-open) is well underway!** It seems like this iteration has some serious competition going on for the top spot., with 3 votes proving simply not enough with so many great entries. Overall, everyone is very impressed with the turn-out and are excited to see which selected works will make it onto the menu for the spring update.
 
-<a id="com"></a><img src="http://nyquill.s-ul.eu/PesZ5xMa"/>
+![](http://nyquill.s-ul.eu/PesZ5xMa) {#com}
 
 **One of the biggest kicks mappers get from Aspire mapping contests is trying to break the game in interesting ways (and be endorsed for it).** -Mo-, one of the entrants of our latest such competition, uploaded a video describing how he achieved some of the effects he made in his entry. His channel also has some other cool discussions on game mechanics and how mappers can utilize them (sort of like a certain other popular youtube channel), so don't stop with that video if you're interested!
 
@@ -42,7 +42,7 @@ The osu!weekly title is extending its length on the front page by exactly one ch
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/n6W-xoWgumU" frameborder="0" allowfullscreen></iframe>
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm"/>
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 [Cookiezi](https://osu.ppy.sh/users/124493) took 8\* FCs to the next level and one-upped it to grab a HD SS off the Loved [DECO\*27 - Ghost Rule](https://osu.ppy.sh/beatmapsets/413117). This play would have been worth 680pp. Watch as Cookiezi nails all the jumps, and almost doesn't nail all the spinners.
 

--- a/news/2017-04-24-osuweekly-101.md
+++ b/news/2017-04-24-osuweekly-101.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/159950987033/osuweekly-101
 The time has come to open a new chapter on osu! History! A new landing page is out to show off a new face of circle clicking. Did you just come out of hibernation? Read on to find out what you slept through!
 
 ![](https://puu.sh/vuJdm/d57f3a5bdf.png)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-04-15-osuweekly-100">Previous</a></td>
 <td align="right"><a href="https://osu.ppy.sh/home/news/2017-05-02-osuweekly-102">Next</a></td>
 </tr></table>
@@ -23,6 +24,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 **A [makeover](https://osu.ppy.sh/home) for our website-in-progress has arrived!** Though it's more likely we'll have more people naturally appreciating it's full glory when we replace the old website, you can check it out right now by *logging out*. This story and much more came from [peppy's development blog](https://blog.ppy.sh/) (which also happens to have a massive new button on the new landing page). If you want to get the scoops straight from the horse's mouth, you should follow that blog closely. We've been slowing down since last week's near daily updates, but there's still plenty of content to dig in on every week!
 
 ![](https://puu.sh/vv0bl/129c821a68.png)
+
 <p style="text-align:center;"><i>Pippi greets our visitors with a smile and the promise of taking over the world</i></p>
 
 **An interesting new ["mapper subscription" service](https://discord.gg/D437P3t) has popped up in the form of a discord bot!** It seems to still be in the early stages of development, but already sees a surge of users much like the number of people who requested it to be in the main game. While it is still a planned feature for the main site eventually, you can go follow all your favorite mappers right now while we work out the road map for everything that has yet to come.
@@ -52,7 +54,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 
 ![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
-[Cookiezi](https://osu.ppy.sh/users/124493) is still an unstoppable player in the current year as he pulls off a crazy HD 45 miss pass on a 10* map, [Hige Driver join. SELEN - DADADADADADADADADADA (Long Version)](https://osu.ppy.sh/beatmaps/663725). You might wanna stick around for the entire video. It gets pretty insane.
+[Cookiezi](https://osu.ppy.sh/users/124493) is still an unstoppable player in the current year as he pulls off a crazy HD 45 miss pass on a 10* map, [Hige Driver join. SELEN - DADADADADADADADADADA (Long Version)](https://osu.ppy.sh/beatmapsets/295422#osu/663725). You might wanna stick around for the entire video. It gets pretty insane.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/PMMahOPH4NM" frameborder="0" allowfullscreen></iframe>
 
@@ -60,7 +62,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/1TuyVMwQ1NI" frameborder="0" allowfullscreen></iframe>
 
-Might as well do it with eyes closed, [v2fax](https://osu.ppy.sh/users/7739269) pulled off an unbelievable 97.69% HDHR FC on [LeaF - Wizdomiot](https://osu.ppy.sh/beatmaps/777192) to give himself 425pp. This is something else for the 19th placed Japanese.
+Might as well do it with eyes closed, [v2fax](https://osu.ppy.sh/users/7739269) pulled off an unbelievable 97.69% HDHR FC on [LeaF - Wizdomiot](https://osu.ppy.sh/beatmapsets/352682#taiko/777192) to give himself 425pp. This is something else for the 19th placed Japanese.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/hDkBjPtqBj8" frameborder="0" allowfullscreen></iframe>
 
@@ -72,9 +74,9 @@ NOTABLE MENTIONS
 
 [Rafis](https://osu.ppy.sh/users/2558286) finally gets some of that sweet pp goodness from an amazing 99.30% HDDT FC play on [TrySail & TRUE - High Free Spirits vs. DREAM SOLISTER](https://osu.ppy.sh/beatmaps/1193476?m=0) on Pentark's Extra, giving him 630pp.
 
-More FL plays! [Mawksee](https://osu.ppy.sh/users/5213472) pulled off a stunning 97.30% HDHRFL FC on [Girl's Day - Ring My Bell](https://osu.ppy.sh/beatmaps/988429) on the Insane difficulty to give him a mere 137pp.
+More FL plays! [Mawksee](https://osu.ppy.sh/users/5213472) pulled off a stunning 97.30% HDHRFL FC on [Girl's Day - Ring My Bell](https://osu.ppy.sh/beatmapsets/460322#osu/988429) on the Insane difficulty to give him a mere 137pp.
 
-[Rohulk](https://osu.ppy.sh/users/3219026) forgot how to get low accuracy and stunned people with a crazy 99.80% HDHR FC on [Camellia - dreamless wanderer](https://osu.ppy.sh/beatmaps/904030) to earn himself 359pp and the No. 1 spot.
+[Rohulk](https://osu.ppy.sh/users/3219026) forgot how to get low accuracy and stunned people with a crazy 99.80% HDHR FC on [Camellia - dreamless wanderer](https://osu.ppy.sh/beatmapsets/417492#osu/904030) to earn himself 359pp and the No. 1 spot.
 
 SCOREWATCH SCORE SHOW
 

--- a/news/2017-04-24-osuweekly-101.md
+++ b/news/2017-04-24-osuweekly-101.md
@@ -18,7 +18,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 - [Around the community](#com)
 - [Scorewatch](#score)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB"/>
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **A [makeover](https://osu.ppy.sh/home) for our website-in-progress has arrived!** Though it's more likely we'll have more people naturally appreciating it's full glory when we replace the old website, you can check it out right now by *logging out*. This story and much more came from [peppy's development blog](https://blog.ppy.sh/) (which also happens to have a massive new button on the new landing page). If you want to get the scoops straight from the horse's mouth, you should follow that blog closely. We've been slowing down since last week's near daily updates, but there's still plenty of content to dig in on every week!
 
@@ -40,7 +40,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 
 **Registrations are open for the [osu!mania PH Summer Tournament!](https://osu.ppy.sh/community/forums/topics/579557.)** This time, they seem to be going to also host a 7K tournament in addition to the 4K tournament they normally do. In line with its namesake, for once, this tournament is only open to those who wear the Philippine flag on their profile.
 
-<a id="com"></a><img src="http://nyquill.s-ul.eu/PesZ5xMa"/>
+![](http://nyquill.s-ul.eu/PesZ5xMa) {#com}
 
 **One of our players discovered that a pretty important aspect of (over)streaming has changed!** A pretty big change was made to the way streams can be hit in the event of a miss. In the past, missing in the middle of the stream meant there was no way to recover the next note. While this change is reflected in a version of the game that is very much a work in progress, it seems like a pretty solid improvement on what we have right now. What do you guys think?
 
@@ -50,7 +50,7 @@ The time has come to open a new chapter on osu! History! A new landing page is o
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/TqYqNf5m-aY" frameborder="0" allowfullscreen></iframe>
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm"/>
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 [Cookiezi](https://osu.ppy.sh/users/124493) is still an unstoppable player in the current year as he pulls off a crazy HD 45 miss pass on a 10* map, [Hige Driver join. SELEN - DADADADADADADADADADA (Long Version)](https://osu.ppy.sh/beatmaps/663725). You might wanna stick around for the entire video. It gets pretty insane.
 

--- a/news/2017-05-02-osuweekly-102.md
+++ b/news/2017-05-02-osuweekly-102.md
@@ -17,7 +17,7 @@ The days of our current client are numbered! With so much going into the work of
 - [Around the community](#com)
 - [Scorewatch](#score)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB"/>
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **We're still going strong with [lazer related updates](https://blog.ppy.sh/)!** Even though a lot of the work is done at a low technical level, at a glance, last week's updates can be summed up like this:
 
@@ -38,7 +38,7 @@ The days of our current client are numbered! With so much going into the work of
 
 **Whoops, we missed out on a pretty neat contest for the past two weeks!** The osu!hello there competition has concluded its registration phase and is primed for judging to happen within the coming days. pishifat will be joining them in a discussion about the entrants as well as an AMA, streamed live on their [twitch channel](https://www.twitch.tv/akamin_) on the 5th of May, 1500 UTC!
 
-<a id="com"></a><img src="http://nyquill.s-ul.eu/PesZ5xMa"/>
+![](http://nyquill.s-ul.eu/PesZ5xMa) {#com}
 
 **It looks like The8bitDrummer had an absolute blast jamming along to the main menu staple that we all know and love!** For those of you who have never heard of the man known for his eccentric drum covers, his channel hosts a variety of well known attempts of him doing live improvisation on songs from around the internet. Nekodex himself [was humbled](https://twitter.com/nekodex/status/857423010046726144) by the cover, and I think we can all agree that we can get addicted to this elaborate expression of rhythm!
 
@@ -48,7 +48,7 @@ The days of our current client are numbered! With so much going into the work of
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/s5E97W2xti4" frameborder="0" allowfullscreen></iframe>
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm">
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 [Vaxei](https://osu.ppy.sh/users/4787150) became one with the night as he set the next HR FC on [DragonForce - Symphony of the Night](https://osu.ppy.sh/beatmapsets/459901#osu/985141) with 98.41% to earn himself 600pp. He was serious about wanting to HR FC Blue Zenith. Very serious indeed.
 

--- a/news/2017-05-11-osuweekly-103.md
+++ b/news/2017-05-11-osuweekly-103.md
@@ -19,7 +19,7 @@ Over 100 issues of the osu!weekly, 10 million users, and 10 years of unforgettab
 - [Around the community](#com)
 - [Scorewatch](#score)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB"/>
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **Mentee applications for both [osu!standard](https://osu.ppy.sh/community/forums/topics/585200) and [osu!catch](https://osu.ppy.sh/community/forums/topics/585850) have started and we're primed to enter a new cycle!** For those of you who are desperately (like me) trying to up their game in the mapping community, what better opportunity is there than this? While mods are dime a dozen, it's not an exaggeration to say getting sincere opinions and critiques is a seldom received gift. If you are sincere in your pursuit of a better beatmap, head on over and apply today!
 
@@ -41,7 +41,7 @@ For the first time in a while, it might be worthwhile to give ourselves a refres
 
 **For the first time ever, osu!taiko will have its [very own edition of the aspire contest!](https://osu.ppy.sh/home/news/2017-05-10-aspire-stage-two-osutaiko-begins)** The excitement is building up as we wait to find out what kind of crazy new ways to break the game mode will emerge. For those who wish to participate, you have a full month (+1 day for timezone reasons) to get your submissions in.
 
-<a id="com"></a><img src="http://nyquill.s-ul.eu/PesZ5xMa"/>
+![](http://nyquill.s-ul.eu/PesZ5xMa) {#com}
 
 **The [osu!speedrunning community](https://www.speedrun.com/Osu/full_game#10_FC) has taken off with some [fierce](https://www.youtube.com/watch?v=M1YvV_XLR6U) [first week](https://www.youtube.com/watch?v=_bH2gxkEZ5I) [competition](https://www.youtube.com/watch?v=XURHiPwoFv4)!**Our very own MillhioreF currently holds the record for the fastest to 10 full combos. When asked about what he had to say to people going after his record, he had [this](http://nyquill.s-ul.eu/EVVVtbAR) to say. While this may seem bizarre for a lot of us, it's always cool to see people find their own enjoyment in the spirit of how rhythm games should be.
 
@@ -51,7 +51,7 @@ For the first time in a while, it might be worthwhile to give ourselves a refres
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/8NItVcsbYuE" frameborder="0" allowfullscreen></iframe>
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm"/>
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 [Cookiezi](https://osu.ppy.sh/users/124493) continues to shoot for the 14,000pp barrier as he made his mark on [Chitose Sara - Merry Merry Go Round](https://osu.ppy.sh/beatmaps/1003944?m=0) with a crazy 99.22% HDDT FC to claim 706pp. With this score, he now has ten 700pp+ top plays. Check it out!
 

--- a/news/2017-05-18-osuweekly-104.md
+++ b/news/2017-05-18-osuweekly-104.md
@@ -16,7 +16,7 @@ We're headed into an action packed summer kicking development into high gear! Th
 - [Weekly news](#news)
 - [Scorewatch](#score)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB"/>
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **There are a lot of updates on multiple development fronts this week, but let's start off with progress on osu!lazer.** For those of you who are new to the sharper-than-cutting-edge side of development, osu!lazer represents the hope and future of our beloved game. The completely [open source](https://github.com/ppy/osu/releases) overhaul of everything from the ground up has been tirelessly worked on by both members of the community and mainstay developers from the team.
 
@@ -36,7 +36,7 @@ We're headed into an action packed summer kicking development into high gear! Th
 ![](http://nyquill.s-ul.eu/jkkumdeh)
 **Registration for the osu!catch world cup is now closed!** Excited to see who made it to your favorite team's roster this year? Check out the [official wiki page](https://github.com/ppy/osu-wiki/blob/master/wiki/Tournaments/CWC/2017/en.md) for further updates, as well as the [discussion thread](https://osu.ppy.sh/community/forums/topics/589552) to share your excitement with everyone else! Live drawings are set to happen on May 28th at 1400 UTC.
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm"/>
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 Starting off the week, [Riviclia](https://osu.ppy.sh/users/1616533) shocked the EZ scene with an amazing 97.98% EZDT FC on [TRUE - Soundscape](https://osu.ppy.sh/beatmapsets/508222#osu/1082245) on StarR's Euphonious, landing him 422pp. Yes, that is still his skin. Best skin.
 

--- a/news/2017-05-25-osuweekly-105.md
+++ b/news/2017-05-25-osuweekly-105.md
@@ -19,7 +19,7 @@ Even with osu!catch World Cup looming over the horizon, you can't let your guard
 - [Around the community](#com)
 - [Scorewatch](#score)
 
-<a id="news"></a><img src="http://nyquill.s-ul.eu/a0GJK4pB">
+![](http://nyquill.s-ul.eu/a0GJK4pB) {#news}
 
 **The live drawings for the [osu!catch World Cup](https://github.com/ppy/osu-wiki/blob/master/wiki/Tournaments/CWC/2017/en.md) will be happening this sunday at 1400 UTC!** Excited to see who your favorite teams will get grouped up with? Tune in over at the [osu!live twitch channel](https://www.twitch.tv/osulive) get in on the first round of formalities before the action!
 
@@ -27,7 +27,7 @@ Even with osu!catch World Cup looming over the horizon, you can't let your guard
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/WRJwYgim3WQ" frameborder="0" allowfullscreen></iframe>
 
-<a id="dev"></a><img src="http://nyquill.s-ul.eu/H63Olpn1"/>
+![](http://nyquill.s-ul.eu/H63Olpn1) {#dev}
 
 osu!lazer saw one of it's busiest weeks yet, with development contribution from the community skyrocketing over the course of the past week. You can check out these and more (recent) updates over at [peppy's development blog](https://blog.ppy.sh/).
 
@@ -37,13 +37,13 @@ osu!lazer saw one of it's busiest weeks yet, with development contribution from 
 
 <div style="width: 100%; height: 0px; position: relative; padding-bottom: 56.250%;"><iframe src="https://streamable.com/s/mqdnc/hboxkt" frameborder="0" width="100%" height="100%" allowfullscreen style="width: 100%; height: 100%; position: absolute;"></iframe></div>
 
-<a id="com"></a><img src="http://nyquill.s-ul.eu/PesZ5xMa"/>
+![](http://nyquill.s-ul.eu/PesZ5xMa) {#com}
 
 **[HappyStick](https://osu.ppy.sh/users/Happystick) had an opportunity to sit down with prolific players [Azer](https://osu.ppy.sh/users/Azer) and [Toy](https://osu.ppy.sh/users/Toy) to try to help new players figure out how to get better at the game.** This seems to be the first in a series of videos/livestreams that Happystick will be putting out with this goal in mind. If you find yourself stuck on how to improve, you should definitely check it out!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/JM7iG6uPdgg" frameborder="0" allowfullscreen></iframe>
 
-<a id="score"></a><img src="http://nyquill.s-ul.eu/We57rqqm"/>
+![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
 [ThePooN](https://osu.ppy.sh/users/718454) choked his way into 10,000pp by setting a crazy 99.17% 4x miss score on [DragonForce - Soldiers of the Wasteland](https://osu.ppy.sh/beatmaps/962194) to give him 551pp and the No. 1 spot on the map. This map has yet to be FC'd, but we're getting there.
 

--- a/news/2017-05-25-osuweekly-105.md
+++ b/news/2017-05-25-osuweekly-105.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/161047067538/osuweekly-105
 Even with osu!catch World Cup looming over the horizon, you can't let your guard down or you'll fall behind on the never ending onslaught of updates. Read on to catch up with everything osu! has to offer!
 
 ![](https://puu.sh/w0pcY/3b6147fb3f.png)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-05-18-osuweekly-104">Previous</a></td>
 <td align="right">Next</td>
 </tr></table>
@@ -45,23 +46,23 @@ osu!lazer saw one of it's busiest weeks yet, with development contribution from 
 
 ![](http://nyquill.s-ul.eu/We57rqqm) {#score}
 
-[ThePooN](https://osu.ppy.sh/users/718454) choked his way into 10,000pp by setting a crazy 99.17% 4x miss score on [DragonForce - Soldiers of the Wasteland](https://osu.ppy.sh/beatmaps/962194) to give him 551pp and the No. 1 spot on the map. This map has yet to be FC'd, but we're getting there.
+[ThePooN](https://osu.ppy.sh/users/718454) choked his way into 10,000pp by setting a crazy 99.17% 4x miss score on [DragonForce - Soldiers of the Wasteland](https://osu.ppy.sh/beatmapsets/448281#osu/962194) to give him 551pp and the No. 1 spot on the map. This map has yet to be FC'd, but we're getting there.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/P_cWhpk1O9U" frameborder="0" allowfullscreen></iframe>
 
-After receiving a PM from HappyStick about wanting his own score to be sniped, [Cookiezi](https://osu.ppy.sh/users/124493) delivered within minutes, setting an outstanding 99.59% HDHR FC on [NU-KO - Pochiko no Shiawase na Nichijou (Long Version)](https://osu.ppy.sh/beatmaps/1154766). That was an effortless 600pp from him...scary.
+After receiving a PM from HappyStick about wanting his own score to be sniped, [Cookiezi](https://osu.ppy.sh/users/124493) delivered within minutes, setting an outstanding 99.59% HDHR FC on [NU-KO - Pochiko no Shiawase na Nichijou (Long Version)](https://osu.ppy.sh/beatmapsets/307034#osu/1154766). That was an effortless 600pp from him...scary.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Mzn3UtVGzUo" frameborder="0" allowfullscreen></iframe>
 
-Continuing on the theme of sniping, [Vaxei](https://osu.ppy.sh/users/4787150) stole Rafis' No. 1 spot on [Camellia - Routing](https://osu.ppy.sh/beatmaps/967546), setting an impressive 99.36% HD FC on the toughest difficulty to earn 530 pp. The score was set only a day after Rafis', so their rivalry is really intense!
+Continuing on the theme of sniping, [Vaxei](https://osu.ppy.sh/users/4787150) stole Rafis' No. 1 spot on [Camellia - Routing](https://osu.ppy.sh/beatmapsets/403282#osu/967546), setting an impressive 99.36% HD FC on the toughest difficulty to earn 530 pp. The score was set only a day after Rafis', so their rivalry is really intense!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/8Dt1bJ_kPM8" frameborder="0" allowfullscreen></iframe>
 
-[ankohime](https://osu.ppy.sh/users/7556189) ascended to new heights after pulling off an incredible 99.12% HDDT FC on the marathon taiko map [simo - Chou Kumikyoku "Nico Nico Douga"](https://osu.ppy.sh/beatmaps/746111?m=1), earning him 606pp. If you've got 7 minutes to spare, do check this out!
+[ankohime](https://osu.ppy.sh/users/7556189) ascended to new heights after pulling off an incredible 99.12% HDDT FC on the marathon taiko map [simo - Chou Kumikyoku "Nico Nico Douga"](https://osu.ppy.sh/beatmapsets/337196#taiko/746111), earning him 606pp. If you've got 7 minutes to spare, do check this out!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/mvxNSrRMejE" frameborder="0" allowfullscreen></iframe>
 
-[Zyph](https://osu.ppy.sh/users/1600432) took accuracy to a whole new level in osu!mania by SSing [(Various Artists) - Jumpstream Of Fighters](https://osu.ppy.sh/beatmaps/1159130) Glorious Crown 5.79* chart. To all mania players, this must be seen!
+[Zyph](https://osu.ppy.sh/users/1600432) took accuracy to a whole new level in osu!mania by SSing [(Various Artists) - Jumpstream Of Fighters](https://osu.ppy.sh/beatmapsets/547215#mania/1159130) Glorious Crown 5.79* chart. To all mania players, this must be seen!
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/IffA9a8rR58" frameborder="0" allowfullscreen></iframe>
 

--- a/news/2017-06-07-osu-weekly-106.md
+++ b/news/2017-06-07-osu-weekly-106.md
@@ -17,7 +17,7 @@ With the osu!catch World Cup blasting off to a thunderous start, we have an acti
 - [Around the community](#com)
 - [CWC Group Stage Recap (by JBHyperion)](#cwc)
 
-<a id="news"></a><img src="https://assets.ppy.sh/media/osu-weekly/weekly-news.png">
+![](https://assets.ppy.sh/media/osu-weekly/weekly-news.png) {#news}
 
 ![](https://puu.sh/wbRYm/c8be6f6a6e.png)
 
@@ -38,7 +38,7 @@ Here's what's happened on the community side of things as of late:
 <div style="width: 100%; height: 0px; position: relative; padding-bottom: 57.428%;"><iframe src="https://streamable.com/s/kb9t5/nbuhqx" frameborder="0" width="100%" height="100%" allowfullscreen style="width: 100%; height: 100%; position: absolute;"></iframe></div>
 <p style="text-align:center"><i>An example of the new 'Daycore' mod from osu!lazer</i></p>
 
-<a id="com"></a><img src="https://assets.ppy.sh/media/osu-weekly/community.png"/>
+![](https://assets.ppy.sh/media/osu-weekly/community.png) {#com}
 
 <iframe width="100%" height="315" src="https://www.youtube.com/embed/_uZ4VexmXZs" frameborder="0" allowfullscreen></iframe>
 
@@ -46,7 +46,7 @@ Here's what's happened on the community side of things as of late:
 
 **A new issue of the [QAT Gazette](http://osuqat.tumblr.com/post/161544954160/the-qat-gazette-6) is bounding around the beatmapping and modding communities.** From a few new QAT joining the team, to the recent ranking criteria proposals, the new wave of Beatmap Nominators and much more, the Gazette is getting fat. Chase it down and catch up on things!
 
-<a id="cwc"></a><img src="https://assets.ppy.sh/media/osu-weekly/osu-catch-logo.png"/>
+![](https://assets.ppy.sh/media/osu-weekly/osu-catch-logo.png) {#cwc}
 
 The arrival of summer heralds the bearing of fruit, and it can only be in the world of osu! where that fruit falls from on high in a dizzying array of patterns to be caught by players for our entertainment.
 

--- a/news/2017-06-07-osu-weekly-106.md
+++ b/news/2017-06-07-osu-weekly-106.md
@@ -8,6 +8,7 @@ tumblr_url: http://osunews.tumblr.com/post/161547924578/osuweekly-106
 With the osu!catch World Cup blasting off to a thunderous start, we have an action packed line-up for you in the glorious form of a full blown recap, and more! Read on to find out!
 
 ![](https://assets.ppy.sh/media/osu-weekly/2017-07-06/header.png)
+
 <table width="100%"><tr><td align="left"><a href="https://osu.ppy.sh/home/news/2017-05-25-osuweekly-105">Previous</a></td>
 </tr></table>
 

--- a/news/2020-02-28-mappers-report-february.md
+++ b/news/2020-02-28-mappers-report-february.md
@@ -137,7 +137,7 @@ For the avid fruit catchers of the world, the **6th osu! Mapping Olympiad** has 
 
 The fantastic Chinese community organized tournament **Newspaper Cup** has made its yearly appearance and has now begun! This will be the contest's 6th yearly installment, making it one of the longest standing community organized mapping contests. All of the relevant information can be found [in this forum post](https://osu.ppy.sh/community/forums/topics/1023671) in both Chinese and English. You have until **March 15th** to submit your entries for one or more of the 4 available songs. Good luck to those planning on entering their creations into the contest!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-02-28-mappers-report-february.md
+++ b/news/2020-02-28-mappers-report-february.md
@@ -50,9 +50,9 @@ A description has been added to the rule "A beatmapset's custom difficulty namin
 - **[Hitsound Additions Requirements](/wiki/Ranking_Criteria#rules.4):** Following this change, osu!mania beatmapsets containing only difficulties of Insane or above do not require hitsound additions.
 - **[Difficulty name requirements](/wiki/Ranking_Criteria/osu!mania#rules):**
 A new specification has been added that sets with a single key mode must not use the key mode in the difficulty name.
-- **[Long note changes in Easy and Normal](/wiki/Ranking_Criteria/osu!mania#-easy):**
+- **[Long note changes in Easy and Normal](/wiki/Ranking_Criteria/osu!mania#easy):**
 The previous guidelines in Easy and Normal that "A long note cannot be released during another long note's body" have been removed. They have been replaced with "long note releases should be at least 1/1 beat from each other" for Easy difficulties and "long note releases should be at least 1/2 beat from each other" for Normal difficulties.
-- **[Chord usage change in Hard](/wiki/Ranking_Criteria/osu!mania#-hard):**
+- **[Chord usage change in Hard](/wiki/Ranking_Criteria/osu!mania#hard):**
 The wording of the guideline that chords should be used sparingly got changed into "Chords within 1/4 streams should be at least 1/1 beat apart from each other".
 
 ## NAT Meetings

--- a/news/2020-04-11-mappers-report-march.md
+++ b/news/2020-04-11-mappers-report-march.md
@@ -143,7 +143,7 @@ Starting up 2 months ago, there’s been a new podcast series hosted by [Cinnabu
 
 Previously announced in [another news post](https://osu.ppy.sh/home/news/2020-03-23-community-mentorship-program-spring-2020-signups-now-open), the Spring 2020 round of Community Mentorship is coming soon! Hosted regularly throughout the year, the mentorship program helps to nurture newer mappers in the community by pairing them up with Mentors. The applications to become a Mentor are already closed, but the Mentee applications will be opening on **April 19th**, so give applying a try if you’re passionate and interested in learning more about mapping!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-04-11-mappers-report-march.md
+++ b/news/2020-04-11-mappers-report-march.md
@@ -30,7 +30,7 @@ The Ranking Criteria. For some a blessing, for others a curse. On top of that, i
 
 ### osu!taiko 
 
-- **[1/3 Patterns in Futsuu](/wiki/Ranking_Criteria/osu!taiko#-futsuu):** The osu!taiko Futsuu difficulty Rule and Guideline regarding 1/3 pattern has been modified. The clause about rest moments was moved from the Rule to the Guideline. 
+- **[1/3 Patterns in Futsuu](/wiki/Ranking_Criteria/osu!taiko#futsuu):** The osu!taiko Futsuu difficulty Rule and Guideline regarding 1/3 pattern has been modified. The clause about rest moments was moved from the Rule to the Guideline. 
 
 ## Open Ranking Criteria Proposals 
 
@@ -88,7 +88,7 @@ Just as last month, the BNG never rests. We always have new additions and retire
 
 ### BN Resignations
 
-- **osu!:** [-Aqua](https://osu.ppy.sh/u/7150015), [Bibbity Bill](https://osu.ppy.sh/users/4446810), [Gero](https://osu.ppy.sh/users/1467715), [Teky](https://osu.ppy.sh/users/10520912) & [Petal](https://osu.ppy.sh/users/7354729)
+- **osu!:** [-Aqua](https://osu.ppy.sh/users/7150015), [Bibbity Bill](https://osu.ppy.sh/users/4446810), [Gero](https://osu.ppy.sh/users/1467715), [Teky](https://osu.ppy.sh/users/10520912) & [Petal](https://osu.ppy.sh/users/7354729)
 - **osu!catch:** [wonjae](https://osu.ppy.sh/users/5032045)
 
 ### NAT Additions

--- a/news/2020-05-11-mappers-report-april.md
+++ b/news/2020-05-11-mappers-report-april.md
@@ -178,7 +178,7 @@ Making waves in the modding community recently is the freshly published modding 
 
 Yes, you heard that right. Until recently, extremely long maps could not be ranked due to breaking the score limit, since the scoreboards wouldn't reflect everyone's plays properly anyways. Now the developers have changed it so that super long maps which break the score limit even without mods will have score v2 force enabled. In such cases, these score v2 scores will be submittable, finally allowing super long maps to have proper leaderboards. This means we'll be seeing extremely long maps ranked in the future, which is a really exciting improvement!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-05-11-mappers-report-april.md
+++ b/news/2020-05-11-mappers-report-april.md
@@ -24,7 +24,7 @@ The [Ranking Criteria](/wiki/Ranking_Criteria) is a set of rules and guidelines 
 
 This month we had no changes in the Ranking Criteria. But there are several open proposals in the [Ranking Criteria forum](https://osu.ppy.sh/community/forums/87). We have listed some of them below!
 
-### Open Ranking Criteria Proposals 
+### Open Ranking Criteria Proposals
 
 For all modes:
 
@@ -51,13 +51,13 @@ For osu!catch:
 
 ## NAT Meetings
 
-If you have any topics which should be discussed in future meetings, or a proposal you'd like to push to NAT, please do not hesitate to make a post about it on the [NAT Meetings forum thread](https://osu.ppy.sh/community/forums/topics/1041618)! 
+If you have any topics which should be discussed in future meetings, or a proposal you'd like to push to NAT, please do not hesitate to make a post about it on the [NAT Meetings forum thread](https://osu.ppy.sh/community/forums/topics/1041618)!
 
 Once enough topics are gathered, future NAT meeting dates will be announced in upcoming Mappers' Report issues, in #modding on the [osu!dev Discord server](https://discord.gg/ppy) and on the forums!
 
 ### [April 11th, 2020 - Genre and Language Settings](https://osu.ppy.sh/community/forums/topics/1059659)
 
-Recent changes to the website allow mappers to set genre and language on their own beatmaps — a feature which had only been available to moderators on the old website. With these changes, the NAT decided to revisit what genres and languages are available and work out some of the kinks in the current list. 
+Recent changes to the website allow mappers to set genre and language on their own beatmaps — a feature which had only been available to moderators on the old website. With these changes, the NAT decided to revisit what genres and languages are available and work out some of the kinks in the current list.
 
 Changes have been proposed, including adding popular genres like Metal, Classical, and Folk, along with adding new categorizations like Vocaloid and Doujin. You can find the full list of suggested changes [on GitHub](https://github.com/ppy/osu-web/issues/5852#issuecomment-616219839), where discussion is still taking place.
 
@@ -74,7 +74,7 @@ New Beatmap Nominators! Quick, request all your beatmaps! Jokes aside, the Beatm
 - **osu!catch:** [Dako](https://osu.ppy.sh/users/11081858)
 - **osu!mania:** [Sun](https://osu.ppy.sh/users/4115819)
 
-Interested in becoming a Beatmap Nominator and deciding what maps reach ranked? Want to help new mappers to get their beatmaps ranked? Head to the [Beatmap Nominator website](https://bn.mappersguild.com/) and apply today! 
+Interested in becoming a Beatmap Nominator and deciding what maps reach ranked? Want to help new mappers to get their beatmaps ranked? Head to the [Beatmap Nominator website](https://bn.mappersguild.com/) and apply today!
 
 ### BN Resignations
 
@@ -87,14 +87,14 @@ Our office cat **[Mao](https://osu.ppy.sh/users/2204515)** has returned! After s
 
 ## Mappers' Showcase
 
-The Mappers' Showcase parades lesser-known mappers from every game mode. 
+The Mappers' Showcase parades lesser-known mappers from every game mode.
 This month features osu!taiko thanks to our selectors [radar](https://osu.ppy.sh/users/7131099) and [Capu](https://osu.ppy.sh/users/2474015).
 
 ### Idealism
 
 **[Idealism](https://osu.ppy.sh/users/3869519)** is an osu!taiko mapper (as well as an osu! top player) from Brazil who has been around the community for a while now, though he definitely deserves more credit for his work in the mapping scene! His maps blend creativity with smooth and interesting patterning which leave a good taste in the mouths of mappers and players alike.
 
-A map of his that truly shines is his rendition of [Cyte - Command Prompt](https://osu.ppy.sh/beatmapsets/1068145#taiko/2236237) ranked at the start of the year. On the top difficulty (mind bogglingly named "C:\Program Files\Difficulties\434f525255505445442046494c45.exe"), Idealism proves that even when mapping genres out of his comfort zone he can still shine. 
+A map of his that truly shines is his rendition of [Cyte - Command Prompt](https://osu.ppy.sh/beatmapsets/1068145#taiko/2236237) ranked at the start of the year. On the top difficulty (mind bogglingly named "C:\Program Files\Difficulties\434f525255505445442046494c45.exe"), Idealism proves that even when mapping genres out of his comfort zone he can still shine.
 
 Some of his other notable and equally as great maps would be his renditions of [Blue on Blue (TamolarM Btlg Remix)](https://osu.ppy.sh/beatmapsets/965135#taiko/2020395) and [White Eternity](https://osu.ppy.sh/beatmapsets/992443#taiko/2075446), where he shows off his addiction to eroge music through his solid mapping! We hope to see more of his maps coming into the ranked section in the rest of 2020, as his potential to shine even brighter clearly shows!
 
@@ -114,23 +114,23 @@ The next month will feature osu!catch — but that's not all! As we want to give
 We're excited as you to see which gems are still hidden in osu!
 
 ## Mapping Contests
- 
+
 Flex your mapping muscles by voting and participating in some of this month's ongoing contests! Contest veterans, however, might find it more appropriate to release tension as they see some of this month's mapping contest results.
- 
+
 ### Monthly Beatmapping Contest
- 
+
 As per usual, the [Monthly Beatmapping Contest](/wiki/Contests/Monthly_Beatmapping_Contest) (*MBC*) is here to provide your regular dosage of competitive mapping! Each month's contest features a different mapping limitation that entries must adhere to.
- 
+
 April's contest is currently in its voting stage! Visit the [contest listing](https://osu.ppy.sh/community/contests/93) to vote for any 2 of the top 6 entries, and keep in mind that sliders in all entries were required to use reverses, meaning normal slider rhythms were not allowed!
- 
+
 If you prefer mapping to voting, May's contest will be in its beatmapping stage up through May 26th! This month's contest takes rhythm restrictions up a hundred notches from last month by requiring all submissions to use the same rhythm template. See the [contest's news post](https://osu.ppy.sh/home/news/2020-05-05-monthly-beatmapping-contest-may) if you'd like to participate!
- 
+
 ### Mapping With Rewards
- 
+
 Mapping With Rewards was a deadline-free mapping contest with a reputation for... well, not having a conclusion. We should've seen that one coming.
- 
+
 The contest required users to submit a full beatmap spread of any game mode for any of 3 specified [Featured Artist](https://osu.ppy.sh/beatmaps/artists) songs (listed below). The submissions were judged anonymously based on their creativity, cohesion as a spread, musical expression, and general judge impressions. It's been 3 years, so let's put this contest to rest by announcing the long-overdue winners of [Mapping With Rewards 2017](https://osu.ppy.sh/home/news/2017-09-23-mapping-with-rewards-returns):
- 
+
 #### [Loki/Thaehan](https://osu.ppy.sh/beatmaps/artists/7) - A New King Is Born
 
 - [osu! mapset](https://osu.ppy.sh/beatmapsets/760694) by [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
@@ -145,13 +145,13 @@ The contest required users to submit a full beatmap spread of any game mode for 
 #### [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) - Fortuna Redux
 
 - [osu! mapset](https://osu.ppy.sh/beatmapsets/712974) by [DTM9 Nowa](https://osu.ppy.sh/users/5428909)
- 
-Each of the winners has been awarded with the Mapping With Rewards profile badge seen below! 
- 
+
+Each of the winners has been awarded with the Mapping With Rewards profile badge seen below!
+
 ![](/wiki/shared/news/2020-05-08-mappers-report-april/mwr_badge2x.png)
- 
+
 Late congratulations to the winners and thank you to [Okoratu](https://osu.ppy.sh/users/1623405), [Mir](https://osu.ppy.sh/users/8688812), [Zetera](https://osu.ppy.sh/users/587737), [Nepuri](https://osu.ppy.sh/users/6637817), [Yuzeyun](https://osu.ppy.sh/users/481582), [Maxus](https://osu.ppy.sh/users/4335785), and [Protastic101](https://osu.ppy.sh/users/6712747) for judging entries over a year ago. Full judging comments and more can be found in [this forum post](https://osu.ppy.sh/community/forums/posts/7139243).
- 
+
 With that said, Mapping With Rewards has reached its end. Closure, *finally*!
 
 ### osu! Beatmapping World Championship 2020
@@ -182,7 +182,7 @@ Yes, you heard that right. Until recently, extremely long maps could not be rank
 
 ---
 
-And that's it for this month! Every month we try to make the Mappers' Report shorter but we simply can't because so much happens in the community. And we're very happy about that! We're excited to see what the next month has for us. 
+And that's it for this month! Every month we try to make the Mappers' Report shorter but we simply can't because so much happens in the community. And we're very happy about that! We're excited to see what the next month has for us.
 Thanks for reading and stay safe and healthy!
 
 See you next month!

--- a/news/2020-07-02-mappers-report-may-june.md
+++ b/news/2020-07-02-mappers-report-may-june.md
@@ -236,7 +236,7 @@ If you'd like to help out by reviewing articles, writing them, or translating th
 
 The world needs you!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-08-09-mappers-report-july.md
+++ b/news/2020-08-09-mappers-report-july.md
@@ -171,7 +171,7 @@ The mapping phase of the Big Fans mapping contest just ended on the 25th and the
 
 Are there any other mapping contests going on, or being announced soon? Please let us know! We would love to give it more attention to the public. Doesn't matter if it's mode or language specific. Head over to the [forum post](https://osu.ppy.sh/community/forums/topics/1027590) where you can find the submission form!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-09-08-mappers-report-august.md
+++ b/news/2020-09-08-mappers-report-august.md
@@ -182,7 +182,7 @@ Have we got your interest? Or do you have more questions regarding the project? 
 
 Mentioned previously in the Mappers' Report, the **osu! Map Cast** has recently concluded its first season with a whopping **23 episodes in total**. This podcast hosted by [Bailie](https://osu.ppy.sh/users/11868659) (previously known as Cinnabun) features conversations with a wide variety of figures in the mapping and modding community, such as mappers both old and new, BNs, NAT, and recently even Ephemeral! The podcast series cover a huge variety of topics, both within and outside of osu! mapping- there's even an episode about Beat Saber in there! If you want to learn more about the osu! community, its members, or just want a chill podcast to listen to in the background, be sure to check out the full episode listing on their [forum post](https://osu.ppy.sh/community/forums/topics/1043221)!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2020-12-31-mappers-report-fall.md
+++ b/news/2020-12-31-mappers-report-fall.md
@@ -237,7 +237,7 @@ Moving away from motivation, time taken, and visuals, we have a [guide all about
 
 Finally, on a bit of a different flavor we have a guide not related to mapping - but modding! The [Modding Mentorship Guide](https://sites.google.com/view/modding-guide/home) written by a long-time mapper and nominator [Cheri](https://osu.ppy.sh/users/5226970) seeks to help give guidance on how to mod and what to look out for from the ground up. This guide covers everything from ranking criteria, to rhythm, to spacing, to low difficulties, and spread. It covers quite a lot! In-depth modding guides of this kind are a bit rarer and left to people often learning on their own, so having a fully fleshed out guide like this will definitely be really helpful to aspiring and semi-experienced modders alike.
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-02-01-mappers-report-january.md
+++ b/news/2021-02-01-mappers-report-january.md
@@ -128,7 +128,7 @@ However, there is one important thing to mention. Having this feature enabled on
 
 If you are unsure about whether or not the content you want to include in your beatmap line up with the rules, feel free to submit a content case on the [Beatmap Nominator website](https://bn.mappersguild.com/discussionvote).
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-03-05-mappers-report-february.md
+++ b/news/2021-03-05-mappers-report-february.md
@@ -107,7 +107,7 @@ To participate, you will need to join the [Discord server](https://discord.gg/fV
 
 May the best and the fastest mapper win!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-04-06-mappers-report-march.md
+++ b/news/2021-04-06-mappers-report-march.md
@@ -164,7 +164,7 @@ Here's a vod of the stream that compiles all aspects of mapping in 9 hours:
 
 <iframe src="https://player.twitch.tv/?video=974267996&parent=osu.ppy.sh&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="100%"></iframe>
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-05-13-mappers-report-april.md
+++ b/news/2021-05-13-mappers-report-april.md
@@ -157,7 +157,7 @@ The winning entry hosting the runner-ups' guest difficulties will be speed-carri
 
 If you're an anime fan, don't let this opportunity pass you by! Have a thorough look at this [forum thread](https://osu.ppy.sh/community/forums/topics/1308172) and you're good to go!
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-05-13-mappers-report-april.md
+++ b/news/2021-05-13-mappers-report-april.md
@@ -114,12 +114,12 @@ If you're craving for some details, [this newspost](https://osu.ppy.sh/home/news
 Next up, the April edition of Monthly Beatmapping Contest greets us with a few novelties. For the first time ever, the contest will entertain osu!catch submissions in addition to osu! and osu!taiko. The submission period has since ended, but for those interested, the limitations for April were as follows:
 
 - **osu!**:
-    - All sliders must use red anchors.
-    - Red anchors must form clear corners in the slidershape.
+  - All sliders must use red anchors.
+  - Red anchors must form clear corners in the slidershape.
 - **osu!taiko**:
-    - No more than 3 of the same note colours in a row.
+  - No more than 3 of the same note colours in a row.
 - **osu!catch**:
-    - Sliders cannot be used.
+  - Sliders cannot be used.
 
 If you're excited to see the results, we suggest you take few minutes to look through [this newspost](https://osu.ppy.sh/home/news/2021-04-08-monthly-beatmapping-contest-april-2021) to keep yourself up-to-date with the details.
 

--- a/news/2021-06-20-mappers-report-may.md
+++ b/news/2021-06-20-mappers-report-may.md
@@ -145,7 +145,7 @@ And of course, such a massive project wouldn't have been left without a showcase
 
 <iframe src="https://player.twitch.tv/?video=1051031340&parent=osu.ppy.sh&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="100%"></iframe>
 
-<a id="conclusion"></a>
+{#conclusion}
 
 ---
 

--- a/news/2021-06-20-mappers-report-may.md
+++ b/news/2021-06-20-mappers-report-may.md
@@ -12,7 +12,7 @@ This month's issue of the Mappers' Report contains the following topics:
 
 - **[Ranking Criteria Changes](#ranking-criteria-changes)**
 - **[Within the Beatmap Nominators and NAT](#within-the-beatmap-nominators-and-nat)**
-- **[Mappers' Showcase](#mappers-showcase)**
+- **[Mappers' Showcase](#mappers'-showcase)**
 - **[Mapping Contests](#mapping-contests)**
 - **[Around the Community](#around-the-community)**
 - **[Conclusion](#conclusion)**


### PR DESCRIPTION
made possible with https://github.com/ppy/osu-web/pull/9186. no hacks required anymore.