### PR TITLE
[ID] Fix typo on `osu!monthly team`

### DIFF
--- a/wiki/People/osu!monthly_team/id.md
+++ b/wiki/People/osu!monthly_team/id.md
@@ -1,6 +1,6 @@
 # Tim osu!monthly
 
-**Tim osu!monthly** merupakan kelompok yang mengelola dan menulis artikel berita pada buletin [osu!monthly](/wiki/Community/osu!monthly).
+**Tim osu!monthly** merupakan kelompok yang mengelola buletin [osu!monthly](/wiki/Community/osu!monthly).
 
 Tim ini terdiri dari para pemain yang aktif di berbagai bidang. Setiap bulannya, tim ini bertugas untuk menyelidiki hal-hal apa saja yang sedang terjadi di sekitar komunitas dan menulis konten yang akan diterbitkan pada [osu!monthly](/wiki/Community/osu!monthly). 
 
@@ -21,11 +21,11 @@ Nama-nama di bawah ini merupakan para anggota tim inti osu!monthly yang bertangg
 | ::{ flag=FR }:: [Pisapou](https://osu.ppy.sh/users/16640021) | Wakil pengelola |
 | ::{ flag=ES }:: [RandomeLoL](https://osu.ppy.sh/users/7080063) | Penulis[^task-mania] |
 | ::{ flag=GB }:: [Tanza3D](https://osu.ppy.sh/users/10379965) | Desainer grafis[^task-Tanza3D] |
-| ::{ flag=ID }:: [Wowcake](https://osu.ppy.sh/users/16121851) | Pembantu |
+| ::{ flag=ID }:: [Wowcake](https://osu.ppy.sh/users/16121851) | Pembantu umum |
 
 ### Kontributor lainnya
 
-Nama-nama di bawah ini merupakan nama-naman= yang tidak tergabung ke dalam tim inti osu!monthly, namun tetap berperan penting dalam penerbitan osu!monthly setiap bulannya. Walaupun mereka tidak menulis artikel yang ada, mereka menyediakan berbagai informasi penting kepada para kontributor utama dari waktu ke waktu.
+Nama-nama di bawah ini merupakan mereka yang tidak tergabung ke dalam tim inti osu!monthly, namun tetap berperan penting dalam penerbitan osu!monthly setiap bulannya. Walaupun mereka tidak menulis artikel, mereka menyediakan berbagai informasi penting kepada para kontributor utama dari waktu ke waktu.
 
 | Nama | Rubrik yang dicakup |
 | :-- | :-- |

--- a/wiki/People/osu!monthly_team/id.md
+++ b/wiki/People/osu!monthly_team/id.md
@@ -25,7 +25,7 @@ Nama-nama di bawah ini merupakan para anggota tim inti osu!monthly yang bertangg
 
 ### Kontributor lainnya
 
-Nama-nama di bawah ini merupakan mereka yang tidak tergabung ke dalam tim inti osu!monthly, namun tetap berperan penting dalam penerbitan osu!monthly setiap bulannya. Walaupun mereka tidak menulis artikel, mereka menyediakan berbagai informasi penting kepada para kontributor utama dari waktu ke waktu.
+Nama-nama di bawah ini merupakan mereka yang tidak tergabung ke dalam tim inti di atas, namun tetap berperan penting dalam penerbitan osu!monthly. Walaupun mereka tidak menulis artikel, mereka menyediakan berbagai informasi penting kepada para kontributor utama setiap bulannya.
 
 | Nama | Rubrik yang dicakup |
 | :-- | :-- |


### PR DESCRIPTION
made this pr mainly to fix this typo right here

![image](https://user-images.githubusercontent.com/36564236/229539458-c5935bf4-5ed0-40d4-a148-1485fac256b0.png)

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
~~- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~ (shouldn't be required given the scope of the pr ig)