### PR TITLE
[FR] Convert date to `DD/MM/YYYY` in `People/Centurion`

### DIFF
--- a/wiki/People/Centurions/fr.md
+++ b/wiki/People/Centurions/fr.md
@@ -22,7 +22,7 @@ Les Centurions sont des utilisateurs qui ont atteint la prestigieuse étape de c
 | ::{ flag=TH }:: [DJPop](https://osu.ppy.sh/users/2363) | [25/10/2007](https://osu.ppy.sh/beatmapsets/122) | [04/08/2010](https://osu.ppy.sh/beatmapsets/17885) |  |
 | ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733) | [23/10/2017](https://osu.ppy.sh/beatmapsets/659371) | [09/07/2022](https://osu.ppy.sh/beatmapsets/1738133) |  |
 | ::{ flag=GR }:: [Genjuro](https://osu.ppy.sh/users/3196091) | [10/04/2019](https://osu.ppy.sh/beatmapsets/921130) | [27/08/2022](https://osu.ppy.sh/beatmapsets/1797642) | [#1](https://osu.ppy.sh/beatmaps/packs/TM1) |
-| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | [2020-03-09](https://osu.ppy.sh/beatmapsets/1112834) | [2023-08-28](https://osu.ppy.sh/beatmapsets/2031892) | [#1](https://osu.ppy.sh/beatmaps/packs/TM16) |
+| ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | [09/03/2020](https://osu.ppy.sh/beatmapsets/1112834) | [28/08/2023](https://osu.ppy.sh/beatmapsets/2031892) | [#1](https://osu.ppy.sh/beatmaps/packs/TM16) |
 | ::{ flag=DE }:: [Lasse](https://osu.ppy.sh/users/896613) | [12/11/2015](https://osu.ppy.sh/beatmapsets/335145) | [29/04/2019](https://osu.ppy.sh/beatmapsets/956716) | [#1](https://osu.ppy.sh/beatmaps/packs/TM11), [#2](https://osu.ppy.sh/beatmaps/packs/TM12)  |
 | ::{ flag=DE }:: [Mir](https://osu.ppy.sh/users/8688812) | [14/04/2017](https://osu.ppy.sh/beatmapsets/540867) | [23/08/2023](https://osu.ppy.sh/beatmapsets/1852680) |  |
 | ::{ flag=US }:: [Nao Tomori](https://osu.ppy.sh/users/5364763) | [13/03/2017](https://osu.ppy.sh/beatmapsets/542755) | [31/08/2019](https://osu.ppy.sh/beatmapsets/894701) | [#1](https://osu.ppy.sh/beatmaps/packs/TM13) |


### PR DESCRIPTION
Corrected date format after #9985 don't convert them.

This reminds me of one thing: would a CI check be possible to avoid this kind of error in the future only for `fr.md`?

If necessary, I can create an issue to track this.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)