### PR TITLE
Improve format of tournament match history notes

### DIFF
--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -196,13 +196,13 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/82e
 
 Saturday, 28 October 2023:
 
-| Team A |  |  | Team B | Match link | VOD link |
-| --: | :-: | :-: | :-- | :-- | :-- |
-| **Chile** ::{ flag=CL }:: | **5** | 3 | ::{ flag=SE }:: Sweden | [#1](https://osu.ppy.sh/community/matches/111062319) | [#1](https://www.twitch.tv/videos/1962215601) |
-| **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=TH }:: Thailand | [#1](https://osu.ppy.sh/community/matches/111063878) | [#1](https://www.twitch.tv/videos/1962257068) |
-| **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=AR }:: Argentina | [#1](https://osu.ppy.sh/community/matches/111072298) | [#1](https://www.twitch.tv/videos/1962618853) |
-| **United Kingdom** ::{ flag=GB }:: | **5** | 3 | ::{ flag=TR }:: Turkey | [#1](https://osu.ppy.sh/community/matches/111073334) | [#1](https://www.twitch.tv/videos/1962709043?t=0h55m18s) |
-| France ::{ flag=FR }:: | 2 | **5** | ::{ flag=BR }:: **Brazil** | [#1](https://osu.ppy.sh/community/matches/111073335) | [#1](https://www.twitch.tv/videos/1962709043) |
+| Team A |  |  | Team B | Notes |
+| --: | :-: | :-: | :-- | :-- |
+| **Chile** ::{ flag=CL }:: | **5** | 3 | ::{ flag=SE }:: Sweden | [Match](https://osu.ppy.sh/community/matches/111062319), [VOD](https://www.twitch.tv/videos/1962215601 "Livestream recording on Twitch") |
+| **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=TH }:: Thailand | [Match](https://osu.ppy.sh/community/matches/111063878), [VOD](https://www.twitch.tv/videos/1962257068 "Livestream recording on Twitch") |
+| **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=AR }:: Argentina | [Match](https://osu.ppy.sh/community/matches/111072298), [VOD](https://www.twitch.tv/videos/1962618853 "Livestream recording on Twitch") |
+| **United Kingdom** ::{ flag=GB }:: | **5** | 3 | ::{ flag=TR }:: Turkey | [Match](https://osu.ppy.sh/community/matches/111073334), [VOD](https://www.twitch.tv/videos/1962709043?t=0h55m18s "Livestream recording on Twitch") |
+| France ::{ flag=FR }:: | 2 | **5** | ::{ flag=BR }:: **Brazil** | [Match](https://osu.ppy.sh/community/matches/111073335), [VOD](https://www.twitch.tv/videos/1962709043 "Livestream recording on Twitch") |
 
 ### Qualifiers
 

--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -198,11 +198,11 @@ Saturday, 28 October 2023:
 
 | Team A |  |  | Team B | Notes |
 | --: | :-: | :-: | :-- | :-- |
-| **Chile** ::{ flag=CL }:: | **5** | 3 | ::{ flag=SE }:: Sweden | [Match](https://osu.ppy.sh/community/matches/111062319), [VOD](https://www.twitch.tv/videos/1962215601 "Livestream recording on Twitch") |
-| **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=TH }:: Thailand | [Match](https://osu.ppy.sh/community/matches/111063878), [VOD](https://www.twitch.tv/videos/1962257068 "Livestream recording on Twitch") |
-| **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=AR }:: Argentina | [Match](https://osu.ppy.sh/community/matches/111072298), [VOD](https://www.twitch.tv/videos/1962618853 "Livestream recording on Twitch") |
-| **United Kingdom** ::{ flag=GB }:: | **5** | 3 | ::{ flag=TR }:: Turkey | [Match](https://osu.ppy.sh/community/matches/111073334), [VOD](https://www.twitch.tv/videos/1962709043?t=0h55m18s "Livestream recording on Twitch") |
-| France ::{ flag=FR }:: | 2 | **5** | ::{ flag=BR }:: **Brazil** | [Match](https://osu.ppy.sh/community/matches/111073335), [VOD](https://www.twitch.tv/videos/1962709043 "Livestream recording on Twitch") |
+| **Chile** ::{ flag=CL }:: | **5** | 3 | ::{ flag=SE }:: Sweden | [Match](https://osu.ppy.sh/community/matches/111062319), [VOD](https://www.twitch.tv/videos/1962215601) |
+| **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=TH }:: Thailand | [Match](https://osu.ppy.sh/community/matches/111063878), [VOD](https://www.twitch.tv/videos/1962257068) |
+| **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=AR }:: Argentina | [Match](https://osu.ppy.sh/community/matches/111072298), [VOD](https://www.twitch.tv/videos/1962618853) |
+| **United Kingdom** ::{ flag=GB }:: | **5** | 3 | ::{ flag=TR }:: Turkey | [Match](https://osu.ppy.sh/community/matches/111073334), [VOD](https://www.twitch.tv/videos/1962709043?t=0h55m18s) |
+| France ::{ flag=FR }:: | 2 | **5** | ::{ flag=BR }:: **Brazil** | [Match](https://osu.ppy.sh/community/matches/111073335), [VOD](https://www.twitch.tv/videos/1962709043) |
 
 ### Qualifiers
 

--- a/wiki/Tournaments/OWC/2023/ko.md
+++ b/wiki/Tournaments/OWC/2023/ko.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 7e2b95804f908dc0bff9ad27a2b60c72e3b6803b
+outdated_translation: true
 tags:
   - OWC
   - OWC2023

--- a/wiki/Tournaments/OWC/2023/zh-tw.md
+++ b/wiki/Tournaments/OWC/2023/zh-tw.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 7e2b95804f908dc0bff9ad27a2b60c72e3b6803b
+outdated_translation: true
 tags:
   - OWC
   - OWC2023

--- a/wiki/Tournaments/TEMPLATE.md
+++ b/wiki/Tournaments/TEMPLATE.md
@@ -124,12 +124,12 @@ If the mappool doesn't use a standard ModType pool structure, alternative titles
 
 Day, date: <!-- e.g. Saturday, 17 June 2018: -->
 
-<!-- For solo tournaments, replace table header with: | Player 1 |  |  | Player 2 | Match link | -->
-| Team 1 |  |  | Team 2 | Match link |
+<!-- For solo tournaments, replace table header with: | Player 1 |  |  | Player 2 | Notes | -->
+| Team 1 |  |  | Team 2 | Notes |
 | --: | :-: | :-: | :-- | :-- |
-| **WINNER** ::{ flag=CODE }:: | **SCORE** | SCORE | ::{ flag=CODE }:: LOSER | [#1](MatchLink) |
-| LOSER ::{ flag=CODE }:: | -1 <!-- It's convention to write "-1" for forfeits, but this isn't required --> | **0** | ::{ flag=CODE }:: **WINNER** | *win by default* |
-| TEAM_A ::{ flag=CODE }:: | 0 | 0 | ::{ flag=CODE }:: TEAM_B | *nullified* |
+| **WINNER** ::{ flag=CODE }:: | **SCORE** | SCORE | ::{ flag=CODE }:: LOSER | [Match](MatchLink) <!-- Include any links or info relevant to the match, such as the match history, livestream recording, etc. --> |
+| LOSER ::{ flag=CODE }:: | -1 <!-- It's convention to write "-1" for forfeits, but this isn't required --> | **0** | ::{ flag=CODE }:: **WINNER** | *Win by default* |
+| TEAM_A ::{ flag=CODE }:: | 0 | 0 | ::{ flag=CODE }:: TEAM_B | *Nullified* |
 
 ## Ruleset
 


### PR DESCRIPTION
applied to owc 2023 as an example, but I think this is a better format than the numbered links thing for any future tournament. https://discord.com/channels/188630481301012481/218677502141399041/1167996377515708436