### PR TITLE
Clarify activity requirement for triggering a probation eval

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -30,7 +30,7 @@ Full Beatmap Nominators with below minimum nomination activity will not be place
 
 Probation is used to monitor new or demoted Beatmap Nominators more closely. The main role for probationary Beatmap Nominators is to establish a foundation as a Beatmap Nominator through exclusively promoting beatmaps in the ranking process. At least one full nominator must be involved in the ranking process for each game mode of a beatmap, so probationary members cannot give the final nomination to a beatmap which has only received nominations from other probationary members for their game mode.
 
-Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting their [activity requirements](/wiki/People/Beatmap_Nominators/Rules#activity), or after one month from being placed there, whichever comes first.
+Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting double their [activity requirements](/wiki/People/Beatmap_Nominators/Rules#requirements), or after one month from being placed there, whichever comes first.
 
 New members of the Beatmap Nominators will be assigned an NAT buddy who they are encouraged to directly contact for questions or guidance. After their first evaluation, if their nominations and behaviour are satisfactory, they will be promoted to the full Beatmap Nominators following a positive evaluation. Otherwise, they will remain on probation for another month or be removed from the Beatmap Nominators.
 

--- a/wiki/People/Beatmap_Nominators/es.md
+++ b/wiki/People/Beatmap_Nominators/es.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 6f2dc0a34d9ff001c9d1f06c87cd10f971158c3f
 tags:
   - BN
   - BNG


### PR DESCRIPTION
side effect from recent changes that we forgot to update