### PR TITLE
Update `OWC 2023` RO16 schedules

### DIFF
--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -126,18 +126,11 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/82e
 
 ## Match schedule: Round of 16
 
-### Friday, 3 November 2023
-
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Philippines ::{ flag=PH }:: | ::{ flag=RO }:: Romania | [Nov 3 (Fri) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231103T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
-
 ### Saturday, 4 November 2023
 
 | Team A | Team B | Match time | Twitch stream |
 | --: | :-- | :-- | :-: |
 | Thailand ::{ flag=TH }:: | ::{ flag=NZ }:: New Zealand | [Nov 4 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T100000&p1=1440&p2=28&p3=264) | [osulive](https://twitch.tv/osulive) |
-| Taiwan ::{ flag=TW }:: | ::{ flag=SE }:: Sweden | [Nov 4 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T130000&p1=1440&p2=241&p3=239) | [osulive](https://twitch.tv/osulive) |
 | South Korea ::{ flag=KR }:: | ::{ flag=CN }:: China | [Nov 4 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T140000&p1=1440&p2=235&p3=33) | [osulive](https://twitch.tv/osulive) |
 | Spain ::{ flag=ES }:: | ::{ flag=NO }:: Norway | [Nov 4 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T150000&p1=1440&p2=141&p3=187) | [osulive](https://twitch.tv/osulive) |
 | Netherlands ::{ flag=NL }:: | ::{ flag=FI }:: Finland | [Nov 4 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T170000&p1=1440&p2=16&p3=101) | [osulive_2](https://twitch.tv/osulive_2) |
@@ -152,6 +145,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/82e
 | Australia ::{ flag=AU }:: | ::{ flag=CL }:: Chile | [Nov 5 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T040000&p1=1440&p2=57&p3=232) | [osulive_2](https://twitch.tv/osulive_2) |
 | Turkey ::{ flag=TR }:: | ::{ flag=ID }:: Indonesia | [Nov 5 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=19&p3=108) | [osulive_2](https://twitch.tv/osulive_2) |
 | Russian Federation ::{ flag=RU }:: | ::{ flag=HK }:: Hong Kong | [Nov 5 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=166&p3=102) | [osulive](https://twitch.tv/osulive) |
+| Taiwan ::{ flag=TW }:: | ::{ flag=SE }:: Sweden | [Nov 5 (Sun) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T133000&p1=1440&p2=241&p3=239) | [osulive](https://twitch.tv/osulive) |
 | Kazakhstan ::{ flag=KZ }:: | ::{ flag=JP }:: Japan | [Nov 5 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p3=248) | [osulive_2](https://twitch.tv/osulive_2) |
 | Philippines ::{ flag=PH }:: | ::{ flag=RO }:: Romania | [Nov 5 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
 | United Kingdom ::{ flag=GB }:: | ::{ flag=UA }:: Ukraine | [Nov 5 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T150000&p1=1440&p2=136&p3=367) | [osulive](https://twitch.tv/osulive) |

--- a/wiki/Tournaments/OWC/2023/ko.md
+++ b/wiki/Tournaments/OWC/2023/ko.md
@@ -126,18 +126,11 @@ osu! 월드컵 2023은 [osu! 팀](/wiki/People/osu!_team)과 여러 명의 커�
 
 ## 경기 일정 : 16강
 
-### 2023년 11월 3일 금요일
-
-| Team A | Team B | 매치 시간 | 트위치 생방송 |
-| --: | :-- | :-- | :-: |
-| 필리핀 ::{ flag=PH }:: | ::{ flag=RO }:: 루마니아 | [Nov 3 (Fri) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231103T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
-
 ### 2023년 11월 4일 토요일
 
 | Team A | Team B | 매치 시간 | 트위치 생방송 |
 | --: | :-- | :-- | :-: |
 | 태국 ::{ flag=TH }:: | ::{ flag=NZ }:: 뉴질랜드 | [Nov 4 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T100000&p1=1440&p2=28&p3=264) | [osulive](https://twitch.tv/osulive) |
-| 대만 ::{ flag=TW }:: | ::{ flag=SE }:: 스웨덴 | [Nov 4 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T130000&p1=1440&p2=241&p3=239) | [osulive](https://twitch.tv/osulive) |
 | 대한민국 ::{ flag=KR }:: | ::{ flag=CN }:: 중국 | [Nov 4 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T140000&p1=1440&p2=235&p3=33) | [osulive](https://twitch.tv/osulive) |
 | 스페인 ::{ flag=ES }:: | ::{ flag=NO }:: 노르웨이 | [Nov 4 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T150000&p1=1440&p2=141&p3=187) | [osulive](https://twitch.tv/osulive) |
 | 네덜란드 ::{ flag=NL }:: | ::{ flag=FI }:: 핀란드 | [Nov 4 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T170000&p1=1440&p2=16&p3=101) | [osulive_2](https://twitch.tv/osulive_2) |
@@ -152,6 +145,7 @@ osu! 월드컵 2023은 [osu! 팀](/wiki/People/osu!_team)과 여러 명의 커�
 | 오스트레일리아 ::{ flag=AU }:: | ::{ flag=CL }:: 칠레 | [Nov 5 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T040000&p1=1440&p2=57&p3=232) | [osulive_2](https://twitch.tv/osulive_2) |
 | 튀르키예 ::{ flag=TR }:: | ::{ flag=ID }:: 인도네시아 | [Nov 5 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=19&p3=108) | [osulive_2](https://twitch.tv/osulive_2) |
 | 러시아 ::{ flag=RU }:: | ::{ flag=HK }:: 홍콩 | [Nov 5 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=166&p3=102) | [osulive](https://twitch.tv/osulive) |
+| 대만 ::{ flag=TW }:: | ::{ flag=SE }:: 스웨덴 | [Nov 5 (Sun) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T133000&p1=1440&p2=241&p3=239) | [osulive_2](https://twitch.tv/osulive_2) |
 | 카자흐스탄 ::{ flag=KZ }:: | ::{ flag=JP }:: 일본 | [Nov 5 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p3=248) | [osulive_2](https://twitch.tv/osulive_2) |
 | 필리핀 ::{ flag=PH }:: | ::{ flag=RO }:: 루마니아 | [Nov 5 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
 | 영국 ::{ flag=GB }:: | ::{ flag=UA }:: 우크라이나 | [Nov 5 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T150000&p1=1440&p2=136&p3=367) | [osulive](https://twitch.tv/osulive) |

--- a/wiki/Tournaments/OWC/2023/zh-tw.md
+++ b/wiki/Tournaments/OWC/2023/zh-tw.md
@@ -126,18 +126,11 @@ osu! World Cup 2023 由 [osu! team](/wiki/People/osu!_team) 團隊以及社群�
 
 ## 賽程： 16 強
 
-### 2023 年 11 月 3 日, 星期五
-
-| A 隊 | B 隊 | 比賽時間 | 直播 |
-| --: | :-- | :-- | :-: |
-| 菲律賓 ::{ flag=PH }:: | ::{ flag=RO }:: 羅馬尼亞 | [11 月 3 日 (五) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231103T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
-
 ### 2023 年 11 月 4 日, 星期六
 
 | A 隊 | B 隊 | 比賽時間 | 直播 |
 | --: | :-- | :-- | :-: |
 | 泰國 ::{ flag=TH }:: | ::{ flag=NZ }:: 紐西蘭 | [11 月 4 日 (六) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T100000&p1=1440&p2=28&p3=264) | [osulive](https://twitch.tv/osulive) |
-| 臺灣 ::{ flag=TW }:: | ::{ flag=SE }:: 瑞典 | [11 月 4 日 (六) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T130000&p1=1440&p2=241&p3=239) | [osulive](https://twitch.tv/osulive) |
 | 韓國 ::{ flag=KR }:: | ::{ flag=CN }:: 中國 | [11 月 4 日 (六) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T140000&p1=1440&p2=235&p3=33) | [osulive](https://twitch.tv/osulive) |
 | 西班牙 ::{ flag=ES }:: | ::{ flag=NO }:: 挪威 | [11 月 4 日 (六) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T150000&p1=1440&p2=141&p3=187) | [osulive](https://twitch.tv/osulive) |
 | 荷蘭 ::{ flag=NL }:: | ::{ flag=FI }:: 芬蘭 | [11 月 4 日 (六) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231104T170000&p1=1440&p2=16&p3=101) | [osulive_2](https://twitch.tv/osulive_2) |
@@ -152,6 +145,7 @@ osu! World Cup 2023 由 [osu! team](/wiki/People/osu!_team) 團隊以及社群�
 | 澳洲 ::{ flag=AU }:: | ::{ flag=CL }:: 智利 | [11 月 5 日 (日) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T040000&p1=1440&p2=57&p3=232) | [osulive_2](https://twitch.tv/osulive_2) |
 | 土耳其 ::{ flag=TR }:: | ::{ flag=ID }:: 印尼 | [11 月 5 日 (日) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=19&p3=108) | [osulive_2](https://twitch.tv/osulive_2) |
 | 俄羅斯 ::{ flag=RU }:: | ::{ flag=HK }:: 香港 | [11 月 5 日 (日) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T130000&p1=1440&p2=166&p3=102) | [osulive](https://twitch.tv/osulive) |
+| 臺灣 ::{ flag=TW }:: | ::{ flag=SE }:: 瑞典 | [11 月 5 日 (六) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T133000&p1=1440&p2=241&p3=239) | [osulive_2](https://twitch.tv/osulive_2) |
 | 哈薩克 ::{ flag=KZ }:: | ::{ flag=JP }:: 日本 | [11 月 5 日 (日) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p3=248) | [osulive_2](https://twitch.tv/osulive_2) |
 | 菲律賓 ::{ flag=PH }:: | ::{ flag=RO }:: 羅馬尼亞 | [11 月 5 日 (日) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T140000&p1=1440&p2=145&p3=49) | [osulive](https://twitch.tv/osulive) |
 | 英國 ::{ flag=GB }:: | ::{ flag=UA }:: 烏克蘭 | [11 月 5 日 (日) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20231105T150000&p1=1440&p2=136&p3=367) | [osulive](https://twitch.tv/osulive) |


### PR DESCRIPTION
Updates the schedule of one match (which was marked to take place on saturday when it should be happening on sunday).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
