### PR TITLE
[DE] Add `Client/Menu tips`

### DIFF
--- a/wiki/Client/Menu_tips/de.md
+++ b/wiki/Client/Menu_tips/de.md
@@ -1,0 +1,116 @@
+---
+tags:
+  - tip
+  - tips
+  - hint
+  - hints
+  - Tipps
+  - Hinweise
+---
+
+<!-- For translators: to translate this page, select the corresponding language in stable and open `Localisation/XX.txt` in your osu! installation folder. Translation keys starting with MenuTip_ and EditorTip_ contain the respective translated tips. The lazer tips aren't localised yet, but it's ok to translate them here while noting that they don't have translations in-game. -->
+
+# Menütipps
+
+Dieser Artikel listet die verschiedenen Tipps auf, die im Spiel vorkommen und nützliche sowie obskure Informationen enthalten. Sie wurden leicht abgeändert in dieser Aufzählung, um Unstimmigkeiten bei der Formatierung zu beheben und um Links hinzuzufügen. Es ist anzumerken, dass sich diese Tipps von den englischen unterscheiden, insbesondere dann, wenn der übersetzte Text auf einer älteren Version basiert.
+
+## Hauptmenü
+
+Diese Tipps erscheinen am unteren Rand des [Hauptmenüs](/wiki/Client/Interface#hauptmenü).
+
+- Du kannst neue [Beatmaps](/wiki/Beatmap) importieren, indem du die [.osz-Datei](/wiki/Client/File_formats/Osz_(file_format)) in das Fenster ziehst, im Explorerfenster doppelklickst oder direkt vom Browser aus von osu! öffnen lässt.
+- Du kannst auch durch große Listen von Beatmaps einfach und schnell navigieren, indem du sie mit gedrückter linker Maustaste verschiebst oder mit der rechten Maustaste an einen bestimmten Punkt in der Liste springst.
+- Du kannst überall in osu! `F8` oder `F9` drücken, um den [Chat](/wiki/Client/Interface/Chat_console) zu öffnen.
+- Ein Rechtsklick auf die Beatmap oder ein Klick auf die `Beatmap-Optionen` öffnet ein Menü, mit dem du deine Beatmaps organisieren kannst.
+- Wenn du das Gefühl hast, dass das Spiel oder der Mauszeiger [nicht schnell genug](/wiki/Performance_troubleshooting) auf deine Eingaben reagieren, stelle in den Optionen ein höheres FPS-Limit ein. Das könnte helfen.
+- In schnellen Liedern kannst du beide Maustasten abwechselnd verwenden oder auf die Tastatur wechseln.
+- Wenn du Probleme damit hast, Videos abzuspielen, informiere dich bitte erst im Wiki, bevor du einen Bug-Report postest.
+- Du kannst überall in osu! einen Screenshot aufnehmen, indem du `F12` drückst.
+- Du kannst anderen beim Spielen zusehen, indem du den [Zuschauermodus](/wiki/Gameplay/Spectating) nutzt. Drücke `F9` für die erweiterte Chat-Anzeige und probiere es aus!
+- Wenn eine neue Version einer Beatmap verfügbar ist, wird an Stelle der Online-Rangliste ein Update-Knopf angezeigt, mit dem du die neueste Version herunterladen kannst.
+- Das Wiki beinhaltet viele nützliche Informationen. [Schau doch mal rein!](/wiki/Main_Page)
+- Wusstest du, dass du neue Beatmaps ganz einfach importieren kannst, indem du die Datei doppelklickst oder ins osu!-Fenster ziehst?
+- Auf der [Punkteübersicht](/wiki/Client/Interface#ergebnisanzeige) kannst du mit `F2` ein [Replay](/wiki/Gameplay/Replay) speichern, egal ob du online oder offline gespielt hast.
+- Wenn du das Gefühl hast, dass die Beats in jeder Beatmap zu früh oder zu spät kommen, solltest du versuchen, in den `Optionen` das `universelle Audio-Offset` anzupassen.
+- Du kannst eine Beatmap am schnellsten wiederfinden, indem du in der [Songauswahl](/wiki/Client/Interface#songauswahl) den Interpreten, den Titel oder den Ersteller der Beatmap eintippst.
+- Der Chat kann automatisch während des Spielens geschlossen werden. Wähle dafür den Schalter in der unteren rechten Ecke, wenn der Chat geöffnet ist.
+- Im Spiel kannst du mit dem Mausrad die Lautstärke anpassen. Wenn du das nicht willst, kannst du dies in den Optionen deaktivieren.
+- Mit der mittleren Maustaste kannst du ein Lied schnell pausieren oder weitermachen. Wenn du das nicht willst, kannst du dies in den Optionen deaktivieren.
+- Über der [Rangliste](/wiki/Client/Interface#rangliste) ist ein Knopf mit einer Sprechblase, mit dem du Schnellzugriff auf diverse Weblinks dieser Beatmap hast.
+- Passe dein osu! Erlebnis mit neuen [Skins](/wiki/Skin) an! Lade sie vom [Skinning Forum](https://osu.ppy.sh/community/forums/15) herunter.
+- Du kannst überall `F8` drücken, um den In-Game-Chat zu öffnen. Tippe `!help` oder `/help` ein, um eine Übersicht über die [verfügbaren Befehle](/wiki/Client/Interface/Chat_console#liste-an-chatbefehlen) zu erhalten.
+- Lege hin und wieder mal eine Pause ein und gönne deinen Augen und Händen eine Pause. Du könntest sie noch brauchen.
+- Ignoriere [nicht gerankte](/wiki/Beatmap/Category) Maps nicht einfach. Wenn du welche findest, die du magst, und [Verbesserungsvorschläge hinterlässt](/wiki/Modding), erhöhst du die Wahrscheinlichkeit, dass sie [gerankt](/wiki/Beatmap_ranking_procedure) wird!
+- Im [Multiplayer-Modus](/wiki/Client/Interface/Multiplayer) kannst du zusammen mit anderen spielen!
+- Hast du dich schon mal gefragt, woher die ganzen Spieler kommen? Drücke `F9` und bewege die Maus über ihr User-Panel!
+- Drücke `F5` in der Songauswahl, um neue Lieder in deinem Songs-Ordner zu importieren.
+- Wenn du `Shift` gedrückt hältst, während du mit `F12` einen Screenshot aufnimmst, wird er automatisch ins Internet hochgeladen.
+- Die Tasten, mit denen du osu! spielst, kannst du unter `Optionen` > `Steuerung` anpassen.
+- Du kannst Beatmaps nach ihren Schwierigkeitseinstellungen [filtern](/wiki/Client/Interface#suche), indem du beispielsweise `ar>8 od=9` ins Suchfeld eingibst. Die unterstützten Schlüsselwörter zum Filtern sind: `ar`, `d`, `hp`, `cs`, `bpm`, `stars`, `length` und `drain`.
+- Wiederhole eine Beatmap direkt, indem du für kurze Zeit `Strg` + `R` hältst!
+
+## Editor
+
+Diese Tipps erscheinen im [Beatmap-Editor](/wiki/Client/Beatmap_editor) unter der [Hit-Objekt-Zeitleiste](/wiki/Client/Beatmap_editor/Timelines#hit-objects).
+
+- Drücke `H`, um die Liste der Tastenkombinationen anzuzeigen.
+- Drücke `V`, um schnell zum letzten Hit-Circle zu springen. Drücke erneut, um an das Ende des Liedes zu gelangen.
+- Timing ist sehr wichtig. Falsches Timing macht es sehr schwierig, die Beats richtig zu platzieren und es ist sehr frustrierend, solche Maps zu spielen. Falls du Hilfe benötigst, lade deine Map im [Beatmap-Help-Forum](https://osu.ppy.sh/community/forums/56) hoch oder frag jemanden im Channel `#modreqs`.
+- [Distance-Snapping](/wiki/Client/Beatmap_editor/Distance_snap) kann dir helfen, das Beat-Spacing besser zu bestimmen, d.h. den richtigen Abstand zwischen Beats zu finden, je nachdem wie weit sie auf der Timeline voneinander entfernt sind.
+- Sei sparsam mit [Spinnern](/wiki/Gameplay/Hit_object/Spinner). [Autoplay](/wiki/Gameplay/Game_modifier/Auto) muss mindestens 1000 Bonuspunkte erhalten, damit der Spinner als spielbar gilt.
+- Falls du zusätzliche Hilfe brauchst, schrei nicht HIIIILFÄÄÄ oder OUENDAAN! Versuch das [FAQ](/wiki/FAQ) auf der Seite zu lesen, frag nach Hilfe im Channel `#modhelp` oder stell deine Map in das [Beatmap-Help-Forum](https://osu.ppy.sh/community/forums/56).
+- Im Allgemeinen gilt meistens: Je schwerer die Beatmap, desto länger werden die [Kombos](/wiki/Beatmapping/Combo). Mach sie aber nicht zu lang! 15 - 18 Beats sind noch akzeptabel.
+- Beats, die übereinander platziert werden, werden im Spielmodus [gestapelt](/wiki/Beatmapping/Mapping_techniques/Stack). Du wirst diese Stapel nicht im Editor sehen, also drücke `F5`, um den [Testmodus](/wiki/Client/Beatmap_editor/Test_mode) auszuführen und sieh sie dir an!
+- Falls du einen Beat nach einem Spinner platzierst, versuche ihn weit genug vom Spinner auf der Timeline zu platzieren, damit der Spieler genug Zeit hat, seinen Mauszeiger neu auszurichten.
+- [AiMod](/wiki/Client/Beatmap_editor/AiMod) (`Strg` + `Shift` + `A`) zu benutzen, ist eine großartige Möglichkeit, um potenzielle Probleme mit einer Beatmap zu beheben, bevor ein [Modder](/wiki/Modding/Modder) sie sich ansieht.
+- Du kannst "kopieren" (`Strg` + `C`) und "einfügen" (`Strg` + `V`) benutzen, um Formationen in deiner Beatmap zu wiederholen. Versuch es interessant zu halten, indem du sie horizontal (`Strg` + `H`) oder vertikal (`Strg` + `J`) spiegelst oder sie drehst (`Strg` + `>` und `Strg` + `<`).
+- Mach deine Beatmap interessanter, indem du Whistle (Pfeife), Finish oder Clap (Klatschen) verwendest, um bestimmte Stellen hervorzuheben! Allerdings kann die übertriebene Nutzung dieser [Töne](/wiki/Beatmapping/Hitsound) den gegenteiligen Effekt haben.
+- Versuche Pausen in deine Maps einzufügen, damit der Spieler sich einen Moment ausruhen kann! Idealerweise sollten Pausen 5 - 15 Sekunden lang sein und alle 40 - 60 Sekunden auftreten. Das ist aber sehr abhängig vom Lied.
+- Falls du eine schwierigere Version einer Beatmap erstellen willst, versuche mehr Beats, wo es geht, hinzuzufügen, verwende weniger oder schnellere [Slider](/wiki/Gameplay/Hit_object/Slider), mache die Kombos länger und verwende die Schwierigkeitseinstellungen im `Song Setup` Fenster.
+- Falls du eine leichtere Version einer Beatmap erstellen willst, versuch nur dem Kernrhythmus deiner originalen Beatmap zu folgen und verwende die Schwierigkeitseinstellungen im `Song-Setup`-Fenster.
+- Versuch die Beats und Slider in Formationen wie Linien, Kurven oder Winkel zu setzen, um deine Map intuitiver spielbar und auch schöner zu machen. [Grid-Snapping](/wiki/Beatmapping/Grid_snapping) könnte dir dabei helfen.
+- Teste deine Map oft, um potenzielle Probleme und Verbesserungen zu sehen.
+- Verwende den Geschwindigkeitsregler in der unteren rechten Ecke des Editors (oder drücke `Strg` + `Hoch` bzw. `Runter`), um das Lied zu verlangsamen. Das macht das Bestimmen des Offsets und das Platzieren von Noten leichter.
+- Wenn du bereits Noten platziert hast und dann das Timing änderst, solltest du nicht vergessen, die Position der Beats und Slider im Optionsmenü neu zu berechnen. Wenn einige Elemente dann immer noch falsch platziert sind, verschiebe sie manuell.
+- In manchen Liedern kann sich das Tempo drastisch verändern. In diesem Fall solltest du das `Timing-Panel` benutzen, um eine weitere Timingsektion zu erstellen, bei der sich das Offset an der Stelle befindet, an der sich das Tempo des Liedes verändert.
+- Lesezeichen können dir und anderen helfen, schnell zu wichtigen Stellen in deiner Beatmap zu gelangen. Geh mit deiner Maus über die [Suchleiste](/wiki/Client/Beatmap_editor/Timelines) am Boden des Editors, um die Lesezeichen anzeigen zu lassen.
+- Wenn du einen Slider platzierst, klicke oft den Weg des Sliders entlang. Dadurch kannst du ihn leichter verändern und ihn schöner gestalten. Du kannst einen weiteren Sliderpunkt hinzufügen, indem du `Strg` gedrückt hältst und zwischen 2 Wegpunkten klickst. Mit einem `Rechtsklick` entfernst du einen Wegpunkt.
+- Extralange Spinner sind ermüdend, während zu kurze Spinner irritieren. Versuche, sie ein paar Sekunden lang zu machen und vermeide es, sehr viele Spinner hintereinander zu platzieren.
+- Mit einem Rechtsklick entfernst du Objekte auf der Map oder der [Timeline](/wiki/Client/Beatmap_editor/Timelines#hit-objects). Ein Rechtsklick auf eine leere Stelle wird die nächste Note zum Anfang einer neuen Kombo machen.
+- Platziere Lesezeichen an wichtigen Stellen deiner Map, z.B. den Anfang einer Timingveränderung, nach einer Pause oder am Anfang des Refrains.
+- Mit `J`/`K` kannst du ausgewählte Noten um einen Schritt nach vorne oder hinten auf der Timeline bewegen.
+- Drücke `F5` oder klicke auf den `Test`-Knopf an der unteren Seite des Editors, um deine Beatmap von dem Punkt an zu testen, an dem du dich gerade befindest. Dies kann dabei helfen, Probleme mit dem [HP-Drain](/wiki/Beatmap/HP_drain_rate) oder der Platzierung der Noten zu erkennen. Des Weiteren hilft es dir dabei, bestimmte Stellen einer Map zu üben.
+- Vergrößere die Timeline, indem du mit deiner Maus auf die Timeline gehst und `Alt` gedrückt hältst, während du dein Mausrad verwendest. Du kannst ebenfalls auf die `Plus-` und `Minustasten` an der linken Seite der Timeline drücken. Das kann die Timeline übersichtlicher machen.
+- Falls du dein Timing doppelt und dreifach überprüfen willst, solltest du die Geschwindigkeit auf (0,25x, 0,50x) stellen. Veränder die Geschwindigkeit mit der Leiste in der unteren rechten Ecke oder benutze `Strg` + `Hoch` bzw. `Runter`.
+- Wenn du dich dazu entscheidest, an einer Map nicht mehr weiterzuarbeiten, macht das nichts. Verlassene Beatmaps werden nach einer gewissen Zeit an Inaktivität [begraben](/wiki/Beatmap/Category#friedhof) und falls du an deiner Map weiterarbeiten willst, klicke einfach auf `Resurrect` in deinem Profilabteil `Beatmaps`!
+- Jedes Gameplay-Element einer Beatmap kann einen Skin bekommen. Benutze einfach die selbe Namensstruktur für die Elemente im Beatmapordner, wie bei normalen Skins.
+- Wenn du Noten kopierst (`Strg` + `C`) wird außerdem der Zeitpunkt von der Timeline und die Kombonummern mit kopiert. Das ist sehr nützlich für Forenposts (besonders für [Mods](/wiki/Modding)).
+- Live-Mapping (`Strg` + `Tab`) erlaubt es dir, Hitcircles schnell mit deiner Taikosteuerung zu platzieren. Diese Option funktioniert aber auch sehr gut für osu!mania Maps.
+- Stelle sicher, dass Slider sich nicht mit sich selbst oder mit anderen Slidern überlappen.
+
+## osu!(lazer)
+
+Diese Tipps erscheinen beim Start von [osu!(lazer)](/wiki/Client/Release_stream/Lazer), vor der Intro-Sequenz. Für diesen Artikel wurden die Tipps übersetzt, da sie im Spiel nur auf Englisch verfügbar sind.
+
+- Du kannst überall `Strg` + `T` drücken, um die Toolbar zu aktivieren oder zu deaktivieren!
+- Du kannst überall `Strg` + `O` drücken, um auf die Optionen zuzugreifen!
+- Alle Einstellungen sind dynamisch und werden in Echtzeit wirksam. Probiere, das Spiel zu pausieren und den Skin zu ändern!
+- Mit jedem Update kommen neue Features hinzu. Bleibe immer auf dem Laufenden!
+- Wenn dir die Bedienelemente zu groß oder zu klein sind, versuche, die UI-Skalierung in den Einstellungen anzupassen!
+- Versuche, die `Bildschirmskalierung` anzupassen, um den Bereich der Benutzeroberfläche oder des Gameplays zu ändern, sogar im Vollbildmodus!
+- Was früher "[osu!direct](/wiki/osu!supporter#osu!direct)" war, ist nun wie auf der Webseite für alle Nutzer verfügbar. Du kannst es überall mit `Strg` + `D` aufrufen!
+- In Replays kann durch das Ziehen des Cursors auf der Schwierigkeitsleiste am unteren Rand des Bildschirms gesprungen werden!
+- Unterstützung für Multithreading bedeutet, dass selbst bei geringen "FPS" deine Eingaben und Beurteilungen präzise sein werden!
+- Probiere, in der Modauswahl herunterzuscrollen, um einen Haufen neuer spaßiger Mods zu entdecken!
+- Die meisten Webinhalte (Profile, Ranglisten etc.) sind über die Symbole in der Symbolleiste direkt im Spiel verfügbar!
+- Erhalte mehr Details, verstecke oder lösche eine Beatmap, indem du mit der rechten Maustaste auf ihr Dialogfeld in der Songauswahl klickst!
+- Alle Löschoperationen sind bis zum Verlassen nur vorübergehend. Stelle versehentlich gelöschte Inhalte in den Wartungseinstellungen wieder her!
+- Probiere das "Playlists"-System aus, das Nutzer ihre eigenen, bleibenden Bestenlisten kreieren lässt!
+- Mit `Strg` + `F11` kannst du Statistiken über Frames und Threads erhalten!
+- Werfe einen Blick unter die Haube der Leistungsindikatoren und aktiviere die ausführliche Leistungsprotokollierung mit `Strg` + `F2`!
+
+## Siehe auch
+
+- [Client/Benutzeroberfläche](/wiki/Client/Interface)
+- [Client/Beatmap-Editor](/wiki/Client/Beatmap_editor)
+- [Client/Tastenkürzel](/wiki/Client/Keyboard_shortcuts)


### PR DESCRIPTION
There are a few other things I would like to change in this article, however, I think this change is too much in regard to the given stable strings. This would require updating the strings in stable themselves. Though, I allowed myself to adjust typos.

For the editor tips, I've used the French translation as a template, because the tips are sorted chaotically when compared to English and you are frantically searching for what links to add otherwise. Although the German translation is somewhat close to the French one, there are still small differences here and there. I'm not sure to have always picked the correct link.

If you want to take a look at the original German localisation file, I've uploaded it for convenience in my [osu-wiki-notes](https://github.com/The-Last-Cookie/osu-wiki-notes/blob/master/data/stable/lang/de.txt) repository.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
