### PR TITLE
Add a tag to `Visual content considerations` article

### DIFF
--- a/wiki/Rules/Visual_content_considerations/en.md
+++ b/wiki/Rules/Visual_content_considerations/en.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - vcc
+---
+
 # Visual content considerations
 
 As per [Community Rule #5](/wiki/Rules#community-rules), all visual content submitted or uploaded to osu! must be considered as appropriate for an all-ages game.


### PR DESCRIPTION
Visual content considerations are commonly abbreviated as VCC so this should help with searchability a lot (I hate typing the full page name in search lol)

`SKIP_OUTDATED_CHECK` because it doesn't make sense to add an english abbreviation to other languages