### PR TITLE
Fix Drum & Bass pack link in `wiki/Medals/Unlock_requirements/Beatmap_packs`

### DIFF
--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/de.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/de.md
@@ -61,7 +61,7 @@
 | Omoi Pack | Schließe alle Beatmaps ab, die im Beatmap-Paket [Omoi Pack](https://osu.ppy.sh/beatmaps/packs/A82) enthalten sind. |
 | Chill Pack | Schließe alle Beatmaps ab, die im Beatmap-Paket [Chill Pack](https://osu.ppy.sh/beatmaps/packs/T108) enthalten sind. |
 | Rohi Pack | Schließe alle Beatmaps ab, die im Beatmap-Paket [Rohi Pack](https://osu.ppy.sh/beatmaps/packs/F2) enthalten sind. |
-| Drum & Bass Pack | Schließe alle Beatmaps ab, die im Beatmap-Paket [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T109) enthalten sind. |
+| Drum & Bass Pack | Schließe alle Beatmaps ab, die im Beatmap-Paket [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T113) enthalten sind. |
 | Mappers' Guild Pack I | Schließe alle Beatmaps ab, die im Beatmap-Paket [Mappers' Guild Pack I](https://osu.ppy.sh/beatmaps/packs/1365) enthalten sind. |
 | Mappers' Guild Pack II | Schließe alle Beatmaps ab, die im Beatmap-Paket [Mappers' Guild Pack II](https://osu.ppy.sh/beatmaps/packs/1450) enthalten sind. |
 | Mappers' Guild Pack III | Schließe alle Beatmaps ab, die im Beatmap-Paket [Mappers' Guild Pack III](https://osu.ppy.sh/beatmaps/packs/1689) enthalten sind. |

--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/en.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/en.md
@@ -61,7 +61,7 @@
 | Omoi Pack | Clear all beatmaps bundled in the [Omoi Pack](https://osu.ppy.sh/beatmaps/packs/A82) beatmap pack. |
 | Chill Pack | Clear all beatmaps bundled in the [Chill Pack](https://osu.ppy.sh/beatmaps/packs/T108) beatmap pack. |
 | Rohi Pack | Clear all beatmaps bundled in the [Rohi Pack](https://osu.ppy.sh/beatmaps/packs/F2) beatmap pack. |
-| Drum & Bass Pack | Clear all beatmaps bundled in the [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T109) beatmap pack. |
+| Drum & Bass Pack | Clear all beatmaps bundled in the [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T113) beatmap pack. |
 | Mappers' Guild Pack I | Clear all beatmaps bundled in the [Mappers' Guild Pack I](https://osu.ppy.sh/beatmaps/packs/1365) beatmap pack. |
 | Mappers' Guild Pack II | Clear all beatmaps bundled in the [Mappers' Guild Pack II](https://osu.ppy.sh/beatmaps/packs/1450) beatmap pack. |
 | Mappers' Guild Pack III | Clear all beatmaps bundled in the [Mappers' Guild Pack III](https://osu.ppy.sh/beatmaps/packs/1689) beatmap pack. |

--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/es.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/es.md
@@ -2,7 +2,7 @@
 
 | Nombre de la medalla | Requisito |
 | :-- | :-- |
-| Video Game Pack vol.1 | Pasa todos los mapas incluidos en el paquete de mapas [Video Game Pack, Volume 1](https://osu.ppy.sh/beatmaps/packs/40).  |
+| Video Game Pack vol.1 | Pasa todos los mapas incluidos en el paquete de mapas [Video Game Pack, Volume 1](https://osu.ppy.sh/beatmaps/packs/40). |
 | Video Game Pack vol.2 | Pasa todos los mapas incluidos en el paquete de mapas [Video Game Pack, Volume 2](https://osu.ppy.sh/beatmaps/packs/48). |
 | Video Game Pack vol.3 | Pasa todos los mapas incluidos en el paquete de mapas [Video Game Pack, Volume 3](https://osu.ppy.sh/beatmaps/packs/70). |
 | Video Game Pack vol.4 | Pasa todos los mapas incluidos en el paquete de mapas [Video Game Pack, Volume 4](https://osu.ppy.sh/beatmaps/packs/364). |

--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/es.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/es.md
@@ -61,7 +61,7 @@
 | Omoi Pack | Pasa todos los mapas incluidos en el paquete de mapas [Omoi Pack](https://osu.ppy.sh/beatmaps/packs/A82). |
 | Chill Pack | Pasa todos los mapas incluidos en el paquete de mapas [Chill Pack](https://osu.ppy.sh/beatmaps/packs/T108). |
 | Rohi Pack | Pasa todos los mapas incluidos en el paquete de mapas [Rohi Pack](https://osu.ppy.sh/beatmaps/packs/F2). |
-| Drum & Bass Pack | Pasa todos los mapas incluidos en el paquete de mapas [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T109). |
+| Drum & Bass Pack | Pasa todos los mapas incluidos en el paquete de mapas [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T113). |
 | Mappers' Guild Pack I | Pasa todos los mapas incluidos en el paquete de mapas [Mappers' Guild Pack I](https://osu.ppy.sh/beatmaps/packs/1365). |
 | Mappers' Guild Pack II | Pasa todos los mapas incluidos en el paquete de mapas [Mappers' Guild Pack II](https://osu.ppy.sh/beatmaps/packs/1450). |
 | Mappers' Guild Pack III | Pasa todos los mapas incluidos en el paquete de mapas [Mappers' Guild Pack III](https://osu.ppy.sh/beatmaps/packs/1689). |

--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/ru.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/ru.md
@@ -61,7 +61,7 @@
 | Omoi Pack | Пройти все карты из подборки [Omoi Pack](https://osu.ppy.sh/beatmaps/packs/A82). |
 | Chill Pack | Пройти все карты из подборки [Chill Pack](https://osu.ppy.sh/beatmaps/packs/T108). |
 | Rohi Pack | Пройти все карты из подборки [Rohi Pack](https://osu.ppy.sh/beatmaps/packs/F2). |
-| Drum & Bass Pack | Пройти все карты из подборки [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T109). |
+| Drum & Bass Pack | Пройти все карты из подборки [Drum & Bass Pack](https://osu.ppy.sh/beatmaps/packs/T113). |
 | Mappers' Guild Pack I | Пройти все карты из подборки [Mappers' Guild Pack I](https://osu.ppy.sh/beatmaps/packs/1365). |
 | Mappers' Guild Pack II | Пройти все карты из подборки [Mappers' Guild Pack II](https://osu.ppy.sh/beatmaps/packs/1450). |
 | Mappers' Guild Pack III | Пройти все карты из подборки [Mappers' Guild Pack III](https://osu.ppy.sh/beatmaps/packs/1689). |


### PR DESCRIPTION
It was linking to another pack https://osu.ppy.sh/community/forums/topics/1847170

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
