### PR TITLE
Fix the year of the SOTY contest in `Contests` wiki page

### DIFF
--- a/wiki/Contests/en.md
+++ b/wiki/Contests/en.md
@@ -239,7 +239,7 @@ The **Skinning Contest** is a skinning contest where artistic creators from all 
 
 | Contest No. | ![Gold crown][GCrown] | ![Silver crown][SCrown] | ![Bronze crown][BCrown] | Results |
 | :-: | :-- | :-- | :-- | :-- |
-| [#1 (2023)](https://osu.ppy.sh/home/news/2023-02-09-skin-of-the-year-2022) | [If there was an endpoint.](https://osu.ppy.sh/community/forums/topics/1672096) by ::{ flag=PE }:: [- Koshiin -](https://osu.ppy.sh/users/19135423) | [Moonshine](https://osu.ppy.sh/community/forums/topics/1610388) by ::{ flag=MY }:: [moonstaar](https://osu.ppy.sh/users/27339355) | [Shiroko Swimsuit](https://osu.ppy.sh/community/forums/topics/1641543) by ::{ flag=TR }:: [BatuhanYtho](https://osu.ppy.sh/users/12091015) | [#1](https://osu.ppy.sh/home/news/2023-03-05-skin-of-the-year-2022-results) |
+| [#1 (2022)](https://osu.ppy.sh/home/news/2023-02-09-skin-of-the-year-2022) | [If there was an endpoint.](https://osu.ppy.sh/community/forums/topics/1672096) by ::{ flag=PE }:: [- Koshiin -](https://osu.ppy.sh/users/19135423) | [Moonshine](https://osu.ppy.sh/community/forums/topics/1610388) by ::{ flag=MY }:: [moonstaar](https://osu.ppy.sh/users/27339355) | [Shiroko Swimsuit](https://osu.ppy.sh/community/forums/topics/1641543) by ::{ flag=TR }:: [BatuhanYtho](https://osu.ppy.sh/users/12091015) | [#1](https://osu.ppy.sh/home/news/2023-03-05-skin-of-the-year-2022-results) |
 
 ### [osu!trivium Quiz](osu!trivium_Quiz)
 


### PR DESCRIPTION
should be the year in review, not when the contest was held