### PR TITLE
Bump osu-wiki-tools to version `2.0.0`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==1.1.4
+osu-wiki-tools==2.0.0


### PR DESCRIPTION
View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v1.1.4...v2.0.0

- Bumps yamlint (required for ppy/osu-wiki#10521)
- Splits --outdated into 3 more granular options
- Makes case sensitivity for link checks toggleable. Now insensitive by default, since the wiki automatically redirects to the correct casing
