### PR TITLE
Update `OWC 2023` links

### DIFF
--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -51,10 +51,10 @@ The osu! World Cup 2023 is run by the [osu! team](/wiki/People/osu!_team) and va
 
 ## Links
 
-- **[Sign up here](https://osu.ppy.sh/community/tournaments/41)**
 - [Information spreadsheet](https://docs.google.com/spreadsheets/d/1kzHae-PAHE7_PLy5L3Nhu97lslRLJoc5T6u-GEW1x6E?rm=minimal)
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/1823846)
 - [Livestream](https://www.twitch.tv/osulive)
+- [Pick'ems page](https://pickem.hwc.hr/tournaments/130) hosted by ::{ flag=DE }:: [hallowatcher](https://osu.ppy.sh/users/1874761)
 
 ## Ruleset
 

--- a/wiki/Tournaments/OWC/2023/ko.md
+++ b/wiki/Tournaments/OWC/2023/ko.md
@@ -51,9 +51,10 @@ osu! 월드컵 2023은 [osu! 팀](/wiki/People/osu!_team)과 여러 명의 커�
 
 ## 링크
 
-- **[등록은 여기에서 가능합니다.](https://osu.ppy.sh/community/tournaments/41)**
+- [정보 스프레드시트](https://docs.google.com/spreadsheets/d/1kzHae-PAHE7_PLy5L3Nhu97lslRLJoc5T6u-GEW1x6E?rm=minimal)
 - [논의 스레드](https://osu.ppy.sh/community/forums/topics/1823846)
 - [실시간 방송](https://www.twitch.tv/osulive)
+- [Pick'em 승부예측 페이지](https://pickem.hwc.hr/tournaments/130) ::{ flag=DE }:: [hallowatcher](https://osu.ppy.sh/users/1874761)가 운영합니다.
 
 ## 규칙
 


### PR DESCRIPTION
Removes sign up link, adds hallowatcher pick'ems page link. Korean translation is taken from last year's wiki article, minor enough that it shouldn't need a review (I hope).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
