### PR TITLE
Bump osu-wiki-tools to version `2.0.2`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.0.1
+osu-wiki-tools==2.0.2


### PR DESCRIPTION
View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.0.1...v2.0.2

Fixes redirect handling being broken after https://github.com/ppy/osu-wiki/pull/10521

required for #10526