### PR TITLE
Update `MWC 7K 2023`

### DIFF
--- a/wiki/Tournaments/MWC/2023_7K/en.md
+++ b/wiki/Tournaments/MWC/2023_7K/en.md
@@ -58,8 +58,6 @@ The osu!mania 7K World Cup 2023 is run by the osu! team and various community me
 
 ## Participants
 
-The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/c9e572884f0e731ba47fed1c11be3b88#file-mwc7k-2023-player-list-csv). 
-
 |  | Country | Members |
 | :-: | :-: | :-- |
 | ::{ flag=AR }:: | **Argentina** | **[lxLucasxl](https://osu.ppy.sh/users/3632846)**, [LeongKat](https://osu.ppy.sh/users/11429144), [Greedom](https://osu.ppy.sh/users/10696707), [ottenst](https://osu.ppy.sh/users/13488325) |
@@ -99,6 +97,8 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/c9e
 | ::{ flag=US }:: | **United States** | **[Terni](https://osu.ppy.sh/users/3279570)**, [-Squishy](https://osu.ppy.sh/users/4372604), [stupud man](https://osu.ppy.sh/users/2141612), [Alter-](https://osu.ppy.sh/users/4980256) |
 | ::{ flag=VE }:: | **Venezuela** | **[Adogg145](https://osu.ppy.sh/users/11956607)**, [sir aelay](https://osu.ppy.sh/users/12055954), [xXShyzDy0133Xx](https://osu.ppy.sh/users/13545528), [JeanfMz](https://osu.ppy.sh/users/25462042) |
 | ::{ flag=VN }:: | **Vietnam** | **[\_Moni\_](https://osu.ppy.sh/users/9710653)**, [\_ShirasuAzusa](https://osu.ppy.sh/users/16297375), [Jasver](https://osu.ppy.sh/users/10673080), [Seiren Shikino](https://osu.ppy.sh/users/8291500) |
+
+The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/c9e572884f0e731ba47fed1c11be3b88#file-mwc7k-2023-player-list-csv). 
 
 ## Match schedule: Round of 16
 


### PR DESCRIPTION
Moves the "complete sign-up list" link to below the player list header as it was causing issues with reading the player list table for one of the applications we rely on

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)