### PR TITLE
Fix link to L0V3 4RR0W 5H007

### DIFF
--- a/news/2022-11-23-new-featured-artist-e0ri4.md
+++ b/news/2022-11-23-new-featured-artist-e0ri4.md
@@ -12,7 +12,7 @@ Rhythm game music, hardcore songs, and *BMS OF FIGHTERS* submissions are the bul
 
 **7** unmatched tracks populate [**E0ri4**'s Featured Artist listing](https://osu.ppy.sh/beatmaps/artists/322). Brush off your mapping muscles and pick up your favourite track.
 
-[L0V3 4RR0W 5H007](https://osu.ppy.sh/beatmapsets?q=featured_artist%3D322%20L0V3%204RR0W%205H007) is the tune that introduced **E0ri4** to the osu! community through beatmaps across multiple rulesets. Check out how the song plays in osu!, osu!taiko, and osu!mania, then head to the editor with any of these other masterpieces:
+[L0V3 4RR0W 5H007](https://osu.ppy.sh/beatmapsets?q=L0V3%204RR0W%205H007&s=any) is the tune that introduced **E0ri4** to the osu! community through beatmaps across multiple rulesets. Check out how the song plays in osu!, osu!taiko, and osu!mania, then head to the editor with any of these other masterpieces:
 
 <div align="center">
     <video width="100%" controls>


### PR DESCRIPTION
Paragraph refers to other rulesets, however previous link did not show any beatmap as the standard beatmap is currently qualified and all others were not found from the `featured_artist` search query.
This pull request only sets to the Any category (all other rulesets are graveyarded) and the `featured_artist` search query is removed.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)