### PR TITLE
Remove extraneous RO16 mention in `GTS/AGTS_2019`

### DIFF
--- a/wiki/Tournaments/GTS/AGTS_2019/en.md
+++ b/wiki/Tournaments/GTS/AGTS_2019/en.md
@@ -430,7 +430,7 @@ Sunday, 18 August 2019:
 
 ### Stage regulations
 
-1. There are seven stages in this tournament: the Qualifiers, the Group Stage, the Round of 16, the Quarterfinals, the Semifinals, the Finals, and the Grand Finals.
+1. There are six stages in this tournament: the Qualifiers, the Group Stage, the Quarterfinals, the Semifinals, the Finals, and the Grand Finals.
 2. The team will be seeded with the average of their ranks on each map during the Qualifiers round.
 3. In case there are more than 32 registered teams, only the top 24 of the Qualifiers will go in the rest of the tournament.
 4. Teams will be drawn in **6 groups of 4** teams during a drawing show which will happen on Sunday August 11th.
@@ -443,12 +443,12 @@ Sunday, 18 August 2019:
 7. In Group stage, 'Win by default' will be considered as win by 4:0, +1.0 score difference ratio.
 8. The winning condition for each stage is:
    - Group Stage: BO9 (win 5 maps)
-   - Round of 16 and Quarterfinals: BO11 (win 6 maps)
+   - Quarterfinals: BO11 (win 6 maps)
    - Semifinals, Finals, and Grand Finals: BO13 (win 7 maps)
 
 ### Mappool instructions
 
-1. There will be 1 mappool for each of the following: Qualifiers, Group Stage, Round of 16, Quarterfinals, Semifinals, Finals, and Grand Finals.
+1. There will be 1 mappool for each of the following: Qualifiers, Group Stage, Quarterfinals, Semifinals, Finals, and Grand Finals.
 2. The Loser's Bracket will play on the same pool as the Winner's bracket of the same weekend.
 3. The Qualifiers pool will be different from all the other rounds, as it will have a format of 2 NoMod maps, 1 Hidden map, 1 HardRock map, 1 DoubleTime map.
 4. Each mappool consists of 7 brackets: NoMod, EX, Hidden, HardRock, DoubleTime, FreeMod, and Tiebreaker.

--- a/wiki/Tournaments/GTS/AGTS_2019/fr.md
+++ b/wiki/Tournaments/GTS/AGTS_2019/fr.md
@@ -3,6 +3,8 @@ tags:
   - AGTS 2019
   - AGTS
   - GTS
+outdated_translation: true
+outdated_since: 5a3ebc439c3cf6450c7d2dad187b03200ece9275
 ---
 
 # Advanced Global Taiko Showdown 2019

--- a/wiki/Tournaments/GTS/AGTS_2019/fr.md
+++ b/wiki/Tournaments/GTS/AGTS_2019/fr.md
@@ -3,8 +3,6 @@ tags:
   - AGTS 2019
   - AGTS
   - GTS
-outdated_translation: true
-outdated_since: 5a3ebc439c3cf6450c7d2dad187b03200ece9275
 ---
 
 # Advanced Global Taiko Showdown 2019
@@ -432,7 +430,7 @@ Dimanche 18 août 2019 :
 
 ### Règlement des matchs
 
-1. Il y a sept (7) étapes dans ce tournoi: les Qualifications, la Phase de Groupes, les, les Quarts de finale, les Demi-finales, les Finales et la/les Grande(s) Finale(s).
+1. Il y a six (6) étapes dans ce tournoi: les Qualifications, la Phase de Groupes, les Quarts de finale, les Demi-finales, les Finales et la/les Grande(s) Finale(s).
 2. Les équipes seront réparties dans des "seeds", en fonction de leurs résultats lors de la phase de Qualifications.
 3. Dans le cas où plus de trente-deux (32) équipes sont inscrites au tournoi, seules les trente-deux (32) meilleures équipes accèderont à la Phase de Groupes.
 4. Les équipes seront réparties en huit **(6) groupes de quatre (4) équipes** chacun durant une diffusion en direct du tirage, qui se déroulera le Dimanche 11 Aoüt.


### PR DESCRIPTION
The schedule doesn't mention a Round of 16. So, to resolve misunderstandings, I propose to remove mentions of RO16 in the rules. See [this discussion on Discord](https://discord.com/channels/188630481301012481/218677502141399041/1052214350884110346).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
