### PR TITLE
Fix outdated link in `Contribution_guide/GitHub_Desktop`

### DIFF
--- a/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/en.md
+++ b/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/en.md
@@ -52,7 +52,7 @@ While branching is technically optional, it is [highly recommended for a couple 
 
 ### Creating new files
 
-*Caution: If you are going to create article files using Windows Explorer, make sure the `File name extensions` option is enabled.* See [How to show or hide file name extensions in Windows Explorer](https://support.microsoft.com/en-us/windows/common-file-name-extensions-in-windows-da4a4430-8e76-89c5-59f7-1cdbbc75cb01) for instructions.
+*Caution: If you are going to create article files using Windows Explorer, make sure the `File name extensions` option is enabled.* See [Common file name extensions in Windows](https://support.microsoft.com/en-us/windows/common-file-name-extensions-in-windows-da4a4430-8e76-89c5-59f7-1cdbbc75cb01) for instructions.
 
 1. Use Windows Explorer, your favourite image editor, and/or your favourite text editor, to create new files. If you are creating new articles or translations, rename the file to follow the [Locales in the Article Styling Criteria](/wiki/Article_styling_criteria/Formatting#locales).
 2. Continue to [Committing and pushing](#committing-and-pushing).

--- a/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/en.md
+++ b/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/en.md
@@ -52,7 +52,7 @@ While branching is technically optional, it is [highly recommended for a couple 
 
 ### Creating new files
 
-*Caution: If you are going to create article files using Windows Explorer, make sure the `File name extensions` option is enabled.* See [How to show or hide file name extensions in Windows Explorer](https://support.microsoft.com/en-us/help/865219/how-to-show-or-hide-file-name-extensions-in-windows-explorer) for instructions.
+*Caution: If you are going to create article files using Windows Explorer, make sure the `File name extensions` option is enabled.* See [How to show or hide file name extensions in Windows Explorer](https://support.microsoft.com/en-us/windows/common-file-name-extensions-in-windows-da4a4430-8e76-89c5-59f7-1cdbbc75cb01) for instructions.
 
 1. Use Windows Explorer, your favourite image editor, and/or your favourite text editor, to create new files. If you are creating new articles or translations, rename the file to follow the [Locales in the Article Styling Criteria](/wiki/Article_styling_criteria/Formatting#locales).
 2. Continue to [Committing and pushing](#committing-and-pushing).

--- a/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/fr.md
+++ b/wiki/osu!_wiki/Contribution_guide/GitHub_Desktop/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: e2bc6e20ae0f8aa6e71d7abf4d7e97239fea8c21
+---
+
 # GitHub Desktop
 
 *Cet article est la suite de [la page principale](/wiki/osu!_wiki/Contribution_guide)* et suppose que vous utilisez [GitHub Desktop](https://desktop.github.com). **Même si vous travaillez localement, vous aurez toujours besoin d'accéder à GitHub pour créer des pull requests afin de réaliser vos changements.


### PR DESCRIPTION
While translating this article (translation will soon follow in another PR), I noticed that the current link leads to a 404 page. I searched for an up-to-date link on the microsoft page. [This article](https://www.howtogeek.com/205086/beginner-how-to-make-windows-show-file-extensions/) may also be used, as it additionally explains the process for Windows 11.
