### PR TITLE
Fetch PR information for the outdated articles check using OAuth token provided by GitHub

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,7 +107,11 @@ jobs:
           MAX_ATTEMPTS=3
           for (( i=1; i<=MAX_ATTEMPTS; i++ )); do
             # get the first commit of the branch associated with the PR; GitHub's ubuntu-latest has curl/jq: https://github.com/actions/virtual-environments
-            API_RESPONSE=$( curl -v ${{ github.event.pull_request.commits_url }}?per_page=1 )
+            API_RESPONSE=$(
+              curl -v \
+                --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+                ${{ github.event.pull_request.commits_url }}?per_page=1
+            )
             if [[ 'array' != $( echo "${API_RESPONSE}" | jq -r 'type' ) ]]; then
               echo "::warning::Unexpected GitHub API response (attempt ${i}/${MAX_ATTEMPTS}): ${API_RESPONSE}"
             else


### PR DESCRIPTION
fixes https://github.com/ppy/osu-wiki/issues/8553 by bumping rate limit from 60 to 1000 requests per hour:

- https://github.com/ppy/osu-wiki/actions/runs/3862600763/jobs/6584270309
	```
	< x-ratelimit-limit: 60
	< x-ratelimit-remaining: 0
	```
- https://github.com/TicClick/osu-wiki/actions/runs/3865895377/jobs/6589671300
	```
	< x-ratelimit-limit: 1000
	< x-ratelimit-remaining: 999
	```

`secrets.GITHUB_TOKEN` is the same as `github.token` supplied by GitHub automatically to the action run, which is temporary and only has read permissions for pull requests from forks: https://docs.github.com/en/actions/security-guides/automatic-token-authentication

auth instructions are from https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#oauth2-token-sent-in-a-header