### PR TITLE
Add missing footnote to `OWC 2023`

### DIFF
--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -602,6 +602,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 ## Notes
 
+[^losers-bracket]: Losers bracket match
 [^potential-match]: Potential match — final matchup depends on the results of the preceding losers bracket matches
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same rating sum


### PR DESCRIPTION
`SKIP_OUTDATED_CHECK` issue is only in the english article