### PR TITLE
Remove `Haitai` from `Community/Projects`

### DIFF
--- a/wiki/Community/Projects/en.md
+++ b/wiki/Community/Projects/en.md
@@ -235,8 +235,6 @@ Tools and/or services made by the osu! community. Feel free to add your own osu!
 
 - [Bonus PP calculator](https://osu.ppy.sh/community/forums/topics/538470) — Calcuates how much bonus pp a user has.
   - [GitHub](https://github.com/RoanH/osu-BonusPP)
-- haitai — Unlock requirements for osu! [medals](/wiki/Medals).
-  - [Website](http://haitai.jp/)
 - [Osekai](https://osu.ppy.sh/community/forums/topics/1427698) — An open-source project dedicated to making websites highly related to osu!, such as [medal unlock requirements](/wiki/Medals/Unlock_requirements) listing or alternative ranking leaderboards.
   - [GitHub](https://github.com/Osekai/osekai) | [Website](https://osekai.net/)
 - [osu! level calculator](https://osu.ppy.sh/community/forums/topics/199230) — Calculates the needed score to achieve a certain level.

--- a/wiki/Community/Projects/fr.md
+++ b/wiki/Community/Projects/fr.md
@@ -231,8 +231,6 @@ Outils et/ou services créés par la communauté d'osu!. Vous êtes libres d'ajo
 
 - [Bonus PP calculator](https://osu.ppy.sh/community/forums/topics/538470)—Calcule le nombre de pp bonus d'un utilisateur.
   - [GitHub](https://github.com/RoanH/osu-BonusPP)
-- haitai—Conditions de déblocage pour les [médailles](/wiki/Medals) d'osu!.
-  - [Site](http://haitai.jp/)
 - [Osekai](https://osu.ppy.sh/community/forums/topics/1427698)—Un projet open-source dédié à la création de sites web fortement liés à osu!, comme la liste [des conditions de déblocage des médailles](/wiki/Medals/Unlock_requirements) ou des classements alternatifs.
   - [GitHub](https://github.com/Osekai/osekai) | [Site](https://osekai.net/)
 - [osu! level calculator](https://osu.ppy.sh/community/forums/topics/199230)—Calcule le score nécessaire pour atteindre un certain niveau.


### PR DESCRIPTION
Haitai no longer exists, just goes to one of those "buy these domain" websites with some sketchy links.
