### PR TITLE
Fix copy error in `Guides/Compressing files`

### DIFF
--- a/wiki/Guides/Compressing_files/en.md
+++ b/wiki/Guides/Compressing_files/en.md
@@ -143,7 +143,7 @@ ffmpeg -i input -c:a libvorbis -q:a 5 -vn -sn -map_metadata -1 -map_chapters -1 
 ```
 
 - `-i input`: Your source file. If the file name contains spaces, wrap it in double quotes (`"`)
-- `-c:a libvorbis`: Specify that the audio should be encoded using the LAME MP3 encoder
+- `-c:a libvorbis`: Specify that the audio should be encoded using the libvorbis encoder
 - `-q:a 5`: Use the same variable bit rate range as in the Audacity example, **where a higher number means higher bit rate**. If you want constant bit rate, you would instead use for instance `-b:a 128k` for a constant 128kbps bit rate
 - `-vn -sn`: Remove video and subtitles if present
 - `-map_metadata -1 -map_chapters -1`: Remove metadata and chapters if present


### PR DESCRIPTION
while im not entirely sure what libvorbis' real name actually is (if i had to give an answer id say "Lavcxx.xx.xxx libvorbis") lame definitely does not encode ogg files
i just assumed this was a copying mistake, i do suggest changing '-q:a 5' to '-q:a 6' just because the average bitrate can go past 192kbps now but i didnt add it in as i thought id leave it to other editors to see if it was a good idea or not

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
