### PR TITLE
Clean up `Gameplay/Perfect (mod)` slightly

### DIFF
--- a/wiki/Gameplay/Game_modifier/Perfect/en.md
+++ b/wiki/Gameplay/Game_modifier/Perfect/en.md
@@ -33,7 +33,7 @@ Any of the following acts **will cause** the Perfect mod to restart the beatmap:
 - Missing a note
 - Obtaining a GOOD or MEH
 - Failing a spinner
-- Sliderbreaking
+- Dropping a slider's [tail](/wiki/Gameplay/Hit_object/Slider/Slidertail) or doing a [slider break](/wiki/Gameplay/Judgement/Slider_break)
 
 Any of the following acts **will not cause** the Perfect mod to restart the beatmap:
 
@@ -46,8 +46,7 @@ This mod has the same effect across all [game modes](/wiki/Game_mode)
 
 ## Trivia
 
-- If there is a skippable prologue, the Perfect mod will not automatically skip it because it uses restart functionality as opposed to a quick-retry.
-- The Perfect mod is a variant of the [Sudden Death](/wiki/Gameplay/Game_modifier/Sudden_Death) mod.
+- If there is a skippable prologue, the Perfect mod will not automatically skip it, because it uses restart functionality, as opposed to a quick retry.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"


### PR DESCRIPTION
- useless trivia point
- PF + sliders (caught by @IlyaDityatyev)
- `SKIP_OUTDATED_CHECK` because I applied both points in https://github.com/ppy/osu-wiki/pull/9779 (other translations are already outdated)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
