### PR TITLE
Fix broken identifiers in news posts

### DIFF
--- a/news/2020/2020-02-28-mappers-report-february.md
+++ b/news/2020/2020-02-28-mappers-report-february.md
@@ -137,7 +137,7 @@ For the avid fruit catchers of the world, the **6th osu! Mapping Olympiad** has 
 
 The fantastic Chinese community organized tournament **Newspaper Cup** has made its yearly appearance and has now begun! This will be the contest's 6th yearly installment, making it one of the longest standing community organized mapping contests. All of the relevant information can be found [in this forum post](https://osu.ppy.sh/community/forums/topics/1023671) in both Chinese and English. You have until **March 15th** to submit your entries for one or more of the 4 available songs. Good luck to those planning on entering their creations into the contest!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-04-11-mappers-report-march.md
+++ b/news/2020/2020-04-11-mappers-report-march.md
@@ -143,7 +143,7 @@ Starting up 2 months ago, there’s been a new podcast series hosted by [Cinnabu
 
 Previously announced in [another news post](https://osu.ppy.sh/home/news/2020-03-23-community-mentorship-program-spring-2020-signups-now-open), the Spring 2020 round of Community Mentorship is coming soon! Hosted regularly throughout the year, the mentorship program helps to nurture newer mappers in the community by pairing them up with Mentors. The applications to become a Mentor are already closed, but the Mentee applications will be opening on **April 19th**, so give applying a try if you’re passionate and interested in learning more about mapping!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-05-11-mappers-report-april.md
+++ b/news/2020/2020-05-11-mappers-report-april.md
@@ -178,7 +178,7 @@ Making waves in the modding community recently is the freshly published modding 
 
 Yes, you heard that right. Until recently, extremely long maps could not be ranked due to breaking the score limit, since the scoreboards wouldn't reflect everyone's plays properly anyways. Now the developers have changed it so that super long maps which break the score limit even without mods will have score v2 force enabled. In such cases, these score v2 scores will be submittable, finally allowing super long maps to have proper leaderboards. This means we'll be seeing extremely long maps ranked in the future, which is a really exciting improvement!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-07-02-mappers-report-may-june.md
+++ b/news/2020/2020-07-02-mappers-report-may-june.md
@@ -236,7 +236,7 @@ If you'd like to help out by reviewing articles, writing them, or translating th
 
 The world needs you!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-08-09-mappers-report-july.md
+++ b/news/2020/2020-08-09-mappers-report-july.md
@@ -171,7 +171,7 @@ The mapping phase of the Big Fans mapping contest just ended on the 25th and the
 
 Are there any other mapping contests going on, or being announced soon? Please let us know! We would love to give it more attention to the public. Doesn't matter if it's mode or language specific. Head over to the [forum post](https://osu.ppy.sh/community/forums/topics/1027590) where you can find the submission form!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-09-08-mappers-report-august.md
+++ b/news/2020/2020-09-08-mappers-report-august.md
@@ -182,7 +182,7 @@ Have we got your interest? Or do you have more questions regarding the project? 
 
 Mentioned previously in the Mappers' Report, the **osu! Map Cast** has recently concluded its first season with a whopping **23 episodes in total**. This podcast hosted by [Bailie](https://osu.ppy.sh/users/11868659) (previously known as Cinnabun) features conversations with a wide variety of figures in the mapping and modding community, such as mappers both old and new, BNs, NAT, and recently even Ephemeral! The podcast series cover a huge variety of topics, both within and outside of osu! mapping- there's even an episode about Beat Saber in there! If you want to learn more about the osu! community, its members, or just want a chill podcast to listen to in the background, be sure to check out the full episode listing on their [forum post](https://osu.ppy.sh/community/forums/topics/1043221)!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2020/2020-12-31-mappers-report-fall.md
+++ b/news/2020/2020-12-31-mappers-report-fall.md
@@ -237,7 +237,7 @@ Moving away from motivation, time taken, and visuals, we have a [guide all about
 
 Finally, on a bit of a different flavor we have a guide not related to mapping - but modding! The [Modding Mentorship Guide](https://sites.google.com/view/modding-guide/home) written by a long-time mapper and nominator [Cheri](https://osu.ppy.sh/users/5226970) seeks to help give guidance on how to mod and what to look out for from the ground up. This guide covers everything from ranking criteria, to rhythm, to spacing, to low difficulties, and spread. It covers quite a lot! In-depth modding guides of this kind are a bit rarer and left to people often learning on their own, so having a fully fleshed out guide like this will definitely be really helpful to aspiring and semi-experienced modders alike.
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2021/2021-02-01-mappers-report-january.md
+++ b/news/2021/2021-02-01-mappers-report-january.md
@@ -128,7 +128,7 @@ However, there is one important thing to mention. Having this feature enabled on
 
 If you are unsure about whether or not the content you want to include in your beatmap line up with the rules, feel free to submit a content case on the [Beatmap Nominator website](https://bn.mappersguild.com/discussionvote).
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2021/2021-03-05-mappers-report-february.md
+++ b/news/2021/2021-03-05-mappers-report-february.md
@@ -107,7 +107,7 @@ To participate, you will need to join the [Discord server](https://discord.gg/fV
 
 May the best and the fastest mapper win!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2021/2021-04-06-mappers-report-march.md
+++ b/news/2021/2021-04-06-mappers-report-march.md
@@ -164,7 +164,7 @@ Here's a vod of the stream that compiles all aspects of mapping in 9 hours:
 
 <iframe src="https://player.twitch.tv/?video=974267996&parent=osu.ppy.sh&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="100%"></iframe>
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2021/2021-05-13-mappers-report-april.md
+++ b/news/2021/2021-05-13-mappers-report-april.md
@@ -157,7 +157,7 @@ The winning entry hosting the runner-ups' guest difficulties will be speed-carri
 
 If you're an anime fan, don't let this opportunity pass you by! Have a thorough look at this [forum thread](https://osu.ppy.sh/community/forums/topics/1308172) and you're good to go!
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2021/2021-06-20-mappers-report-may.md
+++ b/news/2021/2021-06-20-mappers-report-may.md
@@ -145,7 +145,7 @@ And of course, such a massive project wouldn't have been left without a showcase
 
 <iframe src="https://player.twitch.tv/?video=1051031340&parent=osu.ppy.sh&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="100%"></iframe>
 
-{#conclusion}
+::{#conclusion}::
 
 ---
 

--- a/news/2022/2022-12-08-mappers-choice-awards.md
+++ b/news/2022/2022-12-08-mappers-choice-awards.md
@@ -38,99 +38,99 @@ Before we dive into the results, let's take a peek at the various handsome rewar
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-collab-1.png)](https://osu.ppy.sh/beatmapsets/1357624)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-collab-2.png)](https://osu.ppy.sh/beatmapsets/1633250)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-collab-3.png)](https://osu.ppy.sh/beatmapsets/1388906)
-{#osu!-maps-collab}
+{id=osu!-maps-collab}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-complex-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-complex-1.png)](https://osu.ppy.sh/beatmapsets/1312076)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-complex-2.png)](https://osu.ppy.sh/beatmapsets/1376486)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-complex-3.png)](https://osu.ppy.sh/beatmapsets/1306570)
-{#osu!-maps-complex}
+{id=osu!-maps-complex}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-high-bpm-alternator-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-high-bpm-alternator-1.png)](https://osu.ppy.sh/beatmapsets/1301330)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-high-bpm-alternator-2.png)](https://osu.ppy.sh/beatmapsets/1529362)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-high-bpm-alternator-3.png)](https://osu.ppy.sh/beatmapsets/1382362)
-{#osu!-maps-high-bpm-alternator}
+{id=osu!-maps-high-bpm-alternator}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-hitsounding-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-hitsounding-1.png)](https://osu.ppy.sh/beatmapsets/1333932)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-hitsounding-2.png)](https://osu.ppy.sh/beatmapsets/1633250)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-hitsounding-3.png)](https://osu.ppy.sh/beatmapsets/1579180)
-{#osu!-maps-hitsounding}
+{id=osu!-maps-hitsounding}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-marathon-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-marathon-1.png)](https://osu.ppy.sh/beatmapsets/1610231)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-marathon-2.png)](https://osu.ppy.sh/beatmapsets/1459218)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-marathon-3.png)](https://osu.ppy.sh/beatmapsets/1633250)
-{#osu!-maps-marathon}
+{id=osu!-maps-marathon}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-slider-tech-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-slider-tech-1.png)](https://osu.ppy.sh/beatmapsets/1188437)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-slider-tech-2.png)](https://osu.ppy.sh/beatmapsets/1190470)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-slider-tech-3.png)](https://osu.ppy.sh/beatmapsets/1329045)
-{#osu!-maps-slider-tech}
+{id=osu!-maps-slider-tech}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-small-circles-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-small-circles-1.png)](https://osu.ppy.sh/beatmapsets/1283652)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-small-circles-2.png)](https://osu.ppy.sh/beatmapsets/1251587)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-small-circles-3.png)](https://osu.ppy.sh/beatmapsets/1321964)
-{#osu!-maps-small-circles}
+{id=osu!-maps-small-circles}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-unorthodox-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-unorthodox-1.png)](https://osu.ppy.sh/beatmapsets/1376486)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-unorthodox-2.png)](https://osu.ppy.sh/beatmapsets/1329045)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-unorthodox-3.png)](https://osu.ppy.sh/beatmapsets/1322727)
-{#osu!-maps-unorthodox}
+{id=osu!-maps-unorthodox}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-vanilla-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-vanilla-1.png)](https://osu.ppy.sh/beatmapsets/1301789)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-vanilla-2.png)](https://osu.ppy.sh/beatmapsets/1286287)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-vanilla-3.png)](https://osu.ppy.sh/beatmapsets/1312079)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-vanilla-4.png)](https://osu.ppy.sh/beatmapsets/1348249)
-{#osu!-maps-vanilla}
+{id=osu!-maps-vanilla}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-grand-award-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-grand-award-1.png)](https://osu.ppy.sh/beatmapsets/1188437)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-grand-award-2.png)](https://osu.ppy.sh/beatmapsets/1529362)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-maps-grand-award-3.png)](https://osu.ppy.sh/beatmapsets/1610231)
-{#osu!-maps-grand-award}
+{id=osu!-maps-grand-award}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-hitsounder-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-hitsounder-1.png)](https://osu.ppy.sh/users/8972308)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-hitsounder-2.png)](https://osu.ppy.sh/users/10969875)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-hitsounder-3.png)](https://osu.ppy.sh/users/2495509)
-{#osu!-users-hitsounder}
+{id=osu!-users-hitsounder}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-mapper-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-mapper-1.png)](https://osu.ppy.sh/users/7081160)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-mapper-2.png)](https://osu.ppy.sh/users/4966334)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-mapper-3.png)](https://osu.ppy.sh/users/7777875)
-{#osu!-users-mapper}
+{id=osu!-users-mapper}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-modder-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-modder-1.png)](https://osu.ppy.sh/users/3181083)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-modder-2.png)](https://osu.ppy.sh/users/4323406)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-modder-3.png)](https://osu.ppy.sh/users/896613)
-{#osu!-users-modder}
+{id=osu!-users-modder}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-most-promising-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-most-promising-1.png)](https://osu.ppy.sh/users/10562853)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-most-promising-2.png)](https://osu.ppy.sh/users/12551840)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-most-promising-3.png)](https://osu.ppy.sh/users/12704035)
-{#osu!-users-most-promising}
+{id=osu!-users-most-promising}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-outstanding-contributor-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-outstanding-contributor-1.png)](https://osu.ppy.sh/users/4323406)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-outstanding-contributor-2.png)](https://osu.ppy.sh/users/6573093)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-outstanding-contributor-3.png)](https://osu.ppy.sh/users/3178418)
-{#osu!-users-outstanding-contributor}
+{id=osu!-users-outstanding-contributor}
 
 ![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-grand-award-0.png)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-grand-award-1.png)](https://osu.ppy.sh/users/7777875)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-grand-award-2.png)](https://osu.ppy.sh/users/7081160)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-grand-award-3.png)](https://osu.ppy.sh/users/1231762)\
 [![](/wiki/shared/news/2022-12-08-mappers-choice-awards/osu!-users-grand-award-4.png)](https://osu.ppy.sh/users/4323406)
-{#osu!-users-grand-award}
+{id=osu!-users-grand-award}
 
 ## osu!taiko
 


### PR DESCRIPTION
noticed in https://github.com/ppy/osu-wiki/pull/8816/files#r1110018213

![image](https://user-images.githubusercontent.com/36758269/219729424-a6d5edf7-f3b2-4c21-a22e-3d98acd7939b.png)

some unrelated change has made these broken identifiers visible too (see https://github.com/ppy/osu-web/issues/9874)

`{id=identifier}` is needed for special characters like `!`

> Custom attributes need to be attached to an element; it's `::{#idgoeshere}::` for news and wiki if you want to have an anchor in the middle of nowhere:
> 
> ```
> blabhlah
> 
> ::{#id}::
> 
> blabhlah ::{#anchor-in-the-middle-of-text}:: blah
> ```