### PR TITLE
[DE] Retranslate `Ranking_Criteria/osu!taiko`

### DIFF
--- a/wiki/Ranking_Criteria/osu!taiko/de.md
+++ b/wiki/Ranking_Criteria/osu!taiko/de.md
@@ -1,63 +1,183 @@
----
-outdated_translation: true
----
+# Ranking-Kriterien für osu!taiko
 
-# osu!taiko Ranking Kriterien
+***Hinweis: Dieses Dokument ist eine Ergänzung der [allgemeinen Ranking-Kriterien](/wiki/Ranking_Criteria).***
 
-Diese Regeln und Richtlinien wurden in diesem [osu!taiko Diskussions Thread](https://osu.ppy.sh/community/forums/posts/1275323) diskutiert. Mögliche neue Regeln oder Richtlinien können in diesen [Forum](https://osu.ppy.sh/community/forums/87) diskutiert werden, welche dann hinzugefügt werden, wenn es bei der Diskussion zu einer Einigung gekommen ist.
+Die **Ranking-Kriterien für osu!taiko** legen die [Regeln und Richtlinien](/wiki/Ranking_Criteria#general-terms) fest, die [osu!taiko](/wiki/Game_mode/osu!taiko)-spezifische [Beatmaps](/wiki/Beatmap) befolgen müssen, um das [Beatmap-Ranking-Verfahren](/wiki/Beatmap_ranking_procedure) zu durchlaufen.
 
-## Übliche Bedingungen
+## Glossar
 
-### Allgemeines
+### Schwierigkeitsgrade
 
-- **Kantan**: Einfach
-- **Futsuu**: Normal
-- **Muzukashii**: Mittel
-- **Oni**: Dämon/Schwer
-- **Ura**: Extra
+*Hauptartikel: [Benennung von Schwierigkeitsgraden](/wiki/Ranking_Criteria/Difficulty_naming)*
 
-### Spielweise
+- ![](/wiki/shared/diff/easy-t.png?20211215) Kantan
+- ![](/wiki/shared/diff/normal-t.png?20211215) Futsuu
+- ![](/wiki/shared/diff/hard-t.png?20211215) Muzukashii
+- ![](/wiki/shared/diff/insane-t.png?20211215) Oni
+- ![](/wiki/shared/diff/expert-t.png?20211215) Inner/Ura Oni
 
-- **Don**: Rote Note
-- **Kat**: Blaue Note
-- **Drumroll**: Gelber Balken
-- **Shaker**: Spinner
-- **Finisher**: Große blaue oder rote Note
+### Gameplay
 
-## Regeln
+- **Don / Rote Note:** Ein Beat, der mit einer der Trommelmitte zugehörigen Taste getroffen werden kann (Standardtasten `X` und `C`).
+- **Kat / Blaue Note:** Ein Beat, der mit einer dem Trommelrand zugehörigen Taste getroffen werden kann (Standardtasten `Z` und `V`).
+- **Big don / Große rote Note / Finisher-Note:** Ein kräftiger Beat, der für zusätzliche Punkte mit beiden der Trommelmitte zugehörigen Tasten gleichzeitig getroffen werden kann.
+- **Big kat / Große blaue Note / Finisher-Note:** Ein kräftiger Beat, der für zusätzliche Punkte mit beiden dem Trommelrand zugehörigen Tasten gleichzeitig getroffen werden kann.
+- **BPM:** Tempo eines Songs, gemessen in "Beats pro Minute".
+- **Slider/Drumroll:** Ein gelber Balken mit Ticks darin, die mit irgendeiner der zugewiesenen Tasten gespielt werden. Diese Ticks haben meistens eine Taktteilung von 1/4, entsprechend der BPM des Songs. Wenn die BPM geringer als 125 sind, ändert sich die Taktteilung zu 1/8. Wenn die BPM höher als 250 sind, ändert sie sich zu 1/2. Wenn die Slidertick-Rate auf 3 eingestellt ist, werden die Sliderticks stattdessen auf einen 1/3-Takt angepasst.
+- **Spinner:** Ein rundes Element, bei dem Spieler zwischen dem Treffen von Don/Kat für eine bestimmte Anzahl von Malen hin- und herwechseln müssen, was in der Mitte des Spinners angezeigt wird. Dieser Wert hängt von der allgemeinen Schwierigkeit (OD) der Beatmap sowie von der Länge des Spinners ab.
+- **Taktstrich:** Eine Linie, die auf dem Spielfeld erscheint und den Start eines Taktes bestimmt.
+- **Überlappung:** Eine Note, die teilweise oder vollständig andere Noten im Spielfeld überdeckt.
+- **Pause:** Ein Zeitabschnitt ohne Noten, damit Spieler ihre Hand ausruhen und sich auf die bevorstehende Sektion vorbereiten können.
+- **Stream:** Gruppierung aufeinanderfolgender Circles. Normalerweise auf 1/4-Takte geteilt.
+- **Taktteilung:** Ein Strich auf der Zeitleiste, bei dem ein Objekt platziert wird.
+- **Variable Taktteilung:** Eine Kombination mehrerer verschiedener Wege, Noten aufgrund des schwankenden Charakters des Songs innerhalb einer kurzen Zeitspanne zu platzieren.
+- **Slider-Geschwindigkeit:** Die Geschwindigkeit, mit der sich die Noten/Drumrolls/Spinner/Taktstriche horizontal von rechts nach links über das Spielfeld bewegen. Die Ausgangsgeschwindigkeit der Slider kann im Timing-Tab gesteuert werden und zusätzliche Änderungen lassen sich über vererbte (grüne) Timing-Punkte durchführen.
+- **Weiche Änderungen der Slider-Geschwindigkeit:** Eine Mechanik, die einen schrittweisen Übergang von Sektionen mit niedriger zu Sektionen mit höherer Slider-Geschwindigkeit (und umgekehrt) ermöglicht. Um diesen Effekt zu erzielen, werden Übergangsnoten mit unterschiedlichen Slider-Geschwindigkeiten verwendet.
+- **Improvisation:** Mehr Noten haben als der eigentliche Song vorgibt.
+- **Taiko-Vorlagenhintergrund:** Hintergrundbilder, die authentisches Gameplay aus Taiko no Tatsujin simulieren. Sie enthalten meistens einen schwarzen Balken, der den Künstler und den Songtitel in weiß unter dem Spielfeld anzeigt.
 
-Die folgenden Regeln sind genau das: Regeln. Es sind keine Richtlinien und sollten unter keinen Umständen gebrochen werden!
+## Global
 
-- **Finisher Noten**
+Globale Regeln und Richtlinien gelten für alle Arten von osu!taiko-Schwierigkeitsstufen. Rhythmusbezogene Regeln und Leitlinien gelten für Beatmaps mit etwa 180 BPM und 4/4-Taktsignaturen. Wenn dein Song drastisch schneller oder langsamer ist, können einige Variablen anders sein, wie in [Skalierung der BPM anhand der Ranking-Kriterien](/wiki/Ranking_Criteria/Scaling_BPM) ausführlich beschrieben.
 
-Finisher Noten dürfen nicht in der Mitte und am Anfang eines 1/4- oder größeren Takt Streams sein. Am Ende des Streams kann es möglich sein einen Finisher zu setzen, wenn ein akzeptabler Sound vorhanden ist. *Finisher Noten müssen am Ende eines Streams die gegenteilige Farbe von den 4 vorherigen Noten haben.*
+### Allgemein
 
-## Richtlinien
+#### Regeln
 
-Richtlinien sind wichtig und sollten so gut wie möglich eingehalten werden. Wie auch immer, es sind keine Regeln und müssen nicht in allen Fällen eingehalten werden. Wenn Sie eine Richtlinie brechen sollten, sollten Sie sich stets selber fragen: "Macht das, was ich gerade mache, überhaupt Sinn? Würde es dem Spieler wirklich mehr Spaß am Spielen der Map bereiten, wenn ich mich nicht an die Richtlinie halte?" Wenn Sie für sich beide Fragen mit "Ja" geantwortet haben, sollte es kein großes Problem darstellen.
+Alle Regeln sind genau das: **Regeln**. Sie sind **keine** Richtlinien und dürfen **unter keinen Umständen** gebrochen werden.
 
-Wenn Sie gewisse Richtlinien nicht einhalten sollten, versuchen Sie es dann so gut wie möglich zu begründen, um ihre Sichtweise klarzustellen. Für mögliche Ratschläge bzw. Alternativen sollte man stets offen bleiben.
+- **Jede Note muss eine klare, unterscheidbare Farbe zu den vorhergehenden und den nachfolgenden Noten haben.**
+- **Jede Note muss eindeutig einer [musikalischen Ebene](/wiki/Music_theory/Layer) oder Ebeneneinheit zugeordnet werden können, die sie repräsentieren soll, sei es, um eine vom Song vorgegebene Ebene zu erweitern, oder sei es eine zusätzliche, vom Mapper improvisierte Ebene.** Improvisiere nicht in einer Weise, die das Tempo verschiebt, der allgemeinen Musikrichtung widerspricht oder die aktuelle Intensität des Songs falsch interpretiert. Die Improvisation muss entweder eine bestehende Ebene des Songs verbessern oder eine neue hinzufügen. Andernfalls geht der Bezug zum Song verloren, was dem Hauptzweck eines Rhythmusspiels widerspricht.
+- **Die Funktion `Omit first bar line` eines nicht vererbten Timing-Punkts muss verwendet werden, wenn eine Änderung der BPM bzw. eine Rücksetzung des Metronoms das Spielerlebnis durch das Hinzufügen überflüssiger Taktstriche in ästhetischer Hinsicht beeinträchtigen würde.**
+- **Taiko-Hintergrundvorlagen dürfen nicht benutzt werden.** Aufgrund der verschiedenen gängigen Bildschirmauflösungen funktionieren sie nicht so, wie sie ursprünglich gedacht waren.
+- **Slider tails must not be wrongly snapped to correct missing slider ticks.** Dieses Verhalten ist unbeabsichtigt und wird in Zukunft korrigiert.
 
-- **Slidergeschwindigkeit**
+#### Richtlinien
 
-Die Slidergeschwindigkeit (eng. Slider Velocity) sollte auf 1.40 festgelegt sein.
+In **Ausnahmefällen** dürfen die Richtlinien ignoriert werden. Diese außergewöhnlichen Umstände müssen durch eine ausführliche Erklärung gerechtfertigt sein, warum die Richtlinie ignoriert wurde und warum ihre Beachtung die Gesamtqualität des Werks beeinträchtigen würde.
 
-- **Streams**
+- **Vermeide es, wesentliche Bereiche des Hintergrunds mit dem Taiko-Spielfeld zu verdecken.** Wenn dies der Fall ist, solltest du die letzte Null in der Datei `.osu` in der Zeile `0,0,"name_des_hintergrunds.datei_endung",0,0` unter der Überschrift `[Events]` mit Notepad ändern. Positive Werte senken den Hintergrund, während negative Werte ihn anheben.
+- **Wenn die Geschwindigkeit von Slidern verändert wird, sollte diese den Tempoänderungen im Song entsprechen.** Das bedeutet, dass ruhige Teile eines Songs nicht beschleunigt und schnelle Teile nicht verlangsamt werden.
+- **Vermeide es, weiche Änderungen der Slider-Geschwindigkeit in Sektionen mit variabler Taktteilung zu benutzen.** Dadurch wird die Lesbarkeit dieser Taktteilungen beeinträchtigt, daher solltest du die Abweichungen niedrig genug halten, um ein Überlappen zu verhindern.
+- **Vermeide abrupte Änderungen der Slider-Geschwindigkeit innerhalb von Patterns, die bereits überlappen (z. B. 1/4-Streams).** Weiche Änderungen der Slider-Geschwindigkeit sollten in diese Fällen benutzt werden, um sicherzustellen, dass die Patterns lesbar bleiben.
+- **Erhebliche Überlappungen sollten vermieden werden, sodass die Farbe jeder Note noch leicht erkennbar ist und keine unnötige visuelle Störung verursacht.** Überschneidungen sollten nur vorhanden sein, wenn das Tempo des Songs oder die Taktteilung es an dieser Stelle rechtfertigen würde.
+- **Vermeide Rhythmen, die in keiner Weise vorhersehbar sind.** Rhythmus kann durch einheitliche Abstände in der Zeitleiste, die verschiedene Taktteilungen überbrücken, oder durch Pausen intuitiv erzeugt werden.
+- **Kiai-Zeit sollte nur für den Refrain oder hervorgehobene Teile eines Songs benutzt werden.** Von kurzen Kiai-Effekten wird aus mehreren Gründen abgeraten: Sie stören das Spielerlebnis insbesondere auf Computern mit niedriger Leistung und können Probleme für epileptische Nutzer verursachen.
+- **Die Ausgangsgeschwindigkeit von Slidern sollte 1,40 in allen Schwierigkeitsgraden einer Beatmap sein.** Dies soll eine optimale Menge an Noten auf dem Spielfeld sowie den bestmöglichen Abstand zwischen verschiedenen Noten gewährleisten.
+- **Die Slidertick-Rate sollte entsprechend dem Song eingestellt werden.** In den meisten Fällen ist 1 ein guter Wert. Wenn der Song hauptsächlich 1/3 als Taktteilung verwendet, setze die Tickrate auf 3, um die Drumrollticks auf 1/3 festzulegen.
+- **Vermeide, den Fokus auf mehrere [Ebenen](/wiki/Music_theory/Layer) des Songs gleichzeitig zu legen, wenn unklar ist, welcher Rhythmus priorisiert wird.** Spieler sollten in der Lage sein, zu erkennen, welchem Teil des Songs gefolgt wird.
+- **Verwende leise oder stille Spinner nur, wenn es zu einem leisen Abschnitt des Songs passt.** In den meisten anderen Fällen ist ein hörbares Hitsound-Feedback bei Spinnern sehr zu empfehlen.
+- **Songs mit variablen BPM dürfen häufige Änderungen der Slider-Geschwindigkeit beinhalten, um die Scrollgeschwindigkeit, mit der sich Noten bewegen, ungefähr konstant zu halten.** Auf diese Weise werden die Zeitabstände zwischen den Noten leicht erkennbar und verbessern das Spielerlebnis, da Überlappungen durch BPM-Änderungen vermieden werden.
+- **Vermeide visuell störende Noten auf dem Spielfeld mit aktiven Spinnern.** Spinner decken den Großteil des Bildschirms ab, so dass die Beatmap massiv schwieriger zum Lesen wird, wenn die Spinner zu nah an den nachfolgenden Noten enden. Einen 1/2-Takt Abstand zwischen einem Spinner und der folgenden Note löst dieses Problem in der Regel.
+- **Wenn eigene Hitsounds verwendet werden, sollten diese mit Trommeln zu tun haben.** Tiefere Töne sollten als Don und höhere Töne als Kat eingestellt werden.
 
-Für die meisten Maps sollten nur 1/1-, 1/2- oder 1/4-Taktnoten-Streams verwendet werden. 1/3 und 1/6 sollten nur zum Einsatz kommen, wenn das Lied den gleichartigen Takt bereitstellen sollte. 1/8 Streams sollte in jedem Fall vermieden werden.
+## Schwierigkeitsgradabhängig
 
-- **BPM-Änderungen**
+Schwierigkeitsspezifische Regeln und Richtlinien gelten nur für die Schwierigkeitsstufe, bei der sie aufgeführt werden und *betreffen somit nicht **jeden** osu!taiko-Schwierigkeitsgrad*. Rhythmusbezogene Regeln und Leitlinien gelten für Beatmaps mit ungefähr 180 BPM. Wenn dein Song drastisch schneller oder langsamer ist, können einige Variablen anders sein, wie in [Skalierung der BPM anhand der Ranking-Kriterien](/wiki/Ranking_Criteria/Scaling_BPM) ausführlich beschrieben.
 
-Es sollten Überlappungen von Noten (bei verlangsamten Phasen) vermieden werden, da sie dem Spieler verwirren. Sie sollten Inherited Timing Punkte verwenden, um die Noten in der Sektion schrittweise zu verlangsamen. Selbst bei Änderungen der Slidergeschwindigkeit sollte stets die Lesbarkeit (keine Überlappungen) gegeben sein bzw., wenn es beabsichtigt ist, sollte es nicht zu extrem sein.
+### ![](/wiki/shared/diff/easy-t.png?20211215) Kantan
 
-- **Trommelwirbel (Slider)**
+#### Regeln
 
-Gehen Sie sparsam damit um und lassen Sie 1/2-Takt Platz zwischen dem und dem benachbarten Objekt. Vermeiden Sie Slider bei einer BPM von 125 oder niedriger zu verwenden, es sei denn, das Lied ist dazu geeignet. Verwenden Sie eine Tickrate von 3, wenn das Lied im 1/3-Takt ist.
+- **Wenn ein 1/2-Pattern benutzt wird, müssen die Patterns einfach bleiben und auf sie muss eine Pause folgen.** Farbwechsel oder Finisher-Notes dürfen nicht in solchen Patterns verwendet werden. Bei Songs, die einem Swing-Takt folgen, beträgt diese Grenze 1/3.
+- **Noten müssen mindestens einen 1/2-Takt auseinander liegen.** Alles, was schneller ist, ist für Anfänger zu komplex. Bei Songs, die einem Swing-Takt folgen, ist das Mindestmaß stattdessen 1/3.
 
-- **Rüttler (Spinner)**
+#### Richtlinien
 
-Versuch mindestens einen 1/2-Takt zwischen der Note und dem Spinner Platz zu lassen. Sie für Streams zu werden, sollte in Ordnung gehen. Kurze Spinner sind nicht zu empfehlen, da sie die Noten verdecken und dem Spieler zum Versagen führen aufgrund der hohen Anzahl an Tastenanschläge.
+- **1/1-Patterns sollten nicht länger als 7 Noten sein.** Alles, was länger ist, ist für Anfänger wahrscheinlich zu anstrengend. Auf solche Patterns sollte eine Pause folgen.
+- **Die allgemeine Taktteilung sollte hauptsächlich aus 2/1, 4/1 oder langsameren Rhythmen bestehen.** Die gelegentliche Verwendung von 1/1-Rhythmen ist in Ordnung.
+- **Zwischen einem Spinner und der vorhergehenden Note sollte mindestens 1/2 Abstand sein.** Auf diese Weise wird sichergestellt, dass sie nicht übermäßig überlappen und dass die Lesbarkeit gewährleistet ist.
+- **Nach 16/1 bis 20/1 kontinuierlichem Mapping sollte mindestens eine Pause eingefügt werden, die 3/1 oder länger ist.** Seltenere Ruhezeiten sind akzeptabel, wenn das Tempo der Musik Pausen kontraintuitiv macht oder wenn der durchgehend gemappte Teil insgesamt nachsichtiger zum Spieler ist.
+- **Die Slider-Geschwindigkeit darf mit Bedacht verändert werden.** Änderungen sollten nur für Abschnitte mit unterschiedlichem Tempo erfolgen und die Slider-Geschwindigkeit sollte nicht drastisch variieren.
 
-- **Selbsterstellte Hitsounds**
+#### Richtlinien für die Schwierigkeitseinstellungen
 
-Selbsterstellte Hitsounds müssen im Zusammenhang mit Trommeln stehen. Wenn Sie selbsterstellte Hitsounds benutzen, sollten die Töne für die Dons tief/niedrig und für die Kats hoch/leicht sein.
+- Allgemeine Schwierigkeit sollte 4 oder weniger sein.
+- HP-Drain-Rate sollte 6 oder mehr sein. Wenn die Notenanzahl höher ist, darf die HP-Drain-Rate geringfügig auf unter 6 angepasst werden.
+
+### ![](/wiki/shared/diff/normal-t.png?20211215) Futsuu
+
+#### Regeln
+
+- **Wenn ein 1/3-Pattern benutzt wird, müssen die Patterns einfach bleiben.** Farbwechsel oder Finisher-Notes dürfen nicht in solchen Patterns verwendet werden.
+- **Noten müssen mindestens einen 1/3-Takt auseinander liegen.** Alles, was schneller ist, ist für Anfänger zu komplex.
+
+Wenn eine Futsuu-Schwierigkeit erforderlich ist und als *niedrigste Schwierigkeitsstufe* einer Beatmap verwendet wird, muss sie ebenfalls diese Regeln befolgen:
+
+- **Noten müssen mindestens einen 1/2-Takt auseinander liegen.** Alles, was schneller ist, ist für Anfänger zu komplex. Bei Songs, die einem Swing-Takt folgen, ist das Mindestmaß stattdessen 1/3.
+
+#### Richtlinien
+
+- **1/3-Patterns sollten nicht länger als 2 Noten sein.** Alles, was länger ist, ist sehr situationsabhängig und normalerweise zu komplex für neue Spieler. Auf diese Patterns sollte eine Pause innerhalb von 2/1 folgen und Patterns, die 1/2 oder schneller sind, sollten hier gänzlich vermieden werden.
+- **1/2-Patterns sollten nicht länger als 7 Noten sein.** Alles, was länger ist, ist für Anfänger vermutlich zu anstrengend.
+- **Die allgemeine Taktteilung sollte hauptsächlich aus 1/1, 2/1 oder langsameren Rhythmen bestehen.** Die gelegentliche Verwendung von 1/2-Rhythmen ist in Ordnung.
+- **Zwischen einem Spinner und der vorhergehenden Note sollte mindestens 1/2 Abstand sein.** Auf diese Weise wird sichergestellt, dass sie nicht übermäßig überlappen und dass die Lesbarkeit gewährleistet ist.
+- **Nach 16/1 bis 20/1 kontinuierlichem Mapping sollte mindestens eine Pause eingefügt werden, die 2/1 oder länger ist.** Seltenere Ruhezeiten sind akzeptabel, wenn das Tempo der Musik Pausen kontraintuitiv macht oder wenn der durchgehend gemappte Teil insgesamt nachsichtiger zum Spieler ist.
+- **Die Slider-Geschwindigkeit darf geringfügig verändert werden.**
+
+Wenn eine Futsuu-Schwierigkeit erforderlich ist und als *niedrigste Schwierigkeitsstufe* einer Beatmap verwendet wird, muss sie ebenfalls diese Richtlinien befolgen:
+
+- **1/2-Patterns sollten nicht länger als 5 Noten sein.**
+- **Die Slider-Geschwindigkeit darf mit Bedacht verändert werden.** Änderungen sollten nur für Abschnitte mit unterschiedlichem Tempo erfolgen und die Slider-Geschwindigkeit sollte nicht drastisch variieren.
+
+#### Richtlinien für die Schwierigkeitseinstellungen
+
+- Allgemeine Schwierigkeit sollte 5 oder weniger sein.
+- HP-Drain-Rate sollte 5 oder mehr sein. Wenn die Notenanzahl höher ist, darf die HP-Drain-Rate geringfügig auf unter 5 angepasst werden.
+
+### ![](/wiki/shared/diff/hard-t.png?20211215) Muzukashii
+
+#### Regeln
+
+- **Finisher-Notes dürfen nicht in 1/4 oder schnelleren Patterns in dieser Schwierigkeitsstufe platziert werden.** Die Verwendung von Finisher-Notes ist für das Zielpublikum zu kompliziert.
+- **Noten müssen mindestens einen 1/6-Takt auseinander liegen.** Alles, was länger ist, ist für das Zielpublikum dieses Schwierigkeitsgrades zu komplex.
+
+#### Richtlinien
+
+- **1/6-Patterns sollten nicht länger als 4 Noten bei mittleren bis niedrigen BPM (~140) sein.** Alles, was länger ist, ist sehr situationsabhängig und normalerweise zu komplex. Auf solche Patterns sollte eine Pause folgen. Des Weiteren sollten diese Patterns bei höheren BPM gänzlich vermieden werden.
+- **1/4-Patterns sollten nicht länger als 5 Noten sein.** Alles, was länger ist, ist vermutlich zu anstrengend für fortgeschrittene Spieler.
+- **Die allgemeine Taktteilung sollte hauptsächlich aus 1/2, 1/1 oder langsameren Rhythmen bestehen.** Die gelegentliche Verwendung von 1/4-Rhythmen ist in Ordnung.
+- **Zwischen einem Spinner und der vorhergehenden Note sollte mindestens 1/2 Abstand sein.** Auf diese Weise wird sichergestellt, dass sie nicht übermäßig überlappen und dass die Lesbarkeit gewährleistet ist.
+- **Nach 16/1 bis 20/1 kontinuierlichem Mapping sollte mindestens eine Pause eingefügt werden, die 3/2 oder länger ist.** Mindestens 3 aufeinanderfolgende Pausen, die 1/1 lang sind, ist ein akzeptabler Ersatz, wenn das Tempo der Musik Pausen kontraintuitiv macht oder wenn der durchgehend gemappte Teil insgesamt nachsichtiger zum Spieler ist.
+- **Das Editieren der Slider-Geschwindigkeit ist erlaubt**, aber Änderungen sollten nur für Abschnitte mit unterschiedlichem Tempo erfolgen und die Slider-Geschwindigkeit sollte nicht drastisch variieren.
+- **1/4-Patterns mit einem oder mehreren Farbwechsel sollten sparsam verwendet werden.** Sie sollten in Verbindung mit anderen Patterns dieser Art vermieden werden, weil das Zielpublikum dieses Schwierigkeitsgrades nicht an Patterns dieser Komplexität gewöhnt ist.
+- **1/4-Pattern, die länger als 3 Noten sind, sollten maximal einen Farbwechsel am Anfang oder am Ende des Patterns beinhalten.** Komplexere Patterns als diese sind zu anstrengend für fortgeschrittene Spieler. Auf diese Patterns sollte eine Pause folgen.
+
+#### Richtlinien für die Schwierigkeitseinstellungen
+
+- Allgemeine Schwierigkeit sollte 5 oder weniger sein.
+- HP-Drain-Rate sollte 5 oder mehr sein. Wenn die Notenanzahl höher ist, darf die HP-Drain-Rate geringfügig auf unter 5 angepasst werden.
+
+### ![](/wiki/shared/diff/insane-t.png?20211215) Oni
+
+#### Regeln
+
+- **Finisher-Notes dürfen nicht in 1/6 oder schnelleren Patterns in dieser Schwierigkeitsstufe platziert werden.** Die Verwendung von Finisher-Notes ist für das Zielpublikum zu kompliziert.
+- **Finisher-Notes für 1/4-Patterns in dieser Schwierigkeitsstufe dürfen nur am Ende des Patterns platziert werden.** Andere Platzierungen können die Lesbarkeit für das Zielpublikum zu stark beeinträchtigen.
+- **Noten müssen mindestens einen 1/8-Takt auseinander liegen.** Alles, was länger ist, ist für das Zielpublikum dieses Schwierigkeitsgrades zu komplex.
+
+#### Richtlinien
+
+- **1/8-Patterns sollten nicht länger als 2 Noten sein.** Alles, was länger ist, ist sehr situationsabhängig und normalerweise zu komplex. Auf solche Patterns sollte eine Pause folgen.
+- **1/4-Patterns sollten nicht länger als 9 Noten sein.** Alles, was länger ist, ist vermutlich zu anstrengend für das Zielpublikum dieses Schwierigkeitsgrades.
+- **Die allgemeine Taktteilung sollte hauptsächlich aus 1/2 und gelegentlich 1/1-Rhythmen bestehen.** 1/4-Rhythmen dürfen in diesem Schwierigkeitsgrad sehr häufig verwendet werden.
+- **Zwischen einem Spinner und der vorhergehenden Note sollte mindestens 1/4 Abstand sein.** Auf diese Weise wird sichergestellt, dass sie nicht übermäßig überlappen und dass die Lesbarkeit gewährleistet ist.
+- **Nach 16/1 bis 20/1 kontinuierlichem Mapping sollte mindestens eine Pause eingefügt werden, die 1/1 oder länger ist.** Spieler könnten überfordert sein, wenn es nicht genug Pausen gibt oder diese zu kurz sind.
+- **1/4-Patterns, die länger als 5 Noten sind, sollten komplizierte Farbwechsel vermeiden.** Längere Patterns mit solcher Komplexität sind für das Zielpublikum dieser Schwierigkeitsstufe zu anstrengend.
+
+#### Richtlinien für die Schwierigkeitseinstellungen
+
+- Allgemeine Schwierigkeit sollte 5 oder weniger sein.
+- HP-Drain-Rate sollte 5 oder mehr sein. Wenn die Notenanzahl höher ist, darf die HP-Drain-Rate geringfügig auf unter 5 angepasst werden.
+
+### ![](/wiki/shared/diff/expert-t.png?20211215) Inner/Ura Oni
+
+#### Richtlinien
+
+- **Die allgemeine Taktteilung sollte hauptsächlich aus 1/2 und 1/4-Rhythmen bestehen.** 1/4-Rhythmen dürfen in diesem Schwierigkeitsgrad sehr häufig verwendet werden.
+- **Zwischen einem Spinner und der vorhergehenden Note sollte mindestens 1/4 Abstand sein.** Auf diese Weise wird sichergestellt, dass sie nicht übermäßig überlappen und dass die Lesbarkeit gewährleistet ist.
+
+#### Richtlinien für die Schwierigkeitseinstellungen
+
+- Allgemeine Schwierigkeit sollte 5 oder weniger sein.
+- HP-Drain-Rate sollte 5 oder mehr sein. Wenn die Notenanzahl höher ist, darf die HP-Drain-Rate geringfügig auf unter 5 angepasst werden.


### PR DESCRIPTION
This article was outdated since at least 2019 and it even didn't have any diff. I must say, articles from the `ranking criteria` are the most difficult to translate in the whole wiki. The update of `osu!mania` helped me to get a good translation for some terms, but still.

So, the point is, review this carefully.

## Notes

- `snapping` --> `Taktteilung`
- `musical layer` --> `Ebene`
  - The term [`Textur`](https://de.wikipedia.org/wiki/Textur_(Musik)) *might* be a fitting equivalent to layer, though I'm not very knowledgeable in music.
- `limit` --> `Mindestmaß`
  - A possible alternative might be `Minimum`
- `continuing mapping` --> `kontinuierliches/durchgehendes Mapping`
- `mapped` --> `gemappt`

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
