### PR TITLE
Cache `node_modules` in Github Actions to win 40–50s

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
+          key: node-modules-${{ hashFiles('package.json', 'package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
       - name: install remark
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,15 @@ jobs:
           cache: npm
           node-version: 16
 
+      - name: load node_modules from cache
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
       - name: install remark
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: run remark on changed files

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
         run: bash scripts/ci/inspect_binary_file_sizes.sh ${{ github.sha }} ${{ github.sha }}
 
       - name: set up Node.js
+        id: setup-node
         uses: actions/setup-node@v3
         with:
           cache: npm
@@ -34,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
       - name: install remark
         if: steps.cache-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
this speeds the check up by ~40%

- without cache (`install remark`): https://user-images.githubusercontent.com/4686101/196014127-4f1e770f-bb5a-4744-9afc-57a2d5860636.png
- with cache (`install remark`): https://user-images.githubusercontent.com/4686101/196014090-f5709e1e-5804-4ddf-8667-53afa21051e4.png

once this is merged, we need to run the action from `master` once in a while to populate the cache, [or it won't be hit](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)