### PR TITLE
Bump osu-wiki-tools to version `2.1.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.0.2
+osu-wiki-tools==2.1.1


### PR DESCRIPTION
required for https://github.com/ppy/osu-wiki/pull/10526

View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.0.2...v2.1.1

- Allow `no_native_review_since` tag (by @cl8n, some future thing)
- Fix errors for section links within news posts
- Add support for GitHub link checking as suggested by clayton, i.e. links like https://github.com/ppy/osu-wiki/tree/master/news or https://github.com/ppy/osu-wiki/blob/master/CONTRIBUTING.md#testing are checked locally
- Fix links like `![](/img/cat.png)` being ignored (when it should be `![](img/cat.png)`
- Improve error display a bit (no more "wiki/../news" nonsense, etc)