### PR TITLE
Add missing date to `Skinning Contest: Icons of an Era` news post schedule table

### DIFF
--- a/news/2023/2023-05-10-skinning-contest-icons-of-an-era.md
+++ b/news/2023/2023-05-10-skinning-contest-icons-of-an-era.md
@@ -46,9 +46,10 @@ The voting will stay open for 14 days. Once that passes, the top 3 entries will 
 
 ## Schedule
 
-| Event | Time |
-| :-- | :-- |
-| Submission phase | 2023-05-10 |
+| Event | Timestamp |
+| --: | :-- |
+| Announcement | 2023-05-10 |
+| Submission phase | 2023-05-10/2023-07-14 |
 | Voting phase | 2 weeks starting from a separate news post |
 | Results | *TBD* |
 


### PR DESCRIPTION
Adding the entire submission phase to the news post, since apparently we forgot that. This also makes the schedule consistent with [the wiki version](https://osu.ppy.sh/wiki/en/Contests/Skinning_Contest/4), changing `Time` to `Timestamp` was done to be consistent with the current and previous contest wiki articles.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
