### PR TITLE
Fix link text in `Article styling criteria`

### DIFF
--- a/wiki/Article_styling_criteria/Formatting/de.md
+++ b/wiki/Article_styling_criteria/Formatting/de.md
@@ -773,7 +773,7 @@ Die Flaggensymbole benutzen eine Zwei-Buchstaben-Kodierung (alle in Großschreib
 ::{ flag=XX }::
 ```
 
-Wobei `XX` der [ISO 3166-2](https://de.wikipedia.org/wiki/ISO-3166-1-Kodierliste) zwei-Buchstaben Ländercode für die Flagge ist.
+Wobei `XX` der [ISO 3166-1 alpha-2](https://de.wikipedia.org/wiki/ISO-3166-1-Kodierliste) zwei-Buchstaben Ländercode für die Flagge ist.
 
 ## Tabellen
 

--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -773,7 +773,7 @@ The flag icons use the two letter code (in all capital letters) to match a certa
 ::{ flag=XX }::
 ```
 
-Where `XX` is the [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) two-lettered country code for the flag.
+Where `XX` is the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) two-lettered country code for the flag.
 
 ## Tables
 

--- a/wiki/Article_styling_criteria/Formatting/es.md
+++ b/wiki/Article_styling_criteria/Formatting/es.md
@@ -774,7 +774,7 @@ Los íconos de la bandera usan el código de dos letras (en mayúsculas) para co
 ::{ flag=XX }::
 ```
 
-Donde `XX` es el código del país de dos letras de la [ISO 3166-2](https://es.wikipedia.org/wiki/ISO_3166-1_alfa-2) para la bandera.
+Donde `XX` es el código del país de dos letras de la [ISO 3166-1 alpha-2](https://es.wikipedia.org/wiki/ISO_3166-1_alfa-2) para la bandera.
 
 ## Tablas
 

--- a/wiki/Article_styling_criteria/Formatting/ko.md
+++ b/wiki/Article_styling_criteria/Formatting/ko.md
@@ -773,7 +773,7 @@ jpeg-recompress -am smallfry <input> <output>
 ::{ flag=XX }::
 ```
 
-`XX`에는 국기에 대한 [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) 2글자 국가 코드를 입력해 주세요.
+`XX`에는 국기에 대한 [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) 2글자 국가 코드를 입력해 주세요.
 
 ## 표
 

--- a/wiki/Article_styling_criteria/Formatting/ru.md
+++ b/wiki/Article_styling_criteria/Formatting/ru.md
@@ -748,7 +748,7 @@ osu! wiki масштабирует изображения, ширина кото
 ::{ flag=XX }::
 ```
 
-Здесь `XX` — двухбуквенный код страны по [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+Здесь `XX` — двухбуквенный код страны по [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
 ## Таблицы
 

--- a/wiki/Article_styling_criteria/Formatting/zh.md
+++ b/wiki/Article_styling_criteria/Formatting/zh.md
@@ -103,7 +103,7 @@ outdated_since: 29eac89cd535f8b071ca000af8fe4f0be22bdc9b
 
 标签能让网站的搜索引擎更有效地查询文章。标签应该使用与文章相同的语言。并包含英文原文章中所有标签。如果可用，则应使用小写字母。
 
-比如，一篇叫做“谱面讨论”的文章应该包含以下标签：
+比如，一篇叫做"谱面讨论"的文章应该包含以下标签：
 
 ```yaml
 tags:
@@ -783,7 +783,7 @@ jpeg-recompress -am smallfry <input> <output>
 ::{ flag=XX }::
 ```
 
-`XX` 是 [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) 定义的国家或地区用于表示旗帜的两字母代号。
+`XX` 是 [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) 定义的国家或地区用于表示旗帜的两字母代号。
 
 ## 表格
 
@@ -802,7 +802,7 @@ jpeg-recompress -am smallfry <input> <output>
 以下是一个表格例子。
 
 ```markdown
-| “古雅”红队 | 比分 | “雕塑”蓝队 | 平均谱面星数 |
+| "古雅"红队 | 比分 | "雕塑"蓝队 | 平均谱面星数 |
 | :-- | :-: | --: | :-- |
 | **peppy** | 5 - 2 | pippi | 9.3 星 |
 | Aiko | 1 - 6 | **Alisa** | 4.2 星 |


### PR DESCRIPTION
I updated all languages that don't have outdated translation headers at the top

`SKIP_WiKILINK_CHECK`