### PR TITLE
Fix citation in `Beatmap/Genre and language`

### DIFF
--- a/wiki/Beatmap/Genre_and_language/en.md
+++ b/wiki/Beatmap/Genre_and_language/en.md
@@ -37,7 +37,7 @@ A beatmap is unable to be [nominated](/wiki/Beatmap_ranking_procedure#nomination
 | Unspecified | No songs are applicable. This genre is a placeholder until a proper one is set. |
 | Video Game | Made for or made popular by a video game. This is also used for arrangements and remixes of those songs. |
 | Anime | Made for or made popular by an anime or similar medium. |
-| Rock | Mostly focusing on guitars, drums, and bass, typically "built on a foundation of simple unsyncopated rhythms" and characterised by "live performance and a focus on serious and progressive themes" ([*Rock music* on Wikipedia](https://en.wikipedia.org/wiki/Rock_music#Characteristics)). |
+| Rock | Mostly focusing on guitars, drums, and bass, typically "built on a foundation of simple syncopated rhythms" and characterised by "live performance and a focus on serious and progressive themes" ([*Rock music* on Wikipedia](https://en.wikipedia.org/wiki/Rock_music#Characteristics)). |
 | Pop | Prominent in pop culture, and composed to be catchy by use of simple structure and repeated choruses or melodies. |
 | Other | Not belonging to any of the listed genres. |
 | Novelty | Comical or unusual. In osu!, this category primarily includes songs like YouTube Poops, Niconico MADs, and meme music. |

--- a/wiki/Beatmap/Genre_and_language/es.md
+++ b/wiki/Beatmap/Genre_and_language/es.md
@@ -3,7 +3,11 @@ tags:
   - genres
   - languages
   - metadata
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # Género e idioma
 

--- a/wiki/Beatmap/Genre_and_language/fr.md
+++ b/wiki/Beatmap/Genre_and_language/fr.md
@@ -4,7 +4,11 @@ tags:
   - languages
   - metadata
   - langue
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # Genre et langue
 

--- a/wiki/Beatmap/Genre_and_language/id.md
+++ b/wiki/Beatmap/Genre_and_language/id.md
@@ -3,7 +3,11 @@ tags:
   - genres
   - languages
   - metadata
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # Aliran dan bahasa
 

--- a/wiki/Beatmap/Genre_and_language/ja.md
+++ b/wiki/Beatmap/Genre_and_language/ja.md
@@ -3,7 +3,11 @@ tags:
   - genres
   - languages
   - metadata
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # ジャンルと言語
 

--- a/wiki/Beatmap/Genre_and_language/ru.md
+++ b/wiki/Beatmap/Genre_and_language/ru.md
@@ -7,7 +7,11 @@ tags:
   - языки
   - метадата
   - метаданные
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # Жанр и язык
 

--- a/wiki/Beatmap/Genre_and_language/zh.md
+++ b/wiki/Beatmap/Genre_and_language/zh.md
@@ -8,7 +8,11 @@ tags:
   - 流派
   - 语言
   - 元数据
+outdated_translation: true
+outdated_since: 26dcaa7c6a1a7d47d0c5cb61dd01f45263a970bb
 ---
+
+<!--The citation in the rock genre was changed from unsyncopated to syncopated. When updating this article, please make sure if this needs to be adjusted here.-->
 
 # 歌曲风格与语言
 


### PR DESCRIPTION
Noticed this in #10115 

Looking at the wikipedia article, it uses `syncopated` instead of `unsyncopated` now.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
