### PR TITLE
Allow to run oneshot commands in the container with `./run-checks.sh -- [cmd] [args]`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm
 
 WORKDIR /osu-wiki
 COPY package.json package-lock.json scripts/requirements.txt /osu-wiki/
-RUN npm install
+RUN npm install && npm install -g osu-wiki
 RUN pip3 install -r requirements.txt
 
 # Prevent git from refusing to work in a repository with "dubious ownership".

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -25,6 +25,7 @@ function _docker() {
   docker run \
     --volume ${osu_wiki_root}:${container_workdir}/ \
     --volume ${container_workdir}/node_modules \
+    --volume /usr/local/bin \
     --workdir ${container_workdir} osu-wiki bash -c "$*"
 }
 

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -87,7 +87,9 @@ function main() {
       # Changes that are not committed (staged + unstaged + untracked), but without deleted files
       git status --short -v -v --no-renames --porcelain | awk '$1 != "D" { print $2 }'
       # Changes committed so far (may overlap with the above)
-      git diff --no-renames --name-only --diff-filter=d ${first_commit_hash}^
+      if [[ -n ${first_commit_hash} ]]; then
+        git diff --no-renames --name-only --diff-filter=d ${first_commit_hash}^
+      fi
     )
   )
 

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -5,6 +5,19 @@ function print_warning() { printf -- "\e[0;34m$1\e[m\n" 1>&2; }
 function print_success() { printf -- "\e[0;32m$1\e[m\n" 1>&2; }
 function print_ok() { printf -- "$1\n" 1>&2; }
 
+function _build_container() {
+  if ! ( which docker > /dev/null ); then
+    print_error "Missing Docker -- install it from https://docs.docker.com/engine and restart the shell."
+    exit 1
+  fi
+
+  print_ok "Preparing the Docker image..."
+  if ! ( DOCKER_BUILDKIT=1 docker build -q -t osu-wiki . ); then
+    print_error "Failed to build the Docker image."
+    exit 1
+  fi
+}
+
 # Do not shadow node_modules in the container: https://stackoverflow.com/q/29181032#comment97216954_37898591
 function _docker() {
   osu_wiki_root=$( cd -- "$( dirname $0 )" && pwd )
@@ -21,20 +34,46 @@ function _test_wrapper() {
   files=( $( echo "${@: 3}" | tr '\n' ' ' ) )  # bash v3.2 on macOS doesn't support readarray
 
   if test -z "$files"; then
-    print_success "* Skip $test_name test"
+    print_success "* Skipped $test_name test."
   else
     print_ok "* Run $test_name test"
     $command_line "${files[@]}"
     return_code=$?
     if test $return_code -eq 0; then
-      print_success "* Passed $test_name test"
+      print_success "* Passed $test_name test."
     else
-      print_error "* Failed $test_name test (exit code $return_code)"
+      print_error "* Failed $test_name test (exit code $return_code)."
     fi
   fi
 }
 
+function _usage() {
+  echo "Usage: $( basename $0 ) [-- [COMMAND] [ARGS]]"
+  echo -e "Run osu! wiki-related commands in a Docker container.\n"
+  echo -e "Without arguments, run default test suite on all changes, both committed and not.\n"
+  echo "  -- [COMMAND] [ARGS]    run COMMAND in the container, passing ARGS as its arguments"
+}
+
 function main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        _usage
+        exit 2
+        ;;
+      --)
+        shift
+        _build_container
+        _docker $@
+        exit $?
+        ;;
+      *|-*|--*)
+        echo -e "Unrecognized option '$1'\nTry '$( basename $0 ) --help' for more information." 
+        exit 1
+        ;;
+    esac
+  done
+
   current_branch=$( git branch --show-current )
   if test ${current_branch} = 'master'; then
     print_error "Please run this from a feature branch, i.e. not 'master'"
@@ -53,23 +92,14 @@ function main() {
   )
 
   if test -z "${interesting_files}"; then
-    print_success "No changes detected -- nothing to check"
+    print_success "No changes detected -- nothing to check."
     exit 0
   fi
 
   # ppy/osu-wiki#8867 -- disable style checks for non-article Markdown files, such as README.md
   interesting_articles=$( echo "${interesting_files}" | grep -e ^wiki/ -e ^news/ | grep .md$ | grep -E -v '^[A-Z-]+\.md$' )
 
-  if ! ( which docker > /dev/null ); then
-    print_error "Missing Docker. Install it from https://docs.docker.com/engine and restart the shell"
-    exit 1
-  fi
-
-  print_ok "Preparing the Docker image..."
-  if ! ( DOCKER_BUILDKIT=1 docker build -q -t osu-wiki . ); then
-    print_error "Failed to build the Docker image"
-    exit 1
-  fi
+  _build_container
 
   _test_wrapper "file size" "_docker bash scripts/ci/inspect_file_sizes.sh --target" "${interesting_files}"
   _test_wrapper "article style" "_docker bash scripts/ci/run_remark.sh --target" "${interesting_articles}"
@@ -81,4 +111,4 @@ function main() {
   _test_wrapper "article freshness" "_docker osu-wiki-tools check-outdated-articles --workflow --base-commit" "${first_commit_hash}"
 }
 
-main
+main $@

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -25,7 +25,6 @@ function _docker() {
   docker run \
     --volume ${osu_wiki_root}:${container_workdir}/ \
     --volume ${container_workdir}/node_modules \
-    --volume /usr/local/bin \
     --workdir ${container_workdir} osu-wiki bash -c "$*"
 }
 

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -25,7 +25,7 @@ function _docker() {
   docker run \
     --volume ${osu_wiki_root}:${container_workdir}/ \
     --volume ${container_workdir}/node_modules \
-    --workdir ${container_workdir} osu-wiki "$@"
+    --workdir ${container_workdir} osu-wiki bash -c "$*"
 }
 
 function _test_wrapper() {
@@ -64,7 +64,7 @@ function main() {
       --)
         shift
         _build_container
-        _docker $@
+        _docker "$@"
         exit $?
         ;;
       *|-*|--*)


### PR DESCRIPTION
honestly tired of patching the script every time for anything except tests, so here goes -- may be useful for a lot of people potentially.

also, installs https://github.com/cl8n/osu-wiki-bin/ in the container -- it's a good toolbox.

<details>
<summary>examples</summary>


```sh
user@black-cube:~/stuff/osu-wiki$ ./run-checks.sh -- 'whoami; pwd; echo $PATH'
Preparing the Docker image...
sha256:39f3078e4eff64430515758303759d24544396c9ed536b5534eafa73dcef4dc2
root
/osu-wiki
/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

```sh
user@black-cube:~/stuff/osu-wiki$ ./run-checks.sh -- osu-wiki --version
Preparing the Docker image...
sha256:f7373899801752a69c2e1df0255f18aab37e9592f6e93cb39c14c168a679284c
0.20.0
```

</details>