### PR TITLE
Add clause clarifying `Rules/Explicit Content` only covering unchangeable audio content

### DIFF
--- a/wiki/Rules/Explicit_Content/de.md
+++ b/wiki/Rules/Explicit_Content/de.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 164a0364b14766421dfef73d0ebc37dd0356ba20
+outdated_translation: true
+---
+
 # Expliziter Inhalt
 
 ![Screenshot einer Beatmap, die expliziten Inhalt enthält](img/explicit-tag-DE.jpg "Ein Beispiel einer Beatmap, die mit dem Tag 'explizit' markiert wurde.")

--- a/wiki/Rules/Explicit_Content/en.md
+++ b/wiki/Rules/Explicit_Content/en.md
@@ -8,7 +8,9 @@ Regardless of the nature of the audio, make sure it also complies with the [gene
 
 ## What counts as explicit content?
 
-Explicit content refers primarily to the **audio content of a beatmap**, mostly in theme, subject matter, or *heavy* use of explicit language. It does **not** apply to visual elements of a beatmap — those **must** adhere to the [Visual Content Considerations](/wiki/Rules/Visual_Content_Considerations).
+Explicit content refers primarily to the **audio content of a beatmap**, mostly in theme, subject matter, or *heavy* use of explicit language. It does **not** apply to visual elements of a beatmap — those **must** adhere to the [Visual Content Considerations](/wiki/Rules/Visual_Content_Considerations), or to any other user-alterable aspects of a beatmap (such as tags or beatmap difficulty names) which **must** abide by the [osu! community rules](/wiki/Rules) as normal. 
+
+As a general rule of thumb, the explicit content provision creates exceptions only for content that a user cannot reasonably edit with the tools provided to them by the game, and may also be revoked on a per-track basis at the discretion of the osu! team.
 
 Generally speaking, most forms of music are acceptable to use in beatmaps with very few exceptions, so long as they are marked appropriately.
 
@@ -20,7 +22,7 @@ Profanity use must be sustained, significant, heavily inflammatory, or highly re
 
 In addition, vivid and sustained discussion of controversial topics or anything that a reasonable person would consider as "heavy" should be considered as explicit. Some (but not all) examples are:
 
-- Imagery, impact or consequences of suicide
+- Imagery, impact, or consequences of suicide
 - Heavily implied violence 
 - Depiction/discussion of violent consequences in gory detail
 - Extremely overt sexual references or allusions to sexual acts

--- a/wiki/Rules/Explicit_Content/en.md
+++ b/wiki/Rules/Explicit_Content/en.md
@@ -10,7 +10,7 @@ Regardless of the nature of the audio, make sure it also complies with the [gene
 
 Explicit content refers primarily to the **audio content of a beatmap**, mostly in theme, subject matter, or *heavy* use of explicit language. It does **not** apply to visual elements of a beatmap — those **must** adhere to the [Visual Content Considerations](/wiki/Rules/Visual_Content_Considerations), or to any other user-alterable aspects of a beatmap (such as tags or beatmap difficulty names) which **must** abide by the [osu! community rules](/wiki/Rules) as normal. 
 
-As a general rule of thumb, the explicit content provision creates exceptions only for content that a user cannot reasonably edit with the tools provided to them by the game, and may also be revoked on a per-track basis at the discretion of the osu! team.
+As a general rule of thumb, the explicit content provision creates exceptions only for content that a user cannot reasonably edit with the tools provided to them by the game, and may also be revoked on a per-track basis at the discretion of the [osu! support team](/wiki/People/The_Team/Account_support_team).
 
 Generally speaking, most forms of music are acceptable to use in beatmaps with very few exceptions, so long as they are marked appropriately.
 

--- a/wiki/Rules/Explicit_Content/fr.md
+++ b/wiki/Rules/Explicit_Content/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 164a0364b14766421dfef73d0ebc37dd0356ba20
+outdated_translation: true
+---
+
 # Contenu explicite
 
 ![Capture d'écran d'une beatmap contenant un contenu explicite](img/explicit-tag.jpg "Un exemple de beatmap qui est marqué avec le tag 'explicite'.")

--- a/wiki/Rules/Explicit_Content/id.md
+++ b/wiki/Rules/Explicit_Content/id.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 164a0364b14766421dfef73d0ebc37dd0356ba20
+outdated_translation: true
+---
+
 # Konten eksplisit
 
 ![Tampilan beatmap yang mengandung konten eksplisit](img/explicit-tag.jpg "Contoh beatmap yang ditandai dengan label 'eksplisit'.")

--- a/wiki/Rules/Explicit_Content/ru.md
+++ b/wiki/Rules/Explicit_Content/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 164a0364b14766421dfef73d0ebc37dd0356ba20
+outdated_translation: true
+---
+
 # Откровенное содержание
 
 ![](img/explicit-tag.jpg "Пример карты с пометкой «Откровенное содержание».")


### PR DESCRIPTION
This should hopefully clear up some existing readings of the explicit content tag being a catch-all exception to do whatever with a map's contents (such as diffnames, as exemplified in [this recent beatmap discussion](https://osu.ppy.sh/beatmapsets/802260/discussion/-/generalAll#/3542059/9522925)). The reasoning outlined in this addition is not new and refers to existing protocol/intent.