### PR TITLE
Update `Users with unique titles`, `OWC 2023` rules

### DIFF
--- a/wiki/People/Users_with_unique_titles/de.md
+++ b/wiki/People/Users_with_unique_titles/de.md
@@ -35,14 +35,14 @@ Gewinner des [CWC 2022](/wiki/Tournaments/CWC/2022) mit dem Nutzertitel **osu!ca
 - ::{ flag=KR }:: [Rells](https://osu.ppy.sh/users/7937519)
 - ::{ flag=KR }:: [Rocma](https://osu.ppy.sh/users/566276)
 
-Gewinner des [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) mit dem Nutzertitel **osu!mania 4K Champion**:
+Gewinner des [MWC 4K 2023](/wiki/Tournaments/MWC/2023_4K) mit dem Nutzertitel **osu!mania 4K Champion**:
 
-- ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095)
-- ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131)
-- ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661)
-- ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031)
-- ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923)
-- ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868)
+- ::{ flag=US }:: [\[LS\]Dev](https://osu.ppy.sh/users/16407268)
+- ::{ flag=US }:: [cafesito](https://osu.ppy.sh/users/7794488)
+- ::{ flag=US }:: [Hello\_Son](https://osu.ppy.sh/users/17308009)
+- ::{ flag=US }:: [Nepijin](https://osu.ppy.sh/users/11734610)
+- ::{ flag=US }:: [PeachMarrow](https://osu.ppy.sh/users/15926730)
+- ::{ flag=US }:: [TristanJacob11](https://osu.ppy.sh/users/11817838)
 
 Gewinner des [MWC 7K 2023](/wiki/Tournaments/MWC/2023_7K) mit dem Nutzertitel **osu!mania 7K Champion**:
 
@@ -122,6 +122,7 @@ Gewinner der vorherigen osu!mania World Cups mit dem Nutzertitel **Former osu!ma
 | [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) | Former osu!mania 4K Champion: 2020 | ::{ flag=BR }:: [Guilhermeziat](https://osu.ppy.sh/users/3661387), ::{ flag=BR }:: [Kyut](https://osu.ppy.sh/users/9328824), ::{ flag=BR }:: [Punnies](https://osu.ppy.sh/users/8700468) |
 | [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) | Former osu!mania 4K Champion: 2021 | ::{ flag=BR }:: [Amerom](https://osu.ppy.sh/users/5691061), ::{ flag=BR }:: [Lenn](https://osu.ppy.sh/users/11236829), ::{ flag=BR }:: [LeMarcinho](https://osu.ppy.sh/users/13347579), ::{ flag=BR }:: [Lothus](https://osu.ppy.sh/users/9530019), ::{ flag=BR }:: [Orost](https://osu.ppy.sh/users/13601876), ::{ flag=BR }:: [SillyFangirl](https://osu.ppy.sh/users/2288363) |
 | [MWC 7K 2022](/wiki/Tournaments/MWC/2022_7K) | Former osu!mania 7K Champion: 2022 | ::{ flag=KR }:: [0133](https://osu.ppy.sh/users/12346181), ::{ flag=KR }:: [dressurf](https://osu.ppy.sh/users/758406), ::{ flag=KR }:: [Estonians](https://osu.ppy.sh/users/7014697), ::{ flag=KR }:: [yz1155](https://osu.ppy.sh/users/2071008) |
+| [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) | Former osu!mania 4K Champion: 2022 | ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095), ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131), ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661), ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031), ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923), ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868) |
 
 ## Gewinner von offiziellen Mapping-Wettbewerben
 

--- a/wiki/People/Users_with_unique_titles/en.md
+++ b/wiki/People/Users_with_unique_titles/en.md
@@ -35,14 +35,14 @@ Winners of [CWC 2022](/wiki/Tournaments/CWC/2022) with the **osu!catch Champion*
 - ::{ flag=KR }:: [Rells](https://osu.ppy.sh/users/7937519)
 - ::{ flag=KR }:: [Rocma](https://osu.ppy.sh/users/566276)
 
-Winners of [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) with the **osu!mania 4K Champion** user title:
+Winners of [MWC 4K 2023](/wiki/Tournaments/MWC/2023_4K) with the **osu!mania 4K Champion** user title:
 
-- ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095)
-- ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131)
-- ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661)
-- ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031)
-- ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923)
-- ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868)
+- ::{ flag=US }:: [\[LS\]Dev](https://osu.ppy.sh/users/16407268)
+- ::{ flag=US }:: [cafesito](https://osu.ppy.sh/users/7794488)
+- ::{ flag=US }:: [Hello\_Son](https://osu.ppy.sh/users/17308009)
+- ::{ flag=US }:: [Nepijin](https://osu.ppy.sh/users/11734610)
+- ::{ flag=US }:: [PeachMarrow](https://osu.ppy.sh/users/15926730)
+- ::{ flag=US }:: [TristanJacob11](https://osu.ppy.sh/users/11817838)
 
 Winners of [MWC 7K 2023](/wiki/Tournaments/MWC/2023_7K) with the **osu!mania 7K Champion** user title:
 
@@ -121,6 +121,7 @@ Winners of previous osu!mania World Cups with the **Former osu!mania Champion** 
 | [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) | Former osu!mania 4K Champion: 2020 | ::{ flag=BR }:: [Guilhermeziat](https://osu.ppy.sh/users/3661387), ::{ flag=BR }:: [Kyut](https://osu.ppy.sh/users/9328824), ::{ flag=BR }:: [Punnies](https://osu.ppy.sh/users/8700468) |
 | [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) | Former osu!mania 4K Champion: 2021 | ::{ flag=BR }:: [Amerom](https://osu.ppy.sh/users/5691061), ::{ flag=BR }:: [Lenn](https://osu.ppy.sh/users/11236829), ::{ flag=BR }:: [LeMarcinho](https://osu.ppy.sh/users/13347579), ::{ flag=BR }:: [Lothus](https://osu.ppy.sh/users/9530019), ::{ flag=BR }:: [Orost](https://osu.ppy.sh/users/13601876), ::{ flag=BR }:: [SillyFangirl](https://osu.ppy.sh/users/2288363) |
 | [MWC 7K 2022](/wiki/Tournaments/MWC/2022_7K) | Former osu!mania 7K Champion: 2022 | ::{ flag=KR }:: [0133](https://osu.ppy.sh/users/12346181), ::{ flag=KR }:: [dressurf](https://osu.ppy.sh/users/758406), ::{ flag=KR }:: [Estonians](https://osu.ppy.sh/users/7014697), ::{ flag=KR }:: [yz1155](https://osu.ppy.sh/users/2071008) |
+| [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) | Former osu!mania 4K Champion: 2022 | ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095), ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131), ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661), ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031), ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923), ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868) |
 
 ## Official mapping contest winners
 

--- a/wiki/People/Users_with_unique_titles/zh.md
+++ b/wiki/People/Users_with_unique_titles/zh.md
@@ -35,14 +35,14 @@
 - ::{ flag=KR }:: [Rells](https://osu.ppy.sh/users/7937519)
 - ::{ flag=KR }:: [Rocma](https://osu.ppy.sh/users/566276)
 
-拥有 **osu!mania 4K Champion** 头衔的 [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) 冠军：
+拥有 **osu!mania 4K Champion** 头衔的 [MWC 4K 2023](/wiki/Tournaments/MWC/2023_4K) 冠军：
 
-- ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095)
-- ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131)
-- ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661)
-- ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031)
-- ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923)
-- ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868)
+- ::{ flag=US }:: [\[LS\]Dev](https://osu.ppy.sh/users/16407268)
+- ::{ flag=US }:: [cafesito](https://osu.ppy.sh/users/7794488)
+- ::{ flag=US }:: [Hello\_Son](https://osu.ppy.sh/users/17308009)
+- ::{ flag=US }:: [Nepijin](https://osu.ppy.sh/users/11734610)
+- ::{ flag=US }:: [PeachMarrow](https://osu.ppy.sh/users/15926730)
+- ::{ flag=US }:: [TristanJacob11](https://osu.ppy.sh/users/11817838)
 
 拥有 **osu!mania 7K Champion** 头衔的 [MWC 7K 2023](/wiki/Tournaments/MWC/2023_7K) 冠军：
 
@@ -121,6 +121,7 @@
 | [MWC 4K 2020](/wiki/Tournaments/MWC/2020_4K) | Former osu!mania 4K Champion: 2020 | ::{ flag=BR }:: [Guilhermeziat](https://osu.ppy.sh/users/3661387), ::{ flag=BR }:: [Kyut](https://osu.ppy.sh/users/9328824), ::{ flag=BR }:: [Punnies](https://osu.ppy.sh/users/8700468) |
 | [MWC 4K 2021](/wiki/Tournaments/MWC/2021_4K) | Former osu!mania 4K Champion: 2021 | ::{ flag=BR }:: [Amerom](https://osu.ppy.sh/users/5691061), ::{ flag=BR }:: [Lenn](https://osu.ppy.sh/users/11236829), ::{ flag=BR }:: [LeMarcinho](https://osu.ppy.sh/users/13347579), ::{ flag=BR }:: [Lothus](https://osu.ppy.sh/users/9530019), ::{ flag=BR }:: [Orost](https://osu.ppy.sh/users/13601876), ::{ flag=BR }:: [SillyFangirl](https://osu.ppy.sh/users/2288363) |
 | [MWC 7K 2022](/wiki/Tournaments/MWC/2022_7K) | Former osu!mania 7K Champion: 2022 | ::{ flag=KR }:: [0133](https://osu.ppy.sh/users/12346181), ::{ flag=KR }:: [dressurf](https://osu.ppy.sh/users/758406), ::{ flag=KR }:: [Estonians](https://osu.ppy.sh/users/7014697), ::{ flag=KR }:: [yz1155](https://osu.ppy.sh/users/2071008) |
+| [MWC 4K 2022](/wiki/Tournaments/MWC/2022_4K) | Former osu!mania 4K Champion: 2022 | ::{ flag=KR }:: [Flying Samira](https://osu.ppy.sh/users/10329095), ::{ flag=KR }:: [gaesol](https://osu.ppy.sh/users/12452131), ::{ flag=KR }:: [lianic](https://osu.ppy.sh/users/13975661), ::{ flag=KR }:: [Poca](https://osu.ppy.sh/users/8581031), ::{ flag=KR }:: [SuddenDeath](https://osu.ppy.sh/users/6699923), ::{ flag=KR }:: [SnowScent](https://osu.ppy.sh/users/7945868) |
 
 ### 官方作图竞赛冠军
 

--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -121,7 +121,8 @@ The osu! World Cup 2023 is run by the [osu! team](/wiki/People/osu!_team) and va
    - To be successfully accepted on the list, players are required to be placed #5000 or higher on the osu! global ranking, and not have violated the [osu! community rules](/wiki/Rules) within the last 12 months.
 4. All successfully formed teams will be published after the registration phase on this page.
    - A team should have at least 6 players registered to have the chance to play the Qualifier stage.
-5. Tournament staff members are **not** allowed to play in the tournament, with the exception of commentators and streamers.
+5. Tournament staff members are **not** allowed to play in the tournament, with the exception of commentators, streamers, and statisticians.
+   - If any of the roles listed are playing in the tournament, the tournament managers must ensure that they do not have access to any priviledged data, such as Qualifiers score information or mappool information, ahead of time.
 
 ### Qualifier instructions
 

--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -121,8 +121,8 @@ The osu! World Cup 2023 is run by the [osu! team](/wiki/People/osu!_team) and va
    - To be successfully accepted on the list, players are required to be placed #5000 or higher on the osu! global ranking, and not have violated the [osu! community rules](/wiki/Rules) within the last 12 months.
 4. All successfully formed teams will be published after the registration phase on this page.
    - A team should have at least 6 players registered to have the chance to play the Qualifier stage.
-5. Tournament staff members are **not** allowed to play in the tournament, with the exception of commentators, streamers, and statisticians.
-   - If any of the roles listed are playing in the tournament, the tournament managers must ensure that they do not have access to any priviledged data, such as Qualifiers score information or mappool information, ahead of time.
+5. Tournament staff members are **not** allowed to play in the tournament, with the exception of commentators, statisticians, and streamers.
+   - The tournament managers must ensure that such staff members do not have access to any priviledged data, eg. Qualifiers score information, or mappool information before the mappool showcase.
 
 ### Qualifier instructions
 

--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -122,7 +122,7 @@ The osu! World Cup 2023 is run by the [osu! team](/wiki/People/osu!_team) and va
 4. All successfully formed teams will be published after the registration phase on this page.
    - A team should have at least 6 players registered to have the chance to play the Qualifier stage.
 5. Tournament staff members are **not** allowed to play in the tournament, with the exception of commentators, statisticians, and streamers.
-   - The tournament managers must ensure that such staff members do not have access to any priviledged data, eg. Qualifiers score information, or mappool information before the mappool showcase.
+   - The tournament managers must ensure that such staff members do not have access to any priviledged data, e.g. Qualifiers score information, or mappool information before the mappool showcase.
 
 ### Qualifier instructions
 


### PR DESCRIPTION
Bundling a few unrelated changes in a single PR to save a bit of time.

- Updates `Users with unique titles` with the winners of MWC 4K 2023, as well as recipients of the "Former osu!mania 4K Champion: 2022" title.
- Updates `OWC 2023` rules to better document procedures regarding staff members that are also players in the tournament (such as commentators).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)