### PR TITLE
[JA/others] Remove outdated marker and add missing tags in `Gameplay/Grade`

### DIFF
--- a/wiki/Gameplay/Grade/de.md
+++ b/wiki/Gameplay/Grade/de.md
@@ -3,10 +3,13 @@ tags:
   - letter grade
   - rank
   - silver s
+  - silver ss
   - sh
   - xh
   - Rang
   - Benotung
+  - Silber S
+  - Silber SS
 ---
 
 # Note

--- a/wiki/Gameplay/Grade/en.md
+++ b/wiki/Gameplay/Grade/en.md
@@ -3,6 +3,7 @@ tags:
   - letter grade
   - rank
   - silver s
+  - silver ss
   - sh
   - xh
 ---

--- a/wiki/Gameplay/Grade/fr.md
+++ b/wiki/Gameplay/Grade/fr.md
@@ -3,11 +3,15 @@ tags:
   - letter grade
   - rank
   - silver s
+  - silver ss
   - sh
   - xh
   - lettre
   - classement
   - s argenté
+  - ss argenté
+  - s d'argent
+  - ss d'argent
   - notes
 ---
 

--- a/wiki/Gameplay/Grade/ja.md
+++ b/wiki/Gameplay/Grade/ja.md
@@ -3,9 +3,12 @@ tags:
   - letter grade
   - rank
   - silver s
+  - silver ss
   - sh
   - xh
   - ランク
+  - シルバーS
+  - シルバーSS
 ---
 
 # グレード

--- a/wiki/Gameplay/Grade/ja.md
+++ b/wiki/Gameplay/Grade/ja.md
@@ -1,6 +1,10 @@
 ---
-outdated_translation: true
 tags:
+  - letter grade
+  - rank
+  - silver s
+  - sh
+  - xh
   - ランク
 ---
 

--- a/wiki/Gameplay/Grade/zh-tw.md
+++ b/wiki/Gameplay/Grade/zh-tw.md
@@ -6,6 +6,8 @@ tags:
   - sh
   - xh
   - 評價
+  - 銀 s
+  - 銀 ss
 no_native_review: true
 ---
 


### PR DESCRIPTION
japanese no longer outdated as per https://github.com/ppy/osu-wiki/pull/8644

added some other tags while at it (copy-pasting from the text) where applicable

SKIP_OUTDATED_CHECK