### PR TITLE
Update `TWC 2016`, `CWC 2016` prize pool information

### DIFF
--- a/wiki/Tournaments/CWC/2016/en.md
+++ b/wiki/Tournaments/CWC/2016/en.md
@@ -25,11 +25,11 @@ The **osu!catch World Cup 2016** (***CWC 2016***) was a country-based osu!catch 
 
 ## Prizes
 
-| Place | Prizes |
+| Placing | Prizes |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 50% of the raised prize pool, unique profile badge, special user title |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 38% of the raised prize pool, unique profile badge |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 12% of the raised prize pool, unique profile badge |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | $300 per team member, unique profile badge, "osu!catch Champion" user title for one year |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | $160 per team member, unique profile badge |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | $80 per team member, unique profile badge |
 
 ![](img/badge.jpg "CWC 2016 winner badge") ![](img/badge2.jpg "CWC 2016 2nd place badge") ![](img/badge3.jpg "CWC 2016 3rd place badge")
 

--- a/wiki/Tournaments/TWC/2016/en.md
+++ b/wiki/Tournaments/TWC/2016/en.md
@@ -27,9 +27,9 @@ The **osu!taiko World Cup 2016** (***TWC 2016***) was a country-based osu!taiko 
 
 | Placing | Prizes |
 | :-: | :-- |
-| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | 50% of the raised prize pool, unique profile badge, "osu!taiko Champion" user title for one year |
-| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | 38% of the raised prize pool, unique profile badge |
-| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | 12% of the raised prize pool, unique profile badge |
+| ![Gold crown](/wiki/shared/crown-gold.png "1st place") | $300 per team member, unique profile badge, "osu!taiko Champion" user title for one year |
+| ![Silver crown](/wiki/shared/crown-silver.png "2nd place") | $160 per team member, unique profile badge |
+| ![Bronze crown](/wiki/shared/crown-bronze.png "3rd place") | $80 per team member, unique profile badge |
 
 ![](img/badge.jpg "TWC 2016 winner badge") ![](img/badge2.jpg "TWC 2016 2nd place badge") ![](img/badge3.jpg "TWC 2016 3rd place badge")
 


### PR DESCRIPTION
Fixes #8406 

The values mentioned in the issue are not 100% correct, the usual values are 300/160/80 and both TWC/CWC 2017 corroborate these figures. There were internal discussions about exact figures but conversion rates and the fact that it's been 6 years made it hard to get an exact value.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)