### PR TITLE
Update `osu! originals` with `MWC7K 2023` Grand Finals originals

### DIFF
--- a/wiki/osu!_originals/en.md
+++ b/wiki/osu!_originals/en.md
@@ -210,7 +210,9 @@ These songs were later [announced](https://osu.ppy.sh/home/news/2023-02-01-twin-
 | Song | Beatmap | Notes |
 | :-: | :-: | :-- |
 | [Hino Isuka vs. s-don - Glooorious!!](https://www.youtube.com/watch?v=qvf4Wm5t0wM)[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935691) | Finals HB3 |
+| katagiri - Kyuukou[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939261) | Grand Finals tiebreaker |
 | LV.4 feat. Yuu Ikeba - Sentimental Surge[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935688) | Finals RC6 |
+| SAMString - Ataraxia[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939418) | Grand Finals LN3 |
 | Toromaru - Uncharted Sky[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1931471) | Semifinals RC6 |
 
 ### Community-run tournament releases

--- a/wiki/osu!_originals/es.md
+++ b/wiki/osu!_originals/es.md
@@ -214,7 +214,9 @@ Estas canciones son parte de [osu! James Landino Collection EP](https://fanlink.
 | Canción | Beatmap | Notas |
 | :-: | :-: | :-- |
 | [Hino Isuka vs. s-don - Glooorious!!](https://www.youtube.com/watch?v=qvf4Wm5t0wM)[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935691) | Finales HB3 |
+| katagiri - Kyuukou[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939261) | Desempate de la gran final |
 | LV.4 feat. Yuu Ikeba - Sentimental Surge[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935688) | Finales RC6 |
+| SAMString - Ataraxia[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939418) | Gran final LN3 |
 | Toromaru - Uncharted Sky[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1931471) | Semifinales RC6 |
 
 ### Lanzamientos de torneos administrados por la comunidad

--- a/wiki/osu!_originals/fr.md
+++ b/wiki/osu!_originals/fr.md
@@ -214,7 +214,9 @@ Ces chansons font partie du [osu! James Landino Collection EP](https://fanlink.t
 | Musique | Beatmap | Notes |
 | :-: | :-: | :-- |
 | [Hino Isuka vs. s-don - Glooorious!!](https://www.youtube.com/watch?v=qvf4Wm5t0wM)[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935691) | HB3 des finales |
+| katagiri - Kyuukou[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939261) | Tiebreaker des Grandes Finales |
 | LV.4 feat. Yuu Ikeba - Sentimental Surge[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1935688) | RC6 des finales |
+| SAMString - Ataraxia[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1939418) | LN3 des Grandes Finales |
 | Toromaru - Uncharted Sky[^fa] | [#1](https://osu.ppy.sh/beatmapsets/1931471) | RC6 des demi-finales |
 
 ### Sorties des tournois gérés par la communauté


### PR DESCRIPTION
Adds katagiri - Kyuukou and SAMString - Ataraxia, both new releases by existing featured artists. The translations use existing entries on the articles as reference.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
