### PR TITLE
RC metadata change: Change the requirement of romanised title and romanised artist.

### DIFF
--- a/wiki/Ranking_Criteria/en.md
+++ b/wiki/Ranking_Criteria/en.md
@@ -136,11 +136,12 @@ Important to understand before using:
   - Cantonese metadata must be romanised by using the Jyutping system.
   - If the song falls into neither category, this choice is left up to the mapper's discretion and contacting a native speaker is recommended.
 - **Metadata in other languages not specifically covered in this section and lacking official romanisation from the artist must use a system common and recognisable for the language.** Contacting a native speaker is recommended to ensure accuracy in these cases.
+- **If a Unicode song title or artist has an official translation or romanisation provided by the artist, it must be used in the respective romanised field. Self-romanisation can be only available if there's no official translation or romanisation.** If both a translation and romanisation are available, either may be used.
 
 ### Guidelines
 
 - **When a song is covered or remixed and has metadata varying from the original song, use common sense to determine whether the variation was a mistake or an intentional artist choice.**
-- **If multiple metadata options are available, priority should be given to the option which is most easily recognisable and traceable back to the original song or source.** Official romanisations and translations are preferred for romanised fields so long as they are easily found and commonly recognised.
+- **If multiple metadata options are available, priority should be given to the option which is most easily recognisable and traceable back to the original song or source.**
 
 #### Technical
 
@@ -165,7 +166,6 @@ Important to understand before using:
 This category contains explicit allowance statements of concepts and rules that are not commonly straightforward even after reading this whole section of the ranking criteria. In cases where there are multiple options available for a song's metadata, the above standardisation rules for the Ranked and Loved sections take priority.
 
 - **For songs where the composer(s) and singer(s) are different people, the singer(s) may be listed after the composer(s) or circle/group name following a `feat.` indicator.**
-- **If a Unicode song title or artist has an official translation or romanisation provided by the artist, it may be used in the respective romanised field. If both a translation and romanisation are available, either may be used.**
 - **If a beatmap's track was contributed to by multiple artists, they may be listed with commas in between.** If there are 3 or more contributing artists and they are not part of one officially labelled group, `Various Artists` or other descriptive artist labels may be used instead.
 - **For remixes, covers, or performances, the original artist may be used in the artist field, as long as the title field is modified to clearly show that the song is not the original version.** This marker should be in parentheses and contain the remix/cover artist or the performer as well as a descriptor.
 - **For live performances of a song, the title may include a `(Live Ver.)` marker.** Relevant details of the performance should be put in the beatmap description and tags, such as the date and location.


### PR DESCRIPTION
RC proposal thread found [here](https://osu.ppy.sh/community/forums/topics/1670642?n=1). Currently, if a beatmap A is ranked or loved, then beatmap B of the same song should follow the first ranked/loved beatmap's title and artist fields. There's no exception to this unless beatmap A's metadata breaks other rules or is completely wrong. This change makes it so that if an artist has given a translation or romanisation, future beatmaps are able to respect this even if prior beatmaps used a different translation or romanisation.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [ ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
