### PR TITLE
Add missing scheduled match for MWC4K 2022 Quarterfinals

### DIFF
--- a/wiki/Tournaments/MWC/2022_4K/en.md
+++ b/wiki/Tournaments/MWC/2022_4K/en.md
@@ -110,6 +110,7 @@ The osu!mania 4K World Cup 2022 is run by the [osu! team](/wiki/People/The_Team)
 
 | Team A | Team B | Match time |  |
 | --: | :-- | :-- | :-: |
+| Indonesia ::{ flag=ID }:: | ::{ flag=HK }:: Hong Kong | [Aug 27 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220827T130000&p1=1440&p2=108&p3=102) | [^losers-bracket] |
 | France ::{ flag=FR }:: | ::{ flag=NL }:: Netherlands | [Aug 27 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220827T130000&p1=1440&p2=195&p3=16) | [^losers-bracket] |
 | China ::{ flag=CN }:: | ::{ flag=DE }:: Germany | [Aug 27 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220827T130000&p1=1440&p2=33&p3=37) | [^losers-bracket] |
 | Brazil ::{ flag=BR }:: | ::{ flag=TH }:: Thailand | [Aug 27 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20220827T130000&p1=1440&p2=45&p3=28) | [^winners-bracket] |


### PR DESCRIPTION
sync schedule with information sheet (add missing match Indonesia vs Hong Kong)

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
