### PR TITLE
Update `MWC 7K 2024` for the RO16 stage

### DIFF
--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -212,7 +212,7 @@ Sunday, 21 January 2024:
 
 The final standings for the Qualifier stage can be found in the following [spreadsheet](https://docs.google.com/spreadsheets/d/1APCeEFVMGbgxkIhne5ChMBnoNh1dfQwVqZFk37F57A0?rm=minimal).
 
-| Seed | Country | %rank sum[^qualifiers-seeding] | avg. score[^qualifiers-tiebreaker] |
+| Seed | Country | rank sum[^qualifiers-seeding] | avg. score[^qualifiers-tiebreaker] |
 | :-: | :-- | --: | --: |
 | #1 | ::{ flag=KR }:: South Korea | 10 | 1,983,181 |
 | #2 | ::{ flag=CN }:: China | 25 | 1,969,845 |

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -204,7 +204,7 @@ Sunday, 21 January 2024:
 | Netherlands ::{ flag=NL }:: | 4 | **5** | ::{ flag=TW }:: **Taiwan** | [#1](https://osu.ppy.sh/community/matches/112308440) | [#1](https://www.twitch.tv/videos/2039351530) |
 | **Indonesia** ::{ flag=ID }:: | **5** | 0 | ::{ flag=FR }:: France | [#1](https://osu.ppy.sh/community/matches/112308966) |  |
 | **Russian Federation** ::{ flag=RU }:: | **5** | 4 | ::{ flag=DK }:: Denmark | [#1](https://osu.ppy.sh/community/matches/112309921) | [#1](https://www.twitch.tv/videos/2039423606) |
-| United Kingdom ::{ flag=GB }:: | 0 | 0 | ::{ flag=DE }:: Germany | [#1](https://osu.ppy.sh/community/matches/112310876) | [#1](https://www.twitch.tv/videos/2039449910) |
+| United Kingdom ::{ flag=GB }:: | 0 | **5** | ::{ flag=DE }:: Germany | [#1](https://osu.ppy.sh/community/matches/112310876) | [#1](https://www.twitch.tv/videos/2039449910) |
 | **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=EE }:: Estonia | [#1](https://osu.ppy.sh/community/matches/112311940) | [#1](https://www.twitch.tv/videos/2039498579) |
 | **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=ES }:: Spain | [#1](https://osu.ppy.sh/community/matches/112312820) | [#1](https://www.twitch.tv/videos/2039582666) |
 

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -131,7 +131,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 
 ### Round of 16
 
-**[Download the mappack here (47 MB)](https://packs.ppy.sh/P234%20-%20osu%21mania%207K%20World%20Cup%202024%3A%20Round%20of%2016.zip)**
+**[Download the mappack here (59 MB)](https://packs.ppy.sh/P234%20-%20osu%21mania%207K%20World%20Cup%202024%3A%20Round%20of%2016.zip)**
 
 - Rice
   1. [goreshit - toromi hearts 2 (Sped Up Ver.) (Tailsdk) \[MWC RO16 Speed (Cut ver.)\]](https://osu.ppy.sh/beatmapsets/2123251#mania/4461979)
@@ -148,7 +148,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
   2. [Yamajet x Mentalstock - Sequential Emotions (Makiba) \[Sequentia motus\]](https://osu.ppy.sh/beatmapsets/2123268#mania/4462014)
   3. [ZxNX - Fana (Wonki) \[Extra\]](https://osu.ppy.sh/beatmapsets/2123269#mania/4462015)
 - Tiebreaker
-  1. **[Juggernaut. - Invoke (\_Stan) \[Summoning\]](https://osu.ppy.sh/beatmapsets/2123292#mania/4462083)**
+  1. **[Kou! - sub/zerO (\_Stan) \[ice/oveR\]](https://osu.ppy.sh/beatmapsets/2123291#mania/4462082)**
 
 ### Round of 24
 

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -204,7 +204,7 @@ Sunday, 21 January 2024:
 | Netherlands ::{ flag=NL }:: | 4 | **5** | ::{ flag=TW }:: **Taiwan** | [#1](https://osu.ppy.sh/community/matches/112308440) | [#1](https://www.twitch.tv/videos/2039351530) |
 | **Indonesia** ::{ flag=ID }:: | **5** | 0 | ::{ flag=FR }:: France | [#1](https://osu.ppy.sh/community/matches/112308966) |  |
 | **Russian Federation** ::{ flag=RU }:: | **5** | 4 | ::{ flag=DK }:: Denmark | [#1](https://osu.ppy.sh/community/matches/112309921) | [#1](https://www.twitch.tv/videos/2039423606) |
-| United Kingdom ::{ flag=GB }:: | 0 | **5** | ::{ flag=DE }:: Germany | [#1](https://osu.ppy.sh/community/matches/112310876) | [#1](https://www.twitch.tv/videos/2039449910) |
+| United Kingdom ::{ flag=GB }:: | 0 | **5** | ::{ flag=DE }:: **Germany** | [#1](https://osu.ppy.sh/community/matches/112310876) | [#1](https://www.twitch.tv/videos/2039449910) |
 | **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=EE }:: Estonia | [#1](https://osu.ppy.sh/community/matches/112311940) | [#1](https://www.twitch.tv/videos/2039498579) |
 | **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=ES }:: Spain | [#1](https://osu.ppy.sh/community/matches/112312820) | [#1](https://www.twitch.tv/videos/2039582666) |
 

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -131,7 +131,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 
 ### Round of 16
 
-**[Download the mappack here (62 MB, *temporary link*)](https://leoflt.com/s/JRWS)**
+**[Download the mappack here (47 MB)](https://packs.ppy.sh/P234%20-%20osu%21mania%207K%20World%20Cup%202024%3A%20Round%20of%2016.zip)**
 
 - Rice
   1. [goreshit - toromi hearts 2 (Sped Up Ver.) (Tailsdk) \[MWC RO16 Speed (Cut ver.)\]](https://osu.ppy.sh/beatmapsets/2123251#mania/4461979)
@@ -144,11 +144,11 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
   2. [Y&Co. - POODLE (MapleSyrup-) \[So lovely and sweet pretty poodle\]](https://osu.ppy.sh/beatmapsets/2123243#mania/4461965)
   3. [DAZBEE - Adios (Remuring) \[Fall in Love\]](https://osu.ppy.sh/beatmapsets/2123264#mania/4462004)
 - Hybrid
-  1. [Juggernaut. - Invoke (\_Stan) \[Summoning\] *(temporary link)*](https://leoflt.com/s/s3zX)
+  1. [Juggernaut. - Invoke (\_Stan) \[Summoning\]](https://osu.ppy.sh/beatmapsets/2123292#mania/4462083)
   2. [Yamajet x Mentalstock - Sequential Emotions (Makiba) \[Sequentia motus\]](https://osu.ppy.sh/beatmapsets/2123268#mania/4462014)
   3. [ZxNX - Fana (Wonki) \[Extra\]](https://osu.ppy.sh/beatmapsets/2123269#mania/4462015)
 - Tiebreaker
-  1. **[Kou! - subzerO (\_Stan) \[iceoveR\] *(temporary link)*](https://leoflt.com/s/kN4N)**
+  1. **[Juggernaut. - Invoke (\_Stan) \[Summoning\]](https://osu.ppy.sh/beatmapsets/2123292#mania/4462083)**
 
 ### Round of 24
 

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -46,7 +46,7 @@ The osu!mania 7K World Cup 2024 is run by the osu! team and various community me
 | Mappool selector | ::{ flag=US }:: **[\-NoName\-](https://osu.ppy.sh/users/10400730)**, ::{ flag=PL }:: [\_underjoy](https://osu.ppy.sh/users/2235750), ::{ flag=BR }:: [Makiba](https://osu.ppy.sh/users/7539957), ::{ flag=KR }:: [Remuring](https://osu.ppy.sh/users/6522146) |
 | Referee | ::{ flag=US }:: [\[K\]](https://osu.ppy.sh/users/16551387), ::{ flag=FR }:: [Aidown](https://osu.ppy.sh/users/1522146), ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595), ::{ flag=AU }:: [Fairy Bread](https://osu.ppy.sh/users/8306102), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=NL }:: [nik](https://osu.ppy.sh/users/10077264), ::{ flag=IN }:: [Speshimen](https://osu.ppy.sh/users/7720204), ::{ flag=US }:: [tigereyes144](https://osu.ppy.sh/users/6499811), ::{ flag=GB }:: [Yazzehh](https://osu.ppy.sh/users/7068973) |
 | Mappool playtester | ::{ flag=MY }:: [\_Kobii](https://osu.ppy.sh/users/6209713), ::{ flag=PL }:: [\_underjoy](https://osu.ppy.sh/users/2235750), ::{ flag=US }:: [\-NoName\-](https://osu.ppy.sh/users/10400730), ::{ flag=US }:: [Blocko](https://osu.ppy.sh/users/4075092), ::{ flag=CN }:: [Carpihat](https://osu.ppy.sh/users/10085090), ::{ flag=KR }:: [DellyK](https://osu.ppy.sh/users/19791211), ::{ flag=SG }:: [Evening](https://osu.ppy.sh/users/2193881), ::{ flag=US }:: [Jinjin](https://osu.ppy.sh/users/3360737), ::{ flag=JP }:: [LuluM](https://osu.ppy.sh/users/13151924), ::{ flag=BR }:: [Makiba](https://osu.ppy.sh/users/7539957), ::{ flag=PH }:: [MapleSyrup\-](https://osu.ppy.sh/users/1192936), ::{ flag=ES }:: [RandomeLoL](https://osu.ppy.sh/users/7080063), ::{ flag=KR }:: [Remuring](https://osu.ppy.sh/users/6522146), ::{ flag=US }:: [RhymesWithMash](https://osu.ppy.sh/users/18834550), ::{ flag=BR }:: [roko100789](https://osu.ppy.sh/users/3224958), ::{ flag=PH }:: [SurfChu85](https://osu.ppy.sh/users/4469895), ::{ flag=US }:: [Terni](https://osu.ppy.sh/users/3279570) |
-| Mapper | ::{ flag=CN }:: [\_Yiiiii](https://osu.ppy.sh/users/6066359), ::{ flag=US }:: [\-NoName\-](https://osu.ppy.sh/users/10400730), ::{ flag=MY }:: [Critical\_Star](https://osu.ppy.sh/users/3793196), ::{ flag=US }:: [Jinjin](https://osu.ppy.sh/users/3360737), ::{ flag=KR }:: [JuHaa](https://osu.ppy.sh/users/15526127), ::{ flag=DE }:: [Leeju](https://osu.ppy.sh/users/18219603), ::{ flag=BR }:: [Makiba](https://osu.ppy.sh/users/7539957), ::{ flag=PH }:: [MapleSyrup\-](https://osu.ppy.sh/users/1192936), ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785), ::{ flag=PH }:: [paulkappa](https://osu.ppy.sh/users/7115625), ::{ flag=HK }:: [pwhk](https://osu.ppy.sh/users/4887865), ::{ flag=KR }:: [Remuring](https://osu.ppy.sh/users/6522146), ::{ flag=DK }:: [Tailsdk](https://osu.ppy.sh/users/6751666), ::{ flag=KR }:: [Wonki](https://osu.ppy.sh/users/7898495) |
+| Mapper | ::{ flag=CN }:: [\_Stan](https://osu.ppy.sh/users/1653229), ::{ flag=CN }:: [\_Yiiiii](https://osu.ppy.sh/users/6066359), ::{ flag=US }:: [\-NoName\-](https://osu.ppy.sh/users/10400730), ::{ flag=MY }:: [Critical\_Star](https://osu.ppy.sh/users/3793196), ::{ flag=US }:: [Jinjin](https://osu.ppy.sh/users/3360737), ::{ flag=DE }:: [Leeju](https://osu.ppy.sh/users/18219603), ::{ flag=SG }:: [Level 51](https://osu.ppy.sh/users/3617847), ::{ flag=BR }:: [Makiba](https://osu.ppy.sh/users/7539957), ::{ flag=PH }:: [MapleSyrup\-](https://osu.ppy.sh/users/1192936), ::{ flag=ID }:: [Maxus](https://osu.ppy.sh/users/4335785), ::{ flag=PH }:: [paulkappa](https://osu.ppy.sh/users/7115625), ::{ flag=HK }:: [pwhk](https://osu.ppy.sh/users/4887865), ::{ flag=KR }:: [Remuring](https://osu.ppy.sh/users/6522146), ::{ flag=DK }:: [Tailsdk](https://osu.ppy.sh/users/6751666), ::{ flag=KR }:: [Wonki](https://osu.ppy.sh/users/7898495) |
 | Commentator | ::{ flag=US }:: [\-mint\-](https://osu.ppy.sh/users/8976576), ::{ flag=PH }:: [bulmagamerph76](https://osu.ppy.sh/users/11517895), ::{ flag=AR }:: [juankristal](https://osu.ppy.sh/users/443656), ::{ flag=ID }:: [Mipha\-](https://osu.ppy.sh/users/5767941), ::{ flag=AU }:: [PotassiumF](https://osu.ppy.sh/users/4247722), ::{ flag=SG }:: [Raveille](https://osu.ppy.sh/users/1388767), ::{ flag=US }:: [Sparky](https://osu.ppy.sh/users/3187959), ::{ flag=PH }:: [SurfChu85](https://osu.ppy.sh/users/4469895), ::{ flag=US }:: [Toaph Daddy](https://osu.ppy.sh/users/7616811) |
 | Statistician | **::{ flag=FI }:: [shdewz](https://osu.ppy.sh/users/10000899)**, ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) |
 
@@ -106,27 +106,49 @@ The osu!mania 7K World Cup 2024 is run by the osu! team and various community me
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2fdbd125eedb7bf268bd382dab1c05#file-mwc-7k-2024-player-list-csv).
 
-## Match schedule: Round of 24
+## Match schedule: Round of 16
 
-### Saturday, 20 January 2024
-
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Vietnam ::{ flag=VN }:: | ::{ flag=SE }:: Sweden | [Jan 20 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240120T150000&p1=1440&p2=95&p3=239) | [osulive](https://twitch.tv/osulive) |
-| Brazil ::{ flag=BR }:: | ::{ flag=PT }:: Portugal | [Jan 20 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240120T170000&p1=1440&p2=45&p3=133) | [osulive](https://twitch.tv/osulive) |
-
-### Sunday, 21 January 2024
+### Saturday, 27 January 2024
 
 | Team A | Team B | Match time | Twitch stream |
 | --: | :-- | :-- | :-: |
-| Netherlands ::{ flag=NL }:: | ::{ flag=TW }:: Taiwan | [Jan 21 (Sun) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T133000&p1=1440&p2=16&p3=241) | [osulive](https://twitch.tv/osulive) |
-| Indonesia ::{ flag=ID }:: | ::{ flag=FR }:: France | [Jan 21 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T140000&p1=1440&p2=108&p3=195) | [osulive](https://twitch.tv/osulive) |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=DK }:: Denmark | [Jan 21 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T150000&p1=1440&p2=166&p3=69) | [osulive](https://twitch.tv/osulive) |
-| United Kingdom ::{ flag=GB }:: | ::{ flag=DE }:: Germany | [Jan 21 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T160000&p1=1440&p2=136&p3=37) | [osulive](https://twitch.tv/osulive) |
-| Poland ::{ flag=PL }:: | ::{ flag=EE }:: Estonia | [Jan 21 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T170000&p1=1440&p2=262) | [osulive](https://twitch.tv/osulive) |
-| United States ::{ flag=US }:: | ::{ flag=ES }:: Spain | [Jan 21 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240121T180000&p1=1440&p2=263&p3=141) | [osulive](https://twitch.tv/osulive) |
+| South Korea ::{ flag=KR }:: | ::{ flag=TW }:: Taiwan | [Jan 27 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T110000&p1=1440&p2=235&p3=241) | [osulive](https://twitch.tv/osulive) |
+| Japan ::{ flag=JP }:: | ::{ flag=PL }:: Poland | [Jan 27 (Sat) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T120000&p1=1440&p2=248&p3=262) | [osulive](https://twitch.tv/osulive) |
+| Philippines ::{ flag=PH }:: | ::{ flag=VN }:: Vietnam | [Jan 27 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T130000&p1=1440&p2=145&p3=95) | [osulive](https://twitch.tv/osulive) |
+| Australia ::{ flag=AU }:: | ::{ flag=BR }:: Brazil | [Jan 27 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T140000&p1=1440&p2=57&p3=45) | [osulive](https://twitch.tv/osulive) |
+| Thailand ::{ flag=TH }:: | ::{ flag=RU }:: Russian Federation | [Jan 27 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T140000&p1=1440&p2=28&p3=166) | [osulive](https://twitch.tv/osulive) |
+| Canada ::{ flag=CA }:: | ::{ flag=US }:: United States | [Jan 27 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240127T180000&p1=1440&p2=188&p3=263) | [osulive](https://twitch.tv/osulive) |
+
+### Sunday, 28 January 2024
+
+| Team A | Team B | Match time | Twitch stream |
+| --: | :-- | :-- | :-: |
+| China ::{ flag=CN }:: | ::{ flag=DE }:: Germany | [Jan 28 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240128T120000&p1=1440&p2=33&p3=37) | [osulive](https://twitch.tv/osulive) |
+| Malaysia ::{ flag=MY }:: | ::{ flag=ID }:: Indonesia | [Jan 28 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240128T130000&p1=1440&p2=122&p3=108) | [osulive](https://twitch.tv/osulive) |
+| Quarterfinals | mappool showcase | [Jan 28 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240128T140000&p1=1440) | [osulive](https://twitch.tv/osulive) |
 
 ## Mappools
+
+### Round of 16
+
+**[Download the mappack here (62 MB, *temporary link*)](https://leoflt.com/s/JRWS)**
+
+- Rice
+  1. [goreshit - toromi hearts 2 (Sped Up Ver.) (Tailsdk) \[MWC RO16 Speed (Cut ver.)\]](https://osu.ppy.sh/beatmapsets/2123251#mania/4461979)
+  2. [skymuted & Evin a`k - Memory at Angels Landing (Level 51) \[Golden Age\]](https://osu.ppy.sh/beatmapsets/2123235#mania/4461947)
+  3. [Frums - Wavetapper (-NoName-) \[Sound Cubes\]](https://osu.ppy.sh/beatmapsets/2123274#mania/4462022)
+  4. [The Flashbulb - Ninedump (Maxus) \[Night Wonder\]](https://osu.ppy.sh/beatmapsets/2123256#mania/4461987)
+  5. [saaa + kei\_iwata + stuv + wakadori - New York Back Raise (pwhk) \[Full House\]](https://osu.ppy.sh/beatmapsets/2123108#mania/4461721)
+- Long Note
+  1. [KNOWER - More Than Just Another Try (-NoName-) \[Fugue\]](https://osu.ppy.sh/beatmapsets/2123273#mania/4462021)
+  2. [Y&Co. - POODLE (MapleSyrup-) \[So lovely and sweet pretty poodle\]](https://osu.ppy.sh/beatmapsets/2123243#mania/4461965)
+  3. [DAZBEE - Adios (Remuring) \[Fall in Love\]](https://osu.ppy.sh/beatmapsets/2123264#mania/4462004)
+- Hybrid
+  1. [Juggernaut. - Invoke (\_Stan) \[Summoning\] *(temporary link)*](https://leoflt.com/s/s3zX)
+  2. [Yamajet x Mentalstock - Sequential Emotions (Makiba) \[Sequentia motus\]](https://osu.ppy.sh/beatmapsets/2123268#mania/4462014)
+  3. [ZxNX - Fana (Wonki) \[Extra\]](https://osu.ppy.sh/beatmapsets/2123269#mania/4462015)
+- Tiebreaker
+  1. **[Kou! - subzerO (\_Stan) \[iceoveR\] *(temporary link)*](https://leoflt.com/s/kN4N)**
 
 ### Round of 24
 
@@ -163,6 +185,28 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 8. [Raimukun - Cthulhu (Leeju) \[Stage 8: Abyss\]](https://osu.ppy.sh/beatmapsets/2115980#mania/4443612)
 
 ## Match results
+
+### Round of 24
+
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1_xrYtyZ68mQpsfc7q9CVetV9E9BYxyj7Wg28w1d3esY?rm=minimal).
+
+Saturday, 20 January 2024:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **Vietnam** ::{ flag=VN }:: | **5** | 0 | ::{ flag=SE }:: Sweden | [#1](https://osu.ppy.sh/community/matches/112290919) | [#1](https://www.twitch.tv/videos/2038334661) |
+| **Brazil** ::{ flag=BR }:: | **5** | 1 | ::{ flag=PT }:: Portugal | [#1](https://osu.ppy.sh/community/matches/112292934) | [#1](https://www.twitch.tv/videos/2038432046) |
+
+Sunday, 21 January 2024:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| Netherlands ::{ flag=NL }:: | 4 | **5** | ::{ flag=TW }:: **Taiwan** | [#1](https://osu.ppy.sh/community/matches/112308440) | [#1](https://www.twitch.tv/videos/2039351530) |
+| **Indonesia** ::{ flag=ID }:: | **5** | 0 | ::{ flag=FR }:: France | [#1](https://osu.ppy.sh/community/matches/112308966) |  |
+| **Russian Federation** ::{ flag=RU }:: | **5** | 4 | ::{ flag=DK }:: Denmark | [#1](https://osu.ppy.sh/community/matches/112309921) | [#1](https://www.twitch.tv/videos/2039423606) |
+| United Kingdom ::{ flag=GB }:: | 0 | 0 | ::{ flag=DE }:: Germany | [#1](https://osu.ppy.sh/community/matches/112310876) | [#1](https://www.twitch.tv/videos/2039449910) |
+| **Poland** ::{ flag=PL }:: | **5** | 0 | ::{ flag=EE }:: Estonia | [#1](https://osu.ppy.sh/community/matches/112311940) | [#1](https://www.twitch.tv/videos/2039498579) |
+| **United States** ::{ flag=US }:: | **5** | 0 | ::{ flag=ES }:: Spain | [#1](https://osu.ppy.sh/community/matches/112312820) | [#1](https://www.twitch.tv/videos/2039582666) |
 
 ### Qualifiers
 
@@ -289,8 +333,9 @@ The final standings for the Qualifier stage can be found in the following [sprea
 ### Stage instructions
 
 1. Following the Qualifiers, a double-elimination bracket will be played — for teams in the winners bracket, the winning team continues in the same bracket, while the losing team gets moved to the losers bracket, where any further defeats will eliminate the team from the competition.
-2. Teams in the losers bracket must play up to 2 matches each weekend, starting from the Semifinals.
+2. Teams in the losers bracket must play up to 2 matches each weekend, starting from the Quarterfinals.
 3. The top 8 seeded teams from the Qualifiers get a bye for the Round of 24, and start playing on the Round of 16 instead.
+4. Teams that lose their Round of 24 match get a bye for the Round of 16, and start playing the Losers bracket from Quarterfinals onwards.
 
 ![](img/mwc7k2024-bracket.png)
 


### PR DESCRIPTION
Adds RO24 results/RO16 schedules and mappool. Also fixes a few typos on tables and adds additional information on the bracket stage format.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)