### PR TITLE
Sync beatmap upload limits of `osu!supporter` with the supporter page

### DIFF
--- a/wiki/osu!supporter/de.md
+++ b/wiki/osu!supporter/de.md
@@ -84,7 +84,7 @@ osu! bietet eine Lockerung der Grenzwerte für verschiedene Online-Features für
 
 | Wert | Normales Limit | osu!supporter-Limit |
 | :-- | :-: | :-: |
-| [Ausstehende Beatmaps](/wiki/Beatmap/Category#work-in-progress-und-ausstehend) | `2 + min(gerankte Beatmaps, 6)`, bis zu **8**[^pending-beatmaps-ref] | `8 + min(gerankte Beatmaps, 12)`, bis zu **20**[^pending-beatmaps-ref] |
+| [Ausstehende Beatmaps](/wiki/Beatmap/Category#work-in-progress-und-ausstehend) | `4 + min(gerankte Beatmaps, 4)`, bis zu **8**[^pending-beatmaps-ref] | `8 + min(gerankte Beatmaps, 12)`, bis zu **20**[^pending-beatmaps-ref] |
 | Online-Beatmap-Favoriten | 100 | 1000 |
 | Anzahl der Freunde | 250 | 500 |
 

--- a/wiki/osu!supporter/en.md
+++ b/wiki/osu!supporter/en.md
@@ -83,7 +83,7 @@ osu! offers more relaxed limits on various online features to supporters:
 
 | Value | Regular limit | osu!supporter limit |
 | :-- | :-: | :-: |
-| [Pending beatmaps](/wiki/Beatmap/Category#work-in-progress-and-pending) | `2 + min(ranked beatmaps, 6)`, up to **8**[^pending-beatmaps-ref] | `8 + min(ranked beatmaps, 12)`, up to **20**[^pending-beatmaps-ref] |
+| [Pending beatmaps](/wiki/Beatmap/Category#work-in-progress-and-pending) | `4 + min(ranked beatmaps, 4)`, up to **8**[^pending-beatmaps-ref] | `8 + min(ranked beatmaps, 12)`, up to **20**[^pending-beatmaps-ref] |
 | Online beatmap favourites | 100 | 1000 |
 | Friend count | 250 | 500 |
 

--- a/wiki/osu!supporter/es.md
+++ b/wiki/osu!supporter/es.md
@@ -85,7 +85,7 @@ osu! ofrece a los supporters límites incrementados en varias funciones en líne
 
 | Valor | Limite regular | Limite de osu!supporter |
 | :-- | :-: | :-: |
-| [Beatmaps pendientes](/wiki/Beatmap/Category#work-in-progress-and-pending) | `4 + min(beatmaps rankeados, 2)` | `8 + min(beatmaps rankeados, 4)` |
+| [Beatmaps pendientes](/wiki/Beatmap/Category#work-in-progress-and-pending) | `4 + min(beatmaps rankeados, 4)` | `8 + min(beatmaps rankeados, 12)` |
 | Beatmaps favoritos | 100 | 1000 |
 | Amigos | 250 | 500 |
 

--- a/wiki/osu!supporter/fr.md
+++ b/wiki/osu!supporter/fr.md
@@ -83,7 +83,7 @@ osu! propose aux supporters des limites plus souples sur diverses fonctionnalit�
 
 | Valeur | Limite normale | Limite osu!supporter |
 | :-- | :-: | :-: |
-| [Beatmaps en attente](/wiki/Beatmap/Category#work-in-progress-et-en-attente) | `2 + min(beatmaps classées, 6)`, jusqu'à **8**[^pending-beatmaps-ref] | `8 + min(beatmaps classées, 12)`, jusqu'à **20**[^pending-beatmaps-ref] |
+| [Beatmaps en attente](/wiki/Beatmap/Category#work-in-progress-et-en-attente) | `4 + min(beatmaps classées, 4)`, jusqu'à **8**[^pending-beatmaps-ref] | `8 + min(beatmaps classées, 12)`, jusqu'à **20**[^pending-beatmaps-ref] |
 | Beatmap favorites en ligne | 100 | 1000 |
 | Nombre d'amis | 250 | 500 |
 

--- a/wiki/osu!supporter/id.md
+++ b/wiki/osu!supporter/id.md
@@ -83,7 +83,7 @@ Para supporter akan dapat menikmati berbagai fitur online yang osu! tawarkan sec
 
 | Fitur | Batas normal | Batas bagi pengguna dengan osu!supporter |
 | :-- | :-: | :-: |
-| [Beatmap Pending](/wiki/Beatmap/Category#work-in-progress-dan-pending) | `2 + min(jumlah beatmap Ranked, 6)`, hingga **8**[^pending-beatmaps-ref] | `8 + min(jumlah beatmap Ranked, 12)`, hingga **20**[^pending-beatmaps-ref] |
+| [Beatmap Pending](/wiki/Beatmap/Category#work-in-progress-dan-pending) | `4 + min(jumlah beatmap Ranked, 4)`, hingga **8**[^pending-beatmaps-ref] | `8 + min(jumlah beatmap Ranked, 12)`, hingga **20**[^pending-beatmaps-ref] |
 | Beatmap favorit | 100 | 1000 |
 | Teman | 250 | 500 |
 

--- a/wiki/osu!supporter/ru.md
+++ b/wiki/osu!supporter/ru.md
@@ -89,7 +89,7 @@ osu!direct — это инструмент для поиска и скачива
 
 | Параметр | Без osu!supporter | С osu!supporter |
 | :-- | :-: | :-: |
-| [Число загруженных карт](/wiki/Beatmap/Category#work-in-progress-и-pending) | `2 + min(число ранкнутых карт, 6)`, в сумме до **8**[^pending-beatmaps-ref] | `8 + min(число ранкнутых карт, 12)`, в сумме до **20**[^pending-beatmaps-ref] |
+| [Число загруженных карт](/wiki/Beatmap/Category#work-in-progress-и-pending) | `4 + min(число ранкнутых карт, 4)`, в сумме до **8**[^pending-beatmaps-ref] | `8 + min(число ранкнутых карт, 12)`, в сумме до **20**[^pending-beatmaps-ref] |
 | Число карт в избранном на сайте | 100 | 1000 |
 | Число друзей | 250 | 500 |
 

--- a/wiki/osu!supporter/zh.md
+++ b/wiki/osu!supporter/zh.md
@@ -87,7 +87,7 @@ osu! 为支持者们放宽各种在线功能的限额：
 
 | 功能 | 普通玩家限额 | 支持者限额 |
 | :-- | :-: | :-: |
-| [Pending 谱面](/wiki/Beatmap/Category#work-in-progress-和-pending) | `2 + min(Ranked 谱面, 6)`最多 **8** 个[^pending-beatmaps-ref] | `8 + min(Ranked 谱面, 12)`最多 **20** 个[^pending-beatmaps-ref] |
+| [Pending 谱面](/wiki/Beatmap/Category#work-in-progress-和-pending) | `4 + min(Ranked 谱面, 4)`最多 **8** 个[^pending-beatmaps-ref] | `8 + min(Ranked 谱面, 12)`最多 **20** 个[^pending-beatmaps-ref] |
 | 在线收藏的谱面 | 100 | 1000 |
 | 好友数量 | 250 | 500 |
 


### PR DESCRIPTION
![Screenshot 2022-08-30 at 01 09 11](https://user-images.githubusercontent.com/4686101/187314255-c47f7bd9-72de-49b6-b3ef-2428c2b29f1c.png)

(found that when reading https://osu.ppy.sh/community/forums/topics/1637751?n=2)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
