### PR TITLE
CI: Remove unnecessary `git status` check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,10 +21,8 @@ jobs:
 
       - name: detect changed files
         run: |
-          INTERESTING_FILES=$(
-            # Changes committed to this PR so far
-            git diff --no-renames --name-only --diff-filter=d ${{ github.sha }}^
-          )
+          # Changes committed to this PR so far
+          INTERESTING_FILES=$( git diff --no-renames --name-only --diff-filter=d ${{ github.sha }}^ )
 
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           # XXX: env.INTERESTING_FILES will be a single string with newline delimiters.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,12 +22,8 @@ jobs:
       - name: detect changed files
         run: |
           INTERESTING_FILES=$(
-            sort -u < <(
-              # Changes that are not committed (staged + unstaged + untracked), but without deleted files
-              git status --short -v -v --no-renames --porcelain | awk '$1 != "D" { print $2 }'
-              # Changes committed so far (may overlap with the above)
-              git diff --no-renames --name-only --diff-filter=d ${{ github.sha }}^
-            )
+            # Changes committed to this PR so far
+            git diff --no-renames --name-only --diff-filter=d ${{ github.sha }}^
           )
 
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings


### PR DESCRIPTION
There should not be any uncommited changes, so `git status` can be ignored here.