### PR TITLE
Fix wrong date in `CWC 2023`

### DIFF
--- a/wiki/Tournaments/CWC/2023/en.md
+++ b/wiki/Tournaments/CWC/2023/en.md
@@ -117,7 +117,6 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/1c2
 | Chile ::{ flag=CL }:: | ::{ flag=CN }:: China | [May 20 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230520T140000&p1=1440&p2=232&p3=33) |
 | Finland ::{ flag=FI }:: | ::{ flag=FR }:: France | [May 20 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230520T150000&p1=1440&p2=101&p3=195) |
 | Poland ::{ flag=PL }:: | ::{ flag=BR }:: Brazil | [May 20 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230520T170000&p1=1440&p2=262&p3=45) |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=CO }:: Colombia | [May 20 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230520T180000&p1=1440&p2=166&p3=41) |
 
 ### Sunday, 21 May 2023
 
@@ -131,6 +130,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/1c2
 | Germany ::{ flag=DE }:: | ::{ flag=VN }:: Vietnam | [May 21 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230521T130000&p1=1440&p2=37&p3=95) |
 | Italy ::{ flag=IT }:: | ::{ flag=ES }:: Spain | [May 21 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230521T140000&p1=1440&p2=215&p3=141) |
 | Belgium ::{ flag=BE }:: | ::{ flag=AR }:: Argentina | [May 21 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230521T160000&p1=1440&p2=48&p3=51) |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=CO }:: Colombia | [May 21 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230521T180000&p1=1440&p2=166&p3=41) |
 
 ## Mappools
 


### PR DESCRIPTION
Russian Federation vs Colombia ~~May 20 (Sat) 18:00 UTC~~ May 21 (Sun) 18:00 UTC

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
