### PR TITLE
Update `Nomination Assessment Team`, fix a missing link in `Becoming a Beatmap Nominator` and `Guides` 

### DIFF
--- a/wiki/Guides/en.md
+++ b/wiki/Guides/en.md
@@ -26,6 +26,7 @@ Below is a sorted list of guides created by members of the osu! community, most 
 
 *Main page: [Modding](/wiki/Modding)*
 
+- [Common modding mistakes](Common_modding_mistakes)
 - [How to get your map modded](Getting_Your_Map_Modded)
 - [osu!mania modding guide](osu!mania_modding_guide)
 

--- a/wiki/People/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
+++ b/wiki/People/Beatmap_Nominators/Becoming_a_Beatmap_Nominator/en.md
@@ -16,7 +16,7 @@ Modders aiming to apply to the Beatmap Nominators must fulfil the following crit
 
 ### Modding expectations
 
-*See also: [Common modding mistakes](/wiki/Guides) and [osu!mania modding guide](/wiki/Guides/osu!mania_modding_guide)*
+*See also: [Common modding mistakes](/wiki/Guides/Common_modding_mistakes) and [osu!mania modding guide](/wiki/Guides/osu!mania_modding_guide)*
 
 Submitted mods should show that a user is capable of analysing and improving beatmaps to a standard fit for the Beatmap Nominators.
 

--- a/wiki/People/Nomination_Assessment_Team/en.md
+++ b/wiki/People/Nomination_Assessment_Team/en.md
@@ -17,61 +17,61 @@ Members of the NAT are distinguished by their red username and user title. They 
 
 ## Responsibilities
 
-The NAT is responsible for a variety of mapping-related tasks, with each NAT member falling into one of two subgroups: **evaluators** and **advisors**. Each subgroup outlines the responsibilities of its members.
+The NAT is responsible for a variety of mapping-related tasks, which are divided into two categories: **evaluation** and **structural**. Each category outlines the responsibilities of a NAT member, as well as the requirements and expectations for each type of task.
 
-### Evaluators
+### Evaluation
 
-Members of the **evaluator** subgroup are primarily responsible for:
+NAT members who are assigned to the evaluation category (who are also referred as evaluators) are primarily responsible for:
 
 - **Evaluation**: Evaluating the proficiency and activity of both current Beatmap Nominators and applicants. *See [Evaluations](/wiki/People/Nomination_Assessment_Team/Evaluations) for more details.*
 - **Nomination**: Nominating at least 2 beatmaps per month. This helps evaluators keep up to date with the mapping/modding community when evaluating current and aspiring Beatmap Nominators.
   - Modding activity and other contributions may be used as a backup metric when evaluating activity.
 
-Evaluators are in high demand due to the sheer volume of [BN applications](/wiki/People/Beatmap_Nominators/Becoming_a_Beatmap_Nominator). They, unlike advisors, therefore occasionally look for new members to join them and help ease the workload. This is why BNs who wish to join the NAT are primarily judged based on their ability to evaluate, and most NAT members join and stay as evaluators.
+NAT members who are responsible for this category are in high demand due to the sheer volume of [BN applications](/wiki/People/Beatmap_Nominators/Becoming_a_Beatmap_Nominator). Therefore, they occasionally look for new members to join them and help ease the workload. This is why BNs who wish to join the NAT are primarily judged based on their ability to evaluate, and most NAT members join and stay responsible for the evaluation category.
 
-### Advisors
+### Structural
 
-As a group, **advisors** are required to maintain:
+NAT members who are assigned to the structural category are required to maintain:
 
 - **Communication**: Promoting transparency and maintaining good relations with not only the rest of the mapping/modding community, but also within the NAT itself. This includes, but not limited to, making announcements, participating in discussions about proposals, asking/answering questions through surveys, and updating the [ranking criteria](/wiki/Ranking_Criteria) as well as other documentation.
 - **Development**: Developing and maintaining tools and websites to help improve the ranking process (such as [Mapset Verifier](https://github.com/Naxesss/MapsetVerifier), [Aiess](https://github.com/Naxesss/Aiess), or [the NAT/BN website](https://bn.mappersguild.com/home)).
-- **Moderation**: Handling user reports and assessing inappropriate behaviour of Beatmap Nominators, as well as processing beatmap content reviews. This subcategory is a joint effort between the NAT and the GMT.
+- **Moderation**: Handling user reports and assessing inappropriate behaviour of Beatmap Nominators, as well as processing beatmap content reviews. This task is a joint effort between the NAT and the GMT.
 - **Miscellaneous maintenance**: Included but not limited to:
   - Handling [vetoes](/wiki/People/Beatmap_Nominators/Beatmap_Veto).
   - Maintaining the [RC Test](/wiki/People/Beatmap_Nominators/Beatmap_Nominator_Test).
   - Judging nomination reset [severity](SEV_rating).
 
-Advisors make sure that BNs and other members of the mapping/modding community remain informed and feel heard, in addition to maintaining the components required to keep everything running in the mapping/modding scene. Advisors are generally made up of experienced evaluators that prefer to focus on managerial matters regarding the mapping/modding scene.
+NAT members who are primarily handling this category make sure that BNs and other members of the mapping/modding community remain informed and feel heard, in addition to maintaining the components required to keep everything running in the mapping/modding scene. Users belonging to this category are made up of experienced evaluators that prefer to focus on managerial matters regarding the mapping/modding scene.
 
 ---
 
-Dividing the NAT into two groups is necessary for the overall organisation and productivity of the group, allowing for a more streamlined assignment of tasks. Delegating tasks keeps NAT members from being overwhelmed while simultaneously avoiding a diffusion of responsiblity.
+Dividing the NAT workload into two main categories is necessary for the overall organisation and productivity of the group, allowing for a more streamlined assignment of responsibilities. Delegating tasks keeps NAT members from being overwhelmed while simultaneously avoiding a diffusion of responsiblity.
 
-**A member of the NAT can engage with any task within either subgroup despite what their subgroup may be listed as.** For example, if a member of the NAT is an evaluator, they may still make announcements or participate in discussions about proposals. Assigned subgroups only describe what each member is formally responsible for.
+**A member of the NAT can engage with any tasks within any category that they choose, despite what their primary responsibilities may be listed as.** For example, an NAT member who is primarily responsible for evaluations may also help with structural-related tasks, or vice versa.
 
 ## Activity
 
-Depending on their subgroup, each NAT member has different activity requirements. Evaluators are expected to consistently evaluate both applicants and current BNs, while also keeping up to date with the mapping/modding scene on their own through modding. Advisors are expected to uphold key parts of the ranking process on a case-by-case basis.
+Depending on their category, each NAT member has different activity requirements. Members who are responsible for evaluations are expected to consistently evaluate both applicants and current BNs, while also keeping up to date with the mapping/modding scene on their own through modding. Members who are assigned to the structural category are expected to uphold key parts of the ranking process on a case-by-case basis.
 
-Members who are found to be inactive will be confronted by other members of the NAT. If a timely resolution to their inactivity is not feasible, they will be removed from the NAT. Members of the evaluator subgroup working on other mapping-related projects may be moved to the advisor subgroup to better reflect their contribution.
+NAT members who are found to be inactive will be confronted by the [team leaders](#nat-leadership). If a timely resolution to their inactivity is not feasible, they will be removed from the NAT. Members under the evaluation category working on other mapping-related projects may be moved to the structural category to better reflect their contribution.
 
 ## Promotion to the NAT
 
 Before joining the NAT, a user must either be a full member of the Beatmap Nominators, or a former NAT member still involved in the community. Most NAT candidates are initially considered based on their commitment to helping the mapping and modding community, and further demonstration of their ability to contribute to a multitude of NAT responsibilities is usually the basis for being promoted.
 
-Since all new NAT members start off as evaluators, it is important that NAT candidates are exceptional in assessing the proficiency of others. Full BNs may be given the opportunity to participate in [mock evaluations](/wiki/People/Nomination_Assessment_Team/Evaluations#mock-evaluations) or temporarily join the evaluation team, giving them an opportunity to practice. NAT candidates have a much better chance of being promoted if their evaluations are thorough and come to similar conclusions as the NAT (or have supportive reasoning otherwise).
+Since all new NAT members start off in the evaluation category, it is important that NAT candidates are exceptional in assessing the proficiency of others. Full BNs may be given the opportunity to participate in [mock evaluations](/wiki/People/Nomination_Assessment_Team/Evaluations#mock-evaluations) or temporarily join the evaluation team, giving them an opportunity to practice. NAT candidates have a much better chance of being promoted if their evaluations are thorough and come to similar conclusions as the NAT (or have supportive reasoning otherwise).
 
 The NAT keeps tabs on potential NAT candidates over long periods of time, and occasionally convenes to decide if a candidate should be promoted, similar to how BN evaluations are done. BNs are also allowed to ask about joining the NAT if they want to receive feedback and make sure they are being considered. However, depending on the activity and skill set of current NAT members, there may not be a need for new ones. New NAT members will likely be promoted only when one of the current members is becoming less active, or there are new workloads requiring more members, etc.
 
-### Becoming an advisor
+### Joining the structural category
 
-Evaluators who show proficiency in the advisory tasks outlined above, to the point where their current or planned contributions are indispensable and far outweighs their necessity as an evaluator, can become advisors. This is as judged by a designated member in the team capable of this, currently ::{ flag=US }:: [UberFazz](https://osu.ppy.sh/users/8646059), whom NAT members may ask advisor-related questions to.
+NAT members who show proficiency in the structural tasks outlined above, to the point where their current or planned contributions are indispensable and far outweighs their necessity as an evaluator, can opt in to change their designated category. This is as judged by the NAT leaders and handled on a case-by-case basis.
 
-Before adding a new advisor, the addition is sanity checked with the rest of the NAT in case of objections. If no issues arise, the new advisor will then be subject to activity expectations depending on their specific situation. If the contribution of an advisor is considered lacklustre or unnecessary at some later point, again as judged by the designated member, then they will be moved back to being an evaluator.
+Before conducting a category change, the addition is sanity checked with the rest of the NAT in case of objections. If no issues arise, the concerned member will then be subject to different activity expectations depending on their specific situation. If their contribution towards structural tasks is considered lacklustre or unnecessary at some later point, again as judged by the NAT leaders, then they will be moved back to the evaluation category.
 
 ## NAT Leadership
 
-As of March 2023, the NAT has decided to re-adopt the concept of leadership, which was [previously used](/wiki/People/Quality_Assurance_Team/QAT_Leaders) in the [QAT](/wiki/People/Quality_Assurance_Team). NAT leaders have the combined responsibility of both evaluators and advisors so they can watch over and stay involved with every aspect of the NAT.
+As of March 2023, the NAT has decided to re-adopt the concept of leadership, which was [previously used](/wiki/People/Quality_Assurance_Team/QAT_Leaders) in the [QAT](/wiki/People/Quality_Assurance_Team). NAT leaders have the combined responsibility of both evaluation and structural categories so they can watch over and stay involved with every aspect of the NAT.
 
 The current NAT leaders are ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) and ::{ flag=US }:: [radar](https://osu.ppy.sh/users/7131099).
 
@@ -96,56 +96,58 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 
 ### osu!
 
-| Name | Additional languages | Assigned subgroup |
+| Name | Additional languages | Assigned category |
 | :-- | :-- | :-- |
-| ::{ flag=GB }:: [-Mo-](https://osu.ppy.sh/users/2202163) |  | Advisor[^task-mo] |
-| ::{ flag=SG }:: [achyoo](https://osu.ppy.sh/users/7823498) | Chinese | Evaluator |
-| ::{ flag=CA }:: [Agatsu](https://osu.ppy.sh/users/5579871) |  | Evaluator |
-| ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539) | Belarusian, Russian | Evaluator |
-| ::{ flag=HK }:: [Chaoslitz](https://osu.ppy.sh/users/3621552) | Cantonese, Chinese | Evaluator |
-| ::{ flag=BR }:: [Dada](https://osu.ppy.sh/users/9119507) | Portuguese | Evaluator |
-| ::{ flag=AU }:: [elicz1](https://osu.ppy.sh/users/8039342) |  | Evaluator |
-| ::{ flag=CN }:: [Firika](https://osu.ppy.sh/users/9590557) | Chinese | Evaluator |
-| ::{ flag=DE }:: [FuJu](https://osu.ppy.sh/users/10773882) | German | Evaluator |
-| ::{ flag=SE }:: [Naxess](https://osu.ppy.sh/users/8129817) | Swedish | Advisor[^task-naxess] |
-| ::{ flag=GB }:: [nexusqi](https://osu.ppy.sh/users/13822800) |  | Evaluator |
-| ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418) |  | Advisor[^task-pishifat] |
-| ::{ flag=US }:: [StarCastler](https://osu.ppy.sh/users/12402453) |  | Evaluator |
-| ::{ flag=AT }:: [Stixy](https://osu.ppy.sh/users/9000308) | German, Serbian | Evaluator |
-| ::{ flag=US }:: [UberFazz](https://osu.ppy.sh/users/8646059) |  | Advisor[^task-uberfazz] |
-| ::{ flag=BE }:: [yaspo](https://osu.ppy.sh/users/4945926) | Dutch | Evaluator |
-| ::{ flag=US }:: [Yogurtt](https://osu.ppy.sh/users/2649717) |  | Evaluator |
-| ::{ flag=PL }:: [Zelq](https://osu.ppy.sh/users/8953955) | Polish | Evaluator |
+| ::{ flag=GB }:: [-Mo-](https://osu.ppy.sh/users/2202163) |  | Structural[^task-mo] |
+| ::{ flag=SG }:: [achyoo](https://osu.ppy.sh/users/7823498) | Chinese | Evaluation, Structural[^task-achyoo] |
+| ::{ flag=CA }:: [Agatsu](https://osu.ppy.sh/users/5579871) |  | Evaluation |
+| ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539) | Belarusian, Russian | Evaluation |
+| ::{ flag=HK }:: [Chaoslitz](https://osu.ppy.sh/users/3621552) | Cantonese, Chinese | Evaluation |
+| ::{ flag=BR }:: [Dada](https://osu.ppy.sh/users/9119507) | Portuguese | Evaluation |
+| ::{ flag=AU }:: [elicz1](https://osu.ppy.sh/users/8039342) |  | Evaluation |
+| ::{ flag=CN }:: [Firika](https://osu.ppy.sh/users/9590557) | Chinese | Evaluation |
+| ::{ flag=DE }:: [FuJu](https://osu.ppy.sh/users/10773882) | German | Evaluation, Structural[^task-fuju] |
+| ::{ flag=SE }:: [Naxess](https://osu.ppy.sh/users/8129817) | Swedish | Structural[^task-naxess] |
+| ::{ flag=GB }:: [nexusqi](https://osu.ppy.sh/users/13822800) |  | Evaluation |
+| ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418) |  | Structural[^task-pishifat] |
+| ::{ flag=US }:: [StarCastler](https://osu.ppy.sh/users/12402453) |  | Evaluation, Structural[^task-star] |
+| ::{ flag=AT }:: [Stixy](https://osu.ppy.sh/users/9000308) | German, Serbian | Evaluation |
+| ::{ flag=US }:: [UberFazz](https://osu.ppy.sh/users/8646059) |  | Evaluation |
+| ::{ flag=BE }:: [yaspo](https://osu.ppy.sh/users/4945926) | Dutch | Evaluation |
+| ::{ flag=US }:: [Yogurtt](https://osu.ppy.sh/users/2649717) |  | Evaluation |
+| ::{ flag=PL }:: [Zelq](https://osu.ppy.sh/users/8953955) | Polish | Evaluation |
 
 ### osu!taiko
 
-| Name | Additional languages | Assigned subgroup |
+| Name | Additional languages | Assigned category |
 | :-- | :-- | :-- |
-| ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015) | German | Evaluator |
-| ::{ flag=GB }:: [Dusk-](https://osu.ppy.sh/users/6092181) | Urdu, some Arabic | Evaluator |
-| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | Arabic, French, some Italian | Leader |
-| ::{ flag=BR }:: [Ideal](https://osu.ppy.sh/users/3869519) | Portuguese | Evaluator |
-| ::{ flag=US }:: [radar](https://osu.ppy.sh/users/7131099) |  | Leader |
+| ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015) | German | Evaluation |
+| ::{ flag=GB }:: [Dusk-](https://osu.ppy.sh/users/6092181) | Urdu, some Arabic | Evaluation |
+| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | Arabic, French, some Italian | Leadership |
+| ::{ flag=BR }:: [Ideal](https://osu.ppy.sh/users/3869519) | Portuguese | Evaluation |
+| ::{ flag=US }:: [radar](https://osu.ppy.sh/users/7131099) |  | Leadership |
 
 ### osu!catch
 
-| Name | Additional languages | Assigned subgroup |
+| Name | Additional languages | Assigned category |
 | :-- | :-- | :-- |
-| ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565) | Spanish, German | Evaluator |
-| ::{ flag=NL }:: [Greaper](https://osu.ppy.sh/users/2369776) | Dutch | Evaluator |
+| ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565) | Spanish, German | Evaluation |
+| ::{ flag=NL }:: [Greaper](https://osu.ppy.sh/users/2369776) | Dutch | Evaluation |
 
 ### osu!mania
 
-| Name | Additional languages | Assigned subgroup |
+| Name | Additional languages | Assigned category |
 | :-- | :-- | :-- |
-| ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229) | Chinese | Evaluator |
-| ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306) | Vietnamese | Evaluator |
-| ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785) | Indonesian | Evaluator |
-| ::{ flag=US }:: [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Evaluator |
+| ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229) | Chinese | Evaluation |
+| ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306) | Vietnamese | Evaluation |
+| ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785) | Indonesian | Evaluation |
+| ::{ flag=US }:: [Unpredictable](https://osu.ppy.sh/users/7560872) |  | Evaluation |
 
 ## Notes
 
+[^task-achyoo]: Mainly handles veto management for the osu! game mode
+[^task-fuju]: Mainly handles user reports and managing SEV ratings for the osu! game mode
 [^task-mo]: Mainly handles internal discussions, affairs, and documentation
 [^task-naxess]: Mainly maintains [Aiess](https://github.com/Naxesss/Aiess) and [Mapset Verifier](https://github.com/Naxesss/MapsetVerifier)
 [^task-pishifat]: Mainly maintains [the NAT/BN website](https://bn.mappersguild.com/home)
-[^task-uberfazz]: Among other things, manages advisors
+[^task-star]: Mainly maintains the ranking criteria test questions


### PR DESCRIPTION
Changes have already been fully discussed and confirmed with other NATs

