### PR TITLE
Update links in `osu!api` and `Internet Relay Chat`

### DIFF
--- a/wiki/Community/Internet_Relay_Chat/de.md
+++ b/wiki/Community/Internet_Relay_Chat/de.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # Internet Relay Chat
 
 *Für mehr Informationen, siehe: [Internet Relay Chat (Wikipedia)](https://de.wikipedia.org/wiki/Internet_Relay_Chat)*

--- a/wiki/Community/Internet_Relay_Chat/en.md
+++ b/wiki/Community/Internet_Relay_Chat/en.md
@@ -18,7 +18,7 @@ Open settings of your IRC client and fill in the values (you may need to add a s
 - Port: `6667`
 - SSL: disabled
 - Username: your osu! username. Replace spaces with underscores (e.g., `beppy master 1000` becomes `beppy_master_1000`)
-- Password: the password from the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api)
+- Password: the password from the [account settings page](https://osu.ppy.sh/home/account/edit#legacy-api)
 
 *Warning: Your IRC password is different from your account password. **Do not share it with others**.*
 
@@ -62,7 +62,7 @@ Alternatively, use a different server address, `cho.ppy.sh` (you will still conn
 
 Try the following:
 
-1. Make sure you are using the correct password from the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api).
+1. Make sure you are using the correct password from the [account settings page](https://osu.ppy.sh/home/account/edit#legacy-api).
 2. If your username has spaces, replace them with underscores (e.g. `This Username` becomes `This_Username`).
 
 ### Can I use another username?

--- a/wiki/Community/Internet_Relay_Chat/en.md
+++ b/wiki/Community/Internet_Relay_Chat/en.md
@@ -18,7 +18,7 @@ Open settings of your IRC client and fill in the values (you may need to add a s
 - Port: `6667`
 - SSL: disabled
 - Username: your osu! username. Replace spaces with underscores (e.g., `beppy master 1000` becomes `beppy_master_1000`)
-- Password: the password from [IRC Authentication](https://osu.ppy.sh/p/irc) page
+- Password: the password from the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api)
 
 *Warning: Your IRC password is different from your account password. **Do not share it with others**.*
 
@@ -62,7 +62,7 @@ Alternatively, use a different server address, `cho.ppy.sh` (you will still conn
 
 Try the following:
 
-1. Make sure you are using the correct password from the [IRC Authentication page](https://osu.ppy.sh/p/irc).
+1. Make sure you are using the correct password from the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api).
 2. If your username has spaces, replace them with underscores (e.g. `This Username` becomes `This_Username`).
 
 ### Can I use another username?

--- a/wiki/Community/Internet_Relay_Chat/fr.md
+++ b/wiki/Community/Internet_Relay_Chat/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # Internet Relay Chat
 
 *Pour plus d'informations, consultez : [Internet Relay Chat (Wikipédia)](https://fr.wikipedia.org/wiki/Internet_Relay_Chat)*

--- a/wiki/Community/Internet_Relay_Chat/ru.md
+++ b/wiki/Community/Internet_Relay_Chat/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # Internet Relay Chat
 
 *Подробнее об IRC: [Internet Relay Chat (Википедия)](https://ru.wikipedia.org/wiki/Internet_Relay_Chat)*

--- a/wiki/Community/Internet_Relay_Chat/zh.md
+++ b/wiki/Community/Internet_Relay_Chat/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # 互联网中继聊天
 
 *如果要了解更多，请参见[互联网中继聊天](https://zh.wikipedia.org/wiki/IRC)*

--- a/wiki/osu!api/de.md
+++ b/wiki/osu!api/de.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! hat eine öffentliche API, die Entwickler nutzen können, um die osu!-Plattform zu unterstützen und zu erweitern. Früher war sie eher privat und konnte nur auf Anfrage genutzt werden, mittlerweile kann sie allerdings jeder nutzen der über einen osu!-Account verfügt.

--- a/wiki/osu!api/en.md
+++ b/wiki/osu!api/en.md
@@ -2,13 +2,13 @@
 
 osu! has a public [API](https://en.wikipedia.org/wiki/API) that third-party services can use to expand and support the osu! platform. It used to be more private, only to be used on a per-request basis, but now anybody can use the API so long as they have an osu! account.
 
-You can find documentation of the API at [osu-api's Wiki](https://github.com/ppy/osu-api/wiki). The current version of the API uses private keys to authenticate requests. You can apply for an API key at the [application page](https://osu.ppy.sh/p/api) on osu!'s website. Note that the documentation on the osu!api wiki may not be entirely complete or extensive, and the API itself is not under active development.
+You can find documentation of the API at [osu-api's Wiki](https://github.com/ppy/osu-api/wiki). The current version of the API uses private keys to authenticate requests. You can obtain an API key via the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api). Note that the documentation on the osu!api wiki may not be entirely complete or extensive, and the API itself is not under active development.
 
 ---
 
 Version 2 of the osu!api is in the works at [osu-web](https://github.com/ppy/osu-web), and it aims to be much more robust than the original. Documentation (not guaranteed to be up-to-date) can be found on its [reference page](https://docs.ppy.sh).
 
-Authentication for the new API follows the [OAuth 2 protocol](https://oauth.net/2/). Clients can be managed via the [account settings page](https://osu.ppy.sh/home/account/edit).
+Authentication for the new API follows the [OAuth 2 protocol](https://oauth.net/2/). Clients can be managed via the [account settings page § OAuth](https://osu.ppy.sh/home/account/edit#oauth).
 
 ## See also
 

--- a/wiki/osu!api/en.md
+++ b/wiki/osu!api/en.md
@@ -2,13 +2,13 @@
 
 osu! has a public [API](https://en.wikipedia.org/wiki/API) that third-party services can use to expand and support the osu! platform. It used to be more private, only to be used on a per-request basis, but now anybody can use the API so long as they have an osu! account.
 
-You can find documentation of the API at [osu-api's Wiki](https://github.com/ppy/osu-api/wiki). The current version of the API uses private keys to authenticate requests. You can obtain an API key via the [account settings page § Legacy API](https://osu.ppy.sh/home/account/edit#legacy-api). Note that the documentation on the osu!api wiki may not be entirely complete or extensive, and the API itself is not under active development.
+You can find documentation of the API at [osu-api's Wiki](https://github.com/ppy/osu-api/wiki). The current version of the API uses private keys to authenticate requests. You can obtain an API key via the [account settings page](https://osu.ppy.sh/home/account/edit#legacy-api). Note that the documentation on the osu!api wiki may not be entirely complete or extensive, and the API itself is not under active development.
 
 ---
 
 Version 2 of the osu!api is in the works at [osu-web](https://github.com/ppy/osu-web), and it aims to be much more robust than the original. Documentation (not guaranteed to be up-to-date) can be found on its [reference page](https://docs.ppy.sh).
 
-Authentication for the new API follows the [OAuth 2 protocol](https://oauth.net/2/). Clients can be managed via the [account settings page § OAuth](https://osu.ppy.sh/home/account/edit#oauth).
+Authentication for the new API follows the [OAuth 2 protocol](https://oauth.net/2/). Clients can be managed via the [account settings page](https://osu.ppy.sh/home/account/edit#oauth).
 
 ## See also
 

--- a/wiki/osu!api/es.md
+++ b/wiki/osu!api/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! tiene una [API](https://es.wikipedia.org/wiki/API) pública que los servicios de terceros pueden usar para expandir la plataforma de osu!. Solía ser más privada, solo para usarse por solicitud, pero ahora cualquiera puede usar la API siempre que tenga una cuenta de osu!.

--- a/wiki/osu!api/fr.md
+++ b/wiki/osu!api/fr.md
@@ -2,13 +2,13 @@
 
 osu! possède une [API](https://fr.wikipedia.org/wiki/API) publique que des services tiers peuvent utiliser pour développer et soutenir la plateforme osu!. À l'origine plus privée et utilisable uniquement sur demande, elle est à présent disponible pour toutes les personnes possédant un compte osu!.
 
-Vous pouvez trouver la documentation de l'API sur le wiki d'[osu-api](https://github.com/ppy/osu-api/wiki). La version actuelle de l'API utilise des clés privées pour authentifier les requêtes. Vous pouvez demander une clé API sur la [page d'application](https://osu.ppy.sh/p/api) sur le site d'osu!. Notez que la documentation sur le wiki osu-api n'est peut-être pas entièrement complète ni étendue et que l'API elle-même n'est pas en cours de développement actif.
+Vous pouvez trouver la documentation de l'API sur le wiki d'[osu-api](https://github.com/ppy/osu-api/wiki). La version actuelle de l'API utilise des clés privées pour authentifier les requêtes. Vous pouvez obtenir une clé API via la [page des paramètres du compte](https://osu.ppy.sh/home/account/edit#legacy-api). Notez que la documentation sur le wiki osu-api n'est peut-être pas entièrement complète ni étendue et que l'API elle-même n'est pas en cours de développement actif.
 
 ---
 
 La version 2 de l'API d'osu! est en développement sur [osu-web](https://github.com/ppy/osu-web), et vise à être beaucoup plus robuste que l'originale. La documentation (dont la mise à jour n'est pas garantie) peut-être trouvée sur cette [page de référence](https://docs.ppy.sh).
 
-L'authentification pour la nouvelle API suit le [protocole OAuth 2](https://oauth.net/2/). Les clients peuvent être gérés via la [page des paramètres du compte](https://osu.ppy.sh/home/account/edit).
+L'authentification pour la nouvelle API suit le [protocole OAuth 2](https://oauth.net/2/). Les clients peuvent être gérés via la [page des paramètres du compte](https://osu.ppy.sh/home/account/edit#oauth).
 
 ## Voir également
 

--- a/wiki/osu!api/id.md
+++ b/wiki/osu!api/id.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! memiliki [API](https://id.wikipedia.org/wiki/Antarmuka_pemrograman_aplikasi) publik yang dapat digunakan oleh layanan pihak ketiga untuk memperluas dan mendukung platform osu!. Dulunya API ini bersifat pribadi, dan hanya boleh digunakan jika kamu mengajukan permintaan akses, tapi sekarang siapa pun dapat menggunakan API ini selama mereka memiliki akun osu!.

--- a/wiki/osu!api/nl.md
+++ b/wiki/osu!api/nl.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
 ---
 
 # osu!api

--- a/wiki/osu!api/pl.md
+++ b/wiki/osu!api/pl.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! posiada publiczne [API](https://pl.wikipedia.org/wiki/Interfejs_programowania_aplikacji), którego używać mogą zewnętrzne usługi. W przeszłości miały do niego dostęp tylko upoważnione osoby, ale obecnie może z niego korzystać każdy użytkownik osu!.

--- a/wiki/osu!api/pt-br.md
+++ b/wiki/osu!api/pt-br.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! tem uma [API](https://pt.wikipedia.org/wiki/Interface_de_programa%C3%A7%C3%A3o_de_aplica%C3%A7%C3%B5es) pública que pode ser usada por serviços terceirizados para expandir a plataforma do osu!. A API costumava ser privada, utilizável apenas por aqueles que a solicitavam, mas agora qualquer um pode usá-la desde que possua uma conta no osu!.

--- a/wiki/osu!api/ru.md
+++ b/wiki/osu!api/ru.md
@@ -1,6 +1,8 @@
 ---
 no_native_review: true
 needs_cleanup: true  # несколько странных предложений
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
 ---
 
 # osu!api

--- a/wiki/osu!api/th.md
+++ b/wiki/osu!api/th.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! มี [API](https://en.wikipedia.org/wiki/API) สาธารณะให้ใช้สำหรับบริการ Third Party ต่างๆเพื่อที่จะขยายและสนับสนุน osu! เมื่อก่อนมันจะเป็น API ส่วนตัว ซึ่งสามารถใช้ได้เมื่อขอเท่านั้น แต่ตอนนี้ใครก็ได้สามารถใช้ได้ถ้าพวกเขามีบัญชี osu!

--- a/wiki/osu!api/zh.md
+++ b/wiki/osu!api/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 3e76c5b4ca5b874024d6234212525224fe5a8508
+---
+
 # osu!api
 
 osu! 提供了几个公共的 [API](https://zh.wikipedia.org/wiki/应用程序接口)，第三方服务可以使用这些 API 扩展 osu! 平台。这些 API 在以前是非公开使用的，且只能在每个 osu! 客户端发出的请求的基础上使用。但现在只要有一个 osu! 账号，任何人都可以使用这些 API 。


### PR DESCRIPTION
links to current website instead of old website

https://osu.ppy.sh/home/account/edit#legacy-api will work after the next [osu-web deploy](https://github.com/ppy/osu-web/pull/10189)
