### PR TITLE
Correctly list `BeatDivisor` as an integer in `Osu_(file_format)`

### DIFF
--- a/wiki/Client/File_formats/Osu_(file_format)/en.md
+++ b/wiki/Client/File_formats/Osu_(file_format)/en.md
@@ -53,7 +53,7 @@ These options are only relevant when opening maps in the [beatmap editor](/wiki/
 | :-- | :-- | :-- |
 | `Bookmarks` | Comma-separated list of integers | Time in milliseconds of [bookmarks](/wiki/Client/Beatmap_editor/Compose#bottom-(song's-timeline)) |
 | `DistanceSpacing` | Decimal | [Distance snap](/wiki/Client/Beatmap_editor/Distance_snap) multiplier |
-| `BeatDivisor` | Decimal | [Beat snap divisor](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
+| `BeatDivisor` | Integer | [Beat snap divisor](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
 | `GridSize` | Integer | [Grid size](/wiki/Grid_snapping) |
 | `TimelineZoom` | Decimal | Scale factor for the [object timeline](/wiki/Client/Beatmap_editor/Compose#top-left-(hit-objects-timeline)) |
 

--- a/wiki/Client/File_formats/Osu_(file_format)/fr.md
+++ b/wiki/Client/File_formats/Osu_(file_format)/fr.md
@@ -51,7 +51,7 @@ Ces options ne concernent que l'ouverture des beatmaps dans l'[éditeur de beatm
 | :-- | :-- | :-- |
 | `Bookmarks` | Liste d'entiers séparés par des virgules | Temps en millisecondes de [bookmarks](/wiki/Client/Beatmap_editor/Compose#en-bas-(timeline-de-la-musique)) |
 | `DistanceSpacing` | Décimal (Decimal) | Multiplicateur [Distance snap](/wiki/Client/Beatmap_editor/Distance_snap) |
-| `BeatDivisor` | Décimal (Decimal) | [Beat snap divisor](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
+| `BeatDivisor` | Entier (Integer) | [Beat snap divisor](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
 | `GridSize` | Entier (Integer) | [Grid size](/wiki/Grid_snapping) |
 | `TimelineZoom` | Décimal (Decimal) | Facteur d'échelle pour la [timeline des objets](/wiki/Client/Beatmap_editor/Compose#en-haut-à-gauche-(la-timeline-des-objets)) |
 

--- a/wiki/Client/File_formats/Osu_(file_format)/pt-br.md
+++ b/wiki/Client/File_formats/Osu_(file_format)/pt-br.md
@@ -56,7 +56,7 @@ Estas opções são relevantes apenas ao abrir mapas no [editor de beatmap](/wik
 | :-- | :-- | :-- |
 | `Bookmarks` | Lista de inteiros separados por vírgulas | Tempo dos bookmarks em milissegundos |
 | `DistanceSpacing` | Decimal | Multiplicador de distância do snap |
-| `BeatDivisor` | Decimal | Divisor de beat snap |
+| `BeatDivisor` | Inteiro | Divisor de beat snap |
 | `GridSize` | Inteiro | Tamanho da grid |
 | `TimelineZoom` | Decimal | Fator de escala para a timeline de objetos |
 

--- a/wiki/Client/File_formats/Osu_(file_format)/zh.md
+++ b/wiki/Client/File_formats/Osu_(file_format)/zh.md
@@ -51,7 +51,7 @@
 | :-- | :-- | :-- |
 | `Bookmarks` | 逗号分隔的 Integer（整型）数组 | [书签（蓝线）](/wiki/Client/Beatmap_editor/Compose#书签指令)的位置（毫秒） |
 | `DistanceSpacing` | Decimal（精准小数） | [间距锁定](/wiki/Client/Beatmap_editor/Distance_snap)倍率 |
-| `BeatDivisor` | Decimal（精准小数） | [节拍细分](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
+| `BeatDivisor` | Integer（整型） | [节拍细分](/wiki/Client/Beatmap_editor/Beat_Snap_Divisor) |
 | `GridSize` | Integer（整型） | [网格大小](/wiki/Grid_snapping) |
 | `TimelineZoom` | Decimal（精准小数） | [物件时间轴](/wiki/Client/Beatmap_editor/Compose#左上（物件时间轴）)的缩放倍率 |
 


### PR DESCRIPTION
resolves https://github.com/ppy/osu-wiki/issues/7931

the outdated russian translation had it correct interestingly enough, perhaps suggesting that it got incorrectly changed at some point (haven't looked at blame)