### PR TITLE
Bump osu-wiki-tools to version `2.2.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.2.0
+osu-wiki-tools==2.2.1


### PR DESCRIPTION
View changes at
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.2.0...v2.2.1

fixes flags not being removed from identifiers, which incorrectly caused errors for links like https://osu.ppy.sh/home/news/2023-11-08-osu-world-cup-2023-round-of-16-recap#thailand-vs.--new-zealand 