### PR TITLE
Update `MWC 7K 2024` with partial Semifinals results

### DIFF
--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -226,8 +226,6 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 
 ### Semifinals
 
-Detailed statistics for this round can be found [here]().
-
 Saturday, 10 February 2024:
 
 | Team A |  |  | Team B | Match link | VOD link |

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -108,30 +108,16 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 
 ## Match schedule: Semifinals
 
-### Saturday, 10 February 2024
-
-| Team A | Team B | Match time | Twitch stream |  |
-| --: | :-- | :-- | :-: | :-: |
-| Australia ::{ flag=AU }:: | ::{ flag=US }:: United States | [Feb 10 (Sat) 08:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T083000&p1=1440&p2=57&p3=263) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Japan ::{ flag=JP }:: | ::{ flag=RU }:: Russian Federation | [Feb 10 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T110000&p1=1440&p2=248&p3=166) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Thailand ::{ flag=TH }:: | ::{ flag=PL }:: Poland | [Feb 10 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T130000&p1=1440&p2=28&p3=262) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| China ::{ flag=CN }:: | ::{ flag=MY }:: Malaysia | [Feb 10 (Sat) 15:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T153000&p1=1440&p2=33&p3=122) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-
 ### Sunday, 11 February 2024
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
 | Canada ::{ flag=CA }:: | ::{ flag=BR }:: Brazil | [Feb 11 (Sun) 00:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T000000&p1=1440&p2=188&p3=45) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Japan ::{ flag=JP }:: | ::{ flag=US }:: United States | [Feb 11 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T040000&p1=1440&p2=248&p3=263) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Japan ::{ flag=JP }:: | ::{ flag=AU }:: Australia | [Feb 11 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T100000&p1=1440&p2=248&p3=57) | [osulive_2](https://twitch.tv/osulive_2) | [^potential-match] |
-| South Korea ::{ flag=KR }:: | ::{ flag=PH }:: Philippines | [Feb 11 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T100000&p1=1440&p2=235&p3=145) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=AU }:: Australia | [Feb 11 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T120000&p1=1440&p2=166&p3=57) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Japan ::{ flag=JP }:: | ::{ flag=AU }:: Australia | [Feb 11 (Sun) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T090000&p1=1440&p2=248&p3=57) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| South Korea ::{ flag=KR }:: | ::{ flag=PH }:: Philippines | [Feb 11 (Sun) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T103000&p1=1440&p2=235&p3=145) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
 | Thailand ::{ flag=TH }:: | ::{ flag=CA }:: Canada | [Feb 11 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T143000&p1=1440&p2=28&p3=188) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Poland ::{ flag=PL }:: | ::{ flag=CA }:: Canada | [Feb 11 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T143000&p1=1440&p2=262&p3=188) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
 | Thailand ::{ flag=TH }:: | ::{ flag=BR }:: Brazil | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=28&p3=45) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Poland ::{ flag=PL }:: | ::{ flag=BR }:: Brazil | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=262&p3=45) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=US }:: United States | [Feb 11 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T180000&p1=1440&p2=166&p3=263) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
-| Finals | mappool showcase | [Feb 11 (Sun) 19:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T190000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
+| Finals | mappool showcase | [Feb 11 (Sun) 15:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T153000&p1=1440) or [Feb 11 (Sun) 17:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T173000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
 
 ## Mappools
 
@@ -237,6 +223,19 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/fd2
 8. [Raimukun - Cthulhu (Leeju) \[Stage 8: Abyss\]](https://osu.ppy.sh/beatmapsets/2115980#mania/4443612)
 
 ## Match results
+
+### Semifinals
+
+Detailed statistics for this round can be found [here]().
+
+Saturday, 10 February 2024:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **Australia** ::{ flag=AU }:: | **6** | 1 | ::{ flag=US }:: United States | [#1](https://osu.ppy.sh/community/matches/112599980) | [#1](https://www.twitch.tv/videos/2058617517) |
+| **Japan** ::{ flag=JP }:: | **6** | 1 | ::{ flag=RU }:: Russian Federation | [#1](https://osu.ppy.sh/community/matches/112601240) | [#1](https://www.twitch.tv/videos/2058679149) |
+| **Thailand** ::{ flag=TH }:: | **6** | 0 | ::{ flag=PL }:: Poland | [#1](https://osu.ppy.sh/community/matches/112602618) | [#1](https://www.twitch.tv/videos/2058745265) |
+| China ::{ flag=CN }:: | 4 | **6** | ::{ flag=MY }:: **Malaysia** | [#1](https://osu.ppy.sh/community/matches/112604848) | [#1](https://www.twitch.tv/videos/2058868470) |
 
 ### Quarterfinals
 

--- a/wiki/Tournaments/MWC/2024_7K/ko.md
+++ b/wiki/Tournaments/MWC/2024_7K/ko.md
@@ -108,30 +108,16 @@ osu!mania 7키 월드컵 2024는 osu! 팀과 여러명의 커뮤니티 멤버들
 
 ## 매치 일정 : 세미파이널
 
-### 2024년 2월 10일 토요일
-
-| Team A | Team B | 경기 시간 | 트위치 방송 |  |
-| --: | :-- | :-- | :-: | :-: |
-| 오스트레일리아 ::{ flag=AU }:: | ::{ flag=US }:: 미국 | [Feb 10 (Sat) 02:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T020000&p1=1440&p2=57&p3=263) | *TBD* | [^losers-bracket] |
-| 일본 ::{ flag=JP }:: | ::{ flag=RU }:: 러시아 | [Feb 10 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T110000&p1=1440&p2=248&p3=166) | *TBD* | [^losers-bracket] |
-| 태국 ::{ flag=TH }:: | ::{ flag=PL }:: 폴란드 | [Feb 10 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T130000&p1=1440&p2=28&p3=262) | *TBD* | [^losers-bracket] |
-| 캐나다 ::{ flag=CA }:: | ::{ flag=BR }:: 브라질 | [Feb 10 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240210T180000&p1=1440&p2=188&p3=45) | *TBD* | [^losers-bracket] |
-
 ### 2024년 2월 11일 일요일
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
-| South Korea ::{ flag=KR }:: | ::{ flag=PH }:: Philippines | [Feb 11 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T100000&p1=1440&p2=235&p3=145) | *TBD* | [^winners-bracket] |
-| 일본 ::{ flag=JP }:: | ::{ flag=AU }:: 오스트레일리아 | [Feb 11 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T120000&p1=1440&p2=248&p3=57) | *TBD* | [^potential-match] |
-| 러시아 ::{ flag=RU }:: | ::{ flag=AU }:: 오스트레일리아 | [Feb 11 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T120000&p1=1440&p2=166&p3=57) | *TBD* | [^potential-match] |
-| China ::{ flag=CN }:: | ::{ flag=MY }:: Malaysia | [Feb 11 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T130000&p1=1440&p2=33&p3=122) | *TBD* | [^winners-bracket] |
-| 일본 ::{ flag=JP }:: | ::{ flag=US }:: 미국 | [Feb 11 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T150000&p1=1440&p2=248&p3=263) | *TBD* | [^potential-match] |
-| 러시아 ::{ flag=RU }:: | ::{ flag=US }:: 미국 | [Feb 11 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T150000&p1=1440&p2=166&p3=263) | *TBD* | [^potential-match] |
-| 태국 ::{ flag=TH }:: | ::{ flag=CA }:: 캐나다 | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=28&p3=188) | *TBD* | [^potential-match] |
-| 태국 ::{ flag=TH }:: | ::{ flag=BR }:: 브라질 | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=28&p3=45) | *TBD* | [^potential-match] |
-| 폴란드 ::{ flag=PL }:: | ::{ flag=CA }:: 캐나다 | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=262&p3=188) | *TBD* | [^potential-match] |
-| 폴란드 ::{ flag=PL }:: | ::{ flag=BR }:: 브라질 | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=262&p3=45) | *TBD* | [^potential-match] |
-| 파이널 | 맵풀 쇼케이스 | [Feb 11 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T170000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
+| 캐나다 ::{ flag=CA }:: | ::{ flag=BR }:: 브라질 | [Feb 11 (Sun) 00:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T000000&p1=1440&p2=188&p3=45) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| 일본 ::{ flag=JP }:: | ::{ flag=AU }:: 오스트레일리아 | [Feb 11 (Sun) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T090000&p1=1440&p2=248&p3=57) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| 대한민국 ::{ flag=KR }:: | ::{ flag=PH }:: 필리핀 | [Feb 11 (Sun) 10:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T103000&p1=1440&p2=235&p3=145) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| 태국 ::{ flag=TH }:: | ::{ flag=CA }:: 캐나다 | [Feb 11 (Sun) 14:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T143000&p1=1440&p2=28&p3=188) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| 태국 ::{ flag=TH }:: | ::{ flag=BR }:: 브라질 | [Feb 11 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T160000&p1=1440&p2=28&p3=45) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| 파이널 | 맵풀 쇼케이스 | [Feb 11 (Sun) 15:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T153000&p1=1440) 이나 [Feb 11 (Sun) 17:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240211T173000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
 
 ## 맵풀 목록
 
@@ -237,6 +223,17 @@ osu!mania 7키 월드컵 2024는 osu! 팀과 여러명의 커뮤니티 멤버들
 8. [Raimukun - Cthulhu (Leeju) \[Stage 8: Abyss\]](https://osu.ppy.sh/beatmapsets/2115980#mania/4443612)
 
 ## 경기 결과
+
+### 세미파이널
+
+2024년 2월 10일 토요일:
+
+| Team A |  |  | Team B | 경기 링크 | VOD 링크 |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **오스트레일리아** ::{ flag=AU }:: | **6** | 1 | ::{ flag=US }:: 미국 | [#1](https://osu.ppy.sh/community/matches/112599980) | [#1](https://www.twitch.tv/videos/2058617517) |
+| **일본** ::{ flag=JP }:: | **6** | 1 | ::{ flag=RU }:: 러시아 | [#1](https://osu.ppy.sh/community/matches/112601240) | [#1](https://www.twitch.tv/videos/2058679149) |
+| **태국** ::{ flag=TH }:: | **6** | 0 | ::{ flag=PL }:: 폴란드 | [#1](https://osu.ppy.sh/community/matches/112602618) | [#1](https://www.twitch.tv/videos/2058745265) |
+| 중국 ::{ flag=CN }:: | 4 | **6** | ::{ flag=MY }:: **말레이시아** | [#1](https://osu.ppy.sh/community/matches/112604848) | [#1](https://www.twitch.tv/videos/2058868470) |
 
 ### 쿼터파이널
 


### PR DESCRIPTION
Also updates the schedule for tomorrow

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~ (unnecessary, as translations follow the existing template)
