### PR TITLE
Bump `osu-wiki-tools` to version `1.1.1`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==1.1.0
+osu-wiki-tools==1.1.1


### PR DESCRIPTION
fixes `no_native_review` not being in the yaml tag allow list as [reported on discord](https://discord.com/channels/188630481301012481/218677502141399041/1061526007368130570)

view the change at https://github.com/Walavouchey/osu-wiki-tools/commit/d64de29cccee48b1cd94f8b9021bf74acf666b4e