### PR TITLE
Fix mania mapping guide claiming 5K maps can use special style

### DIFF
--- a/wiki/Guides/osu!mania_Mapping_Guide/en.md
+++ b/wiki/Guides/osu!mania_Mapping_Guide/en.md
@@ -94,7 +94,7 @@ Alright! Let's drag the `.mp3` of the song we want to map into osu! and a new ma
 | :-- | :-- |
 | Stacking: | This point has no effect for osu!mania so no need to change anything here. |
 | Allowed Modes: | With this point, you change the mode of the editor to the one you want to use for your map. This guide is about osu!mania so we use "osu!mania" of course. Should you choose "All", your editor will be set to osu!. **Changing this option while in an existing osu!mania map will overwrite the map.** |
-| Use special Style (N+1 style) for osu!mania: | If you map in a keymode which uses a special key (5K and 8K) you can enable this point. This allows the player to swap the **special column** to their left or right depending on their settings. Known in "BMS" as the "Scratch Column", it is commonly used in 7+1K (8K) osu!mania. Mapping 7+1K is akin to mapping a 7K map, but an extra **special column** is generated for the mapper's discretion. |
+| Use special Style (N+1 style) for osu!mania: | If you map in a keymode which uses a special key (6K and 8K) you can enable this point. This allows the player to swap the **special column** to their left or right depending on their settings. Known in "BMS" as the "Scratch Column", it is commonly used in 7+1K (8K) osu!mania. Mapping 7+1K is akin to mapping a 7K map, but an extra **special column** is generated for the mapper's discretion. |
 
 The point **Colours** is not used in osu!mania so we don't need to change anything there.
 

--- a/wiki/Guides/osu!mania_Mapping_Guide/fr.md
+++ b/wiki/Guides/osu!mania_Mapping_Guide/fr.md
@@ -94,7 +94,7 @@ Très bien ! Faisons glisser le `.mp3` de la musique que nous voulons mapper dan
 | :-- | :-- |
 | Stacking : | Cette option n'a pas d'effet pour osu!mania donc pas besoin de changer quoi que ce soit ici. |
 | Allowed Modes : | Avec cette option, vous changez le mode de l'éditeur à celui que vous voulez utiliser pour votre beatmap. Ce guide est consacré à l'osu!mania, nous utilisons donc "osu!mania" bien sûr. Si vous choisissez "All", votre éditeur sera réglé sur osu!mania. **Si vous changez cette option alors que vous êtes dans une beatmap osu!mania existante, celle-ci sera écrasée**. |
-| Use special Style (N+1 style) for osu!mania : | Si vous mappez dans un keymode qui utilise une touche spéciale (5K et 8K), vous pouvez activer ce point. Cela permet au joueur d'échanger la **colonne spéciale** à sa gauche ou à sa droite selon ses réglages. Connue dans "BMS" sous le nom de "Scratch Column", elle est couramment utilisée dans 7+1K (8K) osu!mania. Le mapping en 7+1K est similaire au mapping d'une beatmap 7K, mais une **colonne spéciale** supplémentaire est générée à la discrétion du mappeur. |
+| Use special Style (N+1 style) for osu!mania : | Si vous mappez dans un keymode qui utilise une touche spéciale (6K et 8K), vous pouvez activer ce point. Cela permet au joueur d'échanger la **colonne spéciale** à sa gauche ou à sa droite selon ses réglages. Connue dans "BMS" sous le nom de "Scratch Column", elle est couramment utilisée dans 7+1K (8K) osu!mania. Le mapping en 7+1K est similaire au mapping d'une beatmap 7K, mais une **colonne spéciale** supplémentaire est générée à la discrétion du mappeur. |
 
 L'option **Colours** n'est pas utilisée dans osu!mania donc nous n'avons pas besoin de changer quoi que ce soit ici.
 


### PR DESCRIPTION
So I was reviewing https://github.com/ppy/osu/pull/23429 today. The gist of that pull is that lazer had wrong copy saying that special style was applicable to 5K maps (while - _to the best of my understanding_ - it actually is applicable to 6K maps, or 5K+1). Generally not being very knowledgeable about mania, I figured I'd crosscheck wiki just to be sure, and lo and behold, this guide also says 5K can use special style? Confusion ensues.

I ended up checking source and I am pretty sure that is false, _to the best of my understanding_.

![1683581391](https://user-images.githubusercontent.com/20418176/236939412-9169f58f-2c2b-4f0f-af0f-5e11a0218bd5.png)

To be sure I'm not misreading, I also ran stable. Didn't change much in my view of things, it's still 6K that can be special, _as far as I understand_.

So here I go seeing if the wiki will accept this as a fix as well.

---

I know enough French to also attempt to fix that version as well. I can't read German, but the German version [seems to be saying something about 7K and 9K being special](https://osu.ppy.sh/wiki/de/Guides/osu!mania_Mapping_Guide#advanced) which is just grand, but that translation is outdated and I can't write the language so I'm not touching that. The Indonesian translation is also outdated and also has no mention of special style, so I'm not touching that either.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
