### PR TITLE
Bump osu-wiki-tools to version `1.1.4`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==1.1.3
+osu-wiki-tools==1.1.4


### PR DESCRIPTION
View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v1.1.3...v1.1.4

This fixes fil.md files from being considered. Prereq for #9076

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->
