### PR TITLE
Add missing heading in `osu! originals`

### DIFF
--- a/wiki/osu!_originals/en.md
+++ b/wiki/osu!_originals/en.md
@@ -474,6 +474,8 @@ These songs are part of the [osu! James Landino Collection EP](https://fanlink.t
 
 ### Community-run contest releases
 
+#### ![](/wiki/shared/mode/catch.png) osu!catch Mapping World Cup 2022
+
 | Song |
 | :-: |
 | [SAMString - Akarui Taiyo](https://soundcloud.com/samstring/akarui-taiyo)[^fa] |


### PR DESCRIPTION
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Would apply to en only, would get the translations done in their own prs.