### PR TITLE
Update `TWC 2023`, `CWC 2023`

### DIFF
--- a/wiki/Tournaments/CWC/2023/en.md
+++ b/wiki/Tournaments/CWC/2023/en.md
@@ -15,7 +15,7 @@ The **osu!catch World Cup 2023** (***CWC 2023***) is an upcoming country-based o
 
 | Event | Timestamp |
 | --: | :-- |
-| Registration phase | 2023-04-13/2023-04-27 |
+| Registration phase | 2023-04-13/2023-04-26 (23:59 UTC) |
 | Qualifier showcase | 2023-05-07 (14:00 UTC) |
 | Qualifier stage | 2023-05-13/2023-05-14 |
 | Round of 32 | 2023-05-20/2023-05-21 |

--- a/wiki/Tournaments/TWC/2023/en.md
+++ b/wiki/Tournaments/TWC/2023/en.md
@@ -108,7 +108,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/0ad
 
 | Team A | Team B | Match time |  |
 | --: | :-- | :-- | :-: |
-| Taiwan ::{ flag=TW }:: | ::{ flag=DE }:: Germany | [Apr 29 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230429T110000&p1=1440&p2=241&p3=37) | [^losers-bracket] |
+| Taiwan ::{ flag=TW }:: | ::{ flag=DE }:: Germany | [Apr 29 (Sat) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230429T120000&p1=1440&p2=241&p3=37) | [^losers-bracket] |
 
 ### Sunday, 30 April 2023
 


### PR DESCRIPTION
Updates the schedule for Grand Finals week for `TWC 2023`, and updates the registration deadline for `CWC 2023` on the wiki article to `2023-04-26 23:59:59 UTC+0`

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
