### PR TITLE
Link to and update `User group`

### DIFF
--- a/wiki/Main_Page/en.md
+++ b/wiki/Main_Page/en.md
@@ -115,7 +115,7 @@ osu! wouldn't have been possible without many users helping with development, ma
 
 [osu! team](/wiki/People/osu!_team) • [Developers](/wiki/People/Developers) • [Global Moderation Team](/wiki/People/Global_Moderation_Team) • [Support Team](/wiki/People/Support_Team) • [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) • [Beatmap Nominators](/wiki/People/Beatmap_Nominators) • [osu! Alumni](/wiki/People/osu!_Alumni) • [Project Loved Team](/wiki/People/Project_Loved_Team) • [Beatmap Spotlight Curators](/wiki/People/Beatmap_Spotlight_Curators)
 
-[Community Contributors](/wiki/People/Community_Contributors) • [Users with unique titles](/wiki/People/Users_with_unique_titles) • [Tournament Committee](/wiki/People/Tournament_Committee) • [Performance Points Committee](/wiki/People/Performance_Points_Committee) • [osu! wiki maintainers](/wiki/People/osu!_wiki_maintainers)
+[Community Contributors](/wiki/People/Community_Contributors) • [User group](/wiki/People/User_group) • [Users with unique titles](/wiki/People/Users_with_unique_titles) • [Tournament Committee](/wiki/People/Tournament_Committee) • [Performance Points Committee](/wiki/People/Performance_Points_Committee) • [osu! wiki maintainers](/wiki/People/osu!_wiki_maintainers)
 
 </div>
 <div class="wiki-main-page-panel">

--- a/wiki/People/User_group/en.md
+++ b/wiki/People/User_group/en.md
@@ -24,6 +24,7 @@ Clicking the badges will lead to the respective group listings, while the names 
 | 29 | ![BOT](/wiki/shared/group/BOT.png) | [Chat Bots](/wiki/Bot_account) | Special accounts run by automated services instead of real people |
 | 31 | [![LVD](/wiki/shared/group/LVD.png)](https://osu.ppy.sh/groups/31) | [Project Loved](/wiki/People/Project_Loved_Team) | Recognising the beatmaps that the community loves most |
 | 32 | [![BN](/wiki/shared/group/BN-prob.png)](https://osu.ppy.sh/groups/32) | [Beatmap Nominators (Probationary)](/wiki/People/Beatmap_Nominators#probationary-beatmap-nominators) | Probationary BN that await a positive evaluation to confirm their presence in the team as a full member. |
+| 33 | ![PPY](/wiki/shared/group/PPY.png) | ppy | Reserved for [peppy](/wiki/People/peppy), the creator of osu! |
 | 35 | [![FA](/wiki/shared/group/FA.png)](https://osu.ppy.sh/groups/35) | [Featured Artist](/wiki/People/Featured_Artists) | Musical creators who have partnered with osu! |
 | 47 |  | Announce | Users with permission to send announcement chat messages  |
 | 48 | [![BSC](/wiki/shared/group/BSC.png)](https://osu.ppy.sh/groups/48) | [Beatmap Spotlight Curators](/wiki/People/Beatmap_Spotlight_Curators) | Responsible for selecting high-quality maps for the [Beatmap Spotlights](/wiki/Beatmap_Spotlights) |

--- a/wiki/People/en.md
+++ b/wiki/People/en.md
@@ -32,4 +32,5 @@ Index page for articles about people or groups.
 
 - [peppy](peppy)
 - [Staff log](Staff_log)
+- [User group](User_group)
 - [Users with unique titles](Users_with_unique_titles)


### PR DESCRIPTION
addresses comment in https://github.com/ppy/osu-web/issues/4175#issuecomment-1481877203, this should make the page more accessible

and now people won't need to wonder about the mysteriously unmentioned ppy group badge