### PR TITLE
Revert incorrect `outdated_since` commit hash change

### DIFF
--- a/wiki/Ranking_Criteria/ru.md
+++ b/wiki/Ranking_Criteria/ru.md
@@ -1,6 +1,6 @@
 ---
-outdated_since: 2d4959ec9ad9cb438363d7bf8e8220687a899602
 outdated_translation: true
+outdated_since: 097575f6a3dae8c477c302dce2d1c9f76b71bb89
 ---
 
 # Критерии ранкинга


### PR DESCRIPTION
incorrectly changed in 53df4ff29e1681c3f77c16ca035450695bd7ef57 (https://github.com/ppy/osu-wiki/pull/8859)

didn't catch this during review of the above and was about to bundle this into https://github.com/ppy/osu-wiki/pull/8861, but thought it would be better to fix this separately
