### PR TITLE
Expand `Tournaments`

### DIFF
--- a/wiki/Tournaments/en.md
+++ b/wiki/Tournaments/en.md
@@ -454,6 +454,7 @@ Unofficial tournaments/competitions hosted by the communities.
 | [Asian-Oceanian Taiko Showdown](AOTS/AOTS_1) | 2019-08-09 | 2019-09-15 | ::{ flag=TW }:: [Smallwu](https://osu.ppy.sh/users/2512120) | ::{ flag=JP }:: [Saikoro](https://osu.ppy.sh/users/741819) | ::{ flag=HK }:: [MTDex](https://osu.ppy.sh/users/9468283) |
 | [Indonesian Taiko Showdown 2](AOTS/IDTS_2) | 2021-12-03 | 2022-01-09 | ::{ flag=ID }:: [Servatory](https://osu.ppy.sh/users/4013317) | ::{ flag=ID }:: [freezebear](https://osu.ppy.sh/users/1943301) | ::{ flag=ID }:: [Veltlion](https://osu.ppy.sh/users/10999079) |
 | [Indonesian Taiko Beginner Showdown](AOTS/ITBS_1) | 2022-04-16 | 2022-06-05 | ::{ flag=ID }:: [salym](https://osu.ppy.sh/users/19089549) | ::{ flag=ID }:: [WeebReen](https://osu.ppy.sh/users/10129901) | ::{ flag=ID }:: [N\_jaaayy](https://osu.ppy.sh/users/17787564) |
+| [Indonesian Taiko Beginner Showdown 2](AOTS/ITBS_2) | 2023-06-03 | 2023-07-16 | *TDB* | *TDB* | *TDB* |
 
 #### Ausu!Taiko Tournament
 


### PR DESCRIPTION
Adds `Indonesian Taiko Beginner Showdown 2` into the `Asian-Oceanian Taiko Showdown` community tournament series.

This is to also to reflect a change I made to a still-open (as of time of writing) PR on a major listing update for the Indonesian translation of `Tournaments`.

Also, as of time of writing, folder `AOTS/ITBS_2` does not yet exist but added as the link to said new tournament as a prediction based on naming patterns of past tournaments within that series.

SKIP_WIKILINK_CHECK

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)