### PR TITLE
Fix broken hyperlink in `osu!remix contest #1: Results` newspost

### DIFF
--- a/news/2016-08-29-osuremix-contest-1-results.md
+++ b/news/2016-08-29-osuremix-contest-1-results.md
@@ -37,10 +37,10 @@ We'd also like to give an honorable mention to the third place entry from the co
 <br/>
 
 <center>
-
 [Full results available here!](https://osu.ppy.sh/community/contests/1)
 
 [![Contest results](https://puu.sh/qSlDm/dadeab2780.png)](https://osu.ppy.sh/community/contests/1)
+
 </center>
 
 <br/>

--- a/news/2016-08-29-osuremix-contest-1-results.md
+++ b/news/2016-08-29-osuremix-contest-1-results.md
@@ -37,6 +37,7 @@ We'd also like to give an honorable mention to the third place entry from the co
 <br/>
 
 <center>
+
 [Full results available here!](https://osu.ppy.sh/community/contests/1)
 
 [![Contest results](https://puu.sh/qSlDm/dadeab2780.png)](https://osu.ppy.sh/community/contests/1)


### PR DESCRIPTION
Fixes the following issue:
![firefox_KE5kwEgtre](https://user-images.githubusercontent.com/24534022/187557079-d5bbcd46-84dc-4b39-bbc2-2985c287e630.jpg)
Seems to be caused by the fact that there was not an empty line between the centre and the hyperlink
![image](https://user-images.githubusercontent.com/24534022/187557159-ab3b1611-81c8-4d18-90c4-0e68246652be.png)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~
