### PR TITLE
CI: Update `node_modules` cache on pushes to `master`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package.json', 'package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
+          key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
       - name: install remark
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
-      - name: install remark
+      - name: 'if cache outdated: install node.js dependencies'
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
-      - name: 'if cache outdated: install node.js dependencies'
+      - name: 'if cache is outdated: install node.js dependencies'
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -1,0 +1,41 @@
+name: refresh node_modules cache
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  cache-node-modules:
+    name: update cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: '.'
+
+      - name: set up Node.js
+        id: setup-node
+        uses: actions/setup-node@v3
+        with:
+          cache: npm
+          node-version: 16
+
+      - name: check node_modules cache
+        id: cache-node-modules
+        uses: actions/cache/restore@v3
+        with:
+          path: node_modules
+          lookup-only: true
+          key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
+
+      - name: 'if cache outdated: install node_modules'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: 'if cache outdated: save cache'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -1,9 +1,9 @@
 name: refresh node_modules cache
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    # Runs at 00:20 on day 1 and 15 of every month
+    - cron: '20 0 1,15 * *'
 
 jobs:
   cache-node-modules:

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -1,9 +1,9 @@
 name: refresh node_modules cache
 
 on:
-  schedule:
-    # Runs at 00:20 on day 1 and 15 of every month
-    - cron: '20 0 1,15 * *'
+  push:
+    branches:
+      - master
 
 jobs:
   cache-node-modules:

--- a/.github/workflows/refresh-cache.yml
+++ b/.github/workflows/refresh-cache.yml
@@ -29,11 +29,11 @@ jobs:
           lookup-only: true
           key: node-modules-${{ hashFiles('package-lock.json') }}-${{ steps.setup-node.outputs.node-version }}
 
-      - name: 'if cache outdated: install node_modules'
+      - name: 'if cache is outdated: install node_modules'
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: 'if cache outdated: save cache'
+      - name: 'if cache is outdated: save cache'
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:


### PR DESCRIPTION
This PR adds a CI job that checks whether a `node_modules` cache entry for the current `package-lock.json` exists on the `master` branch.

PRs can use cache entries from the `master` branch, so adding this will speed up the CI for new PRs.

Examples from my fork:
- [Initial cache population](https://github.com/FreezyLemon/osu-wiki/actions/runs/6462542016/job/17544328515) (ca. 60s)
- [Push to master without cache update](https://github.com/FreezyLemon/osu-wiki/actions/runs/6462552336/job/17544355075) (ca. 15s)
- [PR benefitting from the cache](https://github.com/FreezyLemon/osu-wiki/actions/runs/6462585170/job/17544437386) (1s cache restoration vs 40s for `npm ci`)
