### PR TITLE
Update `TWC 2023` Round of 32 schedule

### DIFF
--- a/wiki/Tournaments/TWC/2023/en.md
+++ b/wiki/Tournaments/TWC/2023/en.md
@@ -112,7 +112,6 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/0ad
 | Philippines ::{ flag=PH }:: | ::{ flag=RU }:: Russian Federation | [Mar 25 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230325T150000&p1=1440&p2=145&p3=166) |
 | United States ::{ flag=US }:: | ::{ flag=PT }:: Portugal | [Mar 25 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230325T160000&p1=1440&p2=263&p3=133) |
 | Finland ::{ flag=FI }:: | ::{ flag=MX }:: Mexico | [Mar 25 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230325T170000&p1=1440&p2=101&p3=155) |
-| Canada ::{ flag=CA }:: | ::{ flag=PL }:: Poland | [Mar 25 (Sat) 19:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230325T190000&p1=1440&p2=188&p3=262) |
 
 ### Sunday, 26 March 2023
 
@@ -127,6 +126,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/0ad
 | Taiwan ::{ flag=TW }:: | ::{ flag=VN }:: Vietnam | [Mar 26 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230326T130000&p1=1440&p2=241&p3=95) |
 | Brazil ::{ flag=BR }:: | ::{ flag=NO }:: Norway | [Mar 26 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230326T170000&p1=1440&p2=45&p3=187) |
 | Chile ::{ flag=CL }:: | ::{ flag=CZ }:: Czechia | [Mar 26 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230326T170000&p1=1440&p2=232&p3=204) |
+| Canada ::{ flag=CA }:: | ::{ flag=PL }:: Poland | [Mar 26 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230326T180000&p1=1440&p2=188&p3=262) |
 
 ## Mappools
 


### PR DESCRIPTION
Updates the match schedule with a late reschedule request.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)