### PR TITLE
Output more helpful warnings in file size check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
           echo "${DELIMITER}" >> $GITHUB_ENV
 
       - name: check file sizes
-        run: meta/check-file-sizes.sh
+        run: printf '%s\n' "${{ env.INTERESTING_FILES }}" | xargs meta/check-file-sizes.sh
 
       - name: set up Node.js
         id: setup-node

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
           echo "${DELIMITER}" >> $GITHUB_ENV
 
       - name: check file sizes
-        run: printf '%s\n' "${{ env.INTERESTING_FILES }}" | xargs meta/check-file-sizes.sh
+        run: printf '%s\n' "$INTERESTING_FILES" | xargs meta/check-file-sizes.sh
 
       - name: set up Node.js
         id: setup-node

--- a/meta/check-file-sizes.sh
+++ b/meta/check-file-sizes.sh
@@ -2,8 +2,12 @@
 
 set -eu
 
+osu_wiki_path="$(dirname "$0")/.."
+news_path="$(realpath --relative-to . "$osu_wiki_path/news")"
+wiki_path="$(realpath --relative-to . "$osu_wiki_path/wiki")"
+
 if test $# -eq 0; then
-  set -- news wiki
+  set -- "$news_path" "$wiki_path"
 fi
 
 error_files="$(find "$@" -type f -size +1000000c)"

--- a/meta/check-file-sizes.sh
+++ b/meta/check-file-sizes.sh
@@ -10,7 +10,7 @@ if test $# -eq 0; then
   set -- "$news_path" "$wiki_path"
 fi
 
-error_files="$(find "$@" -type f -size +1000000c)"
+error_files="$(find "$@" "$news_path" "$wiki_path" -type f -size +1000000c)"
 warning_files="$(find "$@" -type f -size +500000c -size -1000001c)"
 
 exec >&2
@@ -22,6 +22,6 @@ fi
 
 if test "$error_files"; then
   printf '\033[31mError:\033[m The following files are larger than 1MB and must be compressed:\n'
-  printf '%s\n' "$error_files" | sort | sed 's/^/  /'
+  printf '%s\n' "$error_files" | sort -u | sed 's/^/  /'
   exit 1
 fi

--- a/meta/check-file-sizes.sh
+++ b/meta/check-file-sizes.sh
@@ -13,11 +13,11 @@ exec >&2
 
 if test "$warning_files"; then
   printf '\033[33mWarning:\033[m The following files are larger than 500kB and should be compressed if possible:\n'
-  printf %s "$warning_files" | sort | sed 's/^/  /'
+  printf '%s\n' "$warning_files" | sort | sed 's/^/  /'
 fi
 
 if test "$error_files"; then
   printf '\033[31mError:\033[m The following files are larger than 1MB and must be compressed:\n'
-  printf %s "$error_files" | sort | sed 's/^/  /'
+  printf '%s\n' "$error_files" | sort | sed 's/^/  /'
   exit 1
 fi


### PR DESCRIPTION
previously I changed the file size check to check *all* files, not just those edited in current PR -- this is good for checking for errors, but made the warnings/suggestions noisy and not very helpful.

here, I made it so that errors will consider all files, and warnings will consider changed files.

SKIP_REMARK (unrelated)