### PR TITLE
Fix typo in `People/Staff_log/2013`

### DIFF
--- a/wiki/People/Staff_log/2013/en.md
+++ b/wiki/People/Staff_log/2013/en.md
@@ -165,7 +165,7 @@
 
 ## September
 
-- Readded [Gabe](https://osu.ppy.sh/users/654108) to Beatmap Appreciation Team (2019-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
+- Readded [Gabe](https://osu.ppy.sh/users/654108) to Beatmap Appreciation Team (2013-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
 - Added [YGOkid8](https://osu.ppy.sh/users/69114) to osu! Alumni (2013-09-05) <!-- https://osu.ppy.sh/community/forums/posts/2555361 -->
 - Moved [Andrea](https://osu.ppy.sh/users/33599) from osu! Alumni to Beatmap Appreciation Team (2013-09-08) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
 - Added [Lissette](https://osu.ppy.sh/users/19835) to osu! Alumni <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->

--- a/wiki/People/Staff_log/2013/ja.md
+++ b/wiki/People/Staff_log/2013/ja.md
@@ -165,7 +165,7 @@
 
 ## 9月
 
-- [Gabe](https://osu.ppy.sh/users/654108)をビートマップアプリーシエイションチームに再追加 (2019-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
+- [Gabe](https://osu.ppy.sh/users/654108)をビートマップアプリーシエイションチームに再追加 (2013-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
 - [YGOkid8](https://osu.ppy.sh/users/69114)をosu! Alumniに追加 (2013-09-05) <!-- https://osu.ppy.sh/community/forums/posts/2555361 -->
 - [Andrea](https://osu.ppy.sh/users/33599)をosu! Alumniからビートマップアプリーシエイションチームへ (2013-09-08) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
 - [Lissette](https://osu.ppy.sh/users/19835)をosu! Alumni <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->に追加

--- a/wiki/People/Staff_log/2013/ru.md
+++ b/wiki/People/Staff_log/2013/ru.md
@@ -165,7 +165,7 @@
 
 ## Сентябрь
 
-- Повторное добавление [Gabe](https://osu.ppy.sh/users/654108) в Beatmap Appreciation Team (2019-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
+- Повторное добавление [Gabe](https://osu.ppy.sh/users/654108) в Beatmap Appreciation Team (2013-09-02) <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->
 - Добавление [YGOkid8](https://osu.ppy.sh/users/69114) в osu! Alumni (2013-09-05) <!-- https://osu.ppy.sh/community/forums/posts/2555361 -->
 - Перемещение [Andrea](https://osu.ppy.sh/users/33599) из osu! Alumni в Beatmap Appreciation Team (2013-09-08) <!-- https://osu.ppy.sh/community/forums/topics/83704 -->
 - Добавление [Lissette](https://osu.ppy.sh/users/19835) в osu! Alumni <!-- https://osu.ppy.sh/community/forums/posts/2563693 -->


### PR DESCRIPTION
As noticed by [Flask](http://osu.ppy.sh/users/959763) via PM.

![image](https://github.com/ppy/osu-wiki/assets/36564236/d6c2fa63-e6f4-4db6-aaeb-3746641f042d)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~ (shouldn't be required)

PS : `SKIP_OUTDATED_CHECK` (as the Thai version of the article uses a very different calendar and thus the change is not applicable)
