### PR TITLE
Fix typo in `Rules/Visual content considerations`

### DIFF
--- a/wiki/Rules/Visual_content_considerations/en.md
+++ b/wiki/Rules/Visual_content_considerations/en.md
@@ -36,7 +36,7 @@ Images or visual elements containing any of the following are **not allowed**:
 - **depictions of deliberately inflammatory political, cultural, religious, or social content**
 - **imagery depicting suicidal or self-harming behaviour, including preparation or imminent attempts**
 
-In addition, images or visual elements that could be reasonably appraised as being of poor quality (in either objective image quality or subjective composition/creation) may also be prevented from being used in a beatmaps in cases where they are not directly related to any relevant subject matter.
+In addition, images or visual elements that could be reasonably appraised as being of poor quality (in either objective image quality or subjective composition/creation) may also be prevented from being used in a beatmap in cases where they are not directly related to any relevant subject matter.
 
 ## Exceptions
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->
Article uses plural "beatmaps" when singular "beatmap" is correct.
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

`SKIP_OUTDATED_CHECK`