### PR TITLE
Update `BN` and `NAT` articles

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -28,11 +28,15 @@ Full Beatmap Nominators with below minimum nomination activity will not be place
 
 ### Probationary Beatmap Nominators
 
-Probation is used to monitor new or concerning Beatmap Nominators more closely. The main role for probationary Beatmap Nominators is to establish a foundation as a Beatmap Nominator through exclusively promoting beatmaps in the ranking process. At least one full nominator must be involved in the ranking process for each game mode of a beatmap, so probationary members cannot give the final nomination to a beatmap which has only received nominations from other probationary members for their game mode.
+Probation is used to monitor new or demoted Beatmap Nominators more closely. The main role for probationary Beatmap Nominators is to establish a foundation as a Beatmap Nominator through exclusively promoting beatmaps in the ranking process. At least one full nominator must be involved in the ranking process for each game mode of a beatmap, so probationary members cannot give the final nomination to a beatmap which has only received nominations from other probationary members for their game mode.
 
-New members of the Beatmap Nominators begin with a one month long probation period. If their nominations and behaviour are satisfactory, they will be promoted to the full Beatmap Nominators following a positive [evaluation](/wiki/People/Nomination_Assessment_Team/Evaluations). Otherwise, they will remain on probation for another month or be removed from the Beatmap Nominators.
+Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting their [activity requirements](https://osu.ppy.sh/wiki/en/People/Beatmap_Nominators/Rules#activity), or after one month from being placed there, whichever comes first.
+
+New members of the Beatmap Nominators will be assigned an NAT buddy who they are encouraged to directly contact for questions or guidance. After their first evaluation, if their nominations and behaviour are satisfactory, they will be promoted to the full Beatmap Nominators following a positive evaluation. Otherwise, they will remain on probation for another month or be removed from the Beatmap Nominators.
 
 When a Beatmap Nominator is placed on probation, they cannot be placed on probation again for the same reason for roughly one year. For example, if a Beatmap Nominator is placed on probation for poor behaviour, they will be removed from the Beatmap Nominators if they exhibit the same poor behaviour again recently, even if they are a full Beatmap Nominator during the second infringement.
+
+A demoted Beatmap Nominator's probation period may be extended by an additional month if there isn't sufficient data to evaluate them, or if they start showing issues different to what they were originally probationed for.
 
 ## Benefits
 

--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -30,7 +30,7 @@ Full Beatmap Nominators with below minimum nomination activity will not be place
 
 Probation is used to monitor new or demoted Beatmap Nominators more closely. The main role for probationary Beatmap Nominators is to establish a foundation as a Beatmap Nominator through exclusively promoting beatmaps in the ranking process. At least one full nominator must be involved in the ranking process for each game mode of a beatmap, so probationary members cannot give the final nomination to a beatmap which has only received nominations from other probationary members for their game mode.
 
-Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting their [activity requirements](https://osu.ppy.sh/wiki/en/People/Beatmap_Nominators/Rules#activity), or after one month from being placed there, whichever comes first.
+Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting their [activity requirements](/wiki/People/Beatmap_Nominators/Rules#activity), or after one month from being placed there, whichever comes first.
 
 New members of the Beatmap Nominators will be assigned an NAT buddy who they are encouraged to directly contact for questions or guidance. After their first evaluation, if their nominations and behaviour are satisfactory, they will be promoted to the full Beatmap Nominators following a positive evaluation. Otherwise, they will remain on probation for another month or be removed from the Beatmap Nominators.
 

--- a/wiki/People/Beatmap_Nominators/es.md
+++ b/wiki/People/Beatmap_Nominators/es.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: b7b99940b9680a1ef404a5e4da458d392e641d02
 tags:
   - BN
   - BNG

--- a/wiki/People/Beatmap_Nominators/zh.md
+++ b/wiki/People/Beatmap_Nominators/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: b7b99940b9680a1ef404a5e4da458d392e641d02
 tags:
   - BN
   - BNG

--- a/wiki/People/Nomination_Assessment_Team/en.md
+++ b/wiki/People/Nomination_Assessment_Team/en.md
@@ -9,7 +9,7 @@ tags:
 
 The **Nomination Assessment Team** (***NAT***) is a team that moderates the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) (*BN*) and ensures the beatmapping side of osu! stays functional.
 
-Members of the NAT are distinguished by their orange red user title, orange [user group](/wiki/People/User_group) badge that reads `NAT`, and their red in-game username. They have site-wide moderation permissions, like the [Global Moderation Team](/wiki/People/Global_Moderation_Team) (*GMT*), and also possess the ability to [nominate](/wiki/Beatmap_ranking_procedure#nominations) and [reset nominations](/wiki/Beatmap_ranking_procedure#nomination-resets) on beatmaps, like [full members](/wiki/People/Beatmap_Nominators#full-beatmap-nominators) of the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) (*BNs*). For most purposes, NAT members are BNs with different responsibilities. Therefore, all [BN rules](/wiki/People/Beatmap_Nominators/Rules) and [expectations](/wiki/People/Beatmap_Nominators/Expectations) apply to NAT members, with some exceptions for activity.
+Members of the NAT are distinguished by their orange red user title, [user group](/wiki/People/User_group) badge that reads `NAT`, and their red in-game username. They have site-wide moderation permissions, like the [Global Moderation Team](/wiki/People/Global_Moderation_Team) (*GMT*), and also possess the ability to [nominate](/wiki/Beatmap_ranking_procedure#nominations) and [reset nominations](/wiki/Beatmap_ranking_procedure#nomination-resets) on beatmaps, like [full members](/wiki/People/Beatmap_Nominators#full-beatmap-nominators) of the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) (*BNs*). For most purposes, NAT members are BNs with different responsibilities. Therefore, all [BN rules](/wiki/People/Beatmap_Nominators/Rules) and [expectations](/wiki/People/Beatmap_Nominators/Expectations) apply to NAT members, with some exceptions for activity.
 
 **All members of the Nomination Assessment Team are sworn to uphold [the Contributor Code of Conduct](/wiki/Rules/Contributor_code_of_conduct) in addition to the normal [Community Rules](/wiki/Rules).**
 
@@ -34,7 +34,7 @@ NAT members responsible for this category are in high demand due to the sheer vo
 NAT members assigned to the structural category are not responsible for any specific game mode, despite being allowed to nominate beatmaps of their previously assigned game mode. They are required to maintain:
 
 - **Communication**: Promoting transparency and maintaining good relations with not only the rest of the mapping/modding community, but also within the NAT itself. This includes, but not limited to, making announcements, participating in discussions about proposals, asking/answering questions through surveys, and updating the [ranking criteria](/wiki/Ranking_criteria) as well as other documentation.
-- **Development**: Developing and maintaining tools and websites to help improve the ranking process (such as [Mapset Verifier](https://github.com/Naxesss/MapsetVerifier), [Aiess](https://github.com/Naxesss/Aiess), or [the NAT/BN website](https://bn.mappersguild.com/home)).
+- **Development**: Developing and maintaining tools and websites to help improve the ranking process (such as [Mapset Verifier](https://github.com/Naxesss/MapsetVerifier), [Aiess](https://github.com/Naxesss/Aiess), or [the BN Management website](https://bn.mappersguild.com)).
 - **Moderation**: Handling user reports and assessing inappropriate behaviour of Beatmap Nominators, as well as processing beatmap content reviews. This task is a joint effort between the NAT and the GMT.
 - **Miscellaneous maintenance**: Included but not limited to:
   - Handling [vetoes](/wiki/People/Beatmap_Nominators/Beatmap_Veto).
@@ -53,7 +53,7 @@ Dividing the NAT workload into two main categories is necessary for the overall 
 
 Depending on their category, each NAT member has different activity requirements. Members responsible for evaluations are expected to consistently evaluate both applicants and current BNs, while also keeping up to date with the mapping/modding scene on their own through modding. Members assigned to the structural category are expected to uphold key parts of the ranking process on a case-by-case basis.
 
-Each month, the NAT members are required to submit a summary of their activity in the [BN/NAT website](https://bn.mappersguild.com/). This summary, alongside other metrics like nomination and evaluation activity, is used to determine whether a member is still active and whether they should remain in the group. The [team leaders](#nat-leadership) will then discuss the activity of each member and decide whether they should remain in the NAT.
+Every 2 months, the NAT members are required to submit a summary of their activity in the [BN Management website](https://bn.mappersguild.com). This summary, alongside other metrics like nomination and evaluation activity, is used to determine whether a member is still active and whether they should remain in the group. The [team leaders](#nat-leadership) will then discuss the activity of each member and decide whether they should remain in the NAT.
 
 The team leaders will confront inactive NAT members, or members who fail to provide a summary in a timely manner. If an appropriate resolution to their inactivity is not feasible, they will be removed from the NAT. Members under the evaluation category working on other mapping-related projects may be moved to the structural category to better reflect their contribution.
 
@@ -132,11 +132,13 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 | Name | Additional languages |
 | :-- | :-- |
 | ::{ flag=HK }:: [Chaoslitz](https://osu.ppy.sh/users/3621552) | Cantonese, Chinese |
+| ::{ flag=GB }:: [ckharv](https://osu.ppy.sh/users/9967026) |  |
 | ::{ flag=BR }:: [Dada](https://osu.ppy.sh/users/9119507) | Portuguese |
 | ::{ flag=BE }:: [enneya](https://osu.ppy.sh/users/10959501) | Dutch |
-| ::{ flag=CN }:: [Firika](https://osu.ppy.sh/users/9590557) | Chinese |
 | ::{ flag=DE }:: [FuJu](https://osu.ppy.sh/users/10773882) | German |
 | ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992) | Chinese |
+| ::{ flag=KR }:: [Luscent](https://osu.ppy.sh/users/2688581) | Korean |
+| ::{ flag=US }:: [Nao Tomori](https://osu.ppy.sh/users/5364763) |  |
 | ::{ flag=US }:: [Noffy](https://osu.ppy.sh/users/1541323) |  |
 | ::{ flag=HK }:: [Petal](https://osu.ppy.sh/users/7354729) | Cantonese, Chinese |
 | ::{ flag=CN }:: [Ryuusei Aika](https://osu.ppy.sh/users/7777875) | Chinese |
@@ -148,10 +150,9 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 
 | Name | Additional languages |
 | :-- | :-- |
-| ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015) | German |
-| ::{ flag=GB }:: [Dusk-](https://osu.ppy.sh/users/6092181) | Urdu, some Arabic |
 | ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976) | Arabic, French, some Italian |
 | ::{ flag=BR }:: [Ideal](https://osu.ppy.sh/users/3869519) | Portuguese |
+| ::{ flag=AT }:: [Yasuho](https://osu.ppy.sh/users/8458835) | German, some French |
 
 #### osu!catch
 
@@ -160,6 +161,7 @@ The [Nomination Assessment Team group page](https://osu.ppy.sh/groups/7) lists a
 | ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565) | Spanish, German |
 | ::{ flag=NL }:: [Greaper](https://osu.ppy.sh/users/2369776) | Dutch |
 | ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637) |  |
+| ::{ flag=BR }:: [zerokt](https://osu.ppy.sh/users/13776127) | Portuguese |
 
 #### osu!mania
 
@@ -186,7 +188,6 @@ The following NAT members are primarily evaluators, but also contribute to struc
 
 | User | Task |
 | :-- | :-- |
-| ::{ flag=DE }:: [Capu](https://osu.ppy.sh/users/2474015) | Handling osu!taiko [SEV ratings](/wiki/People/Nomination_Assessment_Team/SEV_rating) |
 | ::{ flag=BR }:: [Dada](https://osu.ppy.sh/users/9119507) | BN Mentorship organisation |
 | ::{ flag=DE }:: [FuJu](https://osu.ppy.sh/users/10773882) | Handling user reports and osu! [SEV ratings](/wiki/People/Nomination_Assessment_Team/SEV_rating) |
 | ::{ flag=CN }:: [Garden](https://osu.ppy.sh/users/2849992) | Handling content reports |

--- a/wiki/People/Nomination_Assessment_Team/es.md
+++ b/wiki/People/Nomination_Assessment_Team/es.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: f49ac28b8df6074d91b4b8194aa684c088e5091a
 tags:
   - NAT
 ---

--- a/wiki/People/Nomination_Assessment_Team/zh.md
+++ b/wiki/People/Nomination_Assessment_Team/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: f49ac28b8df6074d91b4b8194aa684c088e5091a
 tags:
  - NAT
  - 审核评估


### PR DESCRIPTION
This mainly adds the new NAT buddy system for new BNs that we implemented very recently, a short clarification on extending a demoted BN's probation, and some minor adjustments in NAT article.