### PR TITLE
[DE] Add a translation-specific tag to "User Group" article

### DIFF
--- a/wiki/People/User_group/de.md
+++ b/wiki/People/User_group/de.md
@@ -1,6 +1,7 @@
 ---
 tags:
   - usergroup
+  - Nutzergruppe
 ---
 
 # Benutzergruppe


### PR DESCRIPTION
`Benutzer` and `Nutzer` are synonymous in the wiki, and this new tag allows users to find the article when searching for `Nutzergruppe`.