### PR TITLE
Add `Community Meeting Recap` news post

### DIFF
--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -32,11 +32,11 @@ If you want to view the entire discussion, check out the VOD below:
     <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/bocgaVISSfg" frameborder="0" allowfullscreen></iframe>
 </div>
 
-Much of the discussion this time surrounded a long-debated topic: combo. Specifically, its significant — perhaps too significant — influence on score. These potential changes were discussed:
+Much of the discussion this time surrounded a long-debated topic: combo. Specifically, its significant — perhaps too significant — influence on score. These potential changes for the osu! game mode were discussed:
 
-- Directly decreasing the weight of the first few misses in the osu! game mode, since even one miss can have a huge impact on score.
-- Increasing the proportion in which accuracy affects score compared to combo in the osu! game mode. This was based on a [Twitter poll by peppy](https://twitter.com/ppy/status/1670681566547447808).
-- Drastically decreasing the value of high combos and aggressively scaling combo's influence based on accuracy, for all game modes. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
+- Directly decreasing the weight of the first few misses, since even one miss can have a huge impact on score.
+- Increasing the proportion in which accuracy affects score compared to combo. This was based on a [Twitter poll by peppy](https://twitter.com/ppy/status/1670681566547447808).
+- Drastically decreasing the value of high combos and aggressively scaling combo's influence based on accuracy. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
 
 There were some other issues brought up as well:
 

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -36,15 +36,15 @@ Much of the discussion this time surrounded a long-debated topic: combo. Specifi
 
 - Directly decreasing the weight of the first few misses in the osu! game mode, since even one miss can have a huge impact on score.
 - Increasing the proportion in which accuracy affects score compared to combo in the osu! game mode. This was based on a [Twitter poll by peppy](https://twitter.com/ppy/status/1670681566547447808).
-- Drastically decreasing the value of high combos and aggressively scaling the combo's influence based on accuracy, for all game modes. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
+- Drastically decreasing the value of high combos and aggressively scaling combo's influence based on accuracy, for all game modes. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
 
-There were also some other issues brought up as well:
+There were some other issues brought up as well:
 
 - Hit values for slider ticks and some other judgement types currently don't match osu!(stable), which will be corrected.
-- Slider ends (which currently are almost completely optional to hit), slider hit accuracy and other changes to game mechanics. These will need more discussion.
+- Slider ends (which currently are almost completely optional to hit), slider hit accuracy and other changes to game mechanics have been contentious. These will need more discussion.
 - osu!mania PERFECT judgements are currently required for 100% accuracy, making it an incredibly difficult feat. Also to be discussed separately.
 
-In order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying adjustments to get those scores closer to expectations.
+In order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying changes to get those scores closer to expectations.
 
 This is were *you* come in. The osu! team is looking for feedback on what issues the current ScoreV2 system has in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
 

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -8,7 +8,7 @@ Catch up on the latest community meeting and participate in discussing the final
 
 ![](https://assets.ppy.sh/media/generic-header.png)
 
-Last week a [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
+About a week ago [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
 
 If you missed the [previous meeting](https://www.youtube.com/watch?v=idmI03A8jR8), here's the quick summary of where we have been:
 

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -8,7 +8,7 @@ Catch up on the latest community meeting and participate in discussing the final
 
 ![](https://assets.ppy.sh/media/generic-header.png)
 
-About a week ago [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
+About a week ago, a [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
 
 If you missed the [previous meeting](https://www.youtube.com/watch?v=idmI03A8jR8), here's the quick summary of where we have been:
 

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -4,7 +4,7 @@ title: "Community Meeting Recap"
 date: 2023-07-10 15:00:00 +0000
 ---
 
-Catch up on the latest community meeting and participate in discussing the final changes to osu!(lazer)'s scoring system!
+Catch up on the latest community meeting and participate in discussing the final evolution of osu!'s scoring system!
 
 ![](https://assets.ppy.sh/media/generic-header.png)
 
@@ -22,7 +22,7 @@ And here's where we are now:
 
 - The discussed changes to mod multipliers for speed adjustment mods have been implemented.
 - Further internal discussion has led to the decision that leaderboards will be either wholly or partially wiped **just once** when the new scoring system is finalised, instead of multiple times.
-- ScoreV2 is now implemented as the current scoring system in osu!(lazer). It will be adjusted **one final time and then locked permanently**. Previous scores will be converted to this system.
+- ScoreV2 is now implemented as the current scoring system in osu!(lazer). It will be adjusted **one final time and then locked permanently**, after which all existing scores will be converted to this system.
 
 It's that last point that motivated this meeting. ScoreV2 has proven to be a better scoring system as it has been used for tournament play for years, but there may be issues that could be addressed. *What* adjustments to make, if any, is the big question.
 
@@ -44,12 +44,14 @@ There were some other issues brought up as well:
 - Slider ends (which currently are almost completely optional to hit), slider hit accuracy and other changes to game mechanics have been contentious. These will need more discussion.
 - osu!mania PERFECT judgements are currently required for 100% accuracy, making it an incredibly difficult feat. Also to be discussed separately.
 
+---
+
 In short, ScoreV2 is the future — or at least an improved version of it. But in order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying changes to get those scores closer to expectations.
 
 This is were *you* come in. We're looking for feedback on the current ScoreV2 system in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
 
 Keep in mind that there are as many opinions on scoring as there are players, and any adjustments will therefore focus on aligning things "close enough" to fix widely perceived issues, rather than debating over fine details.
 
-A lot of extensive discourse about scoring has been going on for months already, e.g. in [this GitHub thread](https://github.com/ppy/osu/discussions/24104) concerning ScoreV2 as it currently stands. If want to contribute, post your well-thought-out ideas, aggregated survey findings and feedback for other proposals there.
+A lot of extensive discourse about scoring has been going on for months already, e.g. in [this GitHub thread concerning ScoreV2 as it currently stands](https://github.com/ppy/osu/discussions/24104). If want to contribute, post your well-thought-out ideas, aggregated survey findings and feedback for other proposals there.
 
 —osu! team

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -8,7 +8,7 @@ Catch up on the latest community meeting and participate in discussing the final
 
 ![](https://assets.ppy.sh/media/generic-header.png)
 
-About a week ago, a [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
+A bit over a week ago, a [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
 
 If you missed the [previous meeting](https://www.youtube.com/watch?v=idmI03A8jR8), here's the quick summary of where we have been:
 
@@ -26,17 +26,17 @@ And here's where we are now:
 
 It's that last point that motivated this meeting. ScoreV2 has proven to be a better scoring system as it has been used for tournament play for years, but there may be issues that could be addressed. *What* adjustments to make, if any, is the big question.
 
-If you want to view the entire discussion, check out the VOD below:
+You can binge the entire VOD below:
 
 <div align="center">
     <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/bocgaVISSfg" frameborder="0" allowfullscreen></iframe>
 </div>
 
-Much of the discussion this time surrounded a long-debated topic: combo. Specifically, its significant — perhaps too significant — influence on score. These potential changes for the osu! game mode were discussed:
+Much of the conversation this time surrounded a long-debated topic: combo. Specifically, its significant — perhaps too significant — influence on score. These potential changes for the osu! game mode were discussed:
 
 - Directly decreasing the weight of the first few misses, since even one miss can have a huge impact on score.
 - Increasing the proportion in which accuracy affects score compared to combo. This was based on a [Twitter poll by peppy](https://twitter.com/ppy/status/1670681566547447808).
-- Drastically decreasing the value of high combos and aggressively scaling combo's influence based on accuracy. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
+- Drastically decreasing the value of high combos and aggressively scaling combo's influence based on accuracy. This change has been [submitted for review on GitHub](https://github.com/ppy/osu/pull/24166) already.
 
 There were some other issues brought up as well:
 
@@ -44,12 +44,12 @@ There were some other issues brought up as well:
 - Slider ends (which currently are almost completely optional to hit), slider hit accuracy and other changes to game mechanics have been contentious. These will need more discussion.
 - osu!mania PERFECT judgements are currently required for 100% accuracy, making it an incredibly difficult feat. Also to be discussed separately.
 
-In order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying changes to get those scores closer to expectations.
+In short, ScoreV2 is the future — or at least an improved version of it. But in order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying changes to get those scores closer to expectations.
 
-This is were *you* come in. We're looking for feedback on what issues the current ScoreV2 system has in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
+This is were *you* come in. We're looking for feedback on the current ScoreV2 system in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
 
 Keep in mind that there are as many opinions on scoring as there are players, and any adjustments will therefore focus on aligning things "close enough" to fix widely perceived issues, rather than debating over fine details.
 
-[Join the discussion in this forum thread!](LINK)
+A lot of extensive discourse about scoring has been going on for months already, e.g. in [this GitHub thread](https://github.com/ppy/osu/discussions/24104) concerning ScoreV2 as it currently stands. If want to contribute, post your well-thought-out ideas, aggregated survey findings and feedback for other proposals there.
 
 —osu! team

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -46,10 +46,10 @@ There were some other issues brought up as well:
 
 In order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying changes to get those scores closer to expectations.
 
-This is were *you* come in. The osu! team is looking for feedback on what issues the current ScoreV2 system has in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
+This is were *you* come in. We're looking for feedback on what issues the current ScoreV2 system has in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
 
 Keep in mind that there are as many opinions on scoring as there are players, and any adjustments will therefore focus on aligning things "close enough" to fix widely perceived issues, rather than debating over fine details.
 
 [Join the discussion in this forum thread!](LINK)
 
-—Walavouchey
+—osu! team

--- a/news/2023/2023-07-10-community-meeting-recap.md
+++ b/news/2023/2023-07-10-community-meeting-recap.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title: "Community Meeting Recap"
+date: 2023-07-10 15:00:00 +0000
+---
+
+Catch up on the latest community meeting and participate in discussing the final changes to osu!(lazer)'s scoring system!
+
+![](https://assets.ppy.sh/media/generic-header.png)
+
+Last week a [community meeting](/wiki/Community/osu!_community_meetings) was held to discuss how to proceed with scoring in osu!(lazer) with various people in the community.
+
+If you missed the [previous meeting](https://www.youtube.com/watch?v=idmI03A8jR8), here's the quick summary of where we have been:
+
+- How the leaderboards will be combined was discussed but no definitive conclusion was reached.
+- Leaderboard resets were planned to be performed multiple times until the scoring system would be finalised.
+- Mod multipliers for speed adjustment mods were decided to be rounded to the nearest 0.1x change in speed.
+- The question of whether immediate priority should be put on getting osu!(lazer) ready for tournament use was met with a clear "no".
+- The scoring system used in osu!(lazer) was discussed, with the general sentiment being that it had many issues.
+
+And here's where we are now:
+
+- The discussed changes to mod multipliers for speed adjustment mods have been implemented.
+- Further internal discussion has led to the decision that leaderboards will be either wholly or partially wiped **just once** when the new scoring system is finalised, instead of multiple times.
+- ScoreV2 is now implemented as the current scoring system in osu!(lazer). It will be adjusted **one final time and then locked permanently**. Previous scores will be converted to this system.
+
+It's that last point that motivated this meeting. ScoreV2 has proven to be a better scoring system as it has been used for tournament play for years, but there may be issues that could be addressed. *What* adjustments to make, if any, is the big question.
+
+If you want to view the entire discussion, check out the VOD below:
+
+<div align="center">
+    <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/bocgaVISSfg" frameborder="0" allowfullscreen></iframe>
+</div>
+
+Much of the discussion this time surrounded a long-debated topic: combo. Specifically, its significant — perhaps too significant — influence on score. These potential changes were discussed:
+
+- Directly decreasing the weight of the first few misses in the osu! game mode, since even one miss can have a huge impact on score.
+- Increasing the proportion in which accuracy affects score compared to combo in the osu! game mode. This was based on a [Twitter poll by peppy](https://twitter.com/ppy/status/1670681566547447808).
+- Drastically decreasing the value of high combos and aggressively scaling the combo's influence based on accuracy, for all game modes. This change has been [submitted to GitHub](https://github.com/ppy/osu/pull/24166) already.
+
+There were also some other issues brought up as well:
+
+- Hit values for slider ticks and some other judgement types currently don't match osu!(stable), which will be corrected.
+- Slider ends (which currently are almost completely optional to hit), slider hit accuracy and other changes to game mechanics. These will need more discussion.
+- osu!mania PERFECT judgements are currently required for 100% accuracy, making it an incredibly difficult feat. Also to be discussed separately.
+
+In order to make sensible adjustments, focus should be spent on identifying problematic leaderboards and outlier scores that "feel wrong", to identify underlying issues and experiment with applying adjustments to get those scores closer to expectations.
+
+This is were *you* come in. The osu! team is looking for feedback on what issues the current ScoreV2 system has in order to nail down any remaining issues. The coming months will see the last steps taken to lock in scoring and make scores permanent in the new client.
+
+Keep in mind that there are as many opinions on scoring as there are players, and any adjustments will therefore focus on aligning things "close enough" to fix widely perceived issues, rather than debating over fine details.
+
+[Join the discussion in this forum thread!](LINK)
+
+—Walavouchey

--- a/news/2023/2023-07-11-community-meeting-recap.md
+++ b/news/2023/2023-07-11-community-meeting-recap.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Community Meeting Recap"
-date: 2023-07-10 15:00:00 +0000
+date: 2023-07-11 09:00:00 +0000
 ---
 
 Catch up on the latest community meeting and participate in discussing the final evolution of osu!'s scoring system!

--- a/wiki/Community/osu!_community_meetings/de.md
+++ b/wiki/Community/osu!_community_meetings/de.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: d3592bb35b3055060a588302450b2c9716f9a92f
+---
+
 # osu! Community Meetings
 
 Die **osu! Community Meetings** sind Diskussionsrunden, die vom [osu!-Team](/wiki/People/osu!_team) veranstaltet werden. Das Hauptziel dieser Treffen ist es, jedem die Möglichkeit zu geben, direkt mit den Entwicklern und den für die Verwaltung der Community verantwortlichen Personen zu sprechen, um Probleme zur Diskussion zu stellen oder weitere Überlegungen einzubringen.

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -46,7 +46,7 @@ The first osu! community meeting was hosted on September 19, 2021. All meetings 
 | 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Development update, various community questions |
 | 14 | [April 3, 2022](https://youtu.be/UWT18LaoeKw) | [Meeting notes](https://docs.google.com/document/d/1LzKpXwIKxcpYgEAK4zdEIVuMNJckoo9SWN-UoAvOto8) | Scoring survey results reviewing, various community questions |
 | 15<!-- TODO (walavouchey): there's one before this one but the recording is audio-only and there are no notes yet --> | [February 12, 2023](https://youtu.be/idmI03A8jR8) | [Meeting notes](https://docs.google.com/document/d/13cMCrQN4vvaQFA59BmFHk6D7PH9fwT2ANmhkm5cmzxE) | osu!(lazer) game mechanics and balance |
-| 16 | [July 7, 2023](https://youtu.be/bocgaVISSfg) | [Summary news post](https://osu.ppy.sh/home/news/2023-07-10-community-meeting-recap) | Finalising the scoring system in osu!(lazer) |
+| 16 | [July 7, 2023](https://youtu.be/bocgaVISSfg) | [Summary news post](https://osu.ppy.sh/home/news/2023-07-11-community-meeting-recap) | Finalising the scoring system in osu!(lazer) |
 
 ## Related links
 

--- a/wiki/Community/osu!_community_meetings/en.md
+++ b/wiki/Community/osu!_community_meetings/en.md
@@ -46,7 +46,8 @@ The first osu! community meeting was hosted on September 19, 2021. All meetings 
 | 13 | [March 20, 2022](https://youtu.be/2Cp9rm0rNPQ) | [Meeting notes](https://docs.google.com/document/d/1X6ak_3CXxTYQLz71yhSTsKkl7cm74iaCQ7wecDkE6uQ) | Development update, various community questions |
 | 14 | [April 3, 2022](https://youtu.be/UWT18LaoeKw) | [Meeting notes](https://docs.google.com/document/d/1LzKpXwIKxcpYgEAK4zdEIVuMNJckoo9SWN-UoAvOto8) | Scoring survey results reviewing, various community questions |
 | 15<!-- TODO (walavouchey): there's one before this one but the recording is audio-only and there are no notes yet --> | [February 12, 2023](https://youtu.be/idmI03A8jR8) | [Meeting notes](https://docs.google.com/document/d/13cMCrQN4vvaQFA59BmFHk6D7PH9fwT2ANmhkm5cmzxE) | osu!(lazer) game mechanics and balance |
+| 16 | [July 7, 2023](https://youtu.be/bocgaVISSfg) | [Summary news post](https://osu.ppy.sh/home/news/2023-07-10-community-meeting-recap) | Finalising the scoring system in osu!(lazer) |
 
 ## Related links
 
-- [osu!dev Discord server](https://discord.gg/ppy)
+- [osu! Discord server](https://discord.com/invite/ppy)

--- a/wiki/Community/osu!_community_meetings/fr.md
+++ b/wiki/Community/osu!_community_meetings/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: d3592bb35b3055060a588302450b2c9716f9a92f
+---
+
 # osu! community meetings
 
 Les **osu! community meetings** sont un groupe de discussion organisé par l'[équipe d'osu!](/wiki/People/osu!_team). L'objectif principal de ces meetings est de donner à chacun une chance de parler directement avec les développeurs et les personnes responsables de la gestion de la communauté pour soulever des questions à discuter ou à approfondir.

--- a/wiki/Community/osu!_community_meetings/id.md
+++ b/wiki/Community/osu!_community_meetings/id.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: d3592bb35b3055060a588302450b2c9716f9a92f
+---
+
 # Pertemuan komunitas osu!
 
 **Pertemuan komunitas osu!** merupakan sebuah panel diskusi yang diadakan oleh [tim inti osu!](/wiki/People/osu!_team). Tujuan utama dari pertemuan ini adalah untuk memberikan kesempatan kepada seluruh pihak untuk dapat berbicara secara langsung dengan para pengembang serta orang-orang yang bertanggung jawab dalam mengatur komunitas mengenai berbagai hal yang dirasa perlu untuk dibahas dan dipertimbangkan lebih lanjut.


### PR DESCRIPTION
- no large doc this time, because there weren't that many important details to summarise and paraphrase, and i wanted to be more to-the-point
- some details and explanations are left out to give room for the main points, but do tell if something is just unclear
- my writing tends to be a bit terse so maybe the call to action at the end could be presented more fluidly
- i've put "osu! team" as the author to match the [previous meeting summary post](https://osu.ppy.sh/home/news/2022-03-07-community-meetings-recap) and because i think it fits, but feel free to revert 3e1e1b795cfb17554b90240a740e24e5b329c181 if you don't feel like doing that.
- [x] ~~create forum thread (also open to suggestions on where to direct discussion)~~ linked github thread
- [x] confirm the intended game modes to be affected with https://github.com/ppy/osu/pull/24166
