### PR TITLE
Remove `ModScore` from `Becoming a Beatmap Nominator`

### DIFF
--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -1,17 +1,16 @@
 # Becoming a Beatmap Nominator
 
-Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) need to go through an application process overseen by the [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (NAT). 
+Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) need to go through an application process overseen by the [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (NAT).
 
 Applications are conducted via the [NAT website](http://bn.mappersguild.com/bnapps).
 
-Applicants are required to meet a modding activity requirement, submit at least two maps they have recently modded, and complete a [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
+Applicants are required to reach a minimum [kudosu](/wiki/Modding/Kudosu) threshold, submit at least two maps they have recently modded, and complete a [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 
 ## Basic criteria
 
 Modders aiming to apply to the Beatmap Nominators must fulfil the following criteria:
 
-- They have been modding beatmaps actively for at least 3 months prior to applying.
-- They have accumulated at least 150 or 200 [kudosu](/wiki/Modding/Kudosu) in total, depending on the mode they will apply to.
+- They have accumulated at least 200 [kudosu](/wiki/Modding/Kudosu) for osu! modders, or 150 [kudosu](/wiki/Modding/Kudosu) for osu!taiko/osu!catch/osu!mania modders.
 - They provide 2 to 3 of their mods which they think qualify them to be a part of the Beatmap Nominators.
 
 ### Modding expectations
@@ -24,7 +23,7 @@ The following are modding traits expected of Beatmap Nominators. Failure to disp
 - **Identification of unrankable issues, including ones tools can't detect, such as incorrect timing or metadata**
 - **Comparison between parts of a map to support issues or suggestions**
 - **Commentary about a wide variety of map elements, such as rhythm, spacing, movement, intensity, contrast, and consistency**
-- **Identification of both isolated issues and general map-wide issues** 
+- **Identification of both isolated issues and general map-wide issues**
 - **Consideration of mappers' intentions when identifying issues and giving suggestions**
 
 ### How new potential Beatmap Nominators are chosen
@@ -34,46 +33,19 @@ The following are modding traits expected of Beatmap Nominators. Failure to disp
   - Modding abilities: Knowledge of the general [Ranking Criteria](/wiki/Ranking_Criteria) and specific criteria of each game mode. Additional abilities like Metadata, Timing, and some others will also be taken into consideration.
 - After evaluating each modder, a discussion will be made on whether the modder will join the Beatmap Nominators.
 
-## Modding Activity
-
-In osu!, a certain activity threshold needs to be met to apply as a Beatmap Nominator. This activity requirement does **not** currently apply for osu!taiko, osu!catch, or osu!mania.
-
-### What qualifies as a mod post
-
-- Upon signing up, the website will automatically calculate your kudosu score from the last 3 months.
-- A qualified mod post is a user's posts on a beatmap discussion, in which at least one suggestion/problem got awarded with an upvote, and has been created within the 3 months.
-- The game mode that you modded beatmaps in does not matter as your activity in the modding community as a whole is being measured and not the activity in a certain game mode.
-- The point in time at which the kudosu has been awarded to your mod post **does** matter, as the calculator embed in the website will fetch the data from your own Modding History events.
-
-### How the required minimum score is calculated
-
-- This depends on the total `ModScore` an applicant achieved over the last months. This value is determined according to the following formula:
-
-![ModScore Formula](/wiki/shared/Modscore_new_wiki.png "ModScore Formula")
-
-`m` = Minimum expected number of individual beatmaps modded in a month\
-`M` = Total achieved number of individual beatmaps modded in a month
-
-- [The website](http://bn.mappersguild.com/bnapps) has a tool for calculating `ModScore` on its main page.
-- In order to determine their required minimum score, the sum of the total `ModScore` within the last three months must be greater or equal to zero,
-- The overall minimum threshold is set to the following values:
-  - osu!taiko, osu!catch and osu!mania: `m` = 3 and a total of 150 kudosu or more
-  - osu!: `m` = 4 and a total of 200 kudosu or more
-- It is usually a good idea to keep your score above these numbers, as they can vary slightly depending on the number of applicants.
-
 ## Cooldowns
 
-Depending on your status, your cooldown and modscore requirement before you can apply again may vary.
+Depending on your status, your cooldown before you can apply again may vary.
 
 ### Failed applications
 
 You have these requirements if you failed a Beatmap Nominator application and apply again.
 
-| Type | Cooldown | Activity Requirements |
-| :-- | :-- | :-- |
-| Standard | 90 days | `ModScore` greater than 0 over 90 days |
-| Reduced | 60 days | `ModScore` greater than 0 over 90 days |
-| Failed [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) | 30 days | `ModScore` greater than 0 over 90 days |
+| Type | Cooldown |
+| :-- | :-- |
+| Standard | 90 days |
+| Reduced | 45-60 days |
+| Failed the [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) | 30 days |
 
 ### Rejoining after being removed from the Beatmap Nominators
 
@@ -81,12 +53,12 @@ Users who have recently left the Beatmap Nominators may have different requireme
 
 If you were a Beatmap Nominator before, these requirements apply unless you have failed an application since last time you were a Beatmap Nominator.
 
-Listed `ModScore` requirements only apply to the osu! game mode, and not osu!taiko, osu!catch, and osu!mania. The 8 mod requirement for those applying after being removed for activity is shared across all modes.
+The 8 mod requirement for those applying after being removed for activity is shared across all modes.
 
 | Type | Cooldown | Activity Requirements |
 | :-- | :-- | :-- |
-| Standard | 60 days | `ModScore` greater than 0 over 60 days |
-| Activity | 30 days | `ModScore` irrelevant, but 8 mods in 60 days |
-| Good | 30 days | `ModScore` greater than 0 over 30 days |
+| Standard | 60 days | *N/A* |
+| Activity | 30 days | 8 mods in 60 days |
+| Good | 30 days | *N/A* |
 
 Former Beatmap Nominators who resigned on good terms within the past year will become full members immediately upon rejoining.

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -4,7 +4,7 @@ Users interested in joining the [Beatmap Nominators](/wiki/People/The_Team/Beatm
 
 Applications are conducted via the [NAT website](http://bn.mappersguild.com/bnapps).
 
-Applicants are required to reach a minimum [kudosu](/wiki/Modding/Kudosu) threshold, submit at least two maps they have recently modded, and complete a [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
+Applicants are required to meet a minimum [kudosu](/wiki/Modding/Kudosu) threshold, submit at least two maps they have recently modded, and complete a [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) on the [Ranking Criteria](/wiki/Ranking_Criteria) in order to submit their application. A message from the NAT will be sent once a verdict has been decided. More information on applying can be found on the website.
 
 ## Basic criteria
 
@@ -44,7 +44,7 @@ You have these requirements if you failed a Beatmap Nominator application and ap
 | Type | Cooldown |
 | :-- | :-- |
 | Standard | 90 days |
-| Reduced | 45-60 days |
+| Reduced | 45–60 days |
 | Failed the [Beatmap Nominator Test](/wiki/People/The_Team/Beatmap_Nominators/Beatmap_Nominator_Test) | 30 days |
 
 ### Rejoining after being removed from the Beatmap Nominators
@@ -53,7 +53,7 @@ Users who have recently left the Beatmap Nominators may have different requireme
 
 If you were a Beatmap Nominator before, these requirements apply unless you have failed an application since last time you were a Beatmap Nominator.
 
-The 8 mod requirement for those applying after being removed for activity is shared across all modes.
+The 8-mod requirement for those applying after being removed for activity is shared across all modes.
 
 | Type | Cooldown | Activity Requirements |
 | :-- | :-- | :-- |

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/fr.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 053605ecbcbd1eb5a62e91a331315884fb4b00da
+---
+
 # Devenir un Beatmap Nominator
 
 Les utilisateurs souhaitant rejoindre les [Beatmap Nominators](/wiki/People/The_Team/Beatmap_Nominators) doivent passer par un processus de candidature supervisé par la [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) (NAT).

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/ru.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 053605ecbcbd1eb5a62e91a331315884fb4b00da
+---
+
 # Как стать номинатором
 
 За зачисление в [номинаторы](/wiki/People/The_Team/Beatmap_Nominators) отвечает [команда оценки номинаций](/wiki/People/The_Team/Nomination_Assessment_Team) (NAT).

--- a/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/zh.md
+++ b/wiki/People/The_Team/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 053605ecbcbd1eb5a62e91a331315884fb4b00da
+---
+
 # 成为 BN
 
 想要加入[谱面审核团队 (BN)](/wiki/People/The_Team/Beatmap_Nominators) 的玩家需要在[审核评估团队 (NAT)](/wiki/People/The_Team/Nomination_Assessment_Team) 成员的监管下通过 BN 申请程序。


### PR DESCRIPTION
as of today, we removed modscore requirements from the osu! game mode, which makes it a fully deprecated system.

wanted to update translations but I did a few wording changes so I'd rather not mess things up
