### PR TITLE
Bump osu-wiki-tools to version `2.1.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.1.1
+osu-wiki-tools==2.1.2


### PR DESCRIPTION
View changes at:
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.1.1...v2.1.2

Fixes crash on Linux