### PR TITLE
Fix base commit of outdated articles check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,4 +74,8 @@ jobs:
 
       - name: check if translations are marked as outdated
         if: ${{ !contains(github.event.pull_request.body, 'SKIP_OUTDATED_CHECK') }}
-        run: osu-wiki-tools check-outdated-articles --no-recommend-autofix
+        run: |
+          osu-wiki-tools check-outdated-articles \
+            --base-commit HEAD \
+            --no-recommend-autofix \
+            --outdated-since "$(git log --format=%H master.. | tail -n 1)"


### PR DESCRIPTION
`HEAD` is the right base commit here because it's a merge with the first parent at `master` and second parent at the tip of PR, and then `--outdated-since` was already correct, but I have to write it in explicitly now since it differs from base commit.

will see if i can make this less confusing to think about later...