### PR TITLE
Add `Tournaments/Mappool` article

### DIFF
--- a/wiki/Gameplay/Game_modifier/de.md
+++ b/wiki/Gameplay/Game_modifier/de.md
@@ -4,10 +4,6 @@ tags:
  - game modifier
  - overview
  - list of mods
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
  - Spielmodifikation
  - Übersicht
 ---
@@ -72,16 +68,6 @@ Neben jeder der unten aufgeführten Modifikation werden die Symbole für die kom
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### Verwandte Begriffe
-
-#### NoMod
-
-In [Turnierspielen](/wiki/Tournaments) bezieht sich **NoMod** (***NM***) darauf, keine Mods zu nutzen. Bei vielen Turnieren müssen einige Mods standardmäßig als Teil der Regeln oder des Formats verwendet werden, wie z. B. [No Fail](/wiki/Game_modifier/No_Fail) oder [ScoreV2](/wiki/Game_modifier/ScoreV2), die eine Ausnahme zu diesem Konzept darstellen.
-
-#### FreeMod
-
-In [Turnierspielen](/wiki/Tournaments) bezieht sich **FreeMod** (***FM***) darauf, dass die Mods oder Modkombinationen freigewählt werden können. Einige Turniere sehen ebenfalls Regeln vor, die zusätzliche Kriterien bestimmen, wie z. B. welche Mods erlaubt sind und in welchen Kombinationen oder ob es erlaubt ist, keine Mods zu nutzen, wenn FreeMod festgelegt ist.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/en.md
+++ b/wiki/Gameplay/Game_modifier/en.md
@@ -4,10 +4,6 @@ tags:
  - game modifier
  - overview
  - list of mods
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
 ---
 
 <!-- READ BEFORE EDITING:
@@ -70,16 +66,6 @@ Each of the mods below listed will have their compatible game modes' icon (![][o
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### Related terms
-
-#### NoMod
-
-In [tournament](/wiki/Tournaments) matches, **NoMod** (***NM***) refers to not using any mods. Many tournaments require some mods to be used by default as part of their rules or format, such as [No Fail](/wiki/Game_modifier/No_Fail) or [ScoreV2](/wiki/Game_modifier/ScoreV2), which become exceptions to this notion.
-
-#### FreeMod
-
-In [tournament](/wiki/Tournaments) matches, **FreeMod** (***FM***) refers to being free to choose any mod or mod combination. Some tournaments also provide rules that specify additional criteria such as what mods are allowed and in what combinations, or whether having no mods is allowed when FreeMod is specified.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/fr.md
+++ b/wiki/Gameplay/Game_modifier/fr.md
@@ -4,10 +4,6 @@ tags:
  - game modifier
  - overview
  - list of mods
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
  - modificateur de jeu
  - apercu
  - liste des mods
@@ -69,16 +65,6 @@ Chacun des mods ci-dessous aura l'icône de son mode de jeu compatible (![][osu!
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### Termes connexes
-
-#### NoMod
-
-Dans les matchs des [tournois](/wiki/Tournaments), **NoMod** (***NM***) signifie ne pas utiliser de mods. De nombreux tournois exigent que certains mods soient utilisés par défaut dans le cadre de leurs règles ou de leur format, comme [No Fail](/wiki/Game_modifier/No_Fail) ou [ScoreV2](/wiki/Game_modifier/ScoreV2), qui deviennent des exceptions à cette notion.
-
-#### FreeMod
-
-Dans les matchs des [tournois](/wiki/Tournaments), **FreeMod** (***FM***) signifie que vous êtes libre de choisir n'importe quel mod ou combinaison de mods. Certains tournois prévoient également des règles qui spécifient des critères supplémentaires, tels que les mods autorisés et leurs combinaisons, ou si le fait de ne pas avoir de mods est autorisé lorsque FreeMod est spécifié.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/id.md
+++ b/wiki/Gameplay/Game_modifier/id.md
@@ -5,10 +5,6 @@ tags:
  - overview
  - list of mods
  - daftar mod
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
 ---
 
 # Game modifier
@@ -67,16 +63,6 @@ Tidak semua mod dapat digunakan pada seluruh mode permainan yang ada. Ikon-ikon 
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### Istilah-istilah yang terkait dengan mod
-
-#### NoMod
-
-Dalam lingkungan [turnamen](/wiki/Tournaments), istilah **NoMod** (***NM***) mengacu pada beatmap-beatmap yang harus dimainkan tanpa menggunakan mod apapun di samping mod-mod seperti [No Fail](/wiki/Game_modifier/No_Fail) dan [ScoreV2](/wiki/Game_modifier/ScoreV2) yang pada umumnya merupakan syarat wajib turnamen.
-
-#### FreeMod
-
-Dalam lingkungan [turnamen](/wiki/Tournaments), istilah **FreeMod** (***FM***) mengacu pada beatmap-beatmap yang dapat dimainkan baik dengan ataupun tanpa mod. Turnamen-turnamen tertentu terkadang memiliki aturan khusus yang mempersyaratkan mod-mod apa saja serta komposisi penggunaan mod seperti apa yang diperbolehkan pada beatmap-beatmap FreeMod.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/ru.md
+++ b/wiki/Gameplay/Game_modifier/ru.md
@@ -4,20 +4,11 @@ tags:
  - game modifier
  - overview
  - list of mods
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
  - мод
  - моды
  - игровой мод
  - игровой модификатор
  - список модов
- - номод
- - ноумод
- - без модов
- - фримод
- - фри мод
 ---
 
 # Игровой модификатор
@@ -76,16 +67,6 @@ tags:
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### Связанные термины
-
-#### NoMod
-
-В [турнирных](/wiki/Tournaments) матчах **NoMod** (***NM***) означает отказ от любых модов. Во многих турнирах есть правило, по которому все матчи должны играться с некоторым базовым набором модов (например, [No Fail](/wiki/Game_modifier/No_Fail) или [ScoreV2](/wiki/Game_modifier/ScoreV2)), что имеет приоритет над данным толкованием термина.
-
-#### FreeMod
-
-В [турнирных](/wiki/Tournaments) матчах **FreeMod** (***FM***) означает свободу выбора любых модов или их комбинаций. В некоторых турнирах есть отдельные правила, разъясняющие, какие моды в каких комбинациях допускается выбирать, и можно ли играть без модов вообще, если указан режим FreeMod.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/zh.md
+++ b/wiki/Gameplay/Game_modifier/zh.md
@@ -4,12 +4,6 @@ tags:
  - game modifier
  - overview
  - list of mods
- - NoMod
- - No Mod
- - FreeMod
- - Free Mod
- - NM
- - FM
  - 模组
  - 游戏模组
 ---
@@ -74,16 +68,6 @@ tags:
 - [10K](/wiki/Game_modifier/10K) ![][osu!mania]
 - [Fade Out](/wiki/Game_modifier/Fade_Out) ![][osu!mania]
 - [No Video](/wiki/Game_modifier/No_Video) ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania]
-
-### 相关术语
-
-#### 无模组 (NoMod)
-
-在[比赛](/wiki/Tournaments)对局内，**无模组 (NoMod)** (***NM***) 指游玩谱面时不开启任何游戏模组。许多比赛需要在游玩时默认开启部分模组以符合比赛规定，如 [No Fail](/wiki/Game_modifier/No_Fail) 或者 [ScoreV2](/wiki/Game_modifier/ScoreV2) 模组。因此，这些模组通常不包括在“无模组”限制内。
-
-#### 自由选择模组 (FreeMod)
-
-在[比赛](/wiki/Tournaments)对局内，**自由选择模组 (FreeMod)** (***FM***) 指游玩谱面时可选择开启部分指定的游戏模组。部分比赛也会提供具体的选择规则，确定了哪些模组可供自由选择，哪些模组应被选择，或者是否能在 FM 规则下的谱面内无模组 (NM) 游玩。
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Tournaments/Mappool/en.md
+++ b/wiki/Tournaments/Mappool/en.md
@@ -1,0 +1,95 @@
+---
+stub: true
+tags:
+  - map pool
+  - modpool
+  - mod pool
+  - mappool slot
+  - map pool slot
+  - pool slot
+  - rice
+  - LN
+  - hybrid
+  - SV
+  - no mod
+  - NM
+  - free mod
+  - force mod
+  - forced mod
+  - freemod
+  - forcemod
+  - forcedmod
+  - FM
+  - mixed mod
+  - MM
+  - tiebreaker
+---
+
+# Mappool
+
+A **mappool** is a collection of [beatmaps](/wiki/Beatmap) used in [tournament](/wiki/Tournaments) matches. These mappols may be divided into sections based on which [mods](/wiki/Gameplay/Game_modifier) are used, in which case they are sometimes called *modpools*, or by type of beatmap. The individual beatmaps are said to occupy a numbered *mappool slot* within each section of the mappool. People who create mappools are called *mappoolers* or *mappool selectors*, and the process itself is called *mappooling*.
+
+## Mappool sections
+
+Tournaments except osu!mania ones typically include *Hidden*, *Hard Rock*, and *Double Time* sections of the mappool, which as their names suggest require the respective mods to be active. osu!mania tournaments instead use *Rice*, *LN*, *Hybrid*, and *SV*.
+
+### No Mod
+
+**No Mod** (***NM***) refers to not using any mods. Many tournaments require some mods to be used by default as part of their rules or format, such as [No Fail](/wiki/Game_modifier/No_Fail) or [ScoreV2](/wiki/Game_modifier/ScoreV2), which become exceptions to this notion.
+
+### Free Mod
+
+**Free Mod** (***FM***) refers to being free to choose any mod or mod combination. Some tournaments also provide rules that specify additional criteria such as what mods are allowed and in what combinations, or whether having no mods is allowed when Free Mod is specified.
+
+### Force Mod
+
+**Force Mod** (***FM***) is otherwise the same as [Free Mod](#free-mod), except that it specifies that using at least one mod is mandatory.
+
+### Mixed Mod
+
+**Mixed Mod** (***MM***) means each player in the team has to pick one unique mod or mod combination each. The specific requirements may vary between tournaments.
+
+### Rice
+
+**Rice** is an osu!mania community term for regular notes, in reference to regular notes looking like rice. Rice maps thus contain a lot of regular notes.
+
+### LN
+
+**LN** in osu!mania stands for long note, and thus LN maps contain a lot of them.
+
+### Hybrid
+
+**Hybrid** beatmaps contain both regular and long notes, i.e. is a category in between Rice and LN.
+
+### SV
+
+**SV** stands for slider velocity, which in osu!mania affects scroll speed. SV beatmaps make use of scroll speed variation gimmicks.
+
+### Tiebreaker
+
+**Tiebreakers** are beatmaps used to break ties. These typically focus on a variety of skills, consistent performance, and are usually longer than other such that the better player overall wins. The mod requirements vary between tournaments.
+
+## Mappool slots
+
+Tournament mappools are usually structured such that mappool slots correspond to specific types of beatmaps that require different skills to perform well on them. This encourages strategy and coordination when players and teams pick beatmaps in matches.
+
+In the [osu! game mode](/wiki/Game_mode/osu!), the the beatmap types for each slot number are standardised:
+
+| Slot | Focus |
+| :-- | :-- |
+| NM1 | Aim, consistency |
+| NM2 | Stream |
+| NM3 | Alternating |
+| NM4 | Technical |
+| NM5 | Speed |
+| NM6 | Gimmick |
+| HD1 | Aim control | 
+| HD2 & HD3 | One of low AR, flow aim, or technical |
+| HR1 | Aim |
+| HR2 & HD3 | One of technical, accuracy or small CS |
+| DT1 | High-BPM aim |
+| DT2 | Stamina, or finger control |
+| DT3 | Speed |
+| DT4 | Alternating, finger control, or old-style |
+| FM1, FM2, & FM3 | Awkward aim, flow aim, technical, low AR and small CS. One typically favours Hard Rock, one Hidden, and one somewhere in between. |
+| TB | Various |


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

closes #a-mental-note-in-the-back-of-my-mind

making pr requesting opinions on structure. i'm also not sure if all of this should be in this one article specifically (mainly thinking the mania map types of rice, ln, hybrid and sv)

mappool slot numbers corresponding to map types is apparently well defined in the osu! mode from what i've heard (and seen from digitalhypno's youtube videos on the topic). from my understanding after talking to a few mappoolers, this isn't as standardised in other modes, but different beatmaps in a mappool still focus on different skills just like in osu! tournaments. i'll write more stuff regarding that (and spend some time verifying this with more people) but i'll need a bit of time to think of the best way to present it (which also relates to the structure)

and well if any mappoolers see this feel free to chime in with info or any other remarks

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] link from other articles
- [ ] add redirects / edit links
- [ ] complete information in the article