### PR TITLE
Fix typo in several articles ("alloted" -> "allotted")

### DIFF
--- a/wiki/Tournaments/4DM/2024/en.md
+++ b/wiki/Tournaments/4DM/2024/en.md
@@ -185,7 +185,7 @@ The 4 Digit osu!mania World Cup 2024 is run by various community members.
    4. The roll **winner bans** one Free Mod map.
    5. The roll **winner picks** one Free Mod map.
 5. Once a team reaches half the required points to win the match (rounded up), the opposing team must ban another map from the pool.
-6. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+6. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
    - On subsequent occurrences:

--- a/wiki/Tournaments/CWC/1/en.md
+++ b/wiki/Tournaments/CWC/1/en.md
@@ -73,7 +73,7 @@ The Catch the Beat World Cup was run by various osu!catch community members.
 ## Groups
 
 | Group | Seed 1 | Seed 2 | Seed 3 | Seed 4 | Seed 5 |
-| :--  | :--  | :-- | :-- | :-- | :-- |
+| :-- | :-- | :-- | :-- | :-- | :-- |
 | A | The Hidden Ones | Viciados em Crack | Champion The Beat | Indonesia | Lone wolfs |
 | B | State(s) of the Art | CFC | Hungary CTB | #filipino | Old School |
 | C | Team Nub | half manual player team | Red Fury | German Hentai's | Indonesia II |

--- a/wiki/Tournaments/CWC/1/en.md
+++ b/wiki/Tournaments/CWC/1/en.md
@@ -430,7 +430,7 @@ Time Zone: (...)
 1. In the Group Stage, the teams will be divided into four groups of five teams each.
 2. All the teams from each group will face each other over the course of five weeks.
    - Due to the odd number of teams in each group, all teams **will only be playing on four matchweeks** instead of on all five by default. Team captains are expected to be aware of the schedules announced by the Tournament Management.
-3. Depending on the outcome of a Group Stage match, each team will be alloted Group Stage points to their name as follows:
+3. Depending on the outcome of a Group Stage match, each team will be allotted Group Stage points to their name as follows:
    - Winning a match gives the team +3 Group Stage points.
    - Losing a match gives the team +1 Group Stage point.
    - Forfeiting a match, either by disqualification or by a Lost by Default, penalizes the team by -3 Group Stage points.

--- a/wiki/Tournaments/CWC/2023/en.md
+++ b/wiki/Tournaments/CWC/2023/en.md
@@ -594,7 +594,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
    - The winner of the `!roll` may choose to either pick first and ban second, or pick second and ban first.
    - The loser of the `!roll` will follow the remaining pick order.
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
    - On subsequent occurrences:

--- a/wiki/Tournaments/HOT/1/en.md
+++ b/wiki/Tournaments/HOT/1/en.md
@@ -508,7 +508,7 @@ Monday, 25 May 2020:
 ### Qualifiers rules
 
 1. The match lobby will be created by the referee. Team captains will receive invites; if the team captain is not available, then the referee will invite any player that is online. The invited player has the responsibility to invite their team into the lobby.
-2. Teams have **10 minutes** past the start time to join the lobby. If teams fail to join within the alloted time, the captain is responsible to reschedule their team to another lobby.
+2. Teams have **10 minutes** past the start time to join the lobby. If teams fail to join within the allotted time, the captain is responsible to reschedule their team to another lobby.
 3. The maps will be played in the order as they are listed on the sheet **twice**. The team's best attempt on each map will be taken.
 4. In the event of any disconnection, the player(s) who disconnect will be allowed to replay the map after the lobby by themselves.
 5. 2 players from each team must be present on each map, and teams are free to switch in or out players between maps. Teams may play with different players on the second attempt of the map.
@@ -521,7 +521,7 @@ Monday, 25 May 2020:
 1. The match lobby will be created by the referee. Team captains will receive invites; if the team captain is not available, then the referee will invite any player that is online. The invited player has the responsibility to invite their team into the lobby.
 2. Once all players have joined, captain will be asked to `!roll`. The winner of the `!roll` may elect to pick first of pick second. Warmups are allowed, up to a maximum of **4:30** total time (it can be longer if everyone in the lobby agrees with it). It doesn't really matter who picks the warmups first.
 3. Once warmups are over, the captain on both players' teams will `!roll` for pick and ban order. The higher `!roll` will **ban second and pick first**.
-4. Teams have 90 seconds to select a map; if they fail to choose in the alloted time, the map choice will pass to the other team. This will have no effect on the order of picks afterward. The same condition applies for bans.
+4. Teams have 90 seconds to select a map; if they fail to choose in the allotted time, the map choice will pass to the other team. This will have no effect on the order of picks afterward. The same condition applies for bans.
 5. Once the map choice is locked in, playes will have 90 seconds to ready up. The referee will start the match when all players are ready. If the 90 seconds timer ends, the referee will force an `!mp start 15` command, and the match will start with whoever is in the lobby.
 6. NoFail mod will be enforced on all maps, to prevent teamfails from happening.
 7. In the case of a Tiebreaker, both player will `!roll`. The higher `!roll` will get the first ban, while the lower `!roll` bans the seconds Tiebreaker. The teams will play the last remaining Tiebreaker.

--- a/wiki/Tournaments/MCNC/4K2022/en.md
+++ b/wiki/Tournaments/MCNC/4K2022/en.md
@@ -605,7 +605,7 @@ The final standings for the Qualifiers can be found at the following [spreadshee
 4. Each player must use !roll once in #multiplayer.
    - The winner of the !roll starts picking the first beatmap of the match.
    - The loser of the !roll starts banning one beatmap, followed by the winner of the !roll to ban a beatmap.
-5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than alloted, for the second occurrence: a random map will be chosen from the mappool using !roll X, where X is the number of maps that were neither picked nor banned, excluding the Tiebreaker. Repeat offenders may receive further sanctions from the Tournament Management.
+5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than allotted, for the second occurrence: a random map will be chosen from the mappool using !roll X, where X is the number of maps that were neither picked nor banned, excluding the Tiebreaker. Repeat offenders may receive further sanctions from the Tournament Management.
 6. Players will be given at most 3-minute pause for solving unexpected situations.
 7. Results of the Qualifiers Stage will be published via a Statistics sheet.
 

--- a/wiki/Tournaments/MCNC/7K2022/en.md
+++ b/wiki/Tournaments/MCNC/7K2022/en.md
@@ -326,7 +326,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
 4. Each player must use `!roll` once in `#multiplayer`.
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
-5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than alloted more than once, a random map will be chosen from the mappool using `!roll` with the number of maps that were neither picked nor banned, excluding the tiebreaker. Repeat offenders may receive further sanctions from the Tournament Management.
+5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than allotted more than once, a random map will be chosen from the mappool using `!roll` with the number of maps that were neither picked nor banned, excluding the tiebreaker. Repeat offenders may receive further sanctions from the Tournament Management.
 6. Players will be given at most a 3-minute timeout for solving unexpected situations.
 7. Qualifier results will be published via a statistics sheet.
 

--- a/wiki/Tournaments/MCNC/7K2023/en.md
+++ b/wiki/Tournaments/MCNC/7K2023/en.md
@@ -512,7 +512,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
 4. Each player must use `!roll` once in `#multiplayer`.
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
-5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than alloted more than once, a random map will be chosen from the mappool using `!roll` with the number of maps that were neither picked nor banned, excluding the tiebreaker. Repeat offenders may receive further sanctions from the tournament management.
+5. Players will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a player takes more time than allotted more than once, a random map will be chosen from the mappool using `!roll` with the number of maps that were neither picked nor banned, excluding the tiebreaker. Repeat offenders may receive further sanctions from the tournament management.
 6. Players will be given at most a 3-minute timeout for solving unexpected situations.
 7. Qualifier results will be published via a statistics sheet.
 

--- a/wiki/Tournaments/MWC/2021_4K/en.md
+++ b/wiki/Tournaments/MWC/2021_4K/en.md
@@ -475,7 +475,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
 4. Each captain must use `!roll` once in `#multiplayer`.
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
-5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than alloted, the procedures adopted will be as follows:
+5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than allotted, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/MWC/2022_7K/en.md
+++ b/wiki/Tournaments/MWC/2022_7K/en.md
@@ -443,7 +443,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 4. Each captain must use `!roll` once in `#multiplayer`.
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the  `!roll` to ban a beatmap.
-5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than alloted, the procedures adopted will be as follows:
+5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than allotted, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/MWC/2023_4K/en.md
+++ b/wiki/Tournaments/MWC/2023_4K/en.md
@@ -586,7 +586,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
    2. The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
    3. The winner of the `!roll` starts picking the first beatmap of the match.
 3. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
      - If the team does not pick a map within 15 seconds from when the timer expires, the referee will apply the procedure for subsequent occurrences listed below, i.e. a random pick will be used for a pick timer, and the match will be forcefully started for a ready timer.

--- a/wiki/Tournaments/MWC/2023_7K/en.md
+++ b/wiki/Tournaments/MWC/2023_7K/en.md
@@ -478,7 +478,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the  `!roll` to ban a beatmap.
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/MWC/2024_7K/en.md
+++ b/wiki/Tournaments/MWC/2024_7K/en.md
@@ -545,7 +545,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
    2. The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
    3. The winner of the `!roll` starts picking the first beatmap of the match.
 3. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
      - If the team does not pick a map within 15 seconds from when the timer expires, the referee will apply the procedure for subsequent occurrences listed below, i.e. a random pick will be used for a pick timer, and the match will be forcefully started for a ready timer.

--- a/wiki/Tournaments/OWC/2021/en.md
+++ b/wiki/Tournaments/OWC/2021/en.md
@@ -569,7 +569,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
    - The captain with the higher roll decides which team **picks** first.
    - The captain with the lower roll decides which team **bans** first.
    - **From Quarterfinals onwards, the team that bans first will ban one map, then the other team will ban two maps, then finally the first team will make their final ban.**
-5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than alloted, the procedures adopted will be as follows:
+5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than allotted, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/OWC/2022/en.md
+++ b/wiki/Tournaments/OWC/2022/en.md
@@ -639,7 +639,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
    - The loser of the `!roll` decides which team **bans** first.
    - **From Quarterfinals onwards, the first team will ban one beatmap, followed by two bans from second team, finishing with one ban from the first team.**
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/OWC/2023/en.md
+++ b/wiki/Tournaments/OWC/2023/en.md
@@ -656,7 +656,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
    - The loser of the `!roll` decides which team **bans** first.
    - **From Quarterfinals onwards, the first team will ban one beatmap, followed by two bans from second team, finishing with one ban from the first team.**
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
      - If the team does not pick a map within 15 seconds from when the timer expires, the referee will apply the procedure for subsequent occurrences listed below, i.e. a random pick will be used for a pick timer, and the match will be forcefully started for a ready timer.

--- a/wiki/Tournaments/TMC/2nd/en.md
+++ b/wiki/Tournaments/TMC/2nd/en.md
@@ -507,7 +507,7 @@ The ruleset is mainly based on [osu!mania 4K World Cup 2021](/wiki/Tournaments/M
 4. Each captain must use `!roll` once in `#multiplayer`.
    - The winner of the `!roll` will select which team will pick first.
    - The loser of the `!roll` will select which team will ban first.
-5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than alloted, the procedure adopted will be as follows:
+5. Teams will have 2 minutes to pick a beatmap and 2 minutes to get ready. If a team takes more time than allotted, the procedure adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/TWC/2023/en.md
+++ b/wiki/Tournaments/TWC/2023/en.md
@@ -578,7 +578,7 @@ The final standings for the Qualifier stage can be found at the following [sprea
    - The winner of the `!roll` starts picking the first beatmap of the match.
    - The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -154,7 +154,7 @@ The osu!taiko World Cup 2024 is run by various community members.
    1. The loser of the `!roll` starts banning one beatmap, followed by the winner of the `!roll` to ban a beatmap.
    2. The winner of the `!roll` starts picking the first beatmap of the match.
 3. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+4. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee; in addition, the referee may opt to forcefully use the team's tactical timeout to allow for the team to pick.
      - If the team does not pick a map within 15 seconds from when the timer expires, the referee will apply the procedure for subsequent occurrences listed below, i.e. a random pick will be used for a pick timer, and the match will be forcefully started for a ready timer.

--- a/wiki/Tournaments/YHC/2/en.md
+++ b/wiki/Tournaments/YHC/2/en.md
@@ -283,7 +283,7 @@ This competition has come to an end and resulted in the following podium:
    - Teams may "double pick" (i.e. pick two or more maps from the same mod pool in sequence) without limitations.
    - The loser of the `!roll` 's ban/pick depends on the winner of the `!roll`.
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee
    - On subsequent occurrences:

--- a/wiki/Tournaments/YHC/3/en.md
+++ b/wiki/Tournaments/YHC/3/en.md
@@ -285,7 +285,7 @@ This competition has come to an end and resulted in the following podium:
    - Teams may "double pick" (i.e. pick two or more maps from the same mod pool in sequence) without limitations.
    - The loser of the `!roll` 's ban/pick depends on the winner of the `!roll`.
 4. After bans are decided, both teams will take turns in picking a beatmap from the mappool.
-5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than alloted for either action, the procedures adopted will be as follows:
+5. Teams will be allowed 2 minutes to pick a beatmap and 2 minutes to press the `Ready` button on their client. If a team takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:
      - The team will receive a verbal warning from the referee.
    - On subsequent occurrences:


### PR DESCRIPTION
fixed all of them

- TicClick: `SKIP_OUTDATED_CHECK` for good measure