### PR TITLE
Revert "Fix typo in `Skinning/skin.ini`"

### DIFF
--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -398,7 +398,7 @@ osu! organises the commands with a heading command. Which may look like this `[G
 - `ComboPrefix:`
   - Question: What prefix is used for the combo numbers?
   - Value: text *(path/filename prefix)*
-  - Default: `combo`
+  - Default: `score`
 - `ComboOverlap:`
   - Question: By how many pixels should the combo numbers overlap?
   - Value: *integer*

--- a/wiki/Skinning/skin.ini/fr.md
+++ b/wiki/Skinning/skin.ini/fr.md
@@ -398,7 +398,7 @@ osu! organise les commandes avec une commande d'en-tête. Qui peut ressembler à
 - `ComboPrefix:`
   - Question : Quel préfixe est utilisé pour les numéros de combo ?
   - Valeur : texte *(préfixe du chemin/du nom de fichier)*
-  - Par défaut : `combo`
+  - Par défaut : `score`
 - `ComboOverlap:`
   - Question : De combien de pixels les numéros des combos doivent-ils se chevaucher ?
   - Valeur : *entier*


### PR DESCRIPTION
@ChickenGoldSS 
After some discussion, we've found that we have made a mistake here. The default of combo prefix is indeed score, not combo. I apologize for the mistake I have made.