### PR TITLE
Fix invalid discord link in `Discord servers/osu!mania Modding & Mapping Hub`

### DIFF
--- a/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/de.md
+++ b/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/de.md
@@ -10,7 +10,7 @@
 
 |  |  |
 | :-- | :-- |
-| Einladungslink | <https://discord.gg/maniahub> |
+| Einladungslink | <https://discord.gg/xX9r5GTQAp> |
 
 :::
 

--- a/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/en.md
+++ b/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/en.md
@@ -10,7 +10,7 @@
 
 |  |  |
 | :-- | :-- |
-| Invite link | <https://discord.gg/maniahub> |
+| Invite link | <https://discord.gg/xX9r5GTQAp> |
 
 :::
 

--- a/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/es.md
+++ b/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/es.md
@@ -10,7 +10,7 @@
 
 |  |  |
 | :-- | :-- |
-| Enlace de invitación | <https://discord.gg/maniahub> |
+| Enlace de invitación | <https://discord.gg/xX9r5GTQAp> |
 
 :::
 

--- a/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/fr.md
+++ b/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/fr.md
@@ -10,7 +10,7 @@
 
 |  |  |
 | :-- | :-- |
-| Lien d'invitation | <https://discord.gg/maniahub> |
+| Lien d'invitation | <https://discord.gg/xX9r5GTQAp> |
 
 :::
 

--- a/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/sr.md
+++ b/wiki/Community/Discord_servers/osu!mania_Modding_&_Mapping_Hub/sr.md
@@ -10,7 +10,7 @@
 
 |  |  |
 | :-- | :-- |
-| Линк позивнице | <https://discord.gg/maniahub> |
+| Линк позивнице | <https://discord.gg/xX9r5GTQAp> |
 
 :::
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Changed discord link to a permanent (non-custom) one as the old one became invalid when the server temporarily dropped to level 2. As cool as a custom link is, using a randomized one is better for longevity :c
