### PR TITLE
Improve readability of remark errors in log view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
         "remark-osu": "^0.1.0",
         "remark-preset-lint-markdown-style-guide": "5.1.2",
-        "vfile-reporter-github-action": "^1.0.0",
-        "vfile-reporter-position": "github:TicClick/vfile-reporter-position#update-vfile-message-v3"
+        "vfile-reporter-github-action": "^2.0.0"
       }
     },
     "meta/remark/markdown-table": {},
@@ -125,6 +124,45 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@noomorph/vfile-reporter-position": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@noomorph/vfile-reporter-position/-/vfile-reporter-position-0.2.3.tgz",
+      "integrity": "sha512-Kt0hS5t92quFcIig2CON06C1ZIAhUwm8BXPI94/zK2QHeXnXkGTr3wOvjaafc2WOhcjlYpMa1DQ5DaPSv6SGUg==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "figures": "^5.0.0",
+        "lodash.chunk": "^4.2.0"
+      },
+      "peerDependencies": {
+        "vfile": "^5.0.0"
+      }
+    },
+    "node_modules/@noomorph/vfile-reporter-position/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@noomorph/vfile-reporter-position/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@npmcli/config": {
@@ -255,20 +293,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -355,21 +379,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/character-entities": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
@@ -417,22 +426,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -538,28 +531,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -624,14 +595,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ignore": {
@@ -762,6 +725,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -811,6 +785,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
     },
     "node_modules/longest-streak": {
       "version": "3.0.1",
@@ -3887,17 +3866,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4241,18 +4209,14 @@
       }
     },
     "node_modules/vfile-reporter-github-action": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-1.0.0.tgz",
-      "integrity": "sha512-q3Q8iuH7jSrFixDkeWuc4TjfZ9ZRfn29JO8EmEeoBu9+kV+kMpbVrkLyk4DLD3va1OK4+P8Ho6r8fSUIIgdZEA=="
-    },
-    "node_modules/vfile-reporter-position": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/TicClick/vfile-reporter-position.git#7a7a2949a5d215fcbd1f2fc30b0b8c26194ee830",
-      "license": "MIT",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-2.0.0.tgz",
+      "integrity": "sha512-VaCg6LkoDRnOG7RgPal/+mUwSqYIQ/4UDkYkQGGPpIu8mN5ZnVzYOsdqRRgec+PVpECaFnnd3BWREe0Q4Sx1/Q==",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "figures": "^3.2.0",
-        "vfile": "^5.1.0"
+        "@noomorph/vfile-reporter-position": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/vfile-reporter/node_modules/supports-color": {
@@ -4407,6 +4371,32 @@
         }
       }
     },
+    "@noomorph/vfile-reporter-position": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@noomorph/vfile-reporter-position/-/vfile-reporter-position-0.2.3.tgz",
+      "integrity": "sha512-Kt0hS5t92quFcIig2CON06C1ZIAhUwm8BXPI94/zK2QHeXnXkGTr3wOvjaafc2WOhcjlYpMa1DQ5DaPSv6SGUg==",
+      "requires": {
+        "chalk": "^5.3.0",
+        "figures": "^5.0.0",
+        "lodash.chunk": "^4.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
+          }
+        }
+      }
+    },
     "@npmcli/config": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-4.1.0.tgz",
@@ -4523,14 +4513,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
     },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -4594,15 +4576,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
     "character-entities": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
@@ -4632,19 +4605,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -4719,21 +4679,6 @@
         "format": "^0.2.0"
       }
     },
-    "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        }
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4777,11 +4722,6 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -4866,6 +4806,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
       "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
     },
+    "is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4899,6 +4844,11 @@
         "@npmcli/config": "^4.0.0",
         "import-meta-resolve": "^2.0.0"
       }
+    },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w=="
     },
     "longest-streak": {
       "version": "3.0.1",
@@ -7085,14 +7035,6 @@
         "ansi-regex": "^6.0.1"
       }
     },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7354,17 +7296,11 @@
       }
     },
     "vfile-reporter-github-action": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-1.0.0.tgz",
-      "integrity": "sha512-q3Q8iuH7jSrFixDkeWuc4TjfZ9ZRfn29JO8EmEeoBu9+kV+kMpbVrkLyk4DLD3va1OK4+P8Ho6r8fSUIIgdZEA=="
-    },
-    "vfile-reporter-position": {
-      "version": "git+ssh://git@github.com/TicClick/vfile-reporter-position.git#7a7a2949a5d215fcbd1f2fc30b0b8c26194ee830",
-      "from": "vfile-reporter-position@github:TicClick/vfile-reporter-position#update-vfile-message-v3",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter-github-action/-/vfile-reporter-github-action-2.0.0.tgz",
+      "integrity": "sha512-VaCg6LkoDRnOG7RgPal/+mUwSqYIQ/4UDkYkQGGPpIu8mN5ZnVzYOsdqRRgec+PVpECaFnnd3BWREe0Q4Sx1/Q==",
       "requires": {
-        "chalk": "^4.0.0",
-        "figures": "^3.2.0",
-        "vfile": "^5.1.0"
+        "@noomorph/vfile-reporter-position": "^0.2.3"
       }
     },
     "vfile-sort": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
     "remark-osu": "^0.1.0",
     "remark-preset-lint-markdown-style-guide": "5.1.2",
-    "vfile-reporter-github-action": "^1.0.0",
-    "vfile-reporter-position": "github:TicClick/vfile-reporter-position#update-vfile-message-v3"
+    "vfile-reporter-github-action": "^2.0.0"
   },
   "overrides": {
     "mdast-util-gfm-table": {

--- a/scripts/ci/run_remark.sh
+++ b/scripts/ci/run_remark.sh
@@ -5,7 +5,7 @@ set -u
 
 # https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 NOTICE_PREFIX="\033[0;90mNotice:\033[m "
-REPORTER=vfile-reporter-position
+REPORTER=@noomorph/vfile-reporter-position
 
 if test "${GITHUB_ACTIONS:-}"; then
   NOTICE_PREFIX=::notice::


### PR DESCRIPTION
now you will see output of vfile-reporter-position (the previous format) in logs instead, while still getting annotations