### PR TITLE
Updating `People/The_Team/Beatmap_Nominators`

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -1,6 +1,4 @@
 ---
-outdated_translation: true
-outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -32,7 +32,7 @@ Probation is used to monitor new or concerning Beatmap Nominators more closely. 
 
 New members of the Beatmap Nominators begin with a one month long probation period. If their nominations and behaviour are satisfactory, they will be promoted to the full Beatmap Nominators following a positive [evaluation](/wiki/People/The_Team/Nomination_Assessment_Team/Evaluations). Otherwise, they will remain on probation for another month or be removed from the Beatmap Nominators.
 
-When a Beatmap Nominator is placed on probation, they cannot be placed on probation again for the same reason. For example, if a Beatmap Nominator is placed on probation for poor behaviour, they will be removed from the Beatmap Nominators if they exhibit the same poor behaviour again, even if they are a full Beatmap Nominator during the second infringement.
+When a Beatmap Nominator is placed on probation, they cannot be placed on probation again for the same reason for roughly one year. For example, if a Beatmap Nominator is placed on probation for poor behaviour, they will be removed from the Beatmap Nominators if they exhibit the same poor behaviour again recently, even if they are a full Beatmap Nominator during the second infringement.
 
 ## Team members
 

--- a/wiki/People/The_Team/Beatmap_Nominators/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/en.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/es.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/es.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
+outdated_translation: true
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/fr.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
+outdated_translation: true
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/id.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/id.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
+outdated_translation: true
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/ru.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/ru.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
+outdated_translation: true
 tags:
   - BN
   - BNG

--- a/wiki/People/The_Team/Beatmap_Nominators/zh.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 90734b887c13f9c63f5319c6522a43d75c63a68b
+outdated_translation: true
 tags:
   - BN
   - BNG


### PR DESCRIPTION
Change how long warnings for BNs placed on probations apply to match https://osu.ppy.sh/wiki/en/People/The_Team/Nomination_Assessment_Team/Evaluations#group-phase.1

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [ ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
