### PR TITLE
Add history to `Featured Artist playlists` and `Featured Artist showcase beatmaps` articles

### DIFF
--- a/news/2023/2023-03-15-new-featured-artist-minstrel.md
+++ b/news/2023/2023-03-15-new-featured-artist-minstrel.md
@@ -42,7 +42,7 @@ Play through [this very real beatmap](https://osu.ppy.sh/beatmapsets/1085793) ho
     <source src="https://assets.ppy.sh/artists/349/recollection/Minstrel%20-%20Fiction.mp3">
 </audio>
 
-### Minstrel - Cinderella Cage ~Falling in Love Again~
+### Minstrel - Cinderella Cage \~Falling in Love Again\~
 
 Or try [this map from the video above](https://osu.ppy.sh/beatmapsets/1909142) hosted by [SMOKELIND](https://osu.ppy.sh/users/9327302)!
 

--- a/wiki/Contests/Contest_points/en.md
+++ b/wiki/Contests/Contest_points/en.md
@@ -51,12 +51,13 @@ For team contests, elite mapper points will be evaluated on a case-by-case basis
 | :-- | :-- |
 | ::{ flag=TH }:: [**Ph0eNiiXZ**](https://osu.ppy.sh/users/9463721) | **6** |
 | ::{ flag=TH }:: [Kusuhara Yui](https://osu.ppy.sh/users/9582525) | 5 |
+| ::{ flag=JP }:: [uone](https://osu.ppy.sh/users/5321719) | 3 |
 | ::{ flag=FI }:: [Jaltzu](https://osu.ppy.sh/users/2597417) | 2 |
 | ::{ flag=SG }:: [arcpotato](https://osu.ppy.sh/users/12842392) | 2 |
 | ::{ flag=SG }:: [_gt](https://osu.ppy.sh/users/8301957) | 2 |
 | ::{ flag=GB }:: [Horiiizon](https://osu.ppy.sh/users/8071438) | 2 |
+| ::{ flag=JP }:: [IceOC](https://osu.ppy.sh/users/5482401) | 2 |
 | ::{ flag=US }:: [Nifty](https://osu.ppy.sh/users/4956097) | 1 |
-| ::{ flag=JP }:: [uone](https://osu.ppy.sh/users/5321719) | 1 |
 | ::{ flag=KR }:: [woosungko](https://osu.ppy.sh/users/14184157) | 1 |
 | ::{ flag=US }:: [fieryrage](https://osu.ppy.sh/users/3533958) | 1 |
 

--- a/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
@@ -191,6 +191,7 @@ As of June 2023, the above badges are awarded to any user who achieves 10 points
 ### June 2022
 
 - 8 beatmaps
+- All game modes
 - [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden) mod required
 - [No Fail (NF)](/wiki/Gameplay/Game_modifier/No_Fail) and [Mirror (MR)](/wiki/Gameplay/Game_modifier/Mirror) freemod options
 - Prizes rewarded to top 3 players in each playlist
@@ -198,6 +199,7 @@ As of June 2023, the above badges are awarded to any user who achieves 10 points
 ### July 2022
 
 - 5 beatmaps
+- All game modes
 - 15 allowed attempts across all playlist items
 - [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden), [Hard Rock (HR)](/wiki/Gameplay/Game_modifier/Hard_Rock), [No Fail (NF)](/wiki/Gameplay/Game_modifier/No_Fail) and [Mirror (MR)](/wiki/Gameplay/Game_modifier/Mirror) freemod options
 - Prizes rewarded to top 0.5% of players in each playlist
@@ -210,11 +212,31 @@ As of June 2023, the above badges are awarded to any user who achieves 10 points
 ### March 2023
 
 - Top 8 beatmaps from the [Twin Trials Contest](/wiki/Contests/Twin_Trials_Contest) with separate prizing
+- All game modes
 
-### June 2023
+### May 2023
 
 - 6 beatmaps from May 2023's Featured Artist releases created by the [Mappers' Guild](/wiki/Community/Mappers_Guild)
-- Prizes awarded as per the [cumulative leaderboard](#cumulative-leaderboard), with modifications related to scoring algorithm changes as explained in [this announcement](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek#featured-artist-playlists)
+- Only applicable to osu! and osu!mania game modes
+- [Prizes awarded](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek#featured-artist-playlists) as per the [cumulative leaderboard](#cumulative-leaderboard), with modifications related to scoring algorithm changes as explained in the results announcement
+
+### June/July 2023
+
+- 6 beatmaps from June and July 2023's Featured Artist releases created by the [Mappers' Guild](/wiki/Community/Mappers_Guild)
+- All game modes
+- [Prizes awarded](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu#featured-artist-playlists) as per the [cumulative leaderboard](#cumulative-leaderboard)
+
+### August 2023
+
+- 6 beatmaps from August 2023's Featured Artist releases created by the [Mappers' Guild](/wiki/Community/Mappers_Guild)
+- Only applicable to osu!, osu!taiko, and osu!mania game modes
+- [Prizes awarded](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou#featured-artist-playlists) as per the [cumulative leaderboard](#cumulative-leaderboard)
+
+### September/October 2023
+
+- 6 beatmaps from September and October 2023's Featured Artist releases created by the [Mappers' Guild](/wiki/Community/Mappers_Guild)
+- All game modes
+- Prizes awarded as per the [cumulative leaderboard](#cumulative-leaderboard).
 
 ## Notes
 

--- a/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
@@ -188,6 +188,8 @@ As of June 2023, the above badges are awarded to any user who achieves 10 points
 
 ## Previous playlists
 
+For full playlist details, see the [multiplayer rooms listing](https://osu.ppy.sh/multiplayer/rooms/latest).
+
 ### June 2022
 
 - 8 beatmaps

--- a/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_playlists/en.md
@@ -188,7 +188,7 @@ As of June 2023, the above badges are awarded to any user who achieves 10 points
 
 ## Previous playlists
 
-For full playlist details, see the [multiplayer rooms listing](https://osu.ppy.sh/multiplayer/rooms/latest).
+For full playlist details, see the [multiplayer room listing](https://osu.ppy.sh/multiplayer/rooms/latest).
 
 ### June 2022
 

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/en.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/en.md
@@ -631,6 +631,128 @@ This article lists all the showcase beatmaps that have been created by the membe
 - **[LandRoot](https://osu.ppy.sh/home/news/2022-12-10-new-featured-artist-landroot)** (2022-12-10)
   - (![][osu!]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1834399) hosted by ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
   - (![][osu!taiko]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1474263) hosted by ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015)
+- **[Satyr](https://osu.ppy.sh/home/news/2022-12-14-new-featured-artist-satyr)** (2022-12-14)
+  - (![][osu!]) [Satyr - Picayune](https://osu.ppy.sh/beatmapsets/1902228) hosted by ::{ flag=RU }:: [Blood9](https://osu.ppy.sh/users/11214999)
+- **[nyankobrq](https://osu.ppy.sh/home/news/2022-12-21-new-featured-artist-nyankobrq)** (2022-12-21)
+  - (![][osu!]) [nyankobrq - Snorkel](https://osu.ppy.sh/beatmapsets/1886230) hosted by ::{ flag=JP }:: [Yuuma](https://osu.ppy.sh/users/6644401)
+
+## 2023
+
+### January
+
+- **[Fellowship](https://osu.ppy.sh/home/news/2023-01-07-new-featured-artist-fellowship)** (2023-01-07)
+  - (![][osu!]) [Fellowship - The Frozen Land](https://osu.ppy.sh/beatmapsets/1835572) hosted by ::{ flag=US }:: [nebuwua](https://osu.ppy.sh/users/14729352)
+- **[Euchaeta](https://osu.ppy.sh/home/news/2023-01-11-new-featured-artist-euchaeta)** (2023-01-11)
+  - (![][osu!]) [Euchaeta - A Songwriter's Cosmos](https://osu.ppy.sh/beatmapsets/1858201) hosted by ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+  - (![][osu!]) [Euchaeta - Spirit Away](https://osu.ppy.sh/beatmapsets/1857409) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Etherwood](https://osu.ppy.sh/home/news/2023-01-18-new-featured-artist-etherwood)** (2023-01-18)
+  - (![][osu!]) [Etherwood - Cast Away](https://osu.ppy.sh/beatmapsets/1922699) hosted by ::{ flag=PL }:: [-Sylvari](https://osu.ppy.sh/users/3493804)
+- **[kakichoco](https://osu.ppy.sh/home/news/2023-01-21-new-featured-artist-kakichoco)** (2023-01-21)
+  - (![][osu!]) [kakichoco - Zan'ei](https://osu.ppy.sh/beatmapsets/1888928) hosted by ::{ flag=RU }:: [PandaHero](https://osu.ppy.sh/users/1233255)
+  - (![][osu!]) [kakichoco - Reirou no Hibiki](https://osu.ppy.sh/beatmapsets/1853651) hosted by ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+
+### Febraury
+
+- **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
+  - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) hosted by ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
+- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+  - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) hosted by ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+- **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
+  - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) hosted by ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+  - (![][osu!]) [Cinamoro - Paleturquoise](https://osu.ppy.sh/beatmapsets/1874826) hosted by ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
+- **[yaseta](https://osu.ppy.sh/home/news/2023-02-18-new-featured-artist-yaseta)** (2023-02-18)
+  - (![][osu!]) [yaseta - Dreamy Goat](https://osu.ppy.sh/beatmapsets/1917139) hosted by ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[KASHIWA Daisuke](https://osu.ppy.sh/home/news/2023-02-22-new-featured-artist-kashiwa-daisuke)** (2023-02-22)
+  - (![][osu!]) [KASHIWA Daisuke - Sacred Play Secret Place](https://osu.ppy.sh/beatmapsets/1908078) hosted by ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+- **[Kabocha](https://osu.ppy.sh/home/news/2023-03-01-new-featured-artist-kabocha)** (2023-03-01)
+  - (![][osu!]) [Kabocha feat. mikanzil - HOTCHPOTCH Hitoribocchi](https://osu.ppy.sh/beatmapsets/1934595) hosted by ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+  - (![][osu!taiko]) [Kabocha - Yume no Kuni e feat. miko](https://osu.ppy.sh/beatmapsets/1851518) hosted by ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733)
+
+### March
+
+- **[Mediks](https://osu.ppy.sh/home/news/2023-03-04-new-featured-artist-mediks)** (2023-03-04)
+  - (![][osu!]) [Mediks - Blown Away (feat. Astronaut) (Raise Spirit Remix)](https://osu.ppy.sh/beatmapsets/1950373) hosted by ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033)
+- **[Minstrel](https://osu.ppy.sh/home/news/2023-03-15-new-featured-artist-minstrel)** (2023-03-15)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1900605) hosted by ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1907639) hosted by ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581)
+  - (![][osu!]) [Minstrel - Cinderella Cage ~Falling in Love Again~](https://osu.ppy.sh/beatmapsets/1909142) hosted by ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!]) [Minstrel - futuristic recollection](https://osu.ppy.sh/beatmapsets/1934280) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Kenneyon](https://osu.ppy.sh/home/news/2023-03-22-new-featured-artist-kenneyon)** (2023-03-22)
+  - (![][osu!catch]) [Kenneyon and Kara - Wildflower](https://osu.ppy.sh/beatmapsets/1914385) hosted by ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565)
+- **[Ashrount](https://osu.ppy.sh/home/news/2023-03-25-new-featured-artist-ashrount)** (2023-03-25)
+  - (![][osu!]) [Maverick - opaque](https://osu.ppy.sh/beatmapsets/1955283) hosted by ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+- **[Stars Hollow](https://osu.ppy.sh/home/news/2023-03-31-new-featured-artist-stars-hollow)** (2023-03-31)
+  - (![][osu!]) [Stars Hollow - Stuck to You.](https://osu.ppy.sh/beatmapsets/1966591) hosted by ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418)
+
+### May
+
+- **[tephe](https://osu.ppy.sh/home/news/2023-05-24-new-featured-artist-tephe)** (2023-05-24)
+  - (![][osu!]) [tephe - Genjitsu Escape](https://osu.ppy.sh/beatmapsets/1997470) hosted by ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539)
+- **[Shadren](https://osu.ppy.sh/home/news/2023-05-27-new-featured-artist-shadren)** (2023-05-27)
+  - (![][osu!]) [Shadren - You're Here Forever](https://osu.ppy.sh/beatmapsets/1948970) hosted by ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!]) [Shadren - Agleam (feat. Asperatus)](https://osu.ppy.sh/beatmapsets/1926857) hosted by ::{ flag=UZ }:: [M a r v o l l o](https://osu.ppy.sh/users/5504231)
+
+### June
+
+- **[Andora](https://osu.ppy.sh/home/news/2023-06-03-new-featured-artist-andora)** (2023-06-03)
+  - (![][osu!]) [Andora - Euphoria (feat. WaMi)](https://osu.ppy.sh/beatmapsets/1905874) hosted by ::{ flag=PH }:: [-Aqua](https://osu.ppy.sh/users/7150015)
+  - (![][osu!mania]) [Andora - Flicker (feat. RANASOL)](https://osu.ppy.sh/beatmapsets/1978179) hosted by ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+- **[Junk](https://osu.ppy.sh/home/news/2023-06-17-new-featured-artist-junk)** (2023-06-17)
+  - (![][osu!]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010589) hosted by ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!catch]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2006758) hosted by ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)
+  - (![][osu!taiko]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010165) hosted by ::{ flag=AR }:: [gaston_2199](https://osu.ppy.sh/users/5938161)
+  - (![][osu!catch]) [Junk - Qualia](https://osu.ppy.sh/beatmapsets/2010010) hosted by ::{ flag=NL }:: [Chatie](https://osu.ppy.sh/users/6524765)
+- **[passchooo](https://osu.ppy.sh/home/news/2023-06-24-new-featured-artist-passchooo)** (2023-06-24)
+  - (![][osu!]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/1981957) hosted by ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/2014129) hosted by ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!catch]) [passchooo - david gold took it slow (alt version)](https://osu.ppy.sh/beatmapsets/2014234) hosted by ::{ flag=SG }:: [Xinnoh](https://osu.ppy.sh/users/4236057)
+- **[Ruby My Dear](https://osu.ppy.sh/home/news/2023-07-01-new-featured-artist-ruby-my-dear)** (2023-07-01)
+  - (![][osu!catch]) [Ruby My Dear - Croque Monsieur A Disneyland](https://osu.ppy.sh/beatmapsets/2009607) hosted by ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)
+
+### July
+
+- **[Krimek](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek)** (2023-07-08)
+  - (![][osu!]) [Krimek feat. dokxid - Gravity Hole](https://osu.ppy.sh/beatmapsets/1983505) hosted by ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[YUC'e](https://osu.ppy.sh/home/news/2023-07-15-new-featured-artist-yuce)** (2023-07-15)
+  - (![][osu!taiko]) [YUC'e - Future Candy](https://osu.ppy.sh/beatmapsets/2006776) hosted by ::{ flag=AR }:: [ZelLink](https://osu.ppy.sh/users/6752242)
+  - (![][osu!]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2005892) hosted by ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2008307) hosted by ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [YUC'e - Sugary Galaxy](https://osu.ppy.sh/beatmapsets/2015526) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [YUC'e - PUMP](https://osu.ppy.sh/beatmapsets/2023926) hosted by ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+
+### August
+
+- **[ALLMYFRIENDS](https://osu.ppy.sh/home/news/2023-08-05-new-featured-artist-all-my-friends)** (2023-08-05)
+  - (![][osu!]) [Synthion, Yuuna Nini - By My Side](https://osu.ppy.sh/beatmapsets/1993256) hosted by ::{ flag=US }:: [Shirahane Suou](https://osu.ppy.sh/users/10820856)
+  - (![][osu!]) [awfuless - Temptation (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1983389) hosted by ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [you - Meteor (feat. TEA)](https://osu.ppy.sh/beatmapsets/1984574) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[soowamisu](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu)** (2023-08-19)
+  - (![][osu!]) [soowamisu - .vaporcore](https://osu.ppy.sh/beatmapsets/1999116) hosted by ::{ flag=ID }:: [Kyouren](https://osu.ppy.sh/users/2013571)
+  - (![][osu!]) [soowamisu - floating architecture of an abstract heaven](https://osu.ppy.sh/beatmapsets/1988496) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[beignet](https://osu.ppy.sh/home/news/2023-08-26-new-featured-artist-beignet)** (2023-08-26)
+  - (![][osu!]) [beignet - Sign](https://osu.ppy.sh/beatmapsets/2030991) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [beignet - Mint Comet (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031418) hosted by ::{ flag=ES }:: [Nachmark](https://osu.ppy.sh/users/17584310)
+  - (![][osu!mania]) [beignet - Maple Trick](https://osu.ppy.sh/beatmapsets/2032450) hosted by ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [beignet - S'more](https://osu.ppy.sh/beatmapsets/2050540) hosted by ::{ flag=BA }:: [Stompy_](https://osu.ppy.sh/users/16429579)
+
+### September
+
+- **[C-Show](https://osu.ppy.sh/home/news/2023-09-02-new-featured-artist-c-show)** (2023-09-02)
+  - (![][osu!]) [C-Show - Rocking to the Beat (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031865) hosted by ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2044626) hosted by ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2047648) hosted by ::{ flag=ID }:: [Virtue-](https://osu.ppy.sh/users/6144772)
+  - (![][osu!]) [C-Show feat. Ishizawa Yukari - Border Line](https://osu.ppy.sh/beatmapsets/2035357) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+
+### October
+
+- **[Kou!](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou)** (2023-10-07)
+  - (![][osu!catch]) [Kou! - sub/zerO](https://osu.ppy.sh/beatmapsets/2069616) hosted by ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114)
+- **[ColBreakz](https://osu.ppy.sh/home/news/2023-10-15-new-featured-artist-colbreakz)** (2023-10-15)
+  - (![][osu!]) [ColBreakz - 2011](https://osu.ppy.sh/beatmapsets/2074103) hosted by ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+  - (![][osu!mania]) [Protolizard & ColBreakz - Nevermind](https://osu.ppy.sh/beatmapsets/2072833) hosted by ::{ flag=ID }:: [Ainer](https://osu.ppy.sh/users/13371424)
+  - (![][osu!]) [ColBreakz & Vizzen - Remember](https://osu.ppy.sh/beatmapsets/2052201) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Dustvoxx](https://osu.ppy.sh/home/news/2023-10-28-new-featured-artist-dustvoxx)** (2023-10-28)
+  - (![][osu!]) [Dustvoxx, Laur - FireLight](https://osu.ppy.sh/beatmapsets/2064173) hosted by ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 
 ## History
 

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/en.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/en.md
@@ -655,7 +655,7 @@ This article lists all the showcase beatmaps that have been created by the membe
 
 - **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
   - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) hosted by ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
-- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+- **[Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
   - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) hosted by ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
 - **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
   - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) hosted by ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/fr.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/fr.md
@@ -655,7 +655,7 @@ Cet article répertorie toutes les beatmaps showcase qui ont été créées par 
 
 - **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (04/02/2023)
   - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) organisé par ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
-- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (08/02/2023)
+- **[Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (08/02/2023)
   - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) organisé par ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
 - **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (11/02/2023)
   - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) organisé par ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/fr.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/fr.md
@@ -631,6 +631,128 @@ Cet article répertorie toutes les beatmaps showcase qui ont été créées par 
 - **[LandRoot](https://osu.ppy.sh/home/news/2022-12-10-new-featured-artist-landroot)** (10/12/2022)
   - (![][osu!]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1834399) organisé par ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
   - (![][osu!taiko]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1474263) organisé par ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015)
+- **[Satyr](https://osu.ppy.sh/home/news/2022-12-14-new-featured-artist-satyr)** (14/12/2022)
+  - (![][osu!]) [Satyr - Picayune](https://osu.ppy.sh/beatmapsets/1902228) organisé par ::{ flag=RU }:: [Blood9](https://osu.ppy.sh/users/11214999)
+- **[nyankobrq](https://osu.ppy.sh/home/news/2022-12-21-new-featured-artist-nyankobrq)** (21/12/2022)
+  - (![][osu!]) [nyankobrq - Snorkel](https://osu.ppy.sh/beatmapsets/1886230) organisé par ::{ flag=JP }:: [Yuuma](https://osu.ppy.sh/users/6644401)
+
+## 2023
+
+### Janvier
+
+- **[Fellowship](https://osu.ppy.sh/home/news/2023-01-07-new-featured-artist-fellowship)** (07/01/2023)
+  - (![][osu!]) [Fellowship - The Frozen Land](https://osu.ppy.sh/beatmapsets/1835572) organisé par ::{ flag=US }:: [nebuwua](https://osu.ppy.sh/users/14729352)
+- **[Euchaeta](https://osu.ppy.sh/home/news/2023-01-11-new-featured-artist-euchaeta)** (11/01/2023)
+  - (![][osu!]) [Euchaeta - A Songwriter's Cosmos](https://osu.ppy.sh/beatmapsets/1858201) organisé par ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+  - (![][osu!]) [Euchaeta - Spirit Away](https://osu.ppy.sh/beatmapsets/1857409) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Etherwood](https://osu.ppy.sh/home/news/2023-01-18-new-featured-artist-etherwood)** (18/01/2023)
+  - (![][osu!]) [Etherwood - Cast Away](https://osu.ppy.sh/beatmapsets/1922699) organisé par ::{ flag=PL }:: [-Sylvari](https://osu.ppy.sh/users/3493804)
+- **[kakichoco](https://osu.ppy.sh/home/news/2023-01-21-new-featured-artist-kakichoco)** (21/01/2023)
+  - (![][osu!]) [kakichoco - Zan'ei](https://osu.ppy.sh/beatmapsets/1888928) organisé par ::{ flag=RU }:: [PandaHero](https://osu.ppy.sh/users/1233255)
+  - (![][osu!]) [kakichoco - Reirou no Hibiki](https://osu.ppy.sh/beatmapsets/1853651) organisé par ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+
+### Février
+
+- **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (04/02/2023)
+  - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) organisé par ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
+- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (08/02/2023)
+  - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) organisé par ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+- **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (11/02/2023)
+  - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) organisé par ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+  - (![][osu!]) [Cinamoro - Paleturquoise](https://osu.ppy.sh/beatmapsets/1874826) organisé par ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
+- **[yaseta](https://osu.ppy.sh/home/news/2023-02-18-new-featured-artist-yaseta)** (18/02/2023)
+  - (![][osu!]) [yaseta - Dreamy Goat](https://osu.ppy.sh/beatmapsets/1917139) organisé par ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[KASHIWA Daisuke](https://osu.ppy.sh/home/news/2023-02-22-new-featured-artist-kashiwa-daisuke)** (22/02/2023)
+  - (![][osu!]) [KASHIWA Daisuke - Sacred Play Secret Place](https://osu.ppy.sh/beatmapsets/1908078) organisé par ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+- **[Kabocha](https://osu.ppy.sh/home/news/2023-03-01-new-featured-artist-kabocha)** (01/03/2023)
+  - (![][osu!]) [Kabocha feat. mikanzil - HOTCHPOTCH Hitoribocchi](https://osu.ppy.sh/beatmapsets/1934595) organisé par ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+  - (![][osu!taiko]) [Kabocha - Yume no Kuni e feat. miko](https://osu.ppy.sh/beatmapsets/1851518) organisé par ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733)
+
+### Mars
+
+- **[Mediks](https://osu.ppy.sh/home/news/2023-03-04-new-featured-artist-mediks)** (04/03/2023)
+  - (![][osu!]) [Mediks - Blown Away (feat. Astronaut) (Raise Spirit Remix)](https://osu.ppy.sh/beatmapsets/1950373) organisé par ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033)
+- **[Minstrel](https://osu.ppy.sh/home/news/2023-03-15-new-featured-artist-minstrel)** (15/03/2023)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1900605) organisé par ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1907639) organisé par ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581)
+  - (![][osu!]) [Minstrel - Cinderella Cage ~Falling in Love Again~](https://osu.ppy.sh/beatmapsets/1909142) organisé par ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!]) [Minstrel - futuristic recollection](https://osu.ppy.sh/beatmapsets/1934280) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Kenneyon](https://osu.ppy.sh/home/news/2023-03-22-new-featured-artist-kenneyon)** (22/03/2023)
+  - (![][osu!catch]) [Kenneyon and Kara - Wildflower](https://osu.ppy.sh/beatmapsets/1914385) organisé par ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565)
+- **[Ashrount](https://osu.ppy.sh/home/news/2023-03-25-new-featured-artist-ashrount)** (25/03/2023)
+  - (![][osu!]) [Maverick - opaque](https://osu.ppy.sh/beatmapsets/1955283) organisé par ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+- **[Stars Hollow](https://osu.ppy.sh/home/news/2023-03-31-new-featured-artist-stars-hollow)** (31/03/2023)
+  - (![][osu!]) [Stars Hollow - Stuck to You.](https://osu.ppy.sh/beatmapsets/1966591) organisé par ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418)
+
+### Mai
+
+- **[tephe](https://osu.ppy.sh/home/news/2023-05-24-new-featured-artist-tephe)** (24/05/2023)
+  - (![][osu!]) [tephe - Genjitsu Escape](https://osu.ppy.sh/beatmapsets/1997470) organisé par ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539)
+- **[Shadren](https://osu.ppy.sh/home/news/2023-05-27-new-featured-artist-shadren)** (27/05/2023)
+  - (![][osu!]) [Shadren - You're Here Forever](https://osu.ppy.sh/beatmapsets/1948970) organisé par ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!]) [Shadren - Agleam (feat. Asperatus)](https://osu.ppy.sh/beatmapsets/1926857) organisé par ::{ flag=UZ }:: [M a r v o l l o](https://osu.ppy.sh/users/5504231)
+
+### Juin
+
+- **[Andora](https://osu.ppy.sh/home/news/2023-06-03-new-featured-artist-andora)** (03/06/2023)
+  - (![][osu!]) [Andora - Euphoria (feat. WaMi)](https://osu.ppy.sh/beatmapsets/1905874) organisé par ::{ flag=PH }:: [-Aqua](https://osu.ppy.sh/users/7150015)
+  - (![][osu!mania]) [Andora - Flicker (feat. RANASOL)](https://osu.ppy.sh/beatmapsets/1978179) organisé par ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+- **[Junk](https://osu.ppy.sh/home/news/2023-06-17-new-featured-artist-junk)** (17/06/2023)
+  - (![][osu!]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010589) organisé par ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!catch]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2006758) organisé par ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)
+  - (![][osu!taiko]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010165) organisé par ::{ flag=AR }:: [gaston_2199](https://osu.ppy.sh/users/5938161)
+  - (![][osu!catch]) [Junk - Qualia](https://osu.ppy.sh/beatmapsets/2010010) organisé par ::{ flag=NL }:: [Chatie](https://osu.ppy.sh/users/6524765)
+- **[passchooo](https://osu.ppy.sh/home/news/2023-06-24-new-featured-artist-passchooo)** (24/06/2023)
+  - (![][osu!]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/1981957) organisé par ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/2014129) organisé par ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!catch]) [passchooo - david gold took it slow (alt version)](https://osu.ppy.sh/beatmapsets/2014234) organisé par ::{ flag=SG }:: [Xinnoh](https://osu.ppy.sh/users/4236057)
+- **[Ruby My Dear](https://osu.ppy.sh/home/news/2023-07-01-new-featured-artist-ruby-my-dear)** (01/07/2023)
+  - (![][osu!catch]) [Ruby My Dear - Croque Monsieur A Disneyland](https://osu.ppy.sh/beatmapsets/2009607) organisé par ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)
+
+### Juillet
+
+- **[Krimek](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek)** (08/07/2023)
+  - (![][osu!]) [Krimek feat. dokxid - Gravity Hole](https://osu.ppy.sh/beatmapsets/1983505) organisé par ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[YUC'e](https://osu.ppy.sh/home/news/2023-07-15-new-featured-artist-yuce)** (15/07/2023)
+  - (![][osu!taiko]) [YUC'e - Future Candy](https://osu.ppy.sh/beatmapsets/2006776) organisé par ::{ flag=AR }:: [ZelLink](https://osu.ppy.sh/users/6752242)
+  - (![][osu!]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2005892) organisé par ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2008307) organisé par ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [YUC'e - Sugary Galaxy](https://osu.ppy.sh/beatmapsets/2015526) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [YUC'e - PUMP](https://osu.ppy.sh/beatmapsets/2023926) organisé par ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+
+### Août
+
+- **[ALLMYFRIENDS](https://osu.ppy.sh/home/news/2023-08-05-new-featured-artist-all-my-friends)** (05/08/2023)
+  - (![][osu!]) [Synthion, Yuuna Nini - By My Side](https://osu.ppy.sh/beatmapsets/1993256) organisé par ::{ flag=US }:: [Shirahane Suou](https://osu.ppy.sh/users/10820856)
+  - (![][osu!]) [awfuless - Temptation (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1983389) organisé par ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [you - Meteor (feat. TEA)](https://osu.ppy.sh/beatmapsets/1984574) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[soowamisu](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu)** (19/08/2023)
+  - (![][osu!]) [soowamisu - .vaporcore](https://osu.ppy.sh/beatmapsets/1999116) organisé par ::{ flag=ID }:: [Kyouren](https://osu.ppy.sh/users/2013571)
+  - (![][osu!]) [soowamisu - floating architecture of an abstract heaven](https://osu.ppy.sh/beatmapsets/1988496) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[beignet](https://osu.ppy.sh/home/news/2023-08-26-new-featured-artist-beignet)** (26/08/2023)
+  - (![][osu!]) [beignet - Sign](https://osu.ppy.sh/beatmapsets/2030991) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [beignet - Mint Comet (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031418) organisé par ::{ flag=ES }:: [Nachmark](https://osu.ppy.sh/users/17584310)
+  - (![][osu!mania]) [beignet - Maple Trick](https://osu.ppy.sh/beatmapsets/2032450) organisé par ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [beignet - S'more](https://osu.ppy.sh/beatmapsets/2050540) organisé par ::{ flag=BA }:: [Stompy_](https://osu.ppy.sh/users/16429579)
+
+### Septembre
+
+- **[C-Show](https://osu.ppy.sh/home/news/2023-09-02-new-featured-artist-c-show)** (02/09/2023)
+  - (![][osu!]) [C-Show - Rocking to the Beat (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031865) organisé par ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2044626) organisé par ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2047648) organisé par ::{ flag=ID }:: [Virtue-](https://osu.ppy.sh/users/6144772)
+  - (![][osu!]) [C-Show feat. Ishizawa Yukari - Border Line](https://osu.ppy.sh/beatmapsets/2035357) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+
+### Octobre
+
+- **[Kou!](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou)** (07/10/2023)
+  - (![][osu!catch]) [Kou! - sub/zerO](https://osu.ppy.sh/beatmapsets/2069616) organisé par ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114)
+- **[ColBreakz](https://osu.ppy.sh/home/news/2023-10-15-new-featured-artist-colbreakz)** (15/10/2023)
+  - (![][osu!]) [ColBreakz - 2011](https://osu.ppy.sh/beatmapsets/2074103) organisé par ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+  - (![][osu!mania]) [Protolizard & ColBreakz - Nevermind](https://osu.ppy.sh/beatmapsets/2072833) organisé par ::{ flag=ID }:: [Ainer](https://osu.ppy.sh/users/13371424)
+  - (![][osu!]) [ColBreakz & Vizzen - Remember](https://osu.ppy.sh/beatmapsets/2052201) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Dustvoxx](https://osu.ppy.sh/home/news/2023-10-28-new-featured-artist-dustvoxx)** (28/10/2023)
+  - (![][osu!]) [Dustvoxx, Laur - FireLight](https://osu.ppy.sh/beatmapsets/2064173) organisé par ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 
 ## Histoire
 

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/id.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/id.md
@@ -655,7 +655,7 @@ Artikel ini mencantumkan semua beatmap showcase yang telah dibuat oleh anggota d
 
 - **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
   - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) diurus oleh ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
-- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+- **[Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
   - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) diurus oleh ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
 - **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
   - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) diurus oleh ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/id.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/id.md
@@ -623,11 +623,136 @@ Artikel ini mencantumkan semua beatmap showcase yang telah dibuat oleh anggota d
 - **[Innocent Key](https://osu.ppy.sh/home/news/2022-11-26-new-featured-artist-innocent-key)** (2022-11-26)
   - (![][osu!]) [Innocent Key - Lunatic Red Eyes](https://osu.ppy.sh/beatmapsets/1879868) diurus oleh ::{ flag=TR }:: [Entry](https://osu.ppy.sh/users/10213311)
   - (![][osu!mania]) [Innocent Key - Toho-Assisted-Speedrun!!!](https://osu.ppy.sh/beatmapsets/1852057) diurus oleh ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+
+### Desember
+
 - **[Ekcle](https://osu.ppy.sh/home/news/2022-12-07-new-featured-artist-ekcle)** (2022-12-07)
   - (![][osu!]) [Ekcle - Crafted In Ice](https://osu.ppy.sh/beatmapsets/1868244) diurus oleh ::{ flag=GB }:: [DeviousPanda](https://osu.ppy.sh/users/4966334)
 - **[LandRoot](https://osu.ppy.sh/home/news/2022-12-10-new-featured-artist-landroot)** (2022-12-10)
   - (![][osu!]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1834399) diurus oleh ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
   - (![][osu!taiko]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1474263) diurus oleh ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015)
+- **[Satyr](https://osu.ppy.sh/home/news/2022-12-14-new-featured-artist-satyr)** (2022-12-14)
+  - (![][osu!]) [Satyr - Picayune](https://osu.ppy.sh/beatmapsets/1902228) diurus oleh ::{ flag=RU }:: [Blood9](https://osu.ppy.sh/users/11214999)
+- **[nyankobrq](https://osu.ppy.sh/home/news/2022-12-21-new-featured-artist-nyankobrq)** (2022-12-21)
+  - (![][osu!]) [nyankobrq - Snorkel](https://osu.ppy.sh/beatmapsets/1886230) diurus oleh ::{ flag=JP }:: [Yuuma](https://osu.ppy.sh/users/6644401)
+
+## 2023
+
+### Januari
+
+- **[Fellowship](https://osu.ppy.sh/home/news/2023-01-07-new-featured-artist-fellowship)** (2023-01-07)
+  - (![][osu!]) [Fellowship - The Frozen Land](https://osu.ppy.sh/beatmapsets/1835572) diurus oleh ::{ flag=US }:: [nebuwua](https://osu.ppy.sh/users/14729352)
+- **[Euchaeta](https://osu.ppy.sh/home/news/2023-01-11-new-featured-artist-euchaeta)** (2023-01-11)
+  - (![][osu!]) [Euchaeta - A Songwriter's Cosmos](https://osu.ppy.sh/beatmapsets/1858201) diurus oleh ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+  - (![][osu!]) [Euchaeta - Spirit Away](https://osu.ppy.sh/beatmapsets/1857409) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Etherwood](https://osu.ppy.sh/home/news/2023-01-18-new-featured-artist-etherwood)** (2023-01-18)
+  - (![][osu!]) [Etherwood - Cast Away](https://osu.ppy.sh/beatmapsets/1922699) diurus oleh ::{ flag=PL }:: [-Sylvari](https://osu.ppy.sh/users/3493804)
+- **[kakichoco](https://osu.ppy.sh/home/news/2023-01-21-new-featured-artist-kakichoco)** (2023-01-21)
+  - (![][osu!]) [kakichoco - Zan'ei](https://osu.ppy.sh/beatmapsets/1888928) diurus oleh ::{ flag=RU }:: [PandaHero](https://osu.ppy.sh/users/1233255)
+  - (![][osu!]) [kakichoco - Reirou no Hibiki](https://osu.ppy.sh/beatmapsets/1853651) diurus oleh ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+
+### Februari
+
+- **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
+  - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) diurus oleh ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
+- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+  - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) diurus oleh ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+- **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
+  - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) diurus oleh ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+  - (![][osu!]) [Cinamoro - Paleturquoise](https://osu.ppy.sh/beatmapsets/1874826) diurus oleh ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
+- **[yaseta](https://osu.ppy.sh/home/news/2023-02-18-new-featured-artist-yaseta)** (2023-02-18)
+  - (![][osu!]) [yaseta - Dreamy Goat](https://osu.ppy.sh/beatmapsets/1917139) diurus oleh ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[KASHIWA Daisuke](https://osu.ppy.sh/home/news/2023-02-22-new-featured-artist-kashiwa-daisuke)** (2023-02-22)
+  - (![][osu!]) [KASHIWA Daisuke - Sacred Play Secret Place](https://osu.ppy.sh/beatmapsets/1908078) diurus oleh ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+- **[Kabocha](https://osu.ppy.sh/home/news/2023-03-01-new-featured-artist-kabocha)** (2023-03-01)
+  - (![][osu!]) [Kabocha feat. mikanzil - HOTCHPOTCH Hitoribocchi](https://osu.ppy.sh/beatmapsets/1934595) diurus oleh ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+  - (![][osu!taiko]) [Kabocha - Yume no Kuni e feat. miko](https://osu.ppy.sh/beatmapsets/1851518) diurus oleh ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733)
+
+### Maret
+
+- **[Mediks](https://osu.ppy.sh/home/news/2023-03-04-new-featured-artist-mediks)** (2023-03-04)
+  - (![][osu!]) [Mediks - Blown Away (feat. Astronaut) (Raise Spirit Remix)](https://osu.ppy.sh/beatmapsets/1950373) diurus oleh ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033)
+- **[Minstrel](https://osu.ppy.sh/home/news/2023-03-15-new-featured-artist-minstrel)** (2023-03-15)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1900605) diurus oleh ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1907639) diurus oleh ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581)
+  - (![][osu!]) [Minstrel - Cinderella Cage ~Falling in Love Again~](https://osu.ppy.sh/beatmapsets/1909142) diurus oleh ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!]) [Minstrel - futuristic recollection](https://osu.ppy.sh/beatmapsets/1934280) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Kenneyon](https://osu.ppy.sh/home/news/2023-03-22-new-featured-artist-kenneyon)** (2023-03-22)
+  - (![][osu!catch]) [Kenneyon and Kara - Wildflower](https://osu.ppy.sh/beatmapsets/1914385) diurus oleh ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565)
+- **[Ashrount](https://osu.ppy.sh/home/news/2023-03-25-new-featured-artist-ashrount)** (2023-03-25)
+  - (![][osu!]) [Maverick - opaque](https://osu.ppy.sh/beatmapsets/1955283) diurus oleh ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+- **[Stars Hollow](https://osu.ppy.sh/home/news/2023-03-31-new-featured-artist-stars-hollow)** (2023-03-31)
+  - (![][osu!]) [Stars Hollow - Stuck to You.](https://osu.ppy.sh/beatmapsets/1966591) diurus oleh ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418)
+
+### Mei
+
+- **[tephe](https://osu.ppy.sh/home/news/2023-05-24-new-featured-artist-tephe)** (2023-05-24)
+  - (![][osu!]) [tephe - Genjitsu Escape](https://osu.ppy.sh/beatmapsets/1997470) diurus oleh ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539)
+- **[Shadren](https://osu.ppy.sh/home/news/2023-05-27-new-featured-artist-shadren)** (2023-05-27)
+  - (![][osu!]) [Shadren - You're Here Forever](https://osu.ppy.sh/beatmapsets/1948970) diurus oleh ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!]) [Shadren - Agleam (feat. Asperatus)](https://osu.ppy.sh/beatmapsets/1926857) diurus oleh ::{ flag=UZ }:: [M a r v o l l o](https://osu.ppy.sh/users/5504231)
+
+### Juni
+
+- **[Andora](https://osu.ppy.sh/home/news/2023-06-03-new-featured-artist-andora)** (2023-06-03)
+  - (![][osu!]) [Andora - Euphoria (feat. WaMi)](https://osu.ppy.sh/beatmapsets/1905874) diurus oleh ::{ flag=PH }:: [-Aqua](https://osu.ppy.sh/users/7150015)
+  - (![][osu!mania]) [Andora - Flicker (feat. RANASOL)](https://osu.ppy.sh/beatmapsets/1978179) diurus oleh ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+- **[Junk](https://osu.ppy.sh/home/news/2023-06-17-new-featured-artist-junk)** (2023-06-17)
+  - (![][osu!]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010589) diurus oleh ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!catch]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2006758) diurus oleh ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)
+  - (![][osu!taiko]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010165) diurus oleh ::{ flag=AR }:: [gaston_2199](https://osu.ppy.sh/users/5938161)
+  - (![][osu!catch]) [Junk - Qualia](https://osu.ppy.sh/beatmapsets/2010010) diurus oleh ::{ flag=NL }:: [Chatie](https://osu.ppy.sh/users/6524765)
+- **[passchooo](https://osu.ppy.sh/home/news/2023-06-24-new-featured-artist-passchooo)** (2023-06-24)
+  - (![][osu!]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/1981957) diurus oleh ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/2014129) diurus oleh ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!catch]) [passchooo - david gold took it slow (alt version)](https://osu.ppy.sh/beatmapsets/2014234) diurus oleh ::{ flag=SG }:: [Xinnoh](https://osu.ppy.sh/users/4236057)
+- **[Ruby My Dear](https://osu.ppy.sh/home/news/2023-07-01-new-featured-artist-ruby-my-dear)** (2023-07-01)
+  - (![][osu!catch]) [Ruby My Dear - Croque Monsieur A Disneyland](https://osu.ppy.sh/beatmapsets/2009607) diurus oleh ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)
+
+### Juli
+
+- **[Krimek](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek)** (2023-07-08)
+  - (![][osu!]) [Krimek feat. dokxid - Gravity Hole](https://osu.ppy.sh/beatmapsets/1983505) diurus oleh ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[YUC'e](https://osu.ppy.sh/home/news/2023-07-15-new-featured-artist-yuce)** (2023-07-15)
+  - (![][osu!taiko]) [YUC'e - Future Candy](https://osu.ppy.sh/beatmapsets/2006776) diurus oleh ::{ flag=AR }:: [ZelLink](https://osu.ppy.sh/users/6752242)
+  - (![][osu!]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2005892) diurus oleh ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2008307) diurus oleh ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [YUC'e - Sugary Galaxy](https://osu.ppy.sh/beatmapsets/2015526) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [YUC'e - PUMP](https://osu.ppy.sh/beatmapsets/2023926) diurus oleh ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+
+### Agustus
+
+- **[ALLMYFRIENDS](https://osu.ppy.sh/home/news/2023-08-05-new-featured-artist-all-my-friends)** (2023-08-05)
+  - (![][osu!]) [Synthion, Yuuna Nini - By My Side](https://osu.ppy.sh/beatmapsets/1993256) diurus oleh ::{ flag=US }:: [Shirahane Suou](https://osu.ppy.sh/users/10820856)
+  - (![][osu!]) [awfuless - Temptation (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1983389) diurus oleh ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [you - Meteor (feat. TEA)](https://osu.ppy.sh/beatmapsets/1984574) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[soowamisu](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu)** (2023-08-19)
+  - (![][osu!]) [soowamisu - .vaporcore](https://osu.ppy.sh/beatmapsets/1999116) diurus oleh ::{ flag=ID }:: [Kyouren](https://osu.ppy.sh/users/2013571)
+  - (![][osu!]) [soowamisu - floating architecture of an abstract heaven](https://osu.ppy.sh/beatmapsets/1988496) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[beignet](https://osu.ppy.sh/home/news/2023-08-26-new-featured-artist-beignet)** (2023-08-26)
+  - (![][osu!]) [beignet - Sign](https://osu.ppy.sh/beatmapsets/2030991) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [beignet - Mint Comet (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031418) diurus oleh ::{ flag=ES }:: [Nachmark](https://osu.ppy.sh/users/17584310)
+  - (![][osu!mania]) [beignet - Maple Trick](https://osu.ppy.sh/beatmapsets/2032450) diurus oleh ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [beignet - S'more](https://osu.ppy.sh/beatmapsets/2050540) diurus oleh ::{ flag=BA }:: [Stompy_](https://osu.ppy.sh/users/16429579)
+
+### September
+
+- **[C-Show](https://osu.ppy.sh/home/news/2023-09-02-new-featured-artist-c-show)** (2023-09-02)
+  - (![][osu!]) [C-Show - Rocking to the Beat (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031865) diurus oleh ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2044626) diurus oleh ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2047648) diurus oleh ::{ flag=ID }:: [Virtue-](https://osu.ppy.sh/users/6144772)
+  - (![][osu!]) [C-Show feat. Ishizawa Yukari - Border Line](https://osu.ppy.sh/beatmapsets/2035357) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+
+### Oktober
+
+- **[Kou!](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou)** (2023-10-07)
+  - (![][osu!catch]) [Kou! - sub/zerO](https://osu.ppy.sh/beatmapsets/2069616) diurus oleh ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114)
+- **[ColBreakz](https://osu.ppy.sh/home/news/2023-10-15-new-featured-artist-colbreakz)** (2023-10-15)
+  - (![][osu!]) [ColBreakz - 2011](https://osu.ppy.sh/beatmapsets/2074103) diurus oleh ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+  - (![][osu!mania]) [Protolizard & ColBreakz - Nevermind](https://osu.ppy.sh/beatmapsets/2072833) diurus oleh ::{ flag=ID }:: [Ainer](https://osu.ppy.sh/users/13371424)
+  - (![][osu!]) [ColBreakz & Vizzen - Remember](https://osu.ppy.sh/beatmapsets/2052201) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Dustvoxx](https://osu.ppy.sh/home/news/2023-10-28-new-featured-artist-dustvoxx)** (2023-10-28)
+  - (![][osu!]) [Dustvoxx, Laur - FireLight](https://osu.ppy.sh/beatmapsets/2064173) diurus oleh ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 
 ## Sejarah
 

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ja.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ja.md
@@ -631,6 +631,128 @@
 - **[LandRoot](https://osu.ppy.sh/home/news/2022-12-10-new-featured-artist-landroot)** (2022-12-10)
   - (![][osu!]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1834399) ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)によってホスト
   - (![][osu!taiko]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1474263) ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015)によってホスト
+- **[Satyr](https://osu.ppy.sh/home/news/2022-12-14-new-featured-artist-satyr)** (2022-12-14)
+  - (![][osu!]) [Satyr - Picayune](https://osu.ppy.sh/beatmapsets/1902228) ::{ flag=RU }:: [Blood9](https://osu.ppy.sh/users/11214999)によってホスト
+- **[nyankobrq](https://osu.ppy.sh/home/news/2022-12-21-new-featured-artist-nyankobrq)** (2022-12-21)
+  - (![][osu!]) [nyankobrq - Snorkel](https://osu.ppy.sh/beatmapsets/1886230) ::{ flag=JP }:: [Yuuma](https://osu.ppy.sh/users/6644401)によってホスト
+
+## 2023
+
+### 1月
+
+- **[Fellowship](https://osu.ppy.sh/home/news/2023-01-07-new-featured-artist-fellowship)** (2023-01-07)
+  - (![][osu!]) [Fellowship - The Frozen Land](https://osu.ppy.sh/beatmapsets/1835572) ::{ flag=US }:: [nebuwua](https://osu.ppy.sh/users/14729352)によってホスト
+- **[Euchaeta](https://osu.ppy.sh/home/news/2023-01-11-new-featured-artist-euchaeta)** (2023-01-11)
+  - (![][osu!]) [Euchaeta - A Songwriter's Cosmos](https://osu.ppy.sh/beatmapsets/1858201) ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)によってホスト
+  - (![][osu!]) [Euchaeta - Spirit Away](https://osu.ppy.sh/beatmapsets/1857409) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+- **[Etherwood](https://osu.ppy.sh/home/news/2023-01-18-new-featured-artist-etherwood)** (2023-01-18)
+  - (![][osu!]) [Etherwood - Cast Away](https://osu.ppy.sh/beatmapsets/1922699) ::{ flag=PL }:: [-Sylvari](https://osu.ppy.sh/users/3493804)によってホスト
+- **[kakichoco](https://osu.ppy.sh/home/news/2023-01-21-new-featured-artist-kakichoco)** (2023-01-21)
+  - (![][osu!]) [kakichoco - Zan'ei](https://osu.ppy.sh/beatmapsets/1888928) ::{ flag=RU }:: [PandaHero](https://osu.ppy.sh/users/1233255)によってホスト
+  - (![][osu!]) [kakichoco - Reirou no Hibiki](https://osu.ppy.sh/beatmapsets/1853651) ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)によってホスト
+
+### 2月
+
+- **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
+  - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)によってホスト
+- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+  - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)によってホスト
+- **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
+  - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)によってホスト
+  - (![][osu!]) [Cinamoro - Paleturquoise](https://osu.ppy.sh/beatmapsets/1874826) ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)によってホスト
+- **[yaseta](https://osu.ppy.sh/home/news/2023-02-18-new-featured-artist-yaseta)** (2023-02-18)
+  - (![][osu!]) [yaseta - Dreamy Goat](https://osu.ppy.sh/beatmapsets/1917139) ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)によってホスト
+- **[KASHIWA Daisuke](https://osu.ppy.sh/home/news/2023-02-22-new-featured-artist-kashiwa-daisuke)** (2023-02-22)
+  - (![][osu!]) [KASHIWA Daisuke - Sacred Play Secret Place](https://osu.ppy.sh/beatmapsets/1908078) ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)によってホスト
+- **[Kabocha](https://osu.ppy.sh/home/news/2023-03-01-new-featured-artist-kabocha)** (2023-03-01)
+  - (![][osu!]) [Kabocha feat. mikanzil - HOTCHPOTCH Hitoribocchi](https://osu.ppy.sh/beatmapsets/1934595) ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)によってホスト
+  - (![][osu!taiko]) [Kabocha - Yume no Kuni e feat. miko](https://osu.ppy.sh/beatmapsets/1851518) ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733)によってホスト
+
+### 3月
+
+- **[Mediks](https://osu.ppy.sh/home/news/2023-03-04-new-featured-artist-mediks)** (2023-03-04)
+  - (![][osu!]) [Mediks - Blown Away (feat. Astronaut) (Raise Spirit Remix)](https://osu.ppy.sh/beatmapsets/1950373) ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033)によってホスト
+- **[Minstrel](https://osu.ppy.sh/home/news/2023-03-15-new-featured-artist-minstrel)** (2023-03-15)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1900605) ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)によってホスト
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1907639) ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581)によってホスト
+  - (![][osu!]) [Minstrel - Cinderella Cage ~Falling in Love Again~](https://osu.ppy.sh/beatmapsets/1909142) ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)によってホスト
+  - (![][osu!]) [Minstrel - futuristic recollection](https://osu.ppy.sh/beatmapsets/1934280) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+- **[Kenneyon](https://osu.ppy.sh/home/news/2023-03-22-new-featured-artist-kenneyon)** (2023-03-22)
+  - (![][osu!catch]) [Kenneyon and Kara - Wildflower](https://osu.ppy.sh/beatmapsets/1914385) ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565)によってホスト
+- **[Ashrount](https://osu.ppy.sh/home/news/2023-03-25-new-featured-artist-ashrount)** (2023-03-25)
+  - (![][osu!]) [Maverick - opaque](https://osu.ppy.sh/beatmapsets/1955283) ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)によってホスト
+- **[Stars Hollow](https://osu.ppy.sh/home/news/2023-03-31-new-featured-artist-stars-hollow)** (2023-03-31)
+  - (![][osu!]) [Stars Hollow - Stuck to You.](https://osu.ppy.sh/beatmapsets/1966591) ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418)によってホスト
+
+### 5月
+
+- **[tephe](https://osu.ppy.sh/home/news/2023-05-24-new-featured-artist-tephe)** (2023-05-24)
+  - (![][osu!]) [tephe - Genjitsu Escape](https://osu.ppy.sh/beatmapsets/1997470) ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539)によってホスト
+- **[Shadren](https://osu.ppy.sh/home/news/2023-05-27-new-featured-artist-shadren)** (2023-05-27)
+  - (![][osu!]) [Shadren - You're Here Forever](https://osu.ppy.sh/beatmapsets/1948970) ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)によってホスト
+  - (![][osu!]) [Shadren - Agleam (feat. Asperatus)](https://osu.ppy.sh/beatmapsets/1926857) ::{ flag=UZ }:: [M a r v o l l o](https://osu.ppy.sh/users/5504231)によってホスト
+
+### 6月
+
+- **[Andora](https://osu.ppy.sh/home/news/2023-06-03-new-featured-artist-andora)** (2023-06-03)
+  - (![][osu!]) [Andora - Euphoria (feat. WaMi)](https://osu.ppy.sh/beatmapsets/1905874) ::{ flag=PH }:: [-Aqua](https://osu.ppy.sh/users/7150015)によってホスト
+  - (![][osu!mania]) [Andora - Flicker (feat. RANASOL)](https://osu.ppy.sh/beatmapsets/1978179) ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)によってホスト
+- **[Junk](https://osu.ppy.sh/home/news/2023-06-17-new-featured-artist-junk)** (2023-06-17)
+  - (![][osu!]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010589) ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)によってホスト
+  - (![][osu!catch]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2006758) ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)によってホスト
+  - (![][osu!taiko]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010165) ::{ flag=AR }:: [gaston_2199](https://osu.ppy.sh/users/5938161)によってホスト
+  - (![][osu!catch]) [Junk - Qualia](https://osu.ppy.sh/beatmapsets/2010010) ::{ flag=NL }:: [Chatie](https://osu.ppy.sh/users/6524765)によってホスト
+- **[passchooo](https://osu.ppy.sh/home/news/2023-06-24-new-featured-artist-passchooo)** (2023-06-24)
+  - (![][osu!]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/1981957) ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)によってホスト
+  - (![][osu!mania]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/2014129) ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)によってホスト
+  - (![][osu!catch]) [passchooo - david gold took it slow (alt version)](https://osu.ppy.sh/beatmapsets/2014234) ::{ flag=SG }:: [Xinnoh](https://osu.ppy.sh/users/4236057)によってホスト
+- **[Ruby My Dear](https://osu.ppy.sh/home/news/2023-07-01-new-featured-artist-ruby-my-dear)** (2023-07-01)
+  - (![][osu!catch]) [Ruby My Dear - Croque Monsieur A Disneyland](https://osu.ppy.sh/beatmapsets/2009607) ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)によってホスト
+
+### 7月
+
+- **[Krimek](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek)** (2023-07-08)
+  - (![][osu!]) [Krimek feat. dokxid - Gravity Hole](https://osu.ppy.sh/beatmapsets/1983505) ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)によってホスト
+- **[YUC'e](https://osu.ppy.sh/home/news/2023-07-15-new-featured-artist-yuce)** (2023-07-15)
+  - (![][osu!taiko]) [YUC'e - Future Candy](https://osu.ppy.sh/beatmapsets/2006776) ::{ flag=AR }:: [ZelLink](https://osu.ppy.sh/users/6752242)によってホスト
+  - (![][osu!]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2005892) ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)によってホスト
+  - (![][osu!mania]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2008307) ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)によってホスト
+  - (![][osu!]) [YUC'e - Sugary Galaxy](https://osu.ppy.sh/beatmapsets/2015526) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+  - (![][osu!]) [YUC'e - PUMP](https://osu.ppy.sh/beatmapsets/2023926) ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)によってホスト
+
+### 8月
+
+- **[ALLMYFRIENDS](https://osu.ppy.sh/home/news/2023-08-05-new-featured-artist-all-my-friends)** (2023-08-05)
+  - (![][osu!]) [Synthion, Yuuna Nini - By My Side](https://osu.ppy.sh/beatmapsets/1993256) ::{ flag=US }:: [Shirahane Suou](https://osu.ppy.sh/users/10820856)によってホスト
+  - (![][osu!]) [awfuless - Temptation (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1983389) ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)によってホスト
+  - (![][osu!]) [you - Meteor (feat. TEA)](https://osu.ppy.sh/beatmapsets/1984574) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+- **[soowamisu](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu)** (2023-08-19)
+  - (![][osu!]) [soowamisu - .vaporcore](https://osu.ppy.sh/beatmapsets/1999116) ::{ flag=ID }:: [Kyouren](https://osu.ppy.sh/users/2013571)によってホスト
+  - (![][osu!]) [soowamisu - floating architecture of an abstract heaven](https://osu.ppy.sh/beatmapsets/1988496) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+- **[beignet](https://osu.ppy.sh/home/news/2023-08-26-new-featured-artist-beignet)** (2023-08-26)
+  - (![][osu!]) [beignet - Sign](https://osu.ppy.sh/beatmapsets/2030991) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+  - (![][osu!]) [beignet - Mint Comet (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031418) ::{ flag=ES }:: [Nachmark](https://osu.ppy.sh/users/17584310)によってホスト
+  - (![][osu!mania]) [beignet - Maple Trick](https://osu.ppy.sh/beatmapsets/2032450) ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)によってホスト
+  - (![][osu!]) [beignet - S'more](https://osu.ppy.sh/beatmapsets/2050540) ::{ flag=BA }:: [Stompy_](https://osu.ppy.sh/users/16429579)によってホスト
+
+### 9月
+
+- **[C-Show](https://osu.ppy.sh/home/news/2023-09-02-new-featured-artist-c-show)** (2023-09-02)
+  - (![][osu!]) [C-Show - Rocking to the Beat (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031865) ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)によってホスト
+  - (![][osu!]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2044626) ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)によってホスト
+  - (![][osu!mania]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2047648) ::{ flag=ID }:: [Virtue-](https://osu.ppy.sh/users/6144772)によってホスト
+  - (![][osu!]) [C-Show feat. Ishizawa Yukari - Border Line](https://osu.ppy.sh/beatmapsets/2035357) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+
+### 10月
+
+- **[Kou!](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou)** (2023-10-07)
+  - (![][osu!catch]) [Kou! - sub/zerO](https://osu.ppy.sh/beatmapsets/2069616) ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114)によってホスト
+- **[ColBreakz](https://osu.ppy.sh/home/news/2023-10-15-new-featured-artist-colbreakz)** (2023-10-15)
+  - (![][osu!]) [ColBreakz - 2011](https://osu.ppy.sh/beatmapsets/2074103) ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)によってホスト
+  - (![][osu!mania]) [Protolizard & ColBreakz - Nevermind](https://osu.ppy.sh/beatmapsets/2072833) ::{ flag=ID }:: [Ainer](https://osu.ppy.sh/users/13371424)によってホスト
+  - (![][osu!]) [ColBreakz & Vizzen - Remember](https://osu.ppy.sh/beatmapsets/2052201) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
+- **[Dustvoxx](https://osu.ppy.sh/home/news/2023-10-28-new-featured-artist-dustvoxx)** (2023-10-28)
+  - (![][osu!]) [Dustvoxx, Laur - FireLight](https://osu.ppy.sh/beatmapsets/2064173) ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)によってホスト
 
 ## 歴史
 

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ja.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ja.md
@@ -655,7 +655,7 @@
 
 - **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
   - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)によってホスト
-- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+- **[Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
   - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)によってホスト
 - **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
   - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)によってホスト

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ru.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ru.md
@@ -655,7 +655,7 @@
 
 - **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
   - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) от ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
-- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+- **[Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
   - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) от ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
 - **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
   - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) от ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)

--- a/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ru.md
+++ b/wiki/People/Featured_Artists/Featured_Artist_showcase_beatmaps/ru.md
@@ -631,6 +631,128 @@
 - **[LandRoot](https://osu.ppy.sh/home/news/2022-12-10-new-featured-artist-landroot)** (2022-12-10)
   - (![][osu!]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1834399) от ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
   - (![][osu!taiko]) [LandRoot - Need To De-stress](https://osu.ppy.sh/beatmapsets/1474263) от ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015)
+- **[Satyr](https://osu.ppy.sh/home/news/2022-12-14-new-featured-artist-satyr)** (2022-12-14)
+  - (![][osu!]) [Satyr - Picayune](https://osu.ppy.sh/beatmapsets/1902228) от ::{ flag=RU }:: [Blood9](https://osu.ppy.sh/users/11214999)
+- **[nyankobrq](https://osu.ppy.sh/home/news/2022-12-21-new-featured-artist-nyankobrq)** (2022-12-21)
+  - (![][osu!]) [nyankobrq - Snorkel](https://osu.ppy.sh/beatmapsets/1886230) от ::{ flag=JP }:: [Yuuma](https://osu.ppy.sh/users/6644401)
+
+## 2023
+
+### Январь
+
+- **[Fellowship](https://osu.ppy.sh/home/news/2023-01-07-new-featured-artist-fellowship)** (2023-01-07)
+  - (![][osu!]) [Fellowship - The Frozen Land](https://osu.ppy.sh/beatmapsets/1835572) от ::{ flag=US }:: [nebuwua](https://osu.ppy.sh/users/14729352)
+- **[Euchaeta](https://osu.ppy.sh/home/news/2023-01-11-new-featured-artist-euchaeta)** (2023-01-11)
+  - (![][osu!]) [Euchaeta - A Songwriter's Cosmos](https://osu.ppy.sh/beatmapsets/1858201) от ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+  - (![][osu!]) [Euchaeta - Spirit Away](https://osu.ppy.sh/beatmapsets/1857409) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Etherwood](https://osu.ppy.sh/home/news/2023-01-18-new-featured-artist-etherwood)** (2023-01-18)
+  - (![][osu!]) [Etherwood - Cast Away](https://osu.ppy.sh/beatmapsets/1922699) от ::{ flag=PL }:: [-Sylvari](https://osu.ppy.sh/users/3493804)
+- **[kakichoco](https://osu.ppy.sh/home/news/2023-01-21-new-featured-artist-kakichoco)** (2023-01-21)
+  - (![][osu!]) [kakichoco - Zan'ei](https://osu.ppy.sh/beatmapsets/1888928) от ::{ flag=RU }:: [PandaHero](https://osu.ppy.sh/users/1233255)
+  - (![][osu!]) [kakichoco - Reirou no Hibiki](https://osu.ppy.sh/beatmapsets/1853651) от ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+
+### Февраль
+
+- **[FRASER EDWARDS](https://osu.ppy.sh/home/news/2023-02-04-new-featured-artist-fraser-edwards)** (2023-02-04)
+  - (![][osu!]) [FRASER EDWARDS - Ruination](https://osu.ppy.sh/beatmapsets/1848184) от ::{ flag=GB }:: [Shii](https://osu.ppy.sh/users/9186316)
+- **[ Updates: Liquicity](https://osu.ppy.sh/home/news/2023-02-08-featured-artist-track-updates-liquicity)** (2023-02-08)
+  - (![][osu!]) [Dan Dakota - Stood In The Dark (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1888924) от ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+- **[Cinamoro](https://osu.ppy.sh/home/news/2023-02-11-new-featured-artist-cinamoro)** (2023-02-11)
+  - (![][osu!mania]) [Cinamoro - Another](https://osu.ppy.sh/beatmapsets/1910036) от ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+  - (![][osu!]) [Cinamoro - Paleturquoise](https://osu.ppy.sh/beatmapsets/1874826) от ::{ flag=DE }:: [PaRaDogi](https://osu.ppy.sh/users/2054596)
+- **[yaseta](https://osu.ppy.sh/home/news/2023-02-18-new-featured-artist-yaseta)** (2023-02-18)
+  - (![][osu!]) [yaseta - Dreamy Goat](https://osu.ppy.sh/beatmapsets/1917139) от ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[KASHIWA Daisuke](https://osu.ppy.sh/home/news/2023-02-22-new-featured-artist-kashiwa-daisuke)** (2023-02-22)
+  - (![][osu!]) [KASHIWA Daisuke - Sacred Play Secret Place](https://osu.ppy.sh/beatmapsets/1908078) от ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+- **[Kabocha](https://osu.ppy.sh/home/news/2023-03-01-new-featured-artist-kabocha)** (2023-03-01)
+  - (![][osu!]) [Kabocha feat. mikanzil - HOTCHPOTCH Hitoribocchi](https://osu.ppy.sh/beatmapsets/1934595) от ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992)
+  - (![][osu!taiko]) [Kabocha - Yume no Kuni e feat. miko](https://osu.ppy.sh/beatmapsets/1851518) от ::{ flag=HK }:: [Faputa](https://osu.ppy.sh/users/845733)
+
+### Март
+
+- **[Mediks](https://osu.ppy.sh/home/news/2023-03-04-new-featured-artist-mediks)** (2023-03-04)
+  - (![][osu!]) [Mediks - Blown Away (feat. Astronaut) (Raise Spirit Remix)](https://osu.ppy.sh/beatmapsets/1950373) от ::{ flag=SE }:: [Zer0-](https://osu.ppy.sh/users/4260033)
+- **[Minstrel](https://osu.ppy.sh/home/news/2023-03-15-new-featured-artist-minstrel)** (2023-03-15)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1900605) от ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875)
+  - (![][osu!]) [Minstrel - Yotogibanashi no Kamikakushi](https://osu.ppy.sh/beatmapsets/1907639) от ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581)
+  - (![][osu!]) [Minstrel - Cinderella Cage ~Falling in Love Again~](https://osu.ppy.sh/beatmapsets/1909142) от ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!]) [Minstrel - futuristic recollection](https://osu.ppy.sh/beatmapsets/1934280) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Kenneyon](https://osu.ppy.sh/home/news/2023-03-22-new-featured-artist-kenneyon)** (2023-03-22)
+  - (![][osu!catch]) [Kenneyon and Kara - Wildflower](https://osu.ppy.sh/beatmapsets/1914385) от ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565)
+- **[Ashrount](https://osu.ppy.sh/home/news/2023-03-25-new-featured-artist-ashrount)** (2023-03-25)
+  - (![][osu!]) [Maverick - opaque](https://osu.ppy.sh/beatmapsets/1955283) от ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805)
+- **[Stars Hollow](https://osu.ppy.sh/home/news/2023-03-31-new-featured-artist-stars-hollow)** (2023-03-31)
+  - (![][osu!]) [Stars Hollow - Stuck to You.](https://osu.ppy.sh/beatmapsets/1966591) от ::{ flag=US }:: [pishifat](https://osu.ppy.sh/users/3178418)
+
+### Май
+
+- **[tephe](https://osu.ppy.sh/home/news/2023-05-24-new-featured-artist-tephe)** (2023-05-24)
+  - (![][osu!]) [tephe - Genjitsu Escape](https://osu.ppy.sh/beatmapsets/1997470) от ::{ flag=BY }:: [AirinCat](https://osu.ppy.sh/users/11119539)
+- **[Shadren](https://osu.ppy.sh/home/news/2023-05-27-new-featured-artist-shadren)** (2023-05-27)
+  - (![][osu!]) [Shadren - You're Here Forever](https://osu.ppy.sh/beatmapsets/1948970) от ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!]) [Shadren - Agleam (feat. Asperatus)](https://osu.ppy.sh/beatmapsets/1926857) от ::{ flag=UZ }:: [M a r v o l l o](https://osu.ppy.sh/users/5504231)
+
+### Июнь
+
+- **[Andora](https://osu.ppy.sh/home/news/2023-06-03-new-featured-artist-andora)** (2023-06-03)
+  - (![][osu!]) [Andora - Euphoria (feat. WaMi)](https://osu.ppy.sh/beatmapsets/1905874) от ::{ flag=PH }:: [-Aqua](https://osu.ppy.sh/users/7150015)
+  - (![][osu!mania]) [Andora - Flicker (feat. RANASOL)](https://osu.ppy.sh/beatmapsets/1978179) от ::{ flag=ID }:: [FAMoss](https://osu.ppy.sh/users/7707789)
+- **[Junk](https://osu.ppy.sh/home/news/2023-06-17-new-featured-artist-junk)** (2023-06-17)
+  - (![][osu!]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010589) от ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+  - (![][osu!catch]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2006758) от ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637)
+  - (![][osu!taiko]) [Junk - Yellow Smile (bms edit)](https://osu.ppy.sh/beatmapsets/2010165) от ::{ flag=AR }:: [gaston_2199](https://osu.ppy.sh/users/5938161)
+  - (![][osu!catch]) [Junk - Qualia](https://osu.ppy.sh/beatmapsets/2010010) от ::{ flag=NL }:: [Chatie](https://osu.ppy.sh/users/6524765)
+- **[passchooo](https://osu.ppy.sh/home/news/2023-06-24-new-featured-artist-passchooo)** (2023-06-24)
+  - (![][osu!]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/1981957) от ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [passchooo - chooo2023_1](https://osu.ppy.sh/beatmapsets/2014129) от ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!catch]) [passchooo - david gold took it slow (alt version)](https://osu.ppy.sh/beatmapsets/2014234) от ::{ flag=SG }:: [Xinnoh](https://osu.ppy.sh/users/4236057)
+- **[Ruby My Dear](https://osu.ppy.sh/home/news/2023-07-01-new-featured-artist-ruby-my-dear)** (2023-07-01)
+  - (![][osu!catch]) [Ruby My Dear - Croque Monsieur A Disneyland](https://osu.ppy.sh/beatmapsets/2009607) от ::{ flag=RU }:: [Kimitakari](https://osu.ppy.sh/users/4741164)
+
+### Июль
+
+- **[Krimek](https://osu.ppy.sh/home/news/2023-07-08-new-featured-artist-krimek)** (2023-07-08)
+  - (![][osu!]) [Krimek feat. dokxid - Gravity Hole](https://osu.ppy.sh/beatmapsets/1983505) от ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+- **[YUC'e](https://osu.ppy.sh/home/news/2023-07-15-new-featured-artist-yuce)** (2023-07-15)
+  - (![][osu!taiko]) [YUC'e - Future Candy](https://osu.ppy.sh/beatmapsets/2006776) от ::{ flag=AR }:: [ZelLink](https://osu.ppy.sh/users/6752242)
+  - (![][osu!]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2005892) от ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [YUC'e - SPACE INVADER](https://osu.ppy.sh/beatmapsets/2008307) от ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [YUC'e - Sugary Galaxy](https://osu.ppy.sh/beatmapsets/2015526) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [YUC'e - PUMP](https://osu.ppy.sh/beatmapsets/2023926) от ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337)
+
+### Август
+
+- **[ALLMYFRIENDS](https://osu.ppy.sh/home/news/2023-08-05-new-featured-artist-all-my-friends)** (2023-08-05)
+  - (![][osu!]) [Synthion, Yuuna Nini - By My Side](https://osu.ppy.sh/beatmapsets/1993256) от ::{ flag=US }:: [Shirahane Suou](https://osu.ppy.sh/users/10820856)
+  - (![][osu!]) [awfuless - Temptation (Cut Ver.)](https://osu.ppy.sh/beatmapsets/1983389) от ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [you - Meteor (feat. TEA)](https://osu.ppy.sh/beatmapsets/1984574) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[soowamisu](https://osu.ppy.sh/home/news/2023-08-19-new-featured-artist-soowamisu)** (2023-08-19)
+  - (![][osu!]) [soowamisu - .vaporcore](https://osu.ppy.sh/beatmapsets/1999116) от ::{ flag=ID }:: [Kyouren](https://osu.ppy.sh/users/2013571)
+  - (![][osu!]) [soowamisu - floating architecture of an abstract heaven](https://osu.ppy.sh/beatmapsets/1988496) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[beignet](https://osu.ppy.sh/home/news/2023-08-26-new-featured-artist-beignet)** (2023-08-26)
+  - (![][osu!]) [beignet - Sign](https://osu.ppy.sh/beatmapsets/2030991) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+  - (![][osu!]) [beignet - Mint Comet (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031418) от ::{ flag=ES }:: [Nachmark](https://osu.ppy.sh/users/17584310)
+  - (![][osu!mania]) [beignet - Maple Trick](https://osu.ppy.sh/beatmapsets/2032450) от ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154)
+  - (![][osu!]) [beignet - S'more](https://osu.ppy.sh/beatmapsets/2050540) от ::{ flag=BA }:: [Stompy_](https://osu.ppy.sh/users/16429579)
+
+### Сентябрь
+
+- **[C-Show](https://osu.ppy.sh/home/news/2023-09-02-new-featured-artist-c-show)** (2023-09-02)
+  - (![][osu!]) [C-Show - Rocking to the Beat (Cut Ver.)](https://osu.ppy.sh/beatmapsets/2031865) от ::{ flag=LT }:: [Strategas](https://osu.ppy.sh/users/2971837)
+  - (![][osu!]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2044626) от ::{ flag=RU }:: [SMOKELIND](https://osu.ppy.sh/users/9327302)
+  - (![][osu!mania]) [C-Show - AImee feat. Aitsuki Nakuru](https://osu.ppy.sh/beatmapsets/2047648) от ::{ flag=ID }:: [Virtue-](https://osu.ppy.sh/users/6144772)
+  - (![][osu!]) [C-Show feat. Ishizawa Yukari - Border Line](https://osu.ppy.sh/beatmapsets/2035357) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+
+### Октябрь
+
+- **[Kou!](https://osu.ppy.sh/home/news/2023-10-07-new-featured-artist-kou)** (2023-10-07)
+  - (![][osu!catch]) [Kou! - sub/zerO](https://osu.ppy.sh/beatmapsets/2069616) от ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114)
+- **[ColBreakz](https://osu.ppy.sh/home/news/2023-10-15-new-featured-artist-colbreakz)** (2023-10-15)
+  - (![][osu!]) [ColBreakz - 2011](https://osu.ppy.sh/beatmapsets/2074103) от ::{ flag=HU }:: [Nytrocide_](https://osu.ppy.sh/users/11327918)
+  - (![][osu!mania]) [Protolizard & ColBreakz - Nevermind](https://osu.ppy.sh/beatmapsets/2072833) от ::{ flag=ID }:: [Ainer](https://osu.ppy.sh/users/13371424)
+  - (![][osu!]) [ColBreakz & Vizzen - Remember](https://osu.ppy.sh/beatmapsets/2052201) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
+- **[Dustvoxx](https://osu.ppy.sh/home/news/2023-10-28-new-featured-artist-dustvoxx)** (2023-10-28)
+  - (![][osu!]) [Dustvoxx, Laur - FireLight](https://osu.ppy.sh/beatmapsets/2064173) от ::{ flag=ID }:: [Hinsvar](https://osu.ppy.sh/users/1249323)
 
 ## История
 


### PR DESCRIPTION
a batch of list related changes
- fa showcase maps
- fa playlists

and two tiny things noticed along the way
- a markdown mistake (strikethrough wasn't on news posts back then)
- missed contest points for taiko duo