### PR TITLE
Fix typo in `Ranking Criteria/Difficulty naming`

### DIFF
--- a/wiki/Ranking_Criteria/Difficulty_naming/en.md
+++ b/wiki/Ranking_Criteria/Difficulty_naming/en.md
@@ -194,7 +194,7 @@ The following difficulty names are common alternatives and additions to the defa
 - ![](/wiki/shared/diff/easy-t.png?20211215) Shokyuu: in a default Kantan-Futsuu-Muzukashii-Oni-Inner Oni spread, it refers to the lowest level of difficulty that's below Kantan.
 - ![](/wiki/shared/diff/normal-o.png?20211215) Advanced: in a default Easy-Normal-Hard-Insane-Expert spread, it's a difficulty between Normal and Hard.
 - ![](/wiki/shared/diff/hard-o.png?20211215) Hyper: in a default Easy-Normal-Hard-Insane-Expert spread, a difficulty between Hard and Insane.
-- ![](/wiki/shared/diff/expert-o.png?20211215) Extra: it can used as a substitute for Expert.
+- ![](/wiki/shared/diff/expert-o.png?20211215) Extra: it can be used as a substitute for Expert.
 - ![](/wiki/shared/diff/expertplus-o.png?20211215) Extreme: it can be used to represent a more difficult Expert.
 - ![](/wiki/shared/diff/expertplus-t.png?20211215) Hell Oni: it can be used to represent a more difficult Inner Oni.
 - ![](/wiki/shared/diff/expertplus-c.png?20211215) Deluge: it can be used to represent a more difficult Overdose.


### PR DESCRIPTION
*(SKIP_OUTDATED_CHECK)*

i was pm'd by [Knhesyy](http://osu.ppy.sh/users/8855680) who noticed this typo just now and asked me whether i can fix it for them (as they don't have a GitHub account)

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
