### PR TITLE
Add `Elite Nominators` article

### DIFF
--- a/wiki/Main_page/en.md
+++ b/wiki/Main_page/en.md
@@ -115,7 +115,7 @@ osu! wouldn't have been possible without many users helping with development, ma
 
 [osu! team](/wiki/People/osu!_team) • [Developers](/wiki/People/Developers) • [Featured Artists](/wiki/People/Featured_Artists) • [Global Moderation Team](/wiki/People/Global_Moderation_Team) • [Support Team](/wiki/People/Support_Team) • [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) • [Beatmap Nominators](/wiki/People/Beatmap_Nominators) • [osu! Alumni](/wiki/People/osu!_Alumni) • [Project Loved Team](/wiki/People/Project_Loved_Team) • [Beatmap Spotlight Curators](/wiki/People/Beatmap_Spotlight_Curators)
 
-[Community Contributors](/wiki/People/Community_Contributors) • [User group](/wiki/People/User_group) • [Users with unique titles](/wiki/People/Users_with_unique_titles) • [Centurions](/wiki/People/Centurions) • [Tournament Committee](/wiki/People/Tournament_Committee) • [Performance Points Committee](/wiki/People/Performance_Points_Committee) • [osu! wiki maintainers](/wiki/People/osu!_wiki_maintainers)
+[Community Contributors](/wiki/People/Community_Contributors) • [Elite Nominators](/wiki/People/Elite_Nominators) • [User group](/wiki/People/User_group) • [Users with unique titles](/wiki/People/Users_with_unique_titles) • [Centurions](/wiki/People/Centurions) • [Tournament Committee](/wiki/People/Tournament_Committee) • [Performance Points Committee](/wiki/People/Performance_Points_Committee) • [osu! wiki maintainers](/wiki/People/osu!_wiki_maintainers)
 
 </div>
 <div class="wiki-main-page-panel">

--- a/wiki/Main_page/id.md
+++ b/wiki/Main_page/id.md
@@ -115,7 +115,7 @@ osu! tidak akan dapat berada pada titik ini tanpa dukungan dari mereka yang tela
 
 [Tim inti](/wiki/People/osu!_team) • [Developer](/wiki/People/Developers) • [Featured Artist](/wiki/People/Featured_Artists) • [Global Moderation Team](/wiki/People/Global_Moderation_Team) • [Support Team](/wiki/People/Support_Team) • [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) • [Beatmap Nominator](/wiki/People/Beatmap_Nominators) • [osu! Alumni](/wiki/People/osu!_Alumni) • [Project Loved Team](/wiki/People/Project_Loved_Team) • [Beatmap Spotlight Curators](/wiki/People/Beatmap_Spotlight_Curators)
 
-[Kontributor komunitas](/wiki/People/Community_Contributors) • [Kelompok pengguna](/wiki/People/User_group) • [Pengguna dengan gelar khusus](/wiki/People/Users_with_unique_titles) • [Centurion](/wiki/People/Centurions) • [Komite turnamen](/wiki/People/Tournament_Committee) • [Komite performance point](/wiki/People/Performance_Points_Committee) • [Pengelola osu!wiki](/wiki/People/osu!_wiki_maintainers)
+[Kontributor komunitas](/wiki/People/Community_Contributors) • [Elite Nominator](/wiki/People/Elite_Nominators) • [Kelompok pengguna](/wiki/People/User_group) • [Pengguna dengan gelar khusus](/wiki/People/Users_with_unique_titles) • [Centurion](/wiki/People/Centurions) • [Komite turnamen](/wiki/People/Tournament_Committee) • [Komite performance point](/wiki/People/Performance_Points_Committee) • [Pengelola osu!wiki](/wiki/People/osu!_wiki_maintainers)
 
 </div>
 <div class="wiki-main-page-panel">

--- a/wiki/Main_page/it.md
+++ b/wiki/Main_page/it.md
@@ -1,5 +1,7 @@
 ---
 layout: main_page
+outdated_translation: true
+outdated_since: ee682495814ba758213e136fa7acd2acbd34e753
 ---
 
 <!-- Do not add any empty lines inside this div. -->

--- a/wiki/People/Elite_Nominators/en.md
+++ b/wiki/People/Elite_Nominators/en.md
@@ -1,0 +1,104 @@
+# Elite Nominators
+
+**Elite Nominators** are members of the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) and [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) who went above and beyond the call in order to display an exceptional contribution towards the ranking process and the overall health of the mapping community by standing out as some of the best nominators of their times.
+
+Elite Nominators are selected by the Nomination Assessment Team through multiple factors, including but not limited to:
+
+- Amount of [nominations](/wiki/Beatmap_ranking_procedure#nominations)
+- Quality of nominated beatmaps
+- Quality of modding
+- Amount of [nomination resets](/wiki/Beatmap_ranking_procedure#nomination-resets) received
+- Amount of [Quality Assurance](/wiki/People/Beatmap_Nominators/General_Information#quality-assurance) checks
+- Other notable contributions to the mapping community
+- Other qualities that make the nominator stand out from the rest
+
+Starting from [7 February 2020](https://osu.ppy.sh/home/news/2020-02-07-community-contributors-2019), Elite Nominators are recognised through news posts and are awarded:
+
+- The "Elite Nominator" [user title](/wiki/Community/User_title)
+  - Title lasts until the next Elite Nominators wave and is removed if the user is no longer a Beatmap Nominator
+  - Title increments by 1 for each consecutive year the user is an Elite Nominator
+- A special Elite Nominator [profile badge](/wiki/Community/Profile_badge)
+
+![](https://assets.ppy.sh/profile-badges/elite-nominator.png "Elite Nominator badge")
+
+## 2019
+
+*For the news post, see: [Community Contributors: 2019](https://osu.ppy.sh/home/news/2020-02-07-community-contributors-2019)*
+
+<!-- order of appearance in news post to be consistent with community contributors -->
+
+| Name | Game mode |
+| :-- | :-- |
+| ::{ flag=DE }:: [Mordred](https://osu.ppy.sh/users/7265097) | osu! |
+| ::{ flag=US }:: [Cheri](https://osu.ppy.sh/users/5226970) | osu! |
+| ::{ flag=US }:: [Annabel](https://osu.ppy.sh/users/3388410) | osu! |
+| ::{ flag=TW }:: [bossandy](https://osu.ppy.sh/users/360437) | osu! |
+| ::{ flag=DE }:: [Lasse](https://osu.ppy.sh/users/896613) | osu! |
+| ::{ flag=JP }:: [komasy](https://osu.ppy.sh/users/1980256) | osu!taiko |
+| ::{ flag=TH }:: [Tyistiana](https://osu.ppy.sh/users/1421452) | osu!taiko |
+| ::{ flag=PH }:: [Jemzuu](https://osu.ppy.sh/users/7890134) | osu!catch |
+| ::{ flag=US }:: [wonjae](https://osu.ppy.sh/users/5032045) | osu!catch |
+| ::{ flag=US }:: [-MysticEyes](https://osu.ppy.sh/users/6253266) | osu!mania |
+| ::{ flag=MY }:: [_Kobii](https://osu.ppy.sh/users/6209713) | osu!mania |
+
+## 2020
+
+*For the news post, see: [Community Contributors: 2020](https://osu.ppy.sh/home/news/2021-03-19-community-contributors-2020)*
+
+| Name | Game mode |
+| :-- | :-- |
+| ::{ flag=DE }:: [Mordred](https://osu.ppy.sh/users/7265097) | osu! |
+| ::{ flag=DE }:: [Lasse](https://osu.ppy.sh/users/896613) | osu! |
+| ::{ flag=CA }:: [Agatsu](https://osu.ppy.sh/users/5579871) | osu! |
+| ::{ flag=JP }:: [BaAR_Vendel](https://osu.ppy.sh/users/8679346) | osu! |
+| ::{ flag=CL }:: [Milan-](https://osu.ppy.sh/users/1052994) | osu! |
+| ::{ flag=US }:: [Annabel](https://osu.ppy.sh/users/3388410) | osu!, osu!taiko |
+| ::{ flag=ES }:: [Raiden](https://osu.ppy.sh/users/2239480) | osu!taiko |
+| ::{ flag=PH }:: [Jemzuu](https://osu.ppy.sh/users/7890134) | osu!catch |
+| ::{ flag=ID }:: [Xinely](https://osu.ppy.sh/users/1521445) | osu!catch |
+| ::{ flag=US }:: [Unpredictable](https://osu.ppy.sh/users/7560872) | osu!mania |
+| ::{ flag=ID }:: [Rivals_7](https://osu.ppy.sh/users/4610379) | osu!mania |
+
+## 2021
+
+*For the news post, see: [Community Contributors 2021: Elite Nominators](https://osu.ppy.sh/home/news/2022-03-22-community-contributors-elite-nominators)*
+
+| Name | Game mode |
+| :-- | :-- |
+| ::{ flag=GB }:: [AJT](https://osu.ppy.sh/users/3181083) | osu! |
+| ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992) | osu! |
+| ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323) | osu! |
+| ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581) | osu! |
+| ::{ flag=US }:: [StarCastler](https://osu.ppy.sh/users/12402453) | osu! |
+| ::{ flag=US }:: [UberFazz](https://osu.ppy.sh/users/8646059) | osu! |
+| ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | osu! |
+| ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033) | osu! |
+| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | osu!taiko |
+| ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649) | osu!taiko |
+| ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637) | osu!catch |
+| ::{ flag=US }:: [Nokashi](https://osu.ppy.sh/users/5431196) | osu!catch |
+| ::{ flag=ES }:: [Quenlla](https://osu.ppy.sh/users/4725379) | osu!mania |
+| ::{ flag=CA }:: [guden](https://osu.ppy.sh/users/11626065) | osu!mania |
+| ::{ flag=CN }:: [_Stan](https://osu.ppy.sh/users/1653229) | osu!mania |
+| ::{ flag=KR }:: [Murumoo](https://osu.ppy.sh/users/8001433) | osu!mania |
+
+## 2022
+
+*For the news post, see: [Community Contributors 2022: Elite Nominators](https://osu.ppy.sh/home/news/2023-02-17-community-contributors-elite-nominators-2022)*
+
+| Name | Game mode |
+| :-- | :-- |
+| ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875) | osu! |
+| ::{ flag=DE }:: [FuJu](https://osu.ppy.sh/users/10773882) | osu! |
+| ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302) | osu! |
+| ::{ flag=RU }:: [Mirash](https://osu.ppy.sh/users/2841009) | osu! |
+| ::{ flag=GB }:: [moonpoint](https://osu.ppy.sh/users/9558549) | osu! |
+| ::{ flag=US }:: [fieryrage](https://osu.ppy.sh/users/3533958) | osu! |
+| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | osu!taiko |
+| ::{ flag=US }:: [meiqth](https://osu.ppy.sh/users/12565402) | osu!taiko |
+| ::{ flag=BR }:: [zerokt](https://osu.ppy.sh/users/13776127) | osu!catch |
+| ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637) | osu!catch |
+| ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785) | osu!mania |
+| ::{ flag=CN }:: [gzdongsheng](https://osu.ppy.sh/users/7777875) | osu!mania |
+| ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306) | osu!mania |
+| ::{ flag=KR }:: [secXcscX](https://osu.ppy.sh/users/13543418) | osu!mania |

--- a/wiki/People/Users_with_unique_titles/de.md
+++ b/wiki/People/Users_with_unique_titles/de.md
@@ -172,24 +172,6 @@ Die meisten offiziellen Mapping-Wettbewerbe bieten den Titel **Elite Mapper** al
 - ::{ flag=SE }:: [Xgor](https://osu.ppy.sh/users/98661)
 - ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768)
 
-## Elite Nominators
-
-Seit 2020 werden Mitglieder der [Beatmap-Nominators](/wiki/People/Beatmap_Nominators) und des [Nomination-Assessment-Teams](/wiki/People/Nomination_Assessment_Team) mit einer außergewöhnlichen Leistung zur Unterstützung des Ranglistensystems in einem bestimmten Jahr mit dem Titel **Elite Nominator** ausgezeichnet. Dieser Titel wird zu Beginn jedes Jahres für Beiträge vergeben, die während dem vergangen Jahr gemacht wurden, und halten etwa ein Jahr lang oder bis der Benutzer das Team verlässt.
-
-- ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306)
-- ::{ flag=US }:: [fieryrage](https://osu.ppy.sh/users/3533958)
-- ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)[^elite-note]
-- ::{ flag=CN }:: [gzdongsheng](https://osu.ppy.sh/users/8660315)
-- ::{ flag=US }:: [meiqth](https://osu.ppy.sh/users/12565402)
-- ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785)
-- ::{ flag=RU }:: [Mirash](https://osu.ppy.sh/users/2841009)
-- ::{ flag=GB }:: [moonpoint](https://osu.ppy.sh/users/9558549)
-- ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
-- ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)[^elite-note]
-- ::{ flag=KR }:: [SecxcscX](https://osu.ppy.sh/users/13543418)
-- ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
-- ::{ flag=BR }:: [zerokt](https://osu.ppy.sh/users/13776127)
-
 ## Gewinner des Aspire-Mapping-Wettbewerbs
 
 Die Aspire-Mapping-Wettbewerbe vergeben als Preis eine spezielle Variante des Elite-Mapper-Titels genannt **Elite Mapper: Aspirant**.

--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -171,24 +171,6 @@ Most official mapping contests offer the **Elite Mapper** title as a first-place
 - ::{ flag=SE }:: [Xgor](https://osu.ppy.sh/users/98661)
 - ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768)
 
-## Elite Nominators
-
-Since 2020, members of the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) and [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) with an exceptional display towards supporting the ranking system in a given year are rewarded with the **Elite Nominator** title. This title is given at the beginning of each year for contributions made during the last, and lasts for roughly a year or until the user leaves the team.
-
-- ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306)
-- ::{ flag=US }:: [fieryrage](https://osu.ppy.sh/users/3533958)
-- ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)[^elite-note]
-- ::{ flag=CN }:: [gzdongsheng](https://osu.ppy.sh/users/8660315)
-- ::{ flag=US }:: [meiqth](https://osu.ppy.sh/users/12565402)
-- ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785)
-- ::{ flag=RU }:: [Mirash](https://osu.ppy.sh/users/2841009)
-- ::{ flag=GB }:: [moonpoint](https://osu.ppy.sh/users/9558549)
-- ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
-- ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)[^elite-note]
-- ::{ flag=KR }:: [SecxcscX](https://osu.ppy.sh/users/13543418)
-- ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
-- ::{ flag=BR }:: [zerokt](https://osu.ppy.sh/users/13776127)
-
 ## Aspire mapping contest winners
 
 The Aspire mapping contests feature a special variation of the Elite Mapper title called **Elite Mapper: Aspirant** as a prize.

--- a/wiki/People/Users_with_unique_titles/es.md
+++ b/wiki/People/Users_with_unique_titles/es.md
@@ -171,24 +171,6 @@ La mayoría de los concursos oficiales de mapping ofrecen el título **Elite Map
 - ::{ flag=SE }:: [Xgor](https://osu.ppy.sh/users/98661)
 - ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768)
 
-## Elite Nominators
-
-Desde 2020, los miembros de los [Beatmap Nominators](/wiki/People/Beatmap_Nominators) y [Nomination Assessment Team](/wiki/People/Nomination_Assessment_Team) con una exhibición excepcional para apoyar el sistema de clasificación en un año determinado son recompensados con el título **Elite Nominator**. Este título se otorga al inicio de cada año por las contribuciones realizadas durante el último, y dura aproximadamente un año o hasta que el usuario deja el equipo.
-
-- ::{ flag=VN }:: [Akasha-](https://osu.ppy.sh/users/2596306)
-- ::{ flag=US }:: [fieryrage](https://osu.ppy.sh/users/3533958)
-- ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976)[^elite-note]
-- ::{ flag=CN }:: [gzdongsheng](https://osu.ppy.sh/users/8660315)
-- ::{ flag=US }:: [meiqth](https://osu.ppy.sh/users/12565402)
-- ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785)
-- ::{ flag=RU }:: [Mirash](https://osu.ppy.sh/users/2841009)
-- ::{ flag=GB }:: [moonpoint](https://osu.ppy.sh/users/9558549)
-- ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
-- ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)[^elite-note]
-- ::{ flag=KR }:: [SecxcscX](https://osu.ppy.sh/users/13543418)
-- ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
-- ::{ flag=BR }:: [zerokt](https://osu.ppy.sh/users/13776127)
-
 ## Ganadores de los concursos Aspire mapping
 
 Los concursos de Aspire mapping cuentan con una variación especial del título Elite Mapper llamado **Elite Mapper: Aspirant** como premio.


### PR DESCRIPTION
similar theme to community contributors article

imo having elite nominators in a single section in unique titles article is no longer enough now that we have 4 generations of them + dedicated newsposts, especially when previous table didn't include past elites