### PR TITLE
Update `EGTS 2022` to the Finals stage

### DIFF
--- a/wiki/Tournaments/GTS/EGTS_2022/en.md
+++ b/wiki/Tournaments/GTS/EGTS_2022/en.md
@@ -224,6 +224,34 @@ The Expert Global Taiko Showdown 2022 is run by various community members.
 
 ## Match results
 
+### Quarterfinals
+
+Saturday, 17 September 2022:
+
+| Player 1 |  |  | Player 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **kotohira\_06** ::{ flag=JP }:: | **6** | 2 | ::{ flag=IT }:: Ikkun | [#1](https://osu.ppy.sh/community/matches/103839777) |
+| **ntefy\_** ::{ flag=JP }:: | **6** | 0 | ::{ flag=FI }:: Antti | [#1](https://osu.ppy.sh/community/matches/103842241) |
+| **frz** ::{ flag=DE }:: | **0** | -1 | ::{ flag=TW }:: Smallwu | *win by default* |
+| FrootLoopy542 ::{ flag=US }:: | 2 | **6** | ::{ flag=SE }:: **Nurend** | [#1](https://osu.ppy.sh/community/matches/103848786) |
+| **frukoyurdakul** ::{ flag=TR }:: | **6** | 1 | ::{ flag=GB }:: overdahedge2014 | [#1](https://osu.ppy.sh/community/matches/103852015) |
+| **AuroraPhasmata** ::{ flag=US }:: | **6** | 5 | ::{ flag=FR }:: Ekoro | [#1](https://osu.ppy.sh/community/matches/103856270) |
+
+Sunday, 18 September 2022:
+
+| Player 1 |  |  | Player 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| AuroraPhasmata ::{ flag=US }:: | 2 | **6** | ::{ flag=SE }:: **Nurend** | [#1](https://osu.ppy.sh/community/matches/103858806) |
+| **hz404** ::{ flag=JP }:: | **6** | 5 | ::{ flag=CL }:: Ulqui | [#1](https://osu.ppy.sh/community/matches/103859737) |
+| CheeseStingy ::{ flag=TW }:: | 3 | **6** | ::{ flag=US }:: **Miniature Lamp** | [#1](https://osu.ppy.sh/community/matches/103860715) |
+| ntefy\_ ::{ flag=JP }:: | 5 | **6** | ::{ flag=US }:: **Miniature Lamp** | [#1](https://osu.ppy.sh/community/matches/103864314) |
+| LordEnder ::{ flag=IT }:: | 1 | **6** | ::{ flag=JP }:: kanten\_07 | [#1](https://osu.ppy.sh/community/matches/103867714) |
+| **Grape\_Tea** ::{ flag=JP }:: | **6** | 2 | ::{ flag=DE }:: Minekuchi | [#1](https://osu.ppy.sh/community/matches/103868724) |
+| **kanten\_07** ::{ flag=JP }:: | **6** | 1 | ::{ flag=DE }:: frz | [#1](https://osu.ppy.sh/community/matches/103869764) |
+| **Seren58** ::{ flag=JP }:: | **6** | 0 | ::{ flag=JP }:: Nekomusya7563 | [#1](https://osu.ppy.sh/community/matches/103869844) |
+| frukoyurdakul ::{ flag=TR }:: | 1 | **6** | ::{ flag=JP }:: **kotohira\_06** | [#1](https://osu.ppy.sh/community/matches/103869788) |
+| **goheegy** ::{ flag=GB }:: | **6** | 3 | ::{ flag=JP }:: Six b0xes | [#1](https://osu.ppy.sh/community/matches/103869775) |
+
 ### Round of 16
 
 Saturday, 10 September 2022:

--- a/wiki/Tournaments/GTS/EGTS_2022/en.md
+++ b/wiki/Tournaments/GTS/EGTS_2022/en.md
@@ -74,6 +74,33 @@ The Expert Global Taiko Showdown 2022 is run by various community members.
 
 ## Mappools
 
+### Semifinals
+
+**[Download the mappack here! (90 MB)](https://mega.nz/file/vZgBTbCD#nqRYBScGRkp6tAz6cUUNpHRtVdYUlIUApQkAUzr3x8U)**
+
+- NoMod
+  1. [one fourteen - break through (Ideal) \[Armageddon (EGTS Edit)\]](https://osu.ppy.sh/beatmapsets/1850900#taiko/3802268)
+  2. [Kobaryo - Theme for Psychopath Justice (Hivie) \[you lose (5)\]](https://osu.ppy.sh/beatmapsets/1850906#taiko/3802276)
+  3. [Sven Noon - The Map (uone) \[Taiko\]](https://osu.ppy.sh/beatmapsets/1850669#taiko/3801800)
+  4. [gingus - dont say "i can sample that" for 24 hours challenge (Mew) \[dont say "i can do nm4" for 1 week challenge\]](https://osu.ppy.sh/beatmapsets/1850910#taiko/3802289)
+  5. [MYUKKE. - BUNA\*SYNERGY!!! (KTYN) \[SYNERGY\]](https://osu.ppy.sh/beatmapsets/1851093#taiko/3802715)
+  6. [rN - ad:roreschach (\[Zeth\]) \[pareidolia\]](https://osu.ppy.sh/beatmapsets/1850832#taiko/3802131)
+- Hidden
+  1. [Frums - Living Will (\_mtk) \[Fapu & Mutsuki's Existential Crisis (Zeth ver.)\]](https://osu.ppy.sh/beatmapsets/1850837#taiko/3802137)
+  2. [Xat0li - Rin (MTNTWarz) \[Phantasmagoria\]](https://osu.ppy.sh/beatmapsets/1850743#taiko/3801970)
+- HardRock
+  1. [MonarX - Nanzen Karakurenai No Mai (rubies87) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/1850969#taiko/3802457)
+  2. [Zenpaku - Enkindle feat. vally.exe (Raphalge) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/1850934#taiko/3802329)
+- DoubleTime
+  1. [Ayaponzu\* - Streaming Heart (X a v y) \[Heartbreak\]](https://osu.ppy.sh/beatmapsets/1850620#taiko/3801713)
+  2. [Alquimia - Indomable (Raiden) \[Unbreakable\]](https://osu.ppy.sh/beatmapsets/1850943#taiko/3802364)
+- FreeMod
+  1. [Camellia - THE MUZZLE FACING (Stingy) \[Stingy & Nwolf's Massacre\]](https://osu.ppy.sh/beatmapsets/1850945#taiko/3802374)
+  2. [blobdash - Resentment (Ak1o) \[Inner Hatred\]](https://osu.ppy.sh/beatmapsets/1850544#taiko/3801533)
+  3. [Sad Keyboard Guy - Reflection Shift (Cynplytholowazy) \[Universe\]](https://osu.ppy.sh/beatmapsets/1851049#taiko/3802634)
+- Tiebreaker
+  1. **[takehirotei as ''Infinite Limit'' - Rules of the Chaos Dilemma (MTNTWarz) \[Amplectere Confusionem\]](https://osu.ppy.sh/beatmapsets/1850782#taiko/3802036)**
+
 ### Quarterfinals
 
 **[Download the mappack here! (76 MB)](https://mega.nz/file/WEQ11Sib#F6ggB55W8EkjoVaQkVGY4_9hjOSjxK07estwFq-Weuk)**

--- a/wiki/Tournaments/GTS/EGTS_2022/en.md
+++ b/wiki/Tournaments/GTS/EGTS_2022/en.md
@@ -74,6 +74,33 @@ The Expert Global Taiko Showdown 2022 is run by various community members.
 
 ## Mappools
 
+### Finals
+
+**[Download the mappack here! (91 MB)](https://mega.nz/file/nZg2xKja#c3tBX1VasuktYzJQgkIOlH9PQesl3P6Sb_XilX7OiUY)**
+
+- NoMod
+  1. [Shoebill - improvised mashcore (Raphalge) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/1855255#taiko/3812476)
+  2. [Kobaryo - Put Your F\*cking Phone Down (Kobaryos FTN-Remix) (X a v y) \[Transilient Collab\]](https://osu.ppy.sh/beatmapsets/1855025#taiko/3812009)
+  3. [Frums - Remnants of Turing (UnagiDon) \[CMU's Turing Complete\]](https://osu.ppy.sh/beatmapsets/1855263#taiko/3812489)
+  4. [seatrus - The Daybreak Will Never Come Again. (Cynplytholowazy) \[Eternal Night.\]](https://osu.ppy.sh/beatmapsets/1855143#taiko/3812272)
+  5. [CaNdy Sync - Step&Run with Depression (X a v y) \[Nutes\]](https://osu.ppy.sh/beatmapsets/1855281#taiko/3812536)
+  6. [katagiri - Bootleg Heaven (KTYN) \[Forbidden Collab\]](https://osu.ppy.sh/beatmapsets/1855270#taiko/3812521)
+- Hidden
+  1. [Tyrrer & BilliumMoto - BEBEB3 (Cut Ver.) (MTNTWarz) \[BABABU\]](https://osu.ppy.sh/beatmapsets/1855247#taiko/3812457)
+  2. [U-F SEQUENCER - TEMPEST ZONE -code BLOOD- (DJ Myosuke OVER 500!! Remix) (Ak1o) \[OUTER ONI\]](https://osu.ppy.sh/beatmapsets/1853556#taiko/3808737)
+- HardRock
+  1. [Tanchiky - rE:loaD (Nwolf) \[stage seven\]](https://osu.ppy.sh/beatmapsets/1855285#taiko/3812541)
+  2. [Five Hammer - fffff op.2 (Raphalge) \[Inner Oni (EGTS)\]](https://osu.ppy.sh/beatmapsets/1855286#taiko/3812542)
+- DoubleTime
+  1. [KARUT - Assault Gear (KyeX) \[Overheat\]](https://osu.ppy.sh/beatmapsets/1855274#taiko/3812525)
+  2. [goreshit - o'er the flood (\[Zeth\]) \[cascade\]](https://osu.ppy.sh/beatmapsets/1855113#taiko/3812204)
+- FreeMod
+  1. [Xyris - Terrablazer (Ak1o) \[Eruption\]](https://osu.ppy.sh/beatmapsets/1853559#taiko/3808743)
+  2. [factal - Flux (Hivie) \[Quantum (feat. woosungko)\]](https://osu.ppy.sh/beatmapsets/1855293#taiko/3812555)
+  3. [Laur - Chimi Moryou (Roxy-) \[KurOni (EGTS Ver.)\]](https://osu.ppy.sh/beatmapsets/1855258#taiko/3812482)
+- Tiebreaker
+  1. **[ikaruga\_nex vs. Kagetora. - Grabinschrift der Gotter (Roxy-) \[Flower, Isolate, Nightmare, Aberrant, and the Lucid\]](https://osu.ppy.sh/beatmapsets/1855299#taiko/3812563)**
+
 ### Semifinals
 
 **[Download the mappack here! (90 MB)](https://mega.nz/file/vZgBTbCD#nqRYBScGRkp6tAz6cUUNpHRtVdYUlIUApQkAUzr3x8U)**

--- a/wiki/Tournaments/GTS/EGTS_2022/en.md
+++ b/wiki/Tournaments/GTS/EGTS_2022/en.md
@@ -224,6 +224,26 @@ The Expert Global Taiko Showdown 2022 is run by various community members.
 
 ## Match results
 
+### Semifinals
+
+Saturday, 24 September 2022:
+
+| Player 1 |  |  | Player 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **Minekuchi** ::{ flag=DE }:: | **7** | 5 | ::{ flag=JP }:: kanten\_07 | [#1](https://osu.ppy.sh/community/matches/103992098) |
+| Nekomusya7563 ::{ flag=JP }:: | 1 | **7** | ::{ flag=JP }:: **kotohira\_06** | [#1](https://osu.ppy.sh/community/matches/103994978) |
+| Six b0xes ::{ flag=JP }:: | -1 | **0** | ::{ flag=SE }:: **Nurend** | *win by default* |
+| **Ulqui** ::{ flag=CL }:: | **7** | 3 | ::{ flag=US }:: Miniature Lamp | [#1](https://osu.ppy.sh/community/matches/104009963) |
+
+Sunday, 25 September 2022:
+
+| Player 1 |  |  | Player 2 | Match link |
+| --: | :-: | :-: | :-- | :-- |
+| **Minekuchi** ::{ flag=DE }:: | **0** | -1 | ::{ flag=SE }:: Nurend | *win by default* |
+| **Seren58** ::{ flag=JP }:: | **7** | 2 | ::{ flag=JP }:: hz404 | [#1](https://osu.ppy.sh/community/matches/104021669) |
+| **Grape\_Tea** ::{ flag=JP }:: | **7** | 4 | ::{ flag=GB }:: goheegy | [#1](https://osu.ppy.sh/community/matches/104022632) |
+| kotohira\_06 ::{ flag=JP }:: | 6 | **7** | ::{ flag=CL }:: **Ulqui** | [#1](https://osu.ppy.sh/community/matches/104025263) |
+
 ### Quarterfinals
 
 Saturday, 17 September 2022:


### PR DESCRIPTION
## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

## Description

- Add Semifinals and Finals mappools
- Add Quarterfinals and Semifinals match results