### PR TITLE
Uncomment `no_native_review_since` tags and explain in ASC

### DIFF
--- a/wiki/Announcement_messages/vi.md
+++ b/wiki/Announcement_messages/vi.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # since c4b3e6e569abf87ecfcd1d731ba1e6ca55edbda0
+no_native_review_since: c4b3e6e569abf87ecfcd1d731ba1e6ca55edbda0 AutumnVN
 tags:
   - announce
   - announce usergroup

--- a/wiki/Article_styling_criteria/Formatting/de.md
+++ b/wiki/Article_styling_criteria/Formatting/de.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 16a9623dd2a25dc38ae8879ad2c924f8b7c74a3e
+outdated_translation: true
+---
+
 # Formatierung
 
 *Für die Schriftstandards, siehe: [Artikelgestaltungskriterien/Schrift](../Writing)*

--- a/wiki/Article_styling_criteria/Formatting/en.md
+++ b/wiki/Article_styling_criteria/Formatting/en.md
@@ -106,12 +106,18 @@ tags:
 
 ### Translations without reviews
 
-*Note: Wiki maintainers will determine and apply this mark prior to merging.*
+*Note: Wiki maintainers will determine and apply this tag prior to merging.*
 
-Sometimes, translations are added to the wiki without review from other native speakers of the language. In this case, the `no_native_review` mark is added to let future translators know that it may need to be checked again. This tag must be written as shown below:
+Sometimes, translations are added to the wiki without review from other native speakers of the language. In this case, the `no_native_review` tag is added to let future translators know that it may need to be checked again:
 
 ```yaml
 no_native_review: true
+```
+
+Alternatively, the `no_native_review_since` tag can be used to indicate the commit where the first unreviewed edit was introduced, as well as who edited the translation since then:
+
+```yaml
+no_native_review_since: 5539d9e8c943605a7be186dc3f5ab10569275b05 Doryan
 ```
 
 ## Article naming

--- a/wiki/Article_styling_criteria/Formatting/es.md
+++ b/wiki/Article_styling_criteria/Formatting/es.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 16a9623dd2a25dc38ae8879ad2c924f8b7c74a3e
+outdated_translation: true
+---
+
 # Formato
 
 *Para los estándares de escritura, véase: [Criterios de estilo para artículos/Redacción](../Writing)*\

--- a/wiki/Article_styling_criteria/Formatting/ko.md
+++ b/wiki/Article_styling_criteria/Formatting/ko.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 16a9623dd2a25dc38ae8879ad2c924f8b7c74a3e
+outdated_translation: true
+---
+
 # 서식
 
 *작성 표준에 대한 내용은 [Article style criteria/Writing](../Writing)를 참조하세요.*\

--- a/wiki/Article_styling_criteria/Formatting/ru.md
+++ b/wiki/Article_styling_criteria/Formatting/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 16a9623dd2a25dc38ae8879ad2c924f8b7c74a3e
+outdated_translation: true
+---
+
 # Оформление статей
 
 *См. также: [Содержание статей](/wiki/Article_styling_criteria/Writing)*

--- a/wiki/Article_styling_criteria/Formatting/zh.md
+++ b/wiki/Article_styling_criteria/Formatting/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 16a9623dd2a25dc38ae8879ad2c924f8b7c74a3e
+outdated_translation: true
 tags:
   - 格式
   - 格式化

--- a/wiki/Community/Project_Loved/fr.md
+++ b/wiki/Community/Project_Loved/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: 5539d9e8c943605a7be186dc3f5ab10569275b05 Doryan
+no_native_review_since: 5539d9e8c943605a7be186dc3f5ab10569275b05 Doryan
 ---
 
 # Project Loved

--- a/wiki/Help_centre/Upgrading_to_lazer/vi.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/vi.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # since 08b5cd869b6e404b0861dc7747b72bd232909352
+no_native_review_since: 08b5cd869b6e404b0861dc7747b72bd232909352 AutumnVN
 ---
 
 # Nâng cấp lên lazer

--- a/wiki/Medals/Unlock_requirements/Beatmap_challenge_packs/fr.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_challenge_packs/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
+no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
 ---
 
 # Conditions de déverrouillage des médailles : Beatmap Challenge Packs

--- a/wiki/Medals/Unlock_requirements/Beatmap_packs/fr.md
+++ b/wiki/Medals/Unlock_requirements/Beatmap_packs/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
+no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
 ---
 
 # Conditions de déverrouillage des médailles : Beatmap Packs

--- a/wiki/Medals/Unlock_requirements/Dedication/fr.md
+++ b/wiki/Medals/Unlock_requirements/Dedication/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
+no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
 ---
 
 # Conditions de déverrouillage des médailles : Dedication

--- a/wiki/Medals/Unlock_requirements/fr.md
+++ b/wiki/Medals/Unlock_requirements/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
+no_native_review_since: 509c538fba6a848cf044b98104f2a8466b38bf83 Doryan
 ---
 
 # Conditions de déverrouillage des médailles

--- a/wiki/Ranking_criteria/osu!/fr.md
+++ b/wiki/Ranking_criteria/osu!/fr.md
@@ -1,5 +1,5 @@
 ---
-no_native_review: true # no_native_review_since: ae41434f319c2db2e6b33ddffa0419b663ff039e Doryan
+no_native_review_since: ae41434f319c2db2e6b33ddffa0419b663ff039e Doryan
 ---
 
 # Critères de classement d'osu!


### PR DESCRIPTION
it will cause some extra info to be included on https://osu.wiki soon -- for now it is functionally the same as `no_native_review: true`