### PR TITLE
Add AJT to the list of Elite Nominators on `Users with unique titles`

### DIFF
--- a/wiki/People/Users_with_unique_titles/de.md
+++ b/wiki/People/Users_with_unique_titles/de.md
@@ -165,6 +165,7 @@ Die meisten offiziellen Mapping-Wettbewerbe bieten den Titel **Elite Mapper** al
 Seit 2020 werden Mitglieder der [Beatmap-Nominators](/wiki/People/The_Team/Beatmap_Nominators) und des [Nomination-Assessment-Teams](/wiki/People/The_Team/Nomination_Assessment_Team) mit einer außergewöhnlichen Leistung zur Unterstützung des Ranlistensystems in einem bestimmten Jahr mit dem Titel **Elite Nominator** ausgezeichnet. Dieser Titel wird zu Beginn jedes Jahres für Beiträge vergeben, die während dem vergangen Jahr gemacht wurden, und halten etwa ein Jahr lang oder bis der Benutzer das Team verlässt.
 
 - ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229)
+- ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083)
 - ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065)
 - ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 - ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)

--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -165,6 +165,7 @@ Most official mapping contests offer the **Elite Mapper** title as a first-place
 Since 2020, members of the [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) and [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) with an exceptional display towards supporting the ranking system in a given year are rewarded with the **Elite Nominator** title. This title is given at the beginning of each year for contributions made during the last, and lasts for roughly a year or until the user leaves the team.
 
 - ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229)
+- ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083)
 - ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065)
 - ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 - ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)

--- a/wiki/People/Users_with_unique_titles/es.md
+++ b/wiki/People/Users_with_unique_titles/es.md
@@ -172,6 +172,7 @@ La mayoría de los concursos oficiales de mapping ofrecen el título de **Elite 
 Desde el 2020, los [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) y los miembros del [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) que apoyan activamente en el sistema de clasificación han sido premiados con el título **Elite Nominator**. Este título es otorgado al principio de cada ano por sus contribuciones realizadas durante el anterior, y es revocado una vez que el usuario deja de formar parte del equipo.
 
 - ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229)
+- ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083)
 - ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065)
 - ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 - ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -165,6 +165,7 @@ La plupart des concours officiels de mapping offrent le titre de **Elite Mapper*
 Depuis 2020, l'activité des [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) et des membres de la [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) en faveur du système de classement est récompensée par le titre **Elite Nominator**. Ce titre est attribué au début de chaque année pour les contributions apportées au cours de la précédente, et est retiré lorsque l'utilisateur quitte l'équipe.
 
 - ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229)
+- ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083)
 - ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065)
 - ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 - ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)

--- a/wiki/People/Users_with_unique_titles/fr.md
+++ b/wiki/People/Users_with_unique_titles/fr.md
@@ -4,7 +4,7 @@ Les titres d'utilisateurs sont généralement associés aux [groupes d'utilisate
 
 ## Titulaires actuels de la World Cup
 
-Chaque année, les vainqueurs des [World Cups officielles](/wiki/Tournaments#officielles) reçoivent le titre d'utilisateur **osu!/osu!taiko/osu!catch/osu!mania Champion**  qui dure jusqu'à la conclusion de la prochaine itération de la World Cup correspondante.
+Chaque année, les vainqueurs des [World Cups officielles](/wiki/Tournaments#world-cups-officielles) reçoivent le titre d'utilisateur **osu!/osu!taiko/osu!catch/osu!mania Champion**  qui dure jusqu'à la conclusion de la prochaine itération de la World Cup correspondante.
 
 Les gagnants de l'[OWC 2021](/wiki/Tournaments/OWC/2021) avec le titre d'utilisateur **osu! Champion** :
 

--- a/wiki/People/Users_with_unique_titles/id.md
+++ b/wiki/People/Users_with_unique_titles/id.md
@@ -165,6 +165,7 @@ osu! pada umumnya menganugerahkan para pemenang kontes mapping yang berstatus re
 Sejak tahun 2020, setiap tahunnya osu! menganugerahkan gelar **Elite Nominator** kepada para anggota [Beatmap Nominator (BN)](/wiki/People/The_Team/Beatmap_Nominators) dan [Nomination Assessment Team (NAT)](/wiki/People/The_Team/Nomination_Assessment_Team) yang dinilai telah memberikan kontribusi yang lebih selama setahun ke belakang. Adapun gelar Elite Nominator tersebut akan hilang apabila pengguna yang bersangkutan dikeluarkan dan/atau mengundurkan diri dari BN atau NAT.
 
 - ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229)
+- ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083)
 - ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065)
 - ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 - ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)


### PR DESCRIPTION
At the request of [AJT](http://osu.ppy.sh/users/3181083) himself, whose name is somehow missing from the list of Elite Nominators at the moment.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

`SKIP_OUTDATED_CHECK` (this change is only applicable to certain languages as some locales are still written following the old article instead of the new one) 
