### PR TITLE
Add Afrikaans language to `group-info`

### DIFF
--- a/meta/group-info/en.yaml
+++ b/meta/group-info/en.yaml
@@ -31,6 +31,7 @@ nat:
 languages:
   partial: some <language>
   # Note for translators: The following language names do *not* need to be included in your translation of group-info. The program will use language names from CLDR. However, you may include languages as you see fit if you want to override what the program normally does.
+  af: Afrikaans
   ar: Arabic
   be: Belarusian
   bg: Bulgarian


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Need to add Afrikaans for Zuid-Afrikaan before updating bn/staff listing.