### PR TITLE
Fix lazer logo image link in `Release stream/Lazer` and add `Release stream` stub

### DIFF
--- a/wiki/Client/Release_stream/Lazer/en.md
+++ b/wiki/Client/Release_stream/Lazer/en.md
@@ -13,7 +13,7 @@ tags:
 
 ::: Infobox
 
-![](/img/lazer.png "The osu!(lazer) client logo, a stylised version of the osu! cookie")
+![](img/lazer.png "The osu!(lazer) client logo, a stylised version of the osu! cookie")
 
 [Download](https://osu.ppy.sh/home/download) • [Issue tracker](https://github.com/ppy/osu/issues) • [Discussions](https://github.com/ppy/osu/discussions)
 

--- a/wiki/Client/Release_stream/en.md
+++ b/wiki/Client/Release_stream/en.md
@@ -1,0 +1,14 @@
+---
+stub: true
+---
+
+# Release stream
+
+osu! has a few **release streams**, or game client versions, that receive updates at different rates. In order to catch potential issues early, new features and changes are put into preview versions before making their way to the stable client.
+
+| Stream | Notes |
+| :-- | :-- |
+| Stable | Current, most popular version; [feature-locked](https://en.wikipedia.org/wiki/Freeze_(software_engineering)); receives updates after Beta |
+| Beta | Receives updates after Cutting Edge; feature-locked |
+| Cutting Edge | Receives newest updates; feature-locked |
+| [Lazer](Lazer) | Rewritten game client; most active in development |

--- a/wiki/Client/Release_stream/en.md
+++ b/wiki/Client/Release_stream/en.md
@@ -6,7 +6,7 @@ stub: true
 
 osu! has a few **release streams**, or game client versions, that receive updates at different rates. In order to catch potential issues early, new features and changes are put into preview versions before making their way to the stable client.
 
-| Stream | Notes |
+| Release stream | Notes |
 | :-- | :-- |
 | Stable | Current, most popular version; [feature-locked](https://en.wikipedia.org/wiki/Freeze_(software_engineering)); receives updates after Beta |
 | Beta | Receives updates after Cutting Edge; feature-locked |


### PR DESCRIPTION
the broken image link was completely missed by ci, tracking at https://github.com/Walavouchey/osu-wiki-tools/issues/15

i've quickly cobbled together a release stream index page too because of the link to it in https://osu.ppy.sh/wiki/en/Client being broken. this also wasn't caught by ci, tracking at https://github.com/Walavouchey/osu-wiki-tools/issues/14