### PR TITLE
Fix issues in `New Featured Artist: soowamisu` news post

### DIFF
--- a/news/2023/2023-08-19-new-featured-artist-soowamisu.md
+++ b/news/2023/2023-08-19-new-featured-artist-soowamisu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "New Featured Artist: soowamisu"
-date: 2023-08-19 11:00:00 +0000
+date: 2023-08-19 13:00:00 +0000
 ---
 
 A living, breathing collection of breakcore samples (a.k.a. **soowamisu**) is now part of our Featured Artists!
@@ -16,7 +16,7 @@ A living, breathing collection of breakcore samples (a.k.a. **soowamisu**) is no
 
 <div align="center">
     <video width="95%" controls>
-        <source src="https://assets.ppy.sh/artists/376/release_showcase.mp4" type="video/mp4" preload="none">
+        <source src="https://assets.ppy.sh/artists/376/release_showcase.mp4?1" type="video/mp4" preload="none">
     </video>
 </div>
 
@@ -96,7 +96,7 @@ Playlist leaders earn prizes based on [this cumulative leaderboard](/wiki/People
 | --: | :-- | :-- | :-- |
 | #1 | ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598) | **10** | **10** |
 | #2 | ::{ flag=VN }:: [[ Primakien ]](https://osu.ppy.sh/users/23941998) | 5 | 9 |
-| #3 | ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)[^previous-prize] | 3 | 9 |
+| #3 | ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164) | 3 | 9 |
 | #4 | ::{ flag=BR }:: [Predominador](https://osu.ppy.sh/users/4568537) | 2 | 5 |
 | #5 | ::{ flag=PL }:: [-Filow-](https://osu.ppy.sh/users/3157472) | 2 | 2 |
 | #6 | ::{ flag=TN }:: [-Ken](https://osu.ppy.sh/users/4430811) | 1 | **11** |


### PR DESCRIPTION
merge when the 404'd video is fixed. i've added a query string because browser cache can still show the 404 even if asset cache is purged