### PR TITLE
Update `MWC 4K 2023` for the Grand Finals stage

### DIFF
--- a/wiki/Tournaments/MWC/2023_4K/en.md
+++ b/wiki/Tournaments/MWC/2023_4K/en.md
@@ -111,24 +111,49 @@ Captains are listed in **bold**.
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/4624beb19d9e806ed905ab1718c079c2#file-mwc4k-2023-player-list-csv).
 
-## Match schedule: Finals
+## Match schedule: Grand Finals
 
-### Saturday, 16 September 2023
-
-| Team A | Team B | Match time | Twitch stream |  |
-| --: | :-- | :-- | :-: | :-: |
-| Japan ::{ flag=JP }:: | ::{ flag=TH }:: Thailand | [Sep 16 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230916T110000&p1=1440&p2=248&p3=28) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Brazil ::{ flag=BR }:: | ::{ flag=ID }:: Indonesia | [Sep 16 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230916T160000&p1=1440&p2=45&p3=108) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-
-### Sunday, 17 September 2023
+### Saturday, 23 September 2023
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
-| South Korea ::{ flag=KR }:: | ::{ flag=US }:: United States | [Sep 17 (Sun) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230917T030000&p1=1440&p2=235&p3=263) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-| Thailand ::{ flag=TH }:: | ::{ flag=ID }:: Indonesia | [Sep 17 (Sun) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230917T133000&p1=1440&p2=28&p3=108) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Grand Finals | mappool showcase | [Sep 17 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230917T150000&p1=1440) | [osulive](https://twitch.tv/osulive) |  |
+| South Korea ::{ flag=KR }:: | ::{ flag=ID }:: Indonesia | [Sep 23 (Sat) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230923T120000&p1=1440&p2=235&p3=108) |  | [^losers-grand-finals] |
+
+### Sunday, 24 September 2023
+
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| United States ::{ flag=US }:: | ::{ flag=KR }:: South Korea | [Sep 24 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230924T150000&p1=1440&p2=263&p3=235) |  | [^grand-final] |
+| United States ::{ flag=US }:: | ::{ flag=ID }:: Indonesia | [Sep 24 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20230924T150000&p1=1440&p2=263&p3=108) |  | [^grand-final] |
 
 ## Mappools
+
+### Grand Finals
+
+**[Download the mappack here (166 MB)](https://packs.ppy.sh/P224%20-%20osu!mania%204K%20World%20Cup%202023%3A%20Grand%20Finals.zip)**
+
+- Rice
+  1. [beta - Blue-White Crazystars (11Bit) \[twinkle (edit) x1.05\]](https://osu.ppy.sh/beatmapsets/2031745#mania/4310954)
+  2. [Falcom Sound Team jdk - Believe It!! (lemonguy) \[Eclipse x1.05\]](https://osu.ppy.sh/beatmapsets/1638926#mania/3345153)
+  3. [DJ SHARPNEL - SHINE!! (Shoegazer) \[Sakurakou!! 1.35x (273bpm)\]](https://osu.ppy.sh/beatmapsets/1446657#mania/2979765)
+  4. [Camellia - Shinsha / HgS (Cut Ver.) (-mint-) \[Techno Music Techno Music Techno Music Techno Music\]](https://osu.ppy.sh/beatmapsets/2062237#mania/4311929)
+  5. [Frums - END OF SYSTEM (Pizza69) \[END OF PIZZA 1.05x (189bpm)\]](https://osu.ppy.sh/beatmapsets/2062001#mania/4311169)
+  6. [Shoji Meguro - Last Surprise (elexire) \[Ska's howing 1.05x (edit)\]](https://osu.ppy.sh/beatmapsets/2062238#mania/4311930)
+  7. [Aquellex - Cortex Charger (Halogen-) \[Electrocution\]](https://osu.ppy.sh/beatmapsets/2062236#mania/4311928)
+- Hybrid
+  1. [xi - APOCALYPSE RAY (lemonguy) \[EXCEED\]](https://osu.ppy.sh/beatmapsets/2045249#mania/4269128)
+  2. [Silentroom Remixed by Frums - Angel Echo -L'appel du vide- (Abraxos) \[le mot\]](https://osu.ppy.sh/beatmapsets/2062240#mania/4311937)
+  3. [BilliumMoto - LIGHT LEFT BEHIND (-mint-) \[AND IN THE DARKNESS BIND THEM\]](https://osu.ppy.sh/beatmapsets/2062241#mania/4311938)
+- Long Note
+  1. [Yousei Teikoku - Kyuusei Argyros (MyZterioN-) \[purgatory o'clock (cut)\]](https://osu.ppy.sh/beatmapsets/2062249#mania/4311953)
+  2. [Lime - Selenadia (\[Crz\]Crysarlene) \[Finality 1.05x (238bpm)\]](https://osu.ppy.sh/beatmapsets/2062245#mania/4311944)
+  3. [wa. - Mugen houyou (-mint-) \[Impermanence\]](https://osu.ppy.sh/beatmapsets/1991601#mania/4138053)
+  4. [lapix - Born 2 Lose (guden) \[inhumanly;\]](https://osu.ppy.sh/beatmapsets/2062247#mania/4311951)
+- SV
+  1. [Eliminate - MULA (Cut & Sped Up Ver.) (arccat) \[Patcat's Root of All Evil\]](https://osu.ppy.sh/beatmapsets/2062251#mania/4311956)
+  2. [Kolaa & Mestie - Digibuprofen (Paturages) \[Lauren\]](https://osu.ppy.sh/beatmapsets/2062256#mania/4311995)
+- Tiebreaker
+  1. **[Camellia - Parallel Universe Shifter (-mint-) \[Quantum Field Disruption\]](https://osu.ppy.sh/beatmapsets/2062263#mania/4312004)**
 
 ### Finals
 
@@ -274,12 +299,21 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/462
 
 ### Finals
 
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1voKD7H9x6Wo0B5LdlueuA4LfPo-mBLxUWOfj7-mMlzg/edit?rm=minimal).
+
 Saturday, 16 September 2023:
 
 | Team A |  |  | Team B | Match link | VOD link |
 | --: | :-: | :-: | :-- | :-- | :-- |
 | Japan ::{ flag=JP }:: | 6 | **7** | ::{ flag=TH }:: **Thailand** | [#1](https://osu.ppy.sh/community/matches/110479629) | [#1](https://www.twitch.tv/videos/1926996943) |
 | Brazil ::{ flag=BR }:: | 6 | **7** | ::{ flag=ID }:: **Indonesia** | [#1](https://osu.ppy.sh/community/matches/110484408) | [#1](https://www.twitch.tv/videos/1927139174) |
+
+Sunday, 17 September 2023:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| South Korea ::{ flag=KR }:: | 3 | **7** | ::{ flag=US }:: **United States** | [#1](https://osu.ppy.sh/community/matches/110493949) | [#1](https://www.twitch.tv/videos/1927621031) |
+| Thailand ::{ flag=TH }:: | 4 | **7** | ::{ flag=ID }:: **Indonesia** | [#1](https://osu.ppy.sh/community/matches/110500530) | [#1](https://www.twitch.tv/videos/1927949732) |
 
 ### Semifinals
 
@@ -547,6 +581,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
+     - If the team does not pick a map within 15 seconds from when the timer expires, the referee will apply the procedure for subsequent occurrences listed below, i.e. a random pick will be used for a pick timer, and the match will be forcefully started for a ready timer.
    - On subsequent occurrences:
      - For a pick timer: a random map will be chosen from the mappool using `!roll X`, where X is the number of beatmaps that were neither picked nor banned, excluding the tiebreaker.
      - For a ready timer: the referee will issue the `!mp start 10` command, regardless of how many players from each team are present in the lobby, using `!mp kick` on any extra players for each team, starting from the top (i.e. the first valid player combination for each team will be forced to play the pick). The results for such games are to be taken as is.
@@ -586,7 +621,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 ## Notes
 
-[^winners-bracket]: Winners bracket match
-[^potential-match]: Potential match — final matchup depends on the results of the preceding losers bracket matches
+[^losers-grand-finals]: Losers bracket Grand Finals match
+[^grand-final]: Grand Finals match
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same rating sum


### PR DESCRIPTION
Adds Finals results; adds Grand Finals schedules.
Updates one rule to account for cases where teams continue stalling matches after being warned.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)