### PR TITLE
[IT] Fix spelling error in `Star priority`

### DIFF
--- a/wiki/Modding/Star_priority/it.md
+++ b/wiki/Modding/Star_priority/it.md
@@ -15,4 +15,4 @@ La star priority ha due significati:
 2. Un metodo per determinare se una richiesta di funzionalità è desiderata dalla comunità.
    - Più alta è la star priority, più velocemente viene notata.
    - Gli utenti con osu!supporter possono aumentare la priorità di due stelle (![Star](img/star.png)) per ogni voto, mentre i voti degli utenti normali valgono una sola stella. Gli utenti possono essere in grado di sparare più stelle a seconda del numero di voti rimasti.
-   - *Nota: Il forum delle richieste di funzionalità è attualmente obsoleto ed è stato in gran parte sostituito dal flusso delle [discussioni su Gituhb](https://github.com/ppy/osu/discussions).*
+   - *Nota: Il forum delle richieste di funzionalità è attualmente obsoleto ed è stato in gran parte sostituito dal flusso delle [discussioni su GitHub](https://github.com/ppy/osu/discussions).*


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)

Just a simple fix ("Gituhb" -> "GitHub"), so I don't think this necessarily requires a review, however I am a native Italian speaker myself. 