### PR TITLE
Change osu!(lazer) download link in `Beatmap Spotlights` article.

### DIFF
--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -17,7 +17,7 @@ The [Beatmap Spotlight Curators group page](https://osu.ppy.sh/groups/48) lists 
 
 ## Participation
 
-To participate in the Beatmap Spotlights, download the latest version of the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client from its [GitHub releases page](https://github.com/ppy/osu/releases/latest).
+To participate in the Beatmap Spotlights, download the latest version of the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client from its [GitHub releases page](https://github.com/ppy/osu/releases/latest)or the [osu! download page](https://osu.ppy.sh/home/download).
 
 After installing and logging into your account, head on over to the playlists tab in the play section and find the Spotlights lobbies as denoted by a little pink bar, or filter by them from the top-right corner.
 

--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -17,7 +17,7 @@ The [Beatmap Spotlight Curators group page](https://osu.ppy.sh/groups/48) lists 
 
 ## Participation
 
-To participate in the Beatmap Spotlights, download the latest version of the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client from its [GitHub releases page](https://github.com/ppy/osu/releases/latest) or the [osu! download page](https://osu.ppy.sh/home/download).
+To participate in the Beatmap Spotlights, [download](https://osu.ppy.sh/home/download) the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client.
 
 After installing and logging into your account, head on over to the playlists tab in the play section and find the Spotlights lobbies as denoted by a little pink bar, or filter by them from the top-right corner.
 

--- a/wiki/Beatmap_Spotlights/en.md
+++ b/wiki/Beatmap_Spotlights/en.md
@@ -17,7 +17,7 @@ The [Beatmap Spotlight Curators group page](https://osu.ppy.sh/groups/48) lists 
 
 ## Participation
 
-To participate in the Beatmap Spotlights, download the latest version of the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client from its [GitHub releases page](https://github.com/ppy/osu/releases/latest)or the [osu! download page](https://osu.ppy.sh/home/download).
+To participate in the Beatmap Spotlights, download the latest version of the [osu!(lazer)](/wiki/Client/Release_stream/Lazer) client from its [GitHub releases page](https://github.com/ppy/osu/releases/latest) or the [osu! download page](https://osu.ppy.sh/home/download).
 
 After installing and logging into your account, head on over to the playlists tab in the play section and find the Spotlights lobbies as denoted by a little pink bar, or filter by them from the top-right corner.
 

--- a/wiki/Beatmap_Spotlights/fr.md
+++ b/wiki/Beatmap_Spotlights/fr.md
@@ -6,8 +6,6 @@ tags:
   - tableaux
   - Tableaux de classement
   - Spotlights saisonnier
-outdated_translation: true
-outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 ---
 
 # Beatmap Spotlights
@@ -22,7 +20,7 @@ La [page de groupe des Beatmap Spotlight Curators](https://osu.ppy.sh/groups/48)
 
 ## Participation
 
-Pour participer aux Beatmap Spotlights, téléchargez la dernière version du client [osu!(lazer)](/wiki/Client/Release_stream/Lazer) depuis sa [page de versions GitHub](https://github.com/ppy/osu/releases/latest).
+Pour participer aux Beatmap Spotlights, [téléchargez](https://osu.ppy.sh/home/download) le client [osu!(lazer)](/wiki/Client/Release_stream/Lazer).
 
 Après l'installation et la connexion à votre compte, rendez-vous dans l'onglet des playlists de l'onglet play et trouvez les lobbies Spotlights comme indiqué par une petite barre rose, ou filtrez par eux dans le coin supérieur droit.
 

--- a/wiki/Beatmap_Spotlights/fr.md
+++ b/wiki/Beatmap_Spotlights/fr.md
@@ -6,6 +6,8 @@ tags:
   - tableaux
   - Tableaux de classement
   - Spotlights saisonnier
+outdated_translation: true
+outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 ---
 
 # Beatmap Spotlights

--- a/wiki/Beatmap_Spotlights/ru.md
+++ b/wiki/Beatmap_Spotlights/ru.md
@@ -8,6 +8,8 @@ tags:
   - чарт
   - чарты
   - ранкинг-чарты
+outdated_translation: true
+outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 ---
 
 # Beatmap Spotlights

--- a/wiki/Beatmap_Spotlights/ru.md
+++ b/wiki/Beatmap_Spotlights/ru.md
@@ -8,8 +8,6 @@ tags:
   - чарт
   - чарты
   - ранкинг-чарты
-outdated_translation: true
-outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 ---
 
 # Beatmap Spotlights
@@ -24,7 +22,7 @@ outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 
 ## Участие
 
-Чтобы состязаться с другими игроками, скачайте последнюю версию клиента [osu!(lazer)](/wiki/Client/Release_stream/Lazer) со [страницы релизов на GitHub](https://github.com/ppy/osu/releases/latest).
+Чтобы состязаться с другими игроками, [скачайте](https://osu.ppy.sh/home/download) клиент [osu!(lazer)](/wiki/Client/Release_stream/Lazer).
 
 После установки игры и входа в аккаунт выберите вкладку с плейлистами, чтобы попасть в лобби. Комнаты, посвящённые Beatmap Spotlights, можно найти либо по характерному розовому ярлыку над названием, либо с помощью фильтра в правом верхнем углу.
 

--- a/wiki/Beatmap_Spotlights/zh.md
+++ b/wiki/Beatmap_Spotlights/zh.md
@@ -6,6 +6,8 @@ tags:
   - Seasonal Spotlights
   - 季赛
   - 月赛
+outdated_translation: true
+outdated_since: da3216feaf6915db11c618166c606f06c41345d6
 ---
 
 # 聚光灯


### PR DESCRIPTION
In the participation section, this PR adds a link to download osu!lazer from the osu! download page instead of only linking to the GitHub releases page.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)