### PR TITLE
Fix wrong outdated translation hash in `ASC/Formatting`

### DIFF
--- a/wiki/Article_styling_criteria/Formatting/de.md
+++ b/wiki/Article_styling_criteria/Formatting/de.md
@@ -1,6 +1,6 @@
 ---
 no_native_review: true
-outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
+outdated_since: 545f0d9198fbeaae803d1214ffa2ef61cbc26ea1
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/de.md
+++ b/wiki/Article_styling_criteria/Formatting/de.md
@@ -1,6 +1,6 @@
 ---
 no_native_review: true
-outdated_since: 15fa00673aafde21c13d34647ce08372fd9691de
+outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/es.md
+++ b/wiki/Article_styling_criteria/Formatting/es.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 15fa00673aafde21c13d34647ce08372fd9691de
+outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/es.md
+++ b/wiki/Article_styling_criteria/Formatting/es.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
+outdated_since: 545f0d9198fbeaae803d1214ffa2ef61cbc26ea1
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/fr.md
+++ b/wiki/Article_styling_criteria/Formatting/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 15fa00673aafde21c13d34647ce08372fd9691de
+outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/fr.md
+++ b/wiki/Article_styling_criteria/Formatting/fr.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
+outdated_since: 545f0d9198fbeaae803d1214ffa2ef61cbc26ea1
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/ru.md
+++ b/wiki/Article_styling_criteria/Formatting/ru.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 15fa00673aafde21c13d34647ce08372fd9691de
+outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
 outdated_translation: true
 ---
 

--- a/wiki/Article_styling_criteria/Formatting/ru.md
+++ b/wiki/Article_styling_criteria/Formatting/ru.md
@@ -1,5 +1,5 @@
 ---
-outdated_since: 280f546b4d6cc6603de17556a6c99989398fe205
+outdated_since: 545f0d9198fbeaae803d1214ffa2ef61cbc26ea1
 outdated_translation: true
 ---
 


### PR DESCRIPTION
Change from #9492 

Noticed this, because the wiki status page is not showing any diff for this article.

Every tag with the commit 15fa00673aafde21c13d34647ce08372fd9691de was changed to 280f546b4d6cc6603de17556a6c99989398fe205

Korean already implemented this change and Thai has an even older version.

For the Spanish version, there is a [PR](https://github.com/ppy/osu-wiki/pull/9508) open. I left a comment there.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
