### PR TITLE
Expand `Audio Editing`

### DIFF
--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -8,9 +8,7 @@ This article serves as guide to help you do minor edits to your audio files for 
 
 ## Audacity
 
-[Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the [LAME](https://lame.sourceforge.io) encoding library to be able to export audio in the MP3 audio format.
-
-Since 2017, after the last few patents on the MP3 audio format had expired, the LAME encoding library started to be included in later versions of Audacity on Windows and macOS, thus manual installation is no longer necessary.
+[Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the [LAME](https://lame.sourceforge.io) encoding library to be able to export audio in the MP3 audio format and is built into Audacity on Windows and macOS.
 
 Linux users should refer to the following article on the [Audacity Reference Manual](https://manual.audacityteam.org/man/installing_and_updating_audacity_on_linux.html#linlame) for more information, as certain Linux distributions may still not provide LAME when installing Audacity but most do provide it.
 
@@ -21,9 +19,9 @@ Linux users should refer to the following article on the [Audacity Reference Man
 Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to lower the bit rate on.
-2. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+2. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
    1. Click `File`, then `Export` and `Export as MP3`.
-3. In the "Format Options", change the following settings: 
+3. In the `Format Options`, change the following settings: 
    1. `Preset` as the bit rate mode
    2. `Medium, 145-185 kbps` as the quality.
 4. Navigate to the location you want to save the file as.
@@ -49,9 +47,9 @@ Install and open Audacity then follow these steps:
    2. Click `Paste`
 6. Play through the entire music and make sure that the loop sounds good.
 7. Repeat as needed.
-8. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+8. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
    1. Click `File`, then `Export` and `Export as MP3`.
-9. In the "Format Options", change the following settings: 
+9. In the `Format Options`, change the following settings: 
    1. `Preset` as the bit rate mode
    2. `Medium, 145-185 kbps` as the quality.
 10. Navigate to the location you want to save the file as.
@@ -70,9 +68,9 @@ Install and open Audacity, then follow these steps:
 4. Click and drag the last 3 to 5 seconds towards the end.
 5. Click `Effect`.
 6. Click `Fade Out`.
-7. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+7. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
    1. Click `File`, then `Export` and `Export as MP3`.
-8. In the "Format Options", change the following settings: 
+8. In the `Format Options`, change the following settings: 
    1. `Preset` as the bit rate mode
    2. `Medium, 145-185 kbps` as the quality.
 9. Navigate to the location you want to save the file as.

--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -10,20 +10,20 @@ This article serves as guide to help you do minor edits to your audio files for 
 
 [Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the [LAME](https://lame.sourceforge.io) encoding library to be able to export audio in the MP3 audio format and is built into Audacity on Windows and macOS.
 
-Linux users should refer to the following article on the [Audacity Reference Manual](https://manual.audacityteam.org/man/installing_and_updating_audacity_on_linux.html#linlame) for more information, as certain Linux distributions may still not provide LAME when installing Audacity but most do provide it.
+Linux users should refer to the [Audacity Reference Manual](https://manual.audacityteam.org/man/installing_and_updating_audacity_on_linux.html#linlame) for more information, as certain Linux distributions may not provide LAME when installing Audacity, but most do provide it.
 
 ### Lowering Bit Rate
 
 *For information on compression in general, see: [Compressing files](/wiki/Guides/Compressing_files)*
 
-Install and open Audacity then follow these steps:
+Install and open Audacity, then follow these steps:
 
 1. Open the `.mp3` file that you want to lower the bit rate on.
-2. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
-   1. Click `File`, then `Export` and `Export as MP3`.
+2. Press `Ctrl` + `Shift` + `E`, then in `Save as type:` select `MP3 Files`, or:
+   1. Click `File`, then `Export`, then `Export as MP3`.
 3. In the `Format Options`, change the following settings: 
-   1. `Preset` as the bit rate mode
-   2. `Medium, 145-185 kbps` as the quality.
+   1. `Bit Rate Mode`: `Preset`
+   2. `Quality`: `Medium, 145-185 kbps`
 4. Navigate to the location you want to save the file as.
    - You could rename the file too.
 5. Click `Save` and a dialog will appear to enter metadata.
@@ -47,11 +47,11 @@ Install and open Audacity then follow these steps:
    2. Click `Paste`
 6. Play through the entire music and make sure that the loop sounds good.
 7. Repeat as needed.
-8. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
-   1. Click `File`, then `Export` and `Export as MP3`.
+8. Press `Ctrl` + `Shift` + `E`, then in `Save as type:` select `MP3 Files`, or:
+   1. Click `File`, then `Export`, then `Export as MP3`.
 9. In the `Format Options`, change the following settings: 
-   1. `Preset` as the bit rate mode
-   2. `Medium, 145-185 kbps` as the quality.
+   1. `Bit Rate Mode`: `Preset`
+   2. `Quality`: `Medium, 145-185 kbps`
 10. Navigate to the location you want to save the file as.
     - You could rename the file too.
 11. Click `Save` and a dialog will appear to enter metadata.
@@ -68,11 +68,11 @@ Install and open Audacity, then follow these steps:
 4. Click and drag the last 3 to 5 seconds towards the end.
 5. Click `Effect`.
 6. Click `Fade Out`.
-7. Press `Ctrl` + `Shift` + `E`, then change `Save as type:` to `MP3 Files` or:
-   1. Click `File`, then `Export` and `Export as MP3`.
+7. Press `Ctrl` + `Shift` + `E`, then in `Save as type:` select `MP3 Files`, or:
+   1. Click `File`, then `Export`, then `Export as MP3`.
 8. In the `Format Options`, change the following settings: 
-   1. `Preset` as the bit rate mode
-   2. `Medium, 145-185 kbps` as the quality.
+   1. `Bit Rate Mode`: `Preset`
+   2. `Quality`: `Medium, 145-185 kbps`
 9. Navigate to the location you want to save the file as.
    - You could rename the file too.
 10. Click `Save` and a dialog will appear to enter metadata.
@@ -80,7 +80,7 @@ Install and open Audacity, then follow these steps:
 
 ## mp3DirectCut
 
-[mp3DirectCut](https://mpesch3.de) is a free-to-use audio editing software that can directly edit MP3 files without re-encoding which could result in less quality loss. It is recommended when needing to raise/lower the volume or crop the audio.
+[mp3DirectCut](https://mpesch3.de) is a free-to-use audio editing software that can directly edit MP3 files without re-encoding, often preventing loss of quality. It is recommended when needing to raise/lower the volume or crop the audio.
 
 ### Looping
 

--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -8,27 +8,32 @@ This article serves as guide to help you do minor edits to your audio files for 
 
 ## Audacity (and LAME)
 
-[Audacity](https://www.audacityteam.org/download) is a open source free audio editing and recording software. To properly use this for `.mp3`, you will need to use LAME.
+[Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the [LAME](https://lame.sourceforge.io) encoding library to be able to export audio in the MP3 audio format.
 
-[LAME](https://lame.sourceforge.io) is an `.mp3` encoding library that will allow Audacity to export sound files in the `.mp3` format whilst using different bit rates. To install LAME on Audacity, refer to the [Audacity wiki](https://manual.audacityteam.org/man/faq_installing_the_lame_mp3_encoder.html).
+Since 2017, after the last few patents on the MP3 audio format had expired, the LAME encoding library started to be included in later versions of Audacity on Windows and macOS, thus manual installation is no longer necessary.
+
+Linux users should refer to the following article on the [Audacity Reference Manual](https://manual.audacityteam.org/man/installing_and_updating_audacity_on_linux.html#linlame) for more information, as certain Linux distributions may still not provide LAME when installing Audacity but most do provide it.
 
 ### Lowering Bit Rate
 
-Install Audacity and LAME, open Audacity then follow these steps:
+*For information on compression in general, see: [Compressing files](/wiki/Guides/Compressing_files)*
+
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to lower the bit rate on.
-2. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-3. Change "Save as type:" to `MP3 Files`
-4. In the "Format Options", click on `Average` as the bit rate mode.
-5. Navigate to the location you want to save the file as.
+2. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+3. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
+4. Navigate to the location you want to save the file as.
    - You could rename the file too.
-6. Click `Save`.
+5. Click `Save` and a dialog will appear to enter metadata.
+6. Click `OK` once done entering metadata.
 
 ### Looping
 
-Install Audacity and LAME, open Audacity then follow these steps:
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to loop.
 2. Click and drag to highlight the parts you want to loop.
@@ -44,18 +49,19 @@ Install Audacity and LAME, open Audacity then follow these steps:
    2. Click `Paste`
 6. Play through the entire music and make sure that the loop sounds good.
 7. Repeat as needed.
-8. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-9. Change "Save as type:" to `MP3 Files`
-10. In the "Format Options", click on `Average` as the bit rate mode.
-11. Navigate to the location you want to save the file as.
+8. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+9. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
+10. Navigate to the location you want to save the file as.
     - You could rename the file too.
-12. Click `Save`.
+11. Click `Save` and a dialog will appear to enter metadata.
+12. Click `OK` once done entering metadata.
 
 ### Cropping
 
-Install Audacity and LAME, open Audacity then follow these steps:
+Install and open Audacity then follow these steps:
 
 1. Open the `.mp3` file that you want to crop.
 2. Click and drag to highlight the parts you want to crop.
@@ -64,19 +70,19 @@ Install Audacity and LAME, open Audacity then follow these steps:
 4. Click and drag the last 3 to 5 seconds towards the end.
 5. Click `Effect`.
 6. Click `Fade Out`.
-7. Press `Ctrl` + `Shift` + `E`, or
-   1. Click `File`.
-   2. Click `Export Audio...`.
-8. Change "Save as type:" to `MP3 Files`
-9. In the "Format Options", click on `Average` as the bit rate mode.
-10. Navigate to the location you want to save the file as.
-    - You could rename the file too.
-11. Click `Save`.
+7. Press `Ctrl` + `Shift` + `E`, then change "Save as type:" to `MP3 Files` or:
+   1. Click `File`, then `Export` and `Export as MP3`.
+8. In the "Format Options", change the following settings: 
+   1. `Preset` as the bit rate mode
+   2. `Medium, 145-185 kbps` as the quality.
+9. Navigate to the location you want to save the file as.
+   - You could rename the file too.
+10. Click `Save` and a dialog will appear to enter metadata.
+11. Click `OK` once done entering metadata.
 
 ## mp3DirectCut
 
-[mp3DirectCut](https://mpesch3.de) is a free to use audio editing software.
-This tool is recommended when you only want to raise/lower the volume or crop the audio as it doesn't require you to re-encode the audio, meaning less quality loss.
+[mp3DirectCut](https://mpesch3.de) is a free-to-use audio editing software that can directly edit MP3 files without re-encoding which could result in less quality loss. It is recommended when needing to raise/lower the volume or crop the audio.
 
 ### Looping
 

--- a/wiki/Guides/Audio_Editing/en.md
+++ b/wiki/Guides/Audio_Editing/en.md
@@ -6,7 +6,7 @@ This article serves as guide to help you do minor edits to your audio files for 
 
 *By no means is this the software that you can only use, rather this only lists from those who had added them here. If you know of other tools that could be used and can explain how to use them for the described sections below, please add them.*
 
-## Audacity (and LAME)
+## Audacity
 
 [Audacity](https://www.audacityteam.org/download) is a free, open-source audio editing and recording software. It uses the [LAME](https://lame.sourceforge.io) encoding library to be able to export audio in the MP3 audio format.
 
@@ -61,7 +61,7 @@ Install and open Audacity then follow these steps:
 
 ### Cropping
 
-Install and open Audacity then follow these steps:
+Install and open Audacity, then follow these steps:
 
 1. Open the `.mp3` file that you want to crop.
 2. Click and drag to highlight the parts you want to crop.

--- a/wiki/Guides/Audio_Editing/fr.md
+++ b/wiki/Guides/Audio_Editing/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 96cf49c598294957efd202a00af9e7814a41cdfd
+outdated_translation: true
+---
+
 # Guide de l'édition audio
 
 [osu!academy](/wiki/Community/Video_series/osu!academy) a couvert ce point dans [Episode 15: Audio Encoding (4:02)](https://www.youtube.com/watch?v=muu3HkG38kk). Cet épisode contient aussi comment installer et utiliser Audacity avec la capacité d'exportation `.mp3` de LAME.

--- a/wiki/Guides/Audio_Editing/ja.md
+++ b/wiki/Guides/Audio_Editing/ja.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 96cf49c598294957efd202a00af9e7814a41cdfd
+outdated_translation: true
+---
+
 # Audio editing
 
 [osu!academyの](/wiki/Community/Video_series/osu!academy)[Episode 15](https://www.youtube.com/watch?v=muu3HkG38kk) Audio Encoding (4:02) にてその説明がされています。それにはインストールの方法とAudiacityでLAMEを使用しmp3としてエクスポートする方法も含まれています。

--- a/wiki/Guides/Audio_Editing/pt.md
+++ b/wiki/Guides/Audio_Editing/pt.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 96cf49c598294957efd202a00af9e7814a41cdfd
+outdated_translation: true
+---
+
 # Edição de Audio
 
 A [osu!academy](/wiki/Community/Video_series/osu!academy) já explicou isso em [Episodio 15: Audio Encoding (4:02)](https://www.youtube.com/watch?v=muu3HkG38kk). E também explica como instalar e usar Audacity com a funcionalidade de exportação .mp3 do LAME.

--- a/wiki/Guides/Audio_Editing/ru.md
+++ b/wiki/Guides/Audio_Editing/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 96cf49c598294957efd202a00af9e7814a41cdfd
+outdated_translation: true
+---
+
 # Руководство по редактированию аудио
 
 [osu!academy](/wiki/Community/Video_series/osu!academy) рассказали об этом в [Episode 15: Audio Encoding (4:02)](https://www.youtube.com/watch?v=muu3HkG38kk). В этом выпуске также рассказывается, как установить и использовать Audacity с возможностью экспорта в `.mp3` (LAME). 


### PR DESCRIPTION
This is my second pull request of the day for this guide, as the first one was closed soon after realizing I had forgotten to outdate existing translations of this guide.

There are several updates made in this commit, these are:
1. Mentions on the inclusion of the LAME encoding library after the expiration of the last few patents on the MP3 audio format in 2017. As reference, the [Audacity Reference Manual](https://manual.audacityteam.org/man/faq_installing_the_lame_mp3_encoder.html) and the [Wikipedia article](https://en.wikipedia.org/wiki/MP3#Licensing,_ownership,_and_legislation) on the MP3 audio format also refers to the above fact.
3. Mentions another guide, "Compressing files", for more information on compression in general.
4. Revised Audacity instructions to skip installing LAME (now built-in) and match audio export settings to the previously mentioned guide.
5. Revised mp3DirectCut description.

Note: On the outdate commit, it refers to a merge request number in my fork and not this fork. Please ignore it.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
