### PR TITLE
Make custom hitnormals obligatory in the osu!mania RC

### DIFF
--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -200,7 +200,7 @@ This category contains explicit allowance statements of concepts and rules that 
   - **...not be encoded upwards from a lower bitrate.**
 - **A beatmap may only contain one song file used by all difficulties.** Multiple song files within a single beatmap are unsupported and result in unexpected behaviour with preview times, metadata, etc.
 - **Beatmaps must be [hitsounded](/wiki/Beatmapping/Hitsound).** Hitnormals give feedback to the player, and additions (whistles, claps, and finishes) accent the most important parts of the music.[^normal-vs-addition]
-  - **osu!mania beatmaps do not require hitsound additions.**[^normal-vs-addition] This is to allow for easier approachability to osu!mania mappers of different upbringings. It is still highly recommended to use hitsound additions to improve the feel of your beatmaps.
+  - **osu!mania beatmaps do not require hitsound additions, but a custom hitnormal sample must override the default hitnormal.**[^normal-vs-addition] It is still recommended to use hitsound additions to improve the audible feedback of your beatmaps.
 - **All clicked parts of objects must have at least one hitsound which both...**
   - **...has a clear impact, whose peak is delayed no more than 5 milliseconds.** `normal-hitfinish.wav` from the default skin is exempt from this.
   - **...uses the `.wav` or `.ogg` file format.** `.mp3` should not be used here as it is inherently delayed.


### PR DESCRIPTION
The goal of this PR is to add a simple clarification to the osu!mania exception of the "mandatory hitsounds" rule in General RC. 

While the current wording does not obligate mappers to add one or more custom hitnormal samples overriding the default hitnormal, it has for years beenan unwritten rule and standard *de facto* to override the default hitnormal in all osu!mania ranked sets (in fact, everyone had been interpreting the current ruling as having this meaning). This is done in order to improve the audible feedback of the map for those users who prefer to enable hitsounds. 

Generally this is done to use less "punchy" hitnormals instead of the default ones, which usually become obnoxious to the player due to the high object density and concurrency in osu!mania beatmaps. Hitnormals used by mappers as overrides of course still provide good audible feedback (this is mandated by RC), but they are less overwhelming and provide a better experience for those players who choose to play with hitsounds.

Thus, current RC reads: 

> **osu!mania beatmaps do not require hitsound additions.** This is to allow for easier approachability to osu!mania mappers of different upbringings. It is still highly recommended to use hitsound additions to improve the feel of your beatmaps.

and after discussing among the osu!mania BN and NAT, we propose the following clarification, also simplifying the rule a bit:

> **osu!mania beatmaps do not require hitsound additions, but a custom hitnormal sample must override the default hitnormal.** It is still recommended to use hitsound additions to improve the audible feedback of your beatmaps.

Of course, any proposal for an alternative or more clear wording is welcomed

Cheers
