### PR TITLE
Add missing redirect to "Content usage permissions" article

### DIFF
--- a/wiki/redirect.yaml
+++ b/wiki/redirect.yaml
@@ -2123,6 +2123,7 @@
 # moved in #10397
 
 "usage_permissions":                         "Rules/Content_usage_permissions"
+"rules/content_usage_guidelines":            "Rules/Content_usage_permissions"
 
 # Deleted "osu!monthly team" and moved its contents to a section of "osu!monthly" (#10373)
 "people/osu!monthly_team": "Community/osu!monthly#contributors"


### PR DESCRIPTION
came up while trying to merge another pr. checked with osu-wiki-tools as well