### PR TITLE
Remove misleading combo multiplier note from `Gameplay/Full combo`

### DIFF
--- a/wiki/Gameplay/Full_combo/de.md
+++ b/wiki/Gameplay/Full_combo/de.md
@@ -2,6 +2,8 @@
 stub: true
 tags:
   - FC
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # Full combo

--- a/wiki/Gameplay/Full_combo/en.md
+++ b/wiki/Gameplay/Full_combo/en.md
@@ -12,4 +12,4 @@ Scores that lost combo only via dropped slider ends are widely considered by the
 
 ![Screenshot of full combo and broken combo scores](img/combo-comparison.png "The top score is a full combo, and the bottom score is a broken combo.")
 
-Because the [score](/wiki/Gameplay/Score) of an individual object in [osu!](/wiki/Game_mode/osu!) and [osu!catch](/wiki/Game_mode/osu!catch) [game modes](/wiki/Game_mode) heavily depends on combo multiplier and is virtually unbounded, full combos typically award the most score in these game modes.
+Because the [score](/wiki/Gameplay/Score) of an individual object in [osu!](/wiki/Game_mode/osu!) and [osu!catch](/wiki/Game_mode/osu!catch) heavily depends on combo multiplier and is virtually unbounded, full combos typically award the most score in these game modes.

--- a/wiki/Gameplay/Full_combo/en.md
+++ b/wiki/Gameplay/Full_combo/en.md
@@ -12,4 +12,4 @@ Scores that lost combo only via dropped slider ends are widely considered by the
 
 ![Screenshot of full combo and broken combo scores](img/combo-comparison.png "The top score is a full combo, and the bottom score is a broken combo.")
 
-Due to the [combo multiplier effect](/wiki/Gameplay/Combo_multiplier_effect), full combos will award the most [score](/wiki/Gameplay/Score) in [osu!](/wiki/Game_mode/osu!), [osu!taiko](/wiki/Game_mode/osu!taiko), and [osu!catch](/wiki/Game_mode/osu!catch) [game modes](/wiki/Game_mode).
+Because the [score](/wiki/Gameplay/Score) of an individual object in [osu!](/wiki/Game_mode/osu!) and [osu!catch](/wiki/Game_mode/osu!catch) [game modes](/wiki/Game_mode) heavily depends on combo multiplier and is virtually unbounded, full combos typically award the most score in these game modes.

--- a/wiki/Gameplay/Full_combo/fr.md
+++ b/wiki/Gameplay/Full_combo/fr.md
@@ -2,6 +2,8 @@
 stub: true
 tags:
   - FC
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # Full combo

--- a/wiki/Gameplay/Full_combo/id.md
+++ b/wiki/Gameplay/Full_combo/id.md
@@ -2,6 +2,8 @@
 stub: true
 tags:
   - FC
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # Full combo

--- a/wiki/Gameplay/Full_combo/it.md
+++ b/wiki/Gameplay/Full_combo/it.md
@@ -2,6 +2,8 @@
 stub: true
 tags:
   - FC
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # Full combo

--- a/wiki/Gameplay/Full_combo/ja.md
+++ b/wiki/Gameplay/Full_combo/ja.md
@@ -2,6 +2,8 @@
 stub: true
 tags:
   - FC
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # フルコンボ

--- a/wiki/Gameplay/Full_combo/ru.md
+++ b/wiki/Gameplay/Full_combo/ru.md
@@ -4,6 +4,8 @@ tags:
   - FC
   - ФК
   - Фулл комбо
+outdated_translation: true
+outdated_since: a60c43d582052f143b0e97e1494041cc3b8bd5b7
 ---
 
 # Полное комбо


### PR DESCRIPTION
found when reviewing https://github.com/ppy/osu-wiki/pull/10120 — the [combo multiplier effect](https://github.com/ppy/osu-wiki/blob/master/wiki/Gameplay/Combo_multiplier_effect/en.md) article is about a score decrease bug due to 32-bit integer's eventual overflow, not the quadratic growth of the score

(also, a hit object's value in taiko is limited hence the exclusion)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
