### PR TITLE
Fix indentation and cache of Elite Nominator badge

### DIFF
--- a/wiki/People/Elite_Nominators/en.md
+++ b/wiki/People/Elite_Nominators/en.md
@@ -17,7 +17,7 @@ Starting from [7 February 2020](https://osu.ppy.sh/home/news/2020-02-07-communit
 - The "Elite Nominator" [user title](/wiki/Community/User_title), which lasts for 1 year until the next wave of Elite Nominators or when the user leaves the Beatmap Nominators. In case a user is awarded the title again for consecutive years, the title increments by 1 ("Elite Nominator II", etc.).
 - An Elite Nominator [profile badge](/wiki/Community/Profile_badge), which is permanent.
 
-![Elite Nominator badge](https://assets.ppy.sh/profile-badges/elite-nominator.png "Elite Nominator badge") ![Elite Nominator II badge](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Elite Nominator II badge")
+  ![Elite Nominator badge](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Elite Nominator badge") ![Elite Nominator II badge](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Elite Nominator II badge")
 
 ## List of Elite Nominators
 

--- a/wiki/People/Elite_Nominators/en.md
+++ b/wiki/People/Elite_Nominators/en.md
@@ -16,7 +16,6 @@ Starting from [7 February 2020](https://osu.ppy.sh/home/news/2020-02-07-communit
 
 - The "Elite Nominator" [user title](/wiki/Community/User_title), which lasts for 1 year until the next wave of Elite Nominators or when the user leaves the Beatmap Nominators. In case a user is awarded the title again for consecutive years, the title increments by 1 ("Elite Nominator II", etc.).
 - An Elite Nominator [profile badge](/wiki/Community/Profile_badge), which is permanent.
-
   ![Elite Nominator badge](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Elite Nominator badge") ![Elite Nominator II badge](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Elite Nominator II badge")
 
 ## List of Elite Nominators

--- a/wiki/People/Elite_Nominators/es.md
+++ b/wiki/People/Elite_Nominators/es.md
@@ -17,7 +17,7 @@ A partir del [7 de febrero de 2020](https://osu.ppy.sh/home/news/2020-02-07-comm
 - El [título de usuario](/wiki/Community/User_title) «Elite Nominator», que dura 1 año hasta la próxima ola de Elite Nominators o cuando el usuario abandona los Beatmap Nominators. En caso de que a un usuario se le otorgue el título nuevamente por años consecutivos, el título se incrementa en 1 («Elite Nominator II», etc.).
 - Una [insignia de perfil](/wiki/Community/Profile_badge) Elite Nominator, que es permanente.
 
-![](https://assets.ppy.sh/profile-badges/elite-nominator.png "Insignia de Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Insignia de Elite Nominator II")
+  ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Insignia de Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Insignia de Elite Nominator II")
 
 ## Lista de Elite Nominators
 

--- a/wiki/People/Elite_Nominators/es.md
+++ b/wiki/People/Elite_Nominators/es.md
@@ -16,7 +16,6 @@ A partir del [7 de febrero de 2020](https://osu.ppy.sh/home/news/2020-02-07-comm
 
 - El [título de usuario](/wiki/Community/User_title) «Elite Nominator», que dura 1 año hasta la próxima ola de Elite Nominators o cuando el usuario abandona los Beatmap Nominators. En caso de que a un usuario se le otorgue el título nuevamente por años consecutivos, el título se incrementa en 1 («Elite Nominator II», etc.).
 - Una [insignia de perfil](/wiki/Community/Profile_badge) Elite Nominator, que es permanente.
-
   ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Insignia de Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Insignia de Elite Nominator II")
 
 ## Lista de Elite Nominators

--- a/wiki/People/Elite_Nominators/fr.md
+++ b/wiki/People/Elite_Nominators/fr.md
@@ -20,7 +20,6 @@ Les Elite Nominators sont sélectionnés par la Nomination Assessment Team sur l
 
 - Le [titre d'utilisateur](/wiki/Community/User_title) Elite Nominator, qui dure 1 an jusqu'à la prochaine vague de Elite Nominator ou lorsque l'utilisateur quitte les Beatmap Nominators. Si un utilisateur obtient à nouveau le titre pour des années consécutives, le titre augmente de 1 ("Elite Nominator II", etc.).
 - Un [badge de profil](/wiki/Community/Profile_badge) Elite Nominator, qui est permanent.
-
   ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Badge Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge Elite Nominator II")
 
 ## Liste des Elite Nominators

--- a/wiki/People/Elite_Nominators/fr.md
+++ b/wiki/People/Elite_Nominators/fr.md
@@ -21,7 +21,7 @@ Les Elite Nominators sont sélectionnés par la Nomination Assessment Team sur l
 - Le [titre d'utilisateur](/wiki/Community/User_title) Elite Nominator, qui dure 1 an jusqu'à la prochaine vague de Elite Nominator ou lorsque l'utilisateur quitte les Beatmap Nominators. Si un utilisateur obtient à nouveau le titre pour des années consécutives, le titre augmente de 1 ("Elite Nominator II", etc.).
 - Un [badge de profil](/wiki/Community/Profile_badge) Elite Nominator, qui est permanent.
 
-![](https://assets.ppy.sh/profile-badges/elite-nominator.png "Badge Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge Elite Nominator II")
+  ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Badge Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge Elite Nominator II")
 
 ## Liste des Elite Nominators
 

--- a/wiki/People/Elite_Nominators/it.md
+++ b/wiki/People/Elite_Nominators/it.md
@@ -16,7 +16,6 @@ A partire dal [7 febbraio 2020](https://osu.ppy.sh/home/news/2020-02-07-communit
 
 - Il [titolo utente](/wiki/Community/User_title) "Elite Nominator", che dura per 1 anno fino alla successiva ondata di Elite Nominator o quando l'utente lascia i Beatmap Nominators. Nel caso in cui un utente ottenga nuovamente il titolo per anni consecutivi, il titolo aumenta di 1 ("Elite Nominator II", ecc.).
 - Un [badge del profilo](/wiki/Community/Profile_badge) da Elite Nominator, che è permanente.
-
   ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Badge da Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge da Elite Nominator II")
 
 ## Lista degli Elite Nominators

--- a/wiki/People/Elite_Nominators/it.md
+++ b/wiki/People/Elite_Nominators/it.md
@@ -17,7 +17,7 @@ A partire dal [7 febbraio 2020](https://osu.ppy.sh/home/news/2020-02-07-communit
 - Il [titolo utente](/wiki/Community/User_title) "Elite Nominator", che dura per 1 anno fino alla successiva ondata di Elite Nominator o quando l'utente lascia i Beatmap Nominators. Nel caso in cui un utente ottenga nuovamente il titolo per anni consecutivi, il titolo aumenta di 1 ("Elite Nominator II", ecc.).
 - Un [badge del profilo](/wiki/Community/Profile_badge) da Elite Nominator, che è permanente.
 
-![](https://assets.ppy.sh/profile-badges/elite-nominator.png "Badge da Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge da Elite Nominator II")
+  ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "Badge da Elite Nominator") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "Badge da Elite Nominator II")
 
 ## Lista degli Elite Nominators
 

--- a/wiki/People/Elite_Nominators/zh.md
+++ b/wiki/People/Elite_Nominators/zh.md
@@ -19,7 +19,7 @@
   - 如果玩家连续被评为优秀提名者，则头衔等级会逐年递增 1
 - 一个特别的优秀提名者[主页奖牌](/wiki/Community/Profile_badge)
 
-![](https://assets.ppy.sh/profile-badges/elite-nominator.png "优秀提名者奖牌") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "优秀提名者 II 奖牌")
+  ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "优秀提名者奖牌") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "优秀提名者 II 奖牌")
 
 ## 2019
 

--- a/wiki/People/Elite_Nominators/zh.md
+++ b/wiki/People/Elite_Nominators/zh.md
@@ -18,7 +18,6 @@
   - 头衔会持续到下一批次优秀提名者的选举。如果玩家卸任提名者，将取消头衔
   - 如果玩家连续被评为优秀提名者，则头衔等级会逐年递增 1
 - 一个特别的优秀提名者[主页奖牌](/wiki/Community/Profile_badge)
-
   ![](https://assets.ppy.sh/profile-badges/elite-nominator.png?2024 "优秀提名者奖牌") ![](https://assets.ppy.sh/profile-badges/elite-nominator-2.png "优秀提名者 II 奖牌")
 
 ## 2019


### PR DESCRIPTION
NAT article already [does this](https://github.com/ppy/osu-wiki/blob/master/wiki/People/Nomination_Assessment_Team/en.md?plain=1#L67-L70) which makes badges look better aligned in lists.

