### PR TITLE
Bump osu-wiki-tools to version `1.1.2`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==1.1.1
+osu-wiki-tools==1.1.2


### PR DESCRIPTION
Compare the changes at: https://github.com/Walavouchey/osu-wiki-tools/compare/v1.1.1...v1.1.2

Changes:

- Prevent overwriting content when saving front matter (e.g. HTML in `Main_Page`, when automatically outdating using `osu-wiki-tools check-outdated-articles --auto-commit`, [demo commit](https://github.com/Walavouchey/osu-wiki/pull/30/commits/6c9d526390a1677575b3326427cad0b0c8142845))
- Suppress missing #identifier errors for links to non-existent translations or section links to outdated translations (we always skip these anyway since there's nothing to be done about them without creating or updating the translation linked to)
  - 99 errors down to 59 on `master` at the time I checked with `--all` (202 with `--all --outdated`)
- Fix a case of multi-line coloured text not displaying properly on GitHub action logs
  | [Before](https://github.com/ppy/osu-wiki/actions/runs/4078123196/jobs/7027955727) | [After](https://github.com/Walavouchey/osu-wiki/actions/runs/4097977238/jobs/7066747902) |
  | :-: | :-: |
  | ![image](https://user-images.githubusercontent.com/36758269/216838902-5c693795-0c3f-42af-af7a-7780b163c0bc.png) | ![image](https://user-images.githubusercontent.com/36758269/216838914-e1a836b1-c7ac-4592-ab53-60e618a0c9b8.png) |