### PR TITLE
Update `People/Completionists`

### DIFF
--- a/wiki/People/Completionists/en.md
+++ b/wiki/People/Completionists/en.md
@@ -22,7 +22,7 @@ These people have been verified by the osu! team as completionists:
 | :-- | :-- | :-- |
 | ::{ flag=US }:: [xasuma](https://osu.ppy.sh/users/3172980) | 2019-04-27 | 60,845 |
 | ::{ flag=PL }:: [PookieBear](https://osu.ppy.sh/users/7635621) | 2021-08-11 | 82,298 |
-| ::{ flag=US }:: [EEEEEEEEEEEEEEE](https://osu.ppy.sh/users/2927048) | 2023-03-15 | 97,668 |
+| ::{ flag=US }:: [EEEEEEEEEEEEEEE](https://osu.ppy.sh/users/2927048) | 2023-03-12 | 99,842 |
 
 ### osu!taiko
 

--- a/wiki/People/Completionists/en.md
+++ b/wiki/People/Completionists/en.md
@@ -8,7 +8,7 @@ tags:
 
 **Completionists** are players who have completed every [Ranked](/wiki/Beatmap/Category#ranked) [beatmap](/wiki/Beatmap) of a given [game mode](/wiki/Game_mode). Because the amount of Ranked beatmaps increases every day, this feat becomes progressively more difficult to achieve.
 
-As of September 2023, this achievement is recognised through a [profile badge](/wiki/Community/Profile_badge):
+As of September 2023, this achievement is recognised through a [profile badge](/wiki/Community/Profile_badge) handed out at the discretion of the [osu! team](/wiki/People/osu!_team):
 
 ![osu!](img/osu.png?20230902 "osu! completionist badge") ![osu!taiko](img/taiko.png?20230902 "osu!taiko completionist badge") ![osu!catch](img/catch.png?20230902 "osu!catch completionist badge") ![osu!mania](img/mania.png?20230902 "osu!mania completionist badge")
 


### PR DESCRIPTION
other than the date being wrong, it turns out the query used for checking EEEEEEEEEEEEEEE's completion count [didn't account for approved beatmaps](https://discord.com/channels/188630481301012481/218677502141399041/1148291035466838096) (which are in the ranked section nowadays)

the numbers for the other completionists are sourced from osu!alternative anyway, which is a database (or rather, a discord bot that provides an interface for a database) sourced from data.ppy.sh dumps, which people have been using to track completion progress