### PR TITLE
Fix incorrect date listing on `Centurions`

### DIFF
--- a/wiki/People/Centurions/en.md
+++ b/wiki/People/Centurions/en.md
@@ -11,7 +11,7 @@ Centurions are users who have achieved the prestigious milestone of creating **o
 
 | Name | 1st Ranked beatmap | 100th Ranked beatmap | Centurion packs |
 | :-- | :-- | :-- | :-- |
-| ::{ flag=IT }:: [Andrea](https://osu.ppy.sh/users/33599) | [2009-01-11](https://osu.ppy.sh/beatmapsets/11975) | [2010-12-10](https://osu.ppy.sh/beatmapsets/23100) | [#1](https://osu.ppy.sh/beatmaps/packs/TM8), [#2](https://osu.ppy.sh/beatmaps/packs/TM9), [#3](https://osu.ppy.sh/beatmaps/packs/TM10) |
+| ::{ flag=IT }:: [Andrea](https://osu.ppy.sh/users/33599) | [2009-02-27](https://osu.ppy.sh/beatmapsets/5396) | [2010-12-10](https://osu.ppy.sh/beatmapsets/23100) | [#1](https://osu.ppy.sh/beatmaps/packs/TM8), [#2](https://osu.ppy.sh/beatmaps/packs/TM9), [#3](https://osu.ppy.sh/beatmaps/packs/TM10) |
 | ::{ flag=US }:: [Annabel](https://osu.ppy.sh/users/3388410) | [2018-05-06](https://osu.ppy.sh/beatmapsets/757813) | [2019-09-27](https://osu.ppy.sh/beatmapsets/935244) |  |
 | ::{ flag=US }:: [Ascendance](https://osu.ppy.sh/users/2931883) | [2015-11-02](https://osu.ppy.sh/beatmapsets/329829) | [2019-10-31](https://osu.ppy.sh/beatmapsets/1009824) |  |
 | ::{ flag=TH }:: [DJPop](https://osu.ppy.sh/users/2363) | [2007-10-25](https://osu.ppy.sh/beatmapsets/122) | [2010-08-04](https://osu.ppy.sh/beatmapsets/17885) |  |


### PR DESCRIPTION
As mentioned and requested by one of the Centurion mappers (Andrea) via PM :

![image](https://github.com/ppy/osu-wiki/assets/36564236/8b4988b1-d484-4a0a-a6af-52b39968b38b)

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)