### PR TITLE
Outdate `Beatmap discussion`

### DIFF
--- a/wiki/Beatmap_discussion/en.md
+++ b/wiki/Beatmap_discussion/en.md
@@ -1,5 +1,5 @@
 ---
-outdated: true
+outdated: true  # see https://github.com/ppy/osu-wiki/pull/9865 for general direction
 tags:
   - beatmap discussions
   - modding V2

--- a/wiki/Beatmap_discussion/en.md
+++ b/wiki/Beatmap_discussion/en.md
@@ -1,4 +1,5 @@
 ---
+outdated: true
 tags:
   - beatmap discussions
   - modding V2

--- a/wiki/Beatmap_discussion/es.md
+++ b/wiki/Beatmap_discussion/es.md
@@ -3,6 +3,7 @@ tags:
   - beatmap discussions
   - modding V2
   - MV2
+outdated: true
 no_native_review: true
 ---
 

--- a/wiki/Beatmap_discussion/fr.md
+++ b/wiki/Beatmap_discussion/fr.md
@@ -4,6 +4,7 @@ tags:
   - modding V2
   - MV2
   - discussion de la beatmap
+outdated: true
 ---
 
 <!-- TODO: the interface has changed quite a bit. this whole article should be rechecked to make sure it all makes sense still -->

--- a/wiki/Beatmap_discussion/id.md
+++ b/wiki/Beatmap_discussion/id.md
@@ -3,6 +3,7 @@ tags:
   - beatmap discussions
   - modding V2
   - MV2
+outdated: true
 ---
 
 # Diskusi beatmap


### PR DESCRIPTION
Markdown has been added to the discussion so should be updated to reflect this, furthermore, inaccuracies such as "Tags display important roles below a users name. Only roles relevant for the beatmap discussion are shown." need to be addressed. Images could also do with updating to the newer designs.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)