### PR TITLE
Allow for bot-assisted refereeing on officially supported tournaments 

### DIFF
--- a/wiki/Tournaments/Official_support/de.md
+++ b/wiki/Tournaments/Official_support/de.md
@@ -4,6 +4,8 @@ tags:
   - badges
   - badged
   - Abzeichen
+outdated_translation: true
+outdated_since: 
 ---
 
 # Offizielle Turnierunterstützung

--- a/wiki/Tournaments/Official_support/de.md
+++ b/wiki/Tournaments/Official_support/de.md
@@ -5,7 +5,7 @@ tags:
   - badged
   - Abzeichen
 outdated_translation: true
-outdated_since: 
+outdated_since: 87e666b9ddf53bdfb7dfdbfe70f2589824f96d37
 ---
 
 # Offizielle Turnierunterstützung

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -70,6 +70,7 @@ In addition, all promotional material or any services associated with a tourname
 - If a user satisfies the sign-up criteria (if any), the tournament must not prevent those who pass the screening from participating without both ample evidence presented publicly against them and the approval of the account support team.
   - This includes preventing users who are perceived to be "sandbagging" from play. Should an organiser have valid concerns about the presence of such players affecting the competitive integrity of their tournament, they may raise the issue to the [Tournament Committee](/wiki/People/Tournament_Committee) for a case-by-case review using the [tournament reports form](https://pif.ephemeral.ink/tournament-reports).
 - A dedicated referee must be present during every match. Players cannot "self-ref".
+  - The use of bots is allowed on qualifier stage matches, provided that it is supervised by a staff member.
 - All multiplayer matches relevant to the tournament must be created with the `!mp make` command, so that they do not expire. The results must be recorded and made publicly available on the original tournament forum post in a clear and accessible format.
 
 Once the tournament has concluded, the tournament organisers will need to submit the following to the account support team:

--- a/wiki/Tournaments/Official_support/fr.md
+++ b/wiki/Tournaments/Official_support/fr.md
@@ -3,6 +3,8 @@ tags:
   - badge
   - badges
   - badged
+outdated_translation: true
+outdated_since: 
 ---
 
 # Support officiel aux tournois

--- a/wiki/Tournaments/Official_support/fr.md
+++ b/wiki/Tournaments/Official_support/fr.md
@@ -4,7 +4,7 @@ tags:
   - badges
   - badged
 outdated_translation: true
-outdated_since: 
+outdated_since: 87e666b9ddf53bdfb7dfdbfe70f2589824f96d37
 ---
 
 # Support officiel aux tournois

--- a/wiki/Tournaments/Official_support/zh.md
+++ b/wiki/Tournaments/Official_support/zh.md
@@ -10,7 +10,7 @@ tags:
   - 比赛
   - 锦标赛
 outdated_translation: true
-outdated_since: 
+outdated_since: 87e666b9ddf53bdfb7dfdbfe70f2589824f96d37
 ---
 
 # 官方锦标赛支持

--- a/wiki/Tournaments/Official_support/zh.md
+++ b/wiki/Tournaments/Official_support/zh.md
@@ -9,6 +9,8 @@ tags:
   - 申牌
   - 比赛
   - 锦标赛
+outdated_translation: true
+outdated_since: 
 ---
 
 # 官方锦标赛支持


### PR DESCRIPTION
The tournament committee consensus reached was to allow such bots *only* on qualifier matches, and with human supervision.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)