### PR TITLE
[DE] `Hype`: Use correct translation from web

### DIFF
--- a/wiki/Beatmap/Hype/de.md
+++ b/wiki/Beatmap/Hype/de.md
@@ -6,7 +6,7 @@ tags:
 
 # Hype
 
-Jede [ausstehende](/wiki/Beatmap/Category#work-in-progress-und-ausstehend) [Beatmap](/wiki/Beatmap) hat einen **Hype-Train**, der grob zeigt, wie viele Spieler daran interessiert sind, dass die Beatmap [gerankt](/wiki/Beatmap/Category#ranked) wird. Nutzer können spezielle [Beatmap-Diskussionen](/wiki/Beatmap_discussion) im Tab `Generell (alle Schwierigkeitsstufen)` erstellen und die Option `Hype!` verwenden, um zum Hype-Train beizutragen.
+Jede [ausstehende](/wiki/Beatmap/Category#work-in-progress-und-ausstehend) [Beatmap](/wiki/Beatmap) hat einen **Hype-Train**, der grob zeigt, wie viele Spieler daran interessiert sind, dass die Beatmap [gerankt](/wiki/Beatmap/Category#ranked) wird. Nutzer können spezielle [Beatmap-Diskussionen](/wiki/Beatmap_discussion) im Tab `Allgemein (Alle Difficulties)` erstellen und die Option `Hype!` verwenden, um zum Hype-Train beizutragen.
 
 ## Ranking-Voraussetzung
 


### PR DESCRIPTION
This was an oversight in #10318, caught by @The-Last-Cookie (thanks!)

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
