### PR TITLE
Update `MWC 4K 2023` for the Quarterfinals stage

### DIFF
--- a/wiki/Tournaments/MWC/2023_4K/en.md
+++ b/wiki/Tournaments/MWC/2023_4K/en.md
@@ -117,39 +117,39 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/462
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
-| Vietnam ::{ flag=VN }:: | ::{ flag=AU }:: Australia | [Sep 2 (Sat) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T090000&p1=1440&p2=95&p3=57) |  | [^losers-bracket] |
-| China ::{ flag=CN }:: | ::{ flag=RU }:: Russian Federation | [Sep 2 (Sat) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T103000&p1=1440&p2=33&p3=166) |  | [^losers-bracket] |
-| South Korea ::{ flag=KR }:: | ::{ flag=TH }:: Thailand | [Sep 2 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T130000&p1=1440&p2=235&p3=28) |  | [^winners-bracket] |
-| Singapore ::{ flag=SG }:: | ::{ flag=NL }:: Netherlands | [Sep 2 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T140000&p1=1440&p2=236&p3=16) |  | [^losers-bracket] |
-| France ::{ flag=FR }:: | ::{ flag=MY }:: Malaysia | [Sep 2 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T150000&p1=1440&p2=195&p3=122) |  | [^losers-bracket] |
-| Spain ::{ flag=ES }:: | ::{ flag=DE }:: Germany | [Sep 2 (Sat) 16:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T163000&p1=1440&p2=141&p3=37) |  | [^losers-bracket] |
-| United Kingdom ::{ flag=GB }:: | ::{ flag=IT }:: Italy | [Sep 2 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T180000&p1=1440&p2=136&p3=215) |  | [^losers-bracket] |
-| Canada ::{ flag=CA }:: | ::{ flag=MX }:: Mexico | [Sep 2 (Sat) 19:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T193000&p1=1440&p2=188&p3=155) |  | [^losers-bracket] |
-| United States ::{ flag=US }:: | ::{ flag=CL }:: Chile | [Sep 2 (Sat) 21:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T210000&p1=1440&p2=263&p3=232) |  | [^winners-bracket] |
+| Vietnam ::{ flag=VN }:: | ::{ flag=AU }:: Australia | [Sep 2 (Sat) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T090000&p1=1440&p2=95&p3=57) | *TBD* | [^losers-bracket] |
+| China ::{ flag=CN }:: | ::{ flag=RU }:: Russian Federation | [Sep 2 (Sat) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T103000&p1=1440&p2=33&p3=166) | *TBD* | [^losers-bracket] |
+| South Korea ::{ flag=KR }:: | ::{ flag=TH }:: Thailand | [Sep 2 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T130000&p1=1440&p2=235&p3=28) | *TBD* | [^winners-bracket] |
+| Singapore ::{ flag=SG }:: | ::{ flag=NL }:: Netherlands | [Sep 2 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T140000&p1=1440&p2=236&p3=16) | *TBD* | [^losers-bracket] |
+| France ::{ flag=FR }:: | ::{ flag=MY }:: Malaysia | [Sep 2 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T150000&p1=1440&p2=195&p3=122) | *TBD* | [^losers-bracket] |
+| Spain ::{ flag=ES }:: | ::{ flag=DE }:: Germany | [Sep 2 (Sat) 16:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T163000&p1=1440&p2=141&p3=37) | *TBD* | [^losers-bracket] |
+| United Kingdom ::{ flag=GB }:: | ::{ flag=IT }:: Italy | [Sep 2 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T180000&p1=1440&p2=136&p3=215) | *TBD* | [^losers-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=MX }:: Mexico | [Sep 2 (Sat) 19:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T193000&p1=1440&p2=188&p3=155) | *TBD* | [^losers-bracket] |
+| United States ::{ flag=US }:: | ::{ flag=CL }:: Chile | [Sep 2 (Sat) 21:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T210000&p1=1440&p2=263&p3=232) | *TBD* | [^winners-bracket] |
 
 ### Sunday, 3 September 2023
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
-| Hong Kong ::{ flag=HK }:: | ::{ flag=PE }:: Peru | [Sep 3 (Sun) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T030000&p1=1440&p2=102&p3=131) |  | [^losers-bracket] |
-| Canada ::{ flag=CA }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=188&p3=236) |  | [^potential-match] |
-| Mexico ::{ flag=MX }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=155&p3=236) |  | [^potential-match] |
-| Vietnam ::{ flag=VN }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=136) |  | [^potential-match] |
-| Vietnam ::{ flag=VN }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=215) |  | [^potential-match] |
-| Australia ::{ flag=AU }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=136) |  | [^potential-match] |
-| Australia ::{ flag=AU }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=215) |  | [^potential-match] |
-| Hong Kong ::{ flag=HK }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=141) |  | [^potential-match] |
-| Hong Kong ::{ flag=HK }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=37) |  | [^potential-match] |
-| China ::{ flag=CN }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=195) |  | [^potential-match] |
-| China ::{ flag=CN }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=122) |  | [^potential-match] |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=195) |  | [^potential-match] |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=122) |  | [^potential-match] |
-| Japan ::{ flag=JP }:: | ::{ flag=ID }:: Indonesia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=248&p3=108) |  | [^winners-bracket] |
-| Philippines ::{ flag=PH }:: | ::{ flag=BR }:: Brazil | [Sep 3 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T143000&p1=1440&p2=145&p3=45) |  | [^winners-bracket] |
-| Canada ::{ flag=CA }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=188&p3=16) |  | [^potential-match] |
-| Mexico ::{ flag=MX }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=155&p3=16) |  | [^potential-match] |
-| Peru ::{ flag=PE }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=141) |  | [^potential-match] |
-| Peru ::{ flag=PE }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=37) |  | [^potential-match] |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=PE }:: Peru | [Sep 3 (Sun) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T030000&p1=1440&p2=102&p3=131) | *TBD* | [^losers-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=188&p3=236) | *TBD* | [^potential-match] |
+| Mexico ::{ flag=MX }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=155&p3=236) | *TBD* | [^potential-match] |
+| Vietnam ::{ flag=VN }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=136) | *TBD* | [^potential-match] |
+| Vietnam ::{ flag=VN }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=215) | *TBD* | [^potential-match] |
+| Australia ::{ flag=AU }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=136) | *TBD* | [^potential-match] |
+| Australia ::{ flag=AU }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=215) | *TBD* | [^potential-match] |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=141) | *TBD* | [^potential-match] |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=37) | *TBD* | [^potential-match] |
+| China ::{ flag=CN }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=195) | *TBD* | [^potential-match] |
+| China ::{ flag=CN }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=122) | *TBD* | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=195) | *TBD* | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=122) | *TBD* | [^potential-match] |
+| Japan ::{ flag=JP }:: | ::{ flag=ID }:: Indonesia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=248&p3=108) | *TBD* | [^winners-bracket] |
+| Philippines ::{ flag=PH }:: | ::{ flag=BR }:: Brazil | [Sep 3 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T143000&p1=1440&p2=145&p3=45) | *TBD* | [^winners-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=188&p3=16) | *TBD* | [^potential-match] |
+| Mexico ::{ flag=MX }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=155&p3=16) | *TBD* | [^potential-match] |
+| Peru ::{ flag=PE }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=141) | *TBD* | [^potential-match] |
+| Peru ::{ flag=PE }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=37) | *TBD* | [^potential-match] |
 
 ## Mappools
 

--- a/wiki/Tournaments/MWC/2023_4K/en.md
+++ b/wiki/Tournaments/MWC/2023_4K/en.md
@@ -496,6 +496,6 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 [^winners-bracket]: Winners bracket match
 [^losers-bracket]: Losers bracket match
-[^potential-match]: Potential match – final matchup depends on the results of the preceding Losers Bracket matches
+[^potential-match]: Potential match — final matchup depends on the results of the preceding losers bracket matches
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same rating sum

--- a/wiki/Tournaments/MWC/2023_4K/en.md
+++ b/wiki/Tournaments/MWC/2023_4K/en.md
@@ -111,35 +111,72 @@ Captains are listed in **bold**.
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/4624beb19d9e806ed905ab1718c079c2#file-mwc4k-2023-player-list-csv).
 
-## Match schedule: Round of 16
+## Match schedule: Quarterfinals
 
-### Saturday, 26 August 2023
+### Saturday, 2 September 2023
 
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| South Korea ::{ flag=KR }:: | ::{ flag=GB }:: United Kingdom | [Aug 26 (Sat) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T103000&p1=1440&p2=235&p3=136) | [osulive](https://twitch.tv/osulive) |
-| Philippines ::{ flag=PH }:: | ::{ flag=ES }:: Spain | [Aug 26 (Sat) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T120000&p1=1440&p2=145&p3=141) | [osulive](https://twitch.tv/osulive) |
-| Finland ::{ flag=FI }:: | ::{ flag=RU }:: Russian Federation | [Aug 26 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T130000&p1=1440&p2=101&p3=166) | [osulive](https://twitch.tv/osulive) |
-| Sweden ::{ flag=SE }:: | ::{ flag=MY }:: Malaysia | [Aug 26 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T140000&p1=1440&p2=239&p3=122) |  |
-| Japan ::{ flag=JP }:: | ::{ flag=SG }:: Singapore | [Aug 26 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T140000&p1=1440&p2=248&p3=236) | [osulive](https://twitch.tv/osulive) |
-| Taiwan ::{ flag=TW }:: | ::{ flag=IT }:: Italy | [Aug 26 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T150000&p1=1440&p2=241&p3=215) | [osulive](https://twitch.tv/osulive) |
-| Argentina ::{ flag=AR }:: | ::{ flag=NL }:: Netherlands | [Aug 26 (Sat) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230826T200000&p1=1440&p2=51&p3=16) | [osulive](https://twitch.tv/osulive) |
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| Vietnam ::{ flag=VN }:: | ::{ flag=AU }:: Australia | [Sep 2 (Sat) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T090000&p1=1440&p2=95&p3=57) |  | [^losers-bracket] |
+| China ::{ flag=CN }:: | ::{ flag=RU }:: Russian Federation | [Sep 2 (Sat) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T103000&p1=1440&p2=33&p3=166) |  | [^losers-bracket] |
+| South Korea ::{ flag=KR }:: | ::{ flag=TH }:: Thailand | [Sep 2 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T130000&p1=1440&p2=235&p3=28) |  | [^winners-bracket] |
+| Singapore ::{ flag=SG }:: | ::{ flag=NL }:: Netherlands | [Sep 2 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T140000&p1=1440&p2=236&p3=16) |  | [^losers-bracket] |
+| France ::{ flag=FR }:: | ::{ flag=MY }:: Malaysia | [Sep 2 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T150000&p1=1440&p2=195&p3=122) |  | [^losers-bracket] |
+| Spain ::{ flag=ES }:: | ::{ flag=DE }:: Germany | [Sep 2 (Sat) 16:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T163000&p1=1440&p2=141&p3=37) |  | [^losers-bracket] |
+| United Kingdom ::{ flag=GB }:: | ::{ flag=IT }:: Italy | [Sep 2 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T180000&p1=1440&p2=136&p3=215) |  | [^losers-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=MX }:: Mexico | [Sep 2 (Sat) 19:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T193000&p1=1440&p2=188&p3=155) |  | [^losers-bracket] |
+| United States ::{ flag=US }:: | ::{ flag=CL }:: Chile | [Sep 2 (Sat) 21:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230902T210000&p1=1440&p2=263&p3=232) |  | [^winners-bracket] |
 
-### Sunday, 27 August 2023
+### Sunday, 3 September 2023
 
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Colombia ::{ flag=CO }:: | ::{ flag=AU }:: Australia | [Aug 27 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T040000&p1=1440&p2=41&p3=57) | [osulive](https://twitch.tv/osulive) |
-| Vietnam ::{ flag=VN }:: | ::{ flag=TH }:: Thailand | [Aug 27 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T140000&p1=1440&p2=95&p3=28) | [osulive](https://twitch.tv/osulive) |
-| Brazil ::{ flag=BR }:: | ::{ flag=HK }:: Hong Kong | [Aug 27 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T140000&p1=1440&p2=45&p3=102) |  |
-| Chile ::{ flag=CL }:: | ::{ flag=CN }:: China | [Aug 27 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T150000&p1=1440&p2=232&p3=33) | [osulive](https://twitch.tv/osulive) |
-| Ukraine ::{ flag=UA }:: | ::{ flag=PE }:: Peru | [Aug 27 (Sun) 15:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T153000&p1=1440&p2=367&p3=131) | [osulive_2](https://twitch.tv/osulive_2) |
-| Indonesia ::{ flag=ID }:: | ::{ flag=CA }:: Canada | [Aug 27 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T160000&p1=1440&p2=108&p3=188) | [osulive](https://twitch.tv/osulive) |
-| United States ::{ flag=US }:: | ::{ flag=FR }:: France | [Aug 27 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T170000&p1=1440&p2=263&p3=195) | [osulive](https://twitch.tv/osulive) |
-| Germany ::{ flag=DE }:: | ::{ flag=PL }:: Poland | [Aug 27 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T180000&p1=1440&p2=37&p3=262) | [osulive](https://twitch.tv/osulive) |
-| Venezuela ::{ flag=VE }:: | ::{ flag=MX }:: Mexico | [Aug 27 (Sun) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230827T200000&p1=1440&p3=155) | [osulive](https://twitch.tv/osulive) |
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=PE }:: Peru | [Sep 3 (Sun) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T030000&p1=1440&p2=102&p3=131) |  | [^losers-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=188&p3=236) |  | [^potential-match] |
+| Mexico ::{ flag=MX }:: | ::{ flag=SG }:: Singapore | [Sep 3 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T040000&p1=1440&p2=155&p3=236) |  | [^potential-match] |
+| Vietnam ::{ flag=VN }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=136) |  | [^potential-match] |
+| Vietnam ::{ flag=VN }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=95&p3=215) |  | [^potential-match] |
+| Australia ::{ flag=AU }:: | ::{ flag=GB }:: United Kingdom | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=136) |  | [^potential-match] |
+| Australia ::{ flag=AU }:: | ::{ flag=IT }:: Italy | [Sep 3 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T120000&p1=1440&p2=57&p3=215) |  | [^potential-match] |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=141) |  | [^potential-match] |
+| Hong Kong ::{ flag=HK }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=102&p3=37) |  | [^potential-match] |
+| China ::{ flag=CN }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=195) |  | [^potential-match] |
+| China ::{ flag=CN }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=33&p3=122) |  | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=FR }:: France | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=195) |  | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=MY }:: Malaysia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=166&p3=122) |  | [^potential-match] |
+| Japan ::{ flag=JP }:: | ::{ flag=ID }:: Indonesia | [Sep 3 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T130000&p1=1440&p2=248&p3=108) |  | [^winners-bracket] |
+| Philippines ::{ flag=PH }:: | ::{ flag=BR }:: Brazil | [Sep 3 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T143000&p1=1440&p2=145&p3=45) |  | [^winners-bracket] |
+| Canada ::{ flag=CA }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=188&p3=16) |  | [^potential-match] |
+| Mexico ::{ flag=MX }:: | ::{ flag=NL }:: Netherlands | [Sep 3 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T160000&p1=1440&p2=155&p3=16) |  | [^potential-match] |
+| Peru ::{ flag=PE }:: | ::{ flag=ES }:: Spain | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=141) |  | [^potential-match] |
+| Peru ::{ flag=PE }:: | ::{ flag=DE }:: Germany | [Sep 3 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230903T170000&p1=1440&p2=131&p3=37) |  | [^potential-match] |
 
 ## Mappools
+
+### Quarterfinals
+
+**[Download the mappack here (120 MB)](https://packs.ppy.sh/P221%20-%20osu%21mania%204K%20World%20Cup%202023%3A%20Quarterfinals.zip)**
+
+- Rice
+  1. [linear ring with RNAcid - Gypsophila (MyZterioN-) \[blossom 1.1x (166bpm)\]](https://osu.ppy.sh/beatmapsets/1805950#mania/4283526)
+  2. [seatrus - Cosmo Station (Blessia) \[Orbis x1.1\]](https://osu.ppy.sh/beatmapsets/2046586#mania/4272125)
+  3. [EvOke - Edison (Miaurichesu) \[Challenge (Edit) 1.1x (146bpm)\]](https://osu.ppy.sh/beatmapsets/2050560#mania/4281865)
+  4. [Camellia - Break The Silence (0DZ0) \[Challenge\]](https://osu.ppy.sh/beatmapsets/2051831#mania/4284901)
+  5. [Kazuma Kiryu (CV: Takaya Kuroda) - Baka Mitai (elexire) \[Ska's n no. . (edit)\]](https://osu.ppy.sh/beatmapsets/2051835#mania/4284906)
+  6. [Frums - Nisemono (Pizza69) \[Impostor (cut 1.05x)\]](https://osu.ppy.sh/beatmapsets/2051825#mania/4284888)
+- Hybrid
+  1. [MisoilePunch -Forever- - Bloomin' (guden) \[Flowerin'\]](https://osu.ppy.sh/beatmapsets/2051734#mania/4284664)
+  2. [Camellia - Upload Your Mind :: Download My Soul (Cut Ver.) (-mint-) \[Multidimensional\]](https://osu.ppy.sh/beatmapsets/2051840#mania/4284920)
+  3. [M-O-T-U - Calculator (\[Crz\]FolAH1217) \[.857142\]](https://osu.ppy.sh/beatmapsets/2051746#mania/4284700)
+- Long Note
+  1. [paraoka - Astra Walkthrough (\[Crz\]Crysarlene) \[Faded Stars\]](https://osu.ppy.sh/beatmapsets/2051679#mania/4284564)
+  2. [Helblinde - Heaven's Fall (guden) \[Firmaments\]](https://osu.ppy.sh/beatmapsets/2051737#mania/4284669)
+  3. [Toromaru - Erinyes (Toaph Daddy) \[Enigma\]](https://osu.ppy.sh/beatmapsets/2051839#mania/4284918)
+- SV
+  1. [AltVoid - Sample enSemble (Tidek) \[SV asSemble\]](https://osu.ppy.sh/beatmapsets/2051846#mania/4284932)
+  2. [EZFG - Cyber Thunder Cider (zero2snow) \[??\]](https://osu.ppy.sh/beatmapsets/2051849#mania/4284940)
+- Tiebreaker
+  1. **[Camellia feat. Ninomae Ina'nis - Drenched in Air (elexire) \[Submerge\]](https://osu.ppy.sh/beatmapsets/2051843#mania/4284926)**
 
 ### Round of 16
 
@@ -203,6 +240,36 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/462
 8. [Kou! - Xuasar Charge (0DZ0) \[Stage 8: A Sea of Stars\]](https://osu.ppy.sh/beatmapsets/2039336#mania/4253740)
 
 ## Match results
+
+### Round of 16
+
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1FEhO1h7XNYfx8ZsefF73A9nzO50Hn08wVDMrOfLjgCU/edit?rm=minimal).
+
+Saturday, 26 August 2023:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **South Korea** ::{ flag=KR }:: | **6** | 0 | ::{ flag=GB }:: United Kingdom | [#1](https://osu.ppy.sh/community/matches/110172031) | [#1](https://www.twitch.tv/videos/1910260649) |
+| **Philippines** ::{ flag=PH }:: | **6** | 1 | ::{ flag=ES }:: Spain | [#1](https://osu.ppy.sh/community/matches/110172901) | [#1](https://www.twitch.tv/videos/1910260649?t=0h42m6s) |
+| Finland ::{ flag=FI }:: | 1 | **6** | ::{ flag=RU }:: **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/110173669) | [#1](https://www.twitch.tv/videos/1910260649?t=1h29m21s) |
+| Sweden ::{ flag=SE }:: | 3 | **6** | ::{ flag=MY }:: **Malaysia** | [#1](https://osu.ppy.sh/community/matches/110174563) | [#1](https://www.twitch.tv/videos/1910260649?t=3h8m12s) |
+| **Japan** ::{ flag=JP }:: | **6** | 0 | ::{ flag=SG }:: Singapore | [#1](https://osu.ppy.sh/community/matches/110174495) | [#1](https://www.twitch.tv/videos/1910260649?t=2h16m4s) |
+| Taiwan ::{ flag=TW }:: | 1 | **6** | ::{ flag=IT }:: **Italy** | [#1](https://osu.ppy.sh/community/matches/110175518) | [#1](https://www.twitch.tv/videos/1910260649?t=3h12m31s) |
+| Argentina ::{ flag=AR }:: | 2 | **6** | ::{ flag=NL }:: **Netherlands** | [#1](https://osu.ppy.sh/community/matches/110180189) | [#1](https://www.twitch.tv/videos/1910261498) |
+
+Sunday, 27 August 2023:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| Colombia ::{ flag=CO }:: | 0 | **6** | ::{ flag=AU }:: **Australia** | [#1](https://osu.ppy.sh/community/matches/110185466) | [#1](https://www.twitch.tv/videos/1910262252) |
+| Vietnam ::{ flag=VN }:: | 5 | **6** | ::{ flag=TH }:: **Thailand** | [#1](https://osu.ppy.sh/community/matches/110191325) | [#1](https://www.twitch.tv/videos/1910266325) |
+| **Brazil** ::{ flag=BR }:: | **6** | 2 | ::{ flag=HK }:: Hong Kong | [#1](https://osu.ppy.sh/community/matches/110191308) | [#1](https://www.twitch.tv/videos/1910298188) |
+| **Chile** ::{ flag=CL }:: | **6** | 2 | ::{ flag=CN }:: China | [#1](https://osu.ppy.sh/community/matches/110192153) | [#1](https://www.twitch.tv/videos/1910266325?t=1h14m58s) |
+| Ukraine ::{ flag=UA }:: | 2 | **6** | ::{ flag=PE }:: **Peru** | [#1](https://osu.ppy.sh/community/matches/110192666) | [#1](https://www.twitch.tv/videos/1910299034) |
+| **Indonesia** ::{ flag=ID }:: | **6** | 2 | ::{ flag=CA }:: Canada | [#1](https://osu.ppy.sh/community/matches/110193122) | [#1](https://www.twitch.tv/videos/1910266325?t=1h56m0s) |
+| **United States** ::{ flag=US }:: | **6** | 0 | ::{ flag=FR }:: France | [#1](https://osu.ppy.sh/community/matches/110194104) | [#1](https://www.twitch.tv/videos/1910266325?t=2h55m50s) |
+| **Germany** ::{ flag=DE }:: | **6** | 4 | ::{ flag=PL }:: Poland | [#1](https://osu.ppy.sh/community/matches/110194867) | [#1](https://www.twitch.tv/videos/1910266325?t=3h52m10s) |
+| Venezuela ::{ flag=VE }:: | 0 | **6** | ::{ flag=MX }:: **Mexico** | [#1](https://osu.ppy.sh/community/matches/110196829) | [#1](https://www.twitch.tv/videos/1910296688) |
 
 ### Round of 32
 
@@ -427,5 +494,8 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 ## Notes
 
+[^winners-bracket]: Winners bracket match
+[^losers-bracket]: Losers bracket match
+[^potential-match]: Potential match – final matchup depends on the results of the preceding Losers Bracket matches
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same rating sum


### PR DESCRIPTION
Adds RO16 results/vods/statistics and the Quarterfinals mappool/schedules.


## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
