### PR TITLE
Expand `Audio Editing`.

### DIFF
--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -8,27 +8,32 @@ This article serves as guide to help you do minor edits to your audio files for 
 
 ## Audacity (and LAME)
 
-[Audacity](https://www.audacityteam.org/download) is a open source free audio editing and recording software. To properly use this for `.mp3`, you will need to use LAME.
+[Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the LAME encoding library to be able to export audio in the MP3 audio format.
 
-[LAME](https://lame.sourceforge.io) is an `.mp3` encoding library that will allow Audacity to export sound files in the `.mp3` format whilst using different bit rates. To install LAME on Audacity, refer to the [Audacity wiki](https://manual.audacityteam.org/man/faq_installing_the_lame_mp3_encoder.html).
+Since 2017, after the last few patents on the MP3 audio format had expired, the LAME encoding library started to be included in later versions of Audacity on Windows and macOS, thus manual installation is no longer necessary.
+
+Linux users should refer to the following article on the [Audacity Reference Manual](https://manual.audacityteam.org/man/installing_and_updating_audacity_on_linux.html#linlame) for more information, as certain Linux distributions may still not provide LAME when installing Audacity but most do provide it.
 
 ### Lowering Bit Rate
 
-Install Audacity and LAME, open Audacity then follow these steps:
+*For information on compression in general, see: [Compressing files](/wiki/Guides/Compressing_files)*
+
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to lower the bit rate on.
-2. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-3. Change "Save as type:" to `MP3 Files`
-4. In the "Format Options", click on `Average` as the bit rate mode.
+2. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+3. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
 5. Navigate to the location you want to save the file as.
    - You could rename the file too.
-6. Click `Save`.
+6. Click `Save` and a dialog will appear to enter metadata.
+7. Click `OK` once done entering metadata.
 
 ### Looping
 
-Install Audacity and LAME, open Audacity then follow these steps:
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to loop.
 2. Click and drag to highlight the parts you want to loop.
@@ -44,18 +49,19 @@ Install Audacity and LAME, open Audacity then follow these steps:
    2. Click `Paste`
 6. Play through the entire music and make sure that the loop sounds good.
 7. Repeat as needed.
-8. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-9. Change "Save as type:" to `MP3 Files`
-10. In the "Format Options", click on `Average` as the bit rate mode.
-11. Navigate to the location you want to save the file as.
+8. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+9. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
+10. Navigate to the location you want to save the file as.
     - You could rename the file too.
-12. Click `Save`.
+11. Click `Save` and a dialog will appear to enter metadata.
+12. Click `OK` once done entering metadata.
 
 ### Cropping
 
-Install Audacity and LAME, open Audacity then follow these steps:
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to crop.
 2. Click and drag to highlight the parts you want to crop.
@@ -64,14 +70,15 @@ Install Audacity and LAME, open Audacity then follow these steps:
 4. Click and drag the last 3 to 5 seconds towards the end.
 5. Click `Effect`.
 6. Click `Fade Out`.
-7. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-8. Change "Save as type:" to `MP3 Files`
-9. In the "Format Options", click on `Average` as the bit rate mode.
-10. Navigate to the location you want to save the file as.
-    - You could rename the file too.
-11. Click `Save`.
+7. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+8. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
+9. Navigate to the location you want to save the file as.
+   - You could rename the file too.
+10. Click `Save` and a dialog will appear to enter metadata.
+11. Click `OK` once done entering metadata.
 
 ## mp3DirectCut
 

--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -26,10 +26,10 @@ Install and open Audacity then follow these steps:
 3. In the "Format Options", change the following settings: 
    1. `Preset` as the bit rate mode
    2. `Medium, 145-185 kbps` as the quality.
-5. Navigate to the location you want to save the file as.
+4. Navigate to the location you want to save the file as.
    - You could rename the file too.
-6. Click `Save` and a dialog will appear to enter metadata.
-7. Click `OK` once done entering metadata.
+5. Click `Save` and a dialog will appear to enter metadata.
+6. Click `OK` once done entering metadata.
 
 ### Looping
 


### PR DESCRIPTION
The LAME MP3 library has since been included in Audacity on Windows and macOS after the last few patents covering the MP3 audio format had expired in 2017, thus manual installation is no longer necessary with the exception for select Linux users (but most Linux distributions should already provide LAME by now). The Audacity Reference Manual also mentions this fact about LAME in one of their FAQs.

Also changes have been made to skip the installation of LAME (since it's now built into Audacity), mention the "Compressing files" guide for further information on compression in relation to beatmapping, and match specific encoding parameters to said guide.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)