### PR TITLE
Revert "Replace "x" with "×" in resolutions in `Client/Playfield`"

### DIFF
--- a/wiki/Client/Playfield/en.md
+++ b/wiki/Client/Playfield/en.md
@@ -26,9 +26,9 @@ The **playfield** is a portion of the game window where [hit objects](/wiki/Game
 ![](img/playfield-854x480.png "The osu! window (purple) with the playfield (blue), 16:9 aspect ratio.")
 :::
 
-The playfield's coordinate system uses resolution-independent units called **game pixels**, or osu! pixels, such that a game pixel is equivalent to a pixel when osu! is running at a 640×480 resolution. On higher resolutions, the visual size of game pixels stays the same. The playfield is slightly shifted vertically, placed 8 game pixels lower than the window's centre.
+The playfield's coordinate system uses resolution-independent units called **game pixels**, or osu! pixels, such that a game pixel is equivalent to a pixel when osu! is running at a 640x480 resolution. On higher resolutions, the visual size of game pixels stays the same. The playfield is slightly shifted vertically, placed 8 game pixels lower than the window's centre.
 
-The [beatmap editor](/wiki/Client/Beatmap_editor)'s grid is 512×384 game pixels.
+The [beatmap editor](/wiki/Client/Beatmap_editor)'s grid is 512x384 game pixels.
 
 | Playfield top left | Playfield bottom right | Playfield centre |
 | :-- | :-- | :-- |
@@ -44,7 +44,7 @@ The coordinate system used for storyboards has a slightly different origin point
 
 | Aspect ratio | Screen top left | Screen bottom right | Screen centre | In-bounds dimensions |
 | :-- | :-- | :-- | :-- | :-- |
-| **4:3** | (0, 0) | (640, 480) | (320, 240) | 640×480 |
-| **16:9** | (-107, 0) | (747, 480) | (320, 240) | 854×480 |
+| **4:3** | (0, 0) | (640, 480) | (320, 240) | 640x480 |
+| **16:9** | (-107, 0) | (747, 480) | (320, 240) | 854x480 |
 
 To convert a position in playfield coordinates to storyboard coordinates, add the offset vector (64, 56), which is the position of the playfield's top-left corner in storyboard coordinates.

--- a/wiki/Client/Playfield/es.md
+++ b/wiki/Client/Playfield/es.md
@@ -29,9 +29,9 @@ El **campo de juego** es una parte de la ventana del juego donde se colocan los 
 ![](img/playfield-854x480.png "La ventana de osu! (morada) con el campo de juego (azul), relación de aspecto 16:9.")
 :::
 
-El sistema de coordenadas del campo de juego utiliza unidades independientes de la resolución llamadas **píxeles del juego** u osu! pixels, de modo que un píxel del juego equivale a un píxel cuando osu! se ejecuta a una resolución de 640×480. En resoluciones más altas, el tamaño visual de los píxeles del juego sigue siendo el mismo. El campo de juego está ligeramente desplazado verticalmente, colocado 8 píxeles del juego por debajo del centro de la ventana.
+El sistema de coordenadas del campo de juego utiliza unidades independientes de la resolución llamadas **píxeles del juego** u osu! pixels, de modo que un píxel del juego equivale a un píxel cuando osu! se ejecuta a una resolución de 640x480. En resoluciones más altas, el tamaño visual de los píxeles del juego sigue siendo el mismo. El campo de juego está ligeramente desplazado verticalmente, colocado 8 píxeles del juego por debajo del centro de la ventana.
 
-La cuadrícula del [editor de beatmaps](/wiki/Client/Beatmap_editor) es de 512×384 píxeles del juego.
+La cuadrícula del [editor de beatmaps](/wiki/Client/Beatmap_editor) es de 512x384 píxeles del juego.
 
 | Campo de juego (arriba a la izquierda) | Campo de juego (abajo a la derecha) | Campo de juego (centro) |
 | :-- | :-- | :-- |
@@ -47,7 +47,7 @@ El sistema de coordenadas utilizado para los storyboards tiene un punto de orige
 
 | Relación de aspecto | Pantalla (arriba a la izquierda) | Pantalla (abajo a la derecha) | Pantalla (centro) | Dimensiones dentro de los límites |
 | :-- | :-- | :-- | :-- | :-- |
-| **4:3** | (0, 0) | (640, 480) | (320, 240) | 640×480 |
-| **16:9** | (-107, 0) | (747, 480) | (320, 240) | 854×480 |
+| **4:3** | (0, 0) | (640, 480) | (320, 240) | 640x480 |
+| **16:9** | (-107, 0) | (747, 480) | (320, 240) | 854x480 |
 
 Para convertir una posición en coordenadas del campo de juego en coordenadas del storyboard, agrega el vector de desplazamiento (64, 56), que es la posición de la esquina superior izquierda del campo de juego en las coordenadas del storyboard.


### PR DESCRIPTION
Reverts ppy/osu-wiki#10187 (excuse the new branch)

redundant because Inter has ligatures for this

example

![image](https://github.com/ppy/osu-wiki/assets/36758269/c8b52b48-9f60-4441-96cd-f0d1ec78fa6a)

[more context on discord](https://discord.com/channels/188630481301012481/218677502141399041/1164671420547207309)