### PR TITLE
Replace non-breaking space with a regular space in `Staff log/2023`

### DIFF
--- a/wiki/People/Staff_log/2023/en.md
+++ b/wiki/People/Staff_log/2023/en.md
@@ -374,7 +374,7 @@ Abbreviations for user groups are used throughout this log:
 - 2023-06-23: Moved [Seto Kousuke](https://osu.ppy.sh/users/2857314) from **BN** to **Probationary BN**
 - 2023-06-25: Moved [ssapgosu](https://osu.ppy.sh/users/16564480) from **Probationary BN** to **BN**
 
-#### Removals
+#### Removals
 
 - 2023-06-02: Removed [Jonarwhal](https://osu.ppy.sh/users/3653035) from **BN**
 - 2023-06-05: Removed [Protastic101](https://osu.ppy.sh/users/6712747) from **BN**


### PR DESCRIPTION
For some reason this heading used a non-breaking space instead of a regular space, making it not render properly as a heading on the website and GitHub.

![image](https://github.com/ppy/osu-wiki/assets/8530896/b1289059-db45-4c3d-8b6f-a599c6cc8a3d)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
