### PR TITLE
Remove outdated links from `Performance points`

### DIFF
--- a/wiki/Performance_points/de.md
+++ b/wiki/Performance_points/de.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 # Performance-Points
 
 **Performance-Points** (oder **pp** abgekürzt, auch Performance-Punkte genannt) ist eine Metrik, deren Ziel es ist, den Spielerfortschritt in osu! kontextbezogener zu gestalten.

--- a/wiki/Performance_points/en.md
+++ b/wiki/Performance_points/en.md
@@ -14,8 +14,6 @@ Known thereafter as "pp" (an abbreviation for "performance points"), this new sy
 
 Several months after its reveal, the 20120722-24 osu! release officially implemented the system to fully replace the old [Ranked](/wiki/Beatmap/Category#ranked) score system, with new scores being calculated every 30 minutes. Later on in August of the same year, the system was improved to update in real-time.
 
-*Note: ppv1, the original build of the Performance Points system, also had a changelog, which can be viewed from its [forum topic](https://osu.ppy.sh/community/forums/topics/92185).*
-
 It continued to exist in this capacity for more than a year of service until [Tom94](https://osu.ppy.sh/users/1857058), the creator of the *osu!tp* scoring metric, joined the [osu! team](/wiki/People/The_Team) and implemented his design into the system. The resulting system was titled *ppv2*, and became live on January 27, 2014, therefore renaming the old system to *[ppv1](/wiki/Performance_points/ppv1)*
 
 On January 16, 2021, changes were made to the ppv2 system that aimed to more accurately award pp to more difficult aspects of maps. These changes were made in large part by the help of various individual members of the community such as [Xexxar](https://osu.ppy.sh/users/2773526) and [StanR](https://osu.ppy.sh/users/7217455). The specifics of the changes made are detailed in the [corresponding newspost](https://osu.ppy.sh/home/news/2021-01-14-performance-points-updates). Very briefly, the main points of interest in the update were as follows:
@@ -26,7 +24,7 @@ On January 16, 2021, changes were made to the ppv2 system that aimed to more acc
 - Adjust the rate of pp loss from misses to be more forgiving on longer maps with higher combo
 - Punish lower [accuracy](/wiki/Gameplay/Accuracy) plays with less pp gain
 
-ppv2 is currently in active service, with live updates published to its [changelog](https://osu.ppy.sh/p/changelog?category=pp).
+ppv2 is currently in active service, with live updates published by the [PP Committee](/wiki/People/Performance_Points_Committee).
 
 ## Calculation
 

--- a/wiki/Performance_points/fr.md
+++ b/wiki/Performance_points/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 # Points de performance
 
 Les **points de performance** (abrégé en **pp**) sont une mesure de classement qui vise à être plus contextuellement pertinente pour la progression d'un joueur sur osu!.

--- a/wiki/Performance_points/id.md
+++ b/wiki/Performance_points/id.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 <!-- Pennek also wrote a similar sub-article that may have small bits of extra info. If needed, find it here: https://github.com/ppy/osu-wiki/blob/be1fec96041971d2bace05eb216952a58b7cabbc/wiki/Performance_points/Performance_point_systems/en.md we should probably figure what to do with these two at some point-->
 
 # Performance points

--- a/wiki/Performance_points/ru.md
+++ b/wiki/Performance_points/ru.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
 tags:
   - пп
   - pp

--- a/wiki/Performance_points/th.md
+++ b/wiki/Performance_points/th.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 # Performance points
 
 **Performance points** (หรือเรียกสั้น ๆ ว่า **pp**) มีจุดมุ่งหมายในการแสดงการพัฒนาของผู้เล่นใน osu!

--- a/wiki/Performance_points/tr.md
+++ b/wiki/Performance_points/tr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 # Performans puanları
 
 **Performans puanları** (ya da kısaca **pp**) bir oyuncunun osu!'daki kaydettiği ilerlemeyle nispeten doğru orantılı olmayı amaçlayan bir sıralama ölçütüdür.

--- a/wiki/Performance_points/zh.md
+++ b/wiki/Performance_points/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: b0dbd398396a49d6f8e793dfa279b0c0e65937f1
+---
+
 # 表现分 (Performance points)
 
 **表现分 (Performance points) **又简称为 **pp**，是 osu! 内致力于准确量化玩家实力的指标。


### PR DESCRIPTION
Remove all mentions of the link "https://osu.ppy.sh/home/changelog?category=pp" since it doesn't lead to anything or otherwise inaccessible.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

