### PR TITLE
Improve explanation of the weekly hype limit

### DIFF
--- a/wiki/Beatmap/Hype/en.md
+++ b/wiki/Beatmap/Hype/en.md
@@ -14,6 +14,6 @@ Beatmaps need at least 5 hypes (one complete bar of the hype train) to be eligib
 
 ## Limit
 
-Users start with 10 hypes. Each hype independently takes a week to recharge after being used on a beatmap, meaning all hypes are available again after one week.
+Users start with 10 hypes, and they are consumed when used on beatmaps. Each hype takes a week after use to become available again.
 
 <!-- TODO: images of the beatmap page and the modding page -->

--- a/wiki/Beatmap/Hype/en.md
+++ b/wiki/Beatmap/Hype/en.md
@@ -10,7 +10,7 @@ Every [pending](/wiki/Beatmap/Category#work-in-progress-and-pending) [beatmap](/
 
 ## Ranking requirement
 
-Beatmaps need at least 5 hype (one complete bar of the hype train) to be eligible for [nomination](/wiki/Beatmap_ranking_procedure#nominations), a step towards getting the map ranked.
+Beatmaps need at least 5 hypes (one complete bar of the hype train) to be eligible for [nomination](/wiki/Beatmap_ranking_procedure#nominations), a step towards getting the map ranked.
 
 ## Limit
 

--- a/wiki/Beatmap/Hype/en.md
+++ b/wiki/Beatmap/Hype/en.md
@@ -14,6 +14,6 @@ Beatmaps need at least 5 hype (one complete bar of the hype train) to be eligibl
 
 ## Limit
 
-Users start with 10 hypes, and they are consumed when used on beatmaps. Each hype takes a week to become available again.
+Users start with 10 hypes. Each hype independently takes a week to recharge after being used on a beatmap, meaning all hypes are available again after one week.
 
 <!-- TODO: images of the beatmap page and the modding page -->

--- a/wiki/Beatmap/Hype/fr.md
+++ b/wiki/Beatmap/Hype/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/id.md
+++ b/wiki/Beatmap/Hype/id.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/it.md
+++ b/wiki/Beatmap/Hype/it.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/ja.md
+++ b/wiki/Beatmap/Hype/ja.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/ru.md
+++ b/wiki/Beatmap/Hype/ru.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/vi.md
+++ b/wiki/Beatmap/Hype/vi.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train

--- a/wiki/Beatmap/Hype/zh.md
+++ b/wiki/Beatmap/Hype/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: ffc2b62f3415a9a54a838e55c845a7a0bcd8d681
 stub: true
 tags:
   - train


### PR DESCRIPTION
The wording tries to make it clear that each hype will recharge one week after being used instead of the user recharging one hype per week.

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
