### PR TITLE
[DE] Retranslate `Guides/Using_custom_hitsounds`

### DIFF
--- a/wiki/Guides/Using_custom_hitsounds/de.md
+++ b/wiki/Guides/Using_custom_hitsounds/de.md
@@ -1,49 +1,69 @@
----
-outdated_translation: true
----
+# Eigene Hitsounds benutzen
 
-# Eigene Hitsounds hinzufügen
+In diesem Tutorial wirst du lernen, wie du eigene [Hitsounds](/wiki/Beatmapping/) in deinen [Beatmaps](/wiki/Beatmap) verwendest.
 
-Von dem Thread: *[Wie man einen eigenen Hitsound hinzufügt. (von neonat)](https://osu.ppy.sh/community/forums/posts/3215699)*
+## Eigene Hitsounds erhalten
 
-## Eigene Hitsounds
+Um in deinen Beatmaps eigene Hitsounds zu verwenden, musst du erst einmal welche haben! Die [Bibliothek für selbst erstellte Hitsounds](/wiki/Guides/Custom_Hitsound_Library/) ist eine großartige Ressource, um Ton-Samples wie Becken, Trommeln, Glocken, Pfeifen und mehr zu finden. Alternativ kannst du, falls du nicht das findest was du suchst, auch deine eigenen Samples erstellen!
 
-Als erstes werden einige Hitsounds benötigt.
+Hitsounds sollten in den Formaten `.wav` oder `.ogg` gespeichert sein, da diese keine Wiedervergabeverzögerung haben und sich korrekt wiederholen.
 
-- Man kann sie aus der [Spieler-Hitsound-Bibliothek](/wiki/Guides/Custom_Hitsound_Library) bekommen.
-- Oder man erstellt Hitsounds selber.
+## Eigene Hitsounds hinzufügen
 
-## Manuell die Hitsounds in den Song Ordner einfügen
+Wenn du deine gewünschten Tondateien gefunden hast, verschiebe sie in den Ordner der Beatmap, in der du sie benutzen willst. Falls du nicht weißt, wo du diesen Ordner findest, folge diesen Anweisungen:
 
-Der Song Ordner kann mit folgenen Schritten gefunden werden:
+1. Öffne osu!.
+2. Wähle die `Edit`-Option aus.
+3. Navigiere zu deiner Beatmap und öffne sie.
+5. Klicke auf `Datei` (die Option am linken ende des Navigations-Menüs).
+5. Klicke auf `Songs-Ordner öffnen`.
+6. Füge deinen Dateien hier ein.
 
-1. Öffne osu!
-2. Klicke auf Edit.
-3. Navigiere zu *deine Beatmap hier* und öffne sie.
-4. Klicke oben auf Datein (Files) (Das Menu oben-links, es ist die weiß gefärbte Leiste oben).
-5. Öffne den Song Ordner.
-6. *und füge die Hitsounds ein*
+Falls du osu! auf macOS ausführst, musst du vielleicht eine leicht andere Vorgehensweise wählen:
 
-## Die Wahl welche Art von Ton der Hitsound sein soll
+1. Rechtsklicke auf das osu!-Anwendungsicon und wähle `Paketinhalt anzeigen`.
+2. Finde den Ordner deiner Beatmap in `drive_c -> osu! -> Songs`.
+3. Füge deine Dateien hier ein.
 
-Die Namensgebung ist für "finish", "whistle", "clap" und "normal hit" egal.
+Wenn die Tondateien im Ordner der Beatmap platziert sind, müssen sie angemessen benannt werden, damit osu! sie als Hitsounds erkennt.
 
-Abhängig von welcher Art von den Hitsound man haben möchte, sollte der Dateiname mit "soft", "normal" oder "drum" beginnen.
+In osu! existieren drei Kategorien von Hitsounds, die als *Samplesets* bekannt sind: Normal (N), Soft (S), und Drum (D). Jedes Sampleset kann weiterhin in verschiedene Töne unterteilt werden. Die häufigsten sind: "hitnormal", "hitclap", "hitwhistle" und "hitfinish". Außerdem existieren speziellere Töne, wie die, die während eines Sliders ("sliderslide", slidertick) oder eines Spinners ("spinnerspin") abgespielt werden.
 
-![Tutorial Image 1](img/beatmap-folder-resources.png "Tutorial Image 1")
+*Für eine vollständige Liste an Hitsounds, die modifiziert werden können, siehe: [Skinning-Eintrag zu Hitsounds](/wiki/Skinning/Sounds#hitsounds)*
 
-### Beispiel 1
+Hitsound-Dateien geben die beiden Eigenschaften des Samplesets und des Tontyps folgendermaßen im Namen wieder:
 
-Man hat die Datei (Sagen wir mal Soft clap) `soft-hitclap.wav` genannt.
+`<sampleset>-<ton>.wav`
 
-## Mehrere Hitsound mit den selben Namen
+Hier ist `<sampleset>` entweder "normal", "soft" oder "drum" und `<sound>` ist eine der oben genannten Unterteilungen (z. B. "hitclap").
 
-Wenn mehr Abwechslung gebraucht oder mehr Optionen für Clap und so weiter benötigt wird, kann man einfach eine Zahl dahinter schreiben.
+![](img/beatmap-folder-resources.png "Ein typischer Beatmap-Ordner, der eigene Hitsounds enthält")
 
-### Beispiel 2
+Im oben gezeigten Bild ist der erste aufgelistete Ton mit `soft-hitclap.wav` benannt. Dieser wird den Standard-Hitsound, der beim Treffen eines [Hit-Objekts](/wiki/Hit_Object) mit dem "Soft"-Sampleset und der "hitclap"-Unterteilung abgespielt wird, ersetzen. Beachte, dass dieser Ton nur im *ausgewählten Sampleset*  abgespielt wird. Falls deine Beatmap andere Samplesets verwendet, erfordern diese zusätzliche Hitsound-Dateien (auch dann, wenn du genau das gleiche Tonsample verwendest), zum Beispiel eine `normal-hitclap.wav`, während du das "Normal"-Sampleset verwendest.
 
-Wie `normal-hitclap2.wav` oder wie `soft-hitfinish3.wav`
+## Eigene Hitsounds anwenden
 
-Man sollte nicht vergessen, dass im *Timing Setup* der Hitsound auf Custom mit der jeweiligen Nummer gestellt werden muss.
+![](img/adding-custom-hitsounds.png "osu! anweisen, wie eigene Hitsounds zu verwenden sind")
 
-![Tutorial Image 2](img/adding-custom-hitsounds.png "Tutorial Image 2")
+Damit osu! deine eigenen Hitsounds korrekt abspielt, stelle sicher dass du die zweite Option, "Custom 1", wie im oberen Bild gezeigt ausgewählt hast. Standardmäßig werden eigene Samplesets als `<SS>:C1` abgekürzt, wobei `<SS>` der erste Buchstabe der Sampleset-Gruppe ist. Also entweder N (Normal), S (Soft), oder D (Drum).
+
+Beachte, dass du  nicht jeden Ton im Sampleset mit einem eigenen Ton ersetzen musst. Im ersten Bild wird dir auffallen, dass keine Datei namens `soft-slidertick.wav` vorhanden ist. In diesem Fall wird osu den Standardton für alle regulären Slidertick-Treffer verwenden, wenn das "Soft"-Sampleset verwendet wird.
+
+## Mit mehreren eigenen Hitsound-Sets arbeiten
+
+Manchmal beinhaltet ein Song mehrere verschiedene Musikstile und eine Gruppe von Hitsounds wird nicht zu allen passen. In diesem Fall ist es oft hilfreich, gänzlich andere Hitsounds (oder Hitsound-Gruppen) zu verwenden. Das kann durch das Hinzufügen einer Zahl an das Ende des Dateinamens eines Hitsounds erreicht werden:
+
+`<sampleset>-<ton><#>.wav`
+
+Hier kann `<#>` jede Zahl deiner Wahl sein. Der osu!-Editor unterstützt von Haus aus Zahlen zwischen 2 und 100. Höhere Zahlen können, falls notwendig, durch Bearbeitung der `.osu`-Datei erreicht werden. Beachte, dass die erste Gruppe an Hitsounds nicht zwangsläufig die Zahl "1" verwenden muss, auch wenn mehrere Hitsound-Gruppen verwendet werden. Demnach wird `soft-hitclap1.wav` nicht funktionieren. Stattdessen wird `soft-hitclap.wav` verwendet werden.
+
+Um sicherzustellen, dass die verschieden bezifferten Hitsounds oder Hitsound-Gruppen richtig abgespielt werden, wirst du einen geerbten Timing-Point (grüne Linie) hinzufügen und das Sampleset von "Custom 1" wie unten gezeigt auf die Option darunter setzen müssen. Hier kannst du die Zahl der Hitsound-Gruppe eintragen, die du verwenden willst.
+
+![](img/using-multiple-hitsound-sets.png "Zu einer zweiten eigenen Hitsound-Gruppe wechseln")
+
+Wenn das Sampleset eines geerbten Timing-Points wie oben gezeigt auf `S:C2` gesetzt ist, werden die Standard-Hitsounds und Hitsound-Unterteilungen mit den entsprechend benannten eigenen Hitsounds ersetzt, z. B. `soft-hitclap2.wav`, falls diese vorhanden sind. Diese werden solange verwendet werden, bis ein vererbter Timing-Point mit einem anderen Sampleset erreicht wird - in diesem Bild `02:00:723`, wo das Sampleset wieder auf `S:C1` gewechselt wird.
+
+## Externe Quellen
+
+- [*how to add custom hitsound?*-Forenantwort](https://osu.ppy.sh/community/forums/posts/3215699) von [neonat](https://osu.ppy.sh/users/1561995)
+


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

This is a complete retranslation, since the original article was rewritten. I recommend ignoring the diff and just reading the new article if possible.

Terminology:

- `hitsound addition` -> `Hitsound-Unterteilung`
- `sampleset` -> `Sampleset`

Open to better translations or references to existing translations of those terms if I missed them.

Additionally, I translated the macOS-command `Show package contents` as `Paketinhalt anzeigen`, but I don't own a Mac and found it hard to verify this. Would appreciate an accurate translation. 

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
