### PR TITLE
Remove mention of slider end combo from `Gameplay_differences_in_osu!(lazer)`

### DIFF
--- a/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
+++ b/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
@@ -134,19 +134,6 @@ Until lazer, sliders have only required the accuracy of a 50/MEH judgement to re
 | Intentionally changed | Yes |
 | Needs further consideration | No |
 
-### Slider ends do not contribute to combo nor cause misses
-
-Slider ends used to have the quirk of not breaking combo (and not causing a MISS judgement) if missed. This meant that an S play, which among other things requires zero MISS judgements, would look like a full combo even if some slider ends were missed. Various debates over whether such a play should be called an FC ensued.
-
-From now on slider ends will only affect score and accuracy, but have no effect on combo. This means that a no-miss score always signifies a full combo.
-
-|  |  |
-| :-- | :-: |
-| Breaks backwards compatibility | Yes |
-| Classic mod revert support | Yes |
-| Intentionally changed | Yes |
-| Needs further consideration | Yes |
-
 ### Missing a slider head causes a miss
 
 Missing a slider head (either by not hitting it or hitting it during its miss window) would previously break combo but not cause a MISS judgement, and a judgement could still be received for the missed slider by completing the rest of it. This allowed players to get scores with low max combo while technically having no misses.


### PR DESCRIPTION
No longer accurate since combo was added back to the slider-end.
