### PR TITLE
Update staff listing requirement in `Official tournament support`

### DIFF
--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -53,7 +53,7 @@ If your tournament satisfies the [eligibility criteria](#eligibility), you can m
     - For regional tournaments, the thread may be created in the appropriate language subforum.
   - Public Discord servers or any other off-site chatrooms used for the event.
   - Previous iterations of the same tournament series (only where applicable).
-- A separate list of the users who have registered to participate in the tournament (see [tournament screening](#tournament-screening)).
+- A list of the users who have registered to participate in the tournament (see [tournament screening](#tournament-screening)), as a separate attachment.
 
 Once we receive your request, the account support team will return a list of users who are ineligible to participate in tournaments. Please allow ample time for a response. We will try our best to handle all requests within a week, but we occasionally have large spikes in workload that can make this impossible.
 

--- a/wiki/Tournaments/Official_support/en.md
+++ b/wiki/Tournaments/Official_support/en.md
@@ -11,7 +11,7 @@ tags:
 
 The [osu! team](/wiki/People/osu!_team) runs a program where they may opt to provide community-run tournaments that abide by a certain set of criteria and expectations with extra support, at their discretion.
 
-This article was last updated on September 13, 2023. For any queries and clarifications, please consult the `#tournaments` channel on the [osu! Discord server](https://discord.com/invite/ppy) or send an email to the [account support team](/wiki/People/Account_support_team) via [tournaments@ppy.sh](mailto:tournaments@ppy.sh).
+This article was last updated on January 18, 2024. For any queries and clarifications, please consult the `#tournaments` channel on the [osu! Discord server](https://discord.com/invite/ppy) or send an email to the [account support team](/wiki/People/Account_support_team) via [tournaments@ppy.sh](mailto:tournaments@ppy.sh).
 
 ## Benefits
 
@@ -53,9 +53,7 @@ If your tournament satisfies the [eligibility criteria](#eligibility), you can m
     - For regional tournaments, the thread may be created in the appropriate language subforum.
   - Public Discord servers or any other off-site chatrooms used for the event.
   - Previous iterations of the same tournament series (only where applicable).
-- Separate lists for:
-  - The staff involved in running the tournament.
-  - The users who have registered to participate in the tournament (see [tournament screening](#tournament-screening)).
+- A separate list of the users who have registered to participate in the tournament (see [tournament screening](#tournament-screening)).
 
 Once we receive your request, the account support team will return a list of users who are ineligible to participate in tournaments. Please allow ample time for a response. We will try our best to handle all requests within a week, but we occasionally have large spikes in workload that can make this impossible.
 
@@ -116,6 +114,8 @@ With regards to staff roles, the following rules apply:
 Users under an active tournament ban are expected to disclose their tournament ban status to any officially supported tournament they intend to help with. They may be enlisted as streamers, commentators, or graphic designers at the host's discretion, but we encourage careful consideration of such choices as said individuals have already infringed upon the rules once (or more). They may not act as any other staff role UNLESS the host requests an exemption for them when sending in their initial request for support. The account support team will then assess these on a case-by-case basis with the user's history in mind.
 
 At the support team's discretion, staff members whose conduct directly results in a tournament losing its official support may not fulfil the same roles in, nor be the host or admin of, another badged tournament for at least 4 months. In the event this cooldown is applied to a user, they will be informed directly through the [tournament team](mailto:tournaments@ppy.sh).
+
+A list of all tournament staff must be publicly visible in an easily accessible location. This list may be contained within the tournament's forum post, website, or spreadsheet.
 
 ### Players
 


### PR DESCRIPTION
Removed requirement to include a list of staff in screening email, added requirement to have a public list of staff, updated date article was last updated. Per tournament committee discussion.