### PR TITLE
Replace the `task-list-completed` GitHub app with a GitHub action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,8 @@ on:
       - synchronize
       - edited
 
+permissions: {}
+
 jobs:
   ci:
     name: changed files

--- a/.github/workflows/manual-sync.yml
+++ b/.github/workflows/manual-sync.yml
@@ -14,6 +14,9 @@ on:
         required: true
         default: "false"
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     name: Execute Sync Task

--- a/.github/workflows/task-list-checker.yml
+++ b/.github/workflows/task-list-checker.yml
@@ -1,0 +1,20 @@
+name: GitHub Task List Checker
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+jobs:
+  task-list-checker:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write  # required for https://docs.github.com/rest/commits/statuses#create-a-commit-status
+    steps:
+      - name: Check for incomplete task list items
+        uses: Shopify/task-list-checker@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/task-list-checker.yml
+++ b/.github/workflows/task-list-checker.yml
@@ -8,11 +8,11 @@ on:
       - reopened
       - synchronize
       - edited
+permissions:
+  statuses: write
 jobs:
   task-list-checker:
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write  # required for https://docs.github.com/rest/commits/statuses#create-a-commit-status
     steps:
       - name: Check for incomplete task list items
         uses: Shopify/task-list-checker@main

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   welcome-new-contributor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
unfortunately this seems necessary due to https://github.com/stilliard/github-task-list-completed/issues/25 -- the check coming from the `task-list-completed` app occasionally becomes stale, only displaying the "Waiting for status to be reported" placeholder, and whether or not you can break its torpor is pure luck (it's probably something on GitHub's end, but I personally can't care anymore)

https://github.com/Shopify/task-list-checker is the new action. keep in mind that it only considers the PR's description, while [`task-list-completed`](https://github.com/marketplace/task-list-completed) reads all comments and tests them for checkboxes

@peppy please:

- [ ] uninstall https://github.com/marketplace/task-list-completed from the repo
- [ ] change `GITHUB_TOKEN` access to `Read and write permissions` in the repo settings → actions