### PR TITLE
Bump osu-wiki-tools to version `1.1.3`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==1.1.2
+osu-wiki-tools==1.1.3


### PR DESCRIPTION
View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v1.1.2...v1.1.3

This fixes news posts getting skipped by the link checker.

Presumably regressed in https://github.com/ppy/osu-wiki/commit/19e619c2751ba4070c8393b27ffe28881642ce3f. Will follow up with fixes to affected news posts if any.

