### PR TITLE
Update `TWC 2024` rules, links

### DIFF
--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -52,6 +52,7 @@ The osu!taiko World Cup 2024 is run by various community members.
 
 ## Links
 
+- [Information spreadsheet](https://docs.google.com/spreadsheets/d/1qGOprVVOTXTBGw2xwDhvTxjpp92SEA1NkQIBJ1gI9xY?rm=minimal)
 - [Discussion thread](https://osu.ppy.sh/community/forums/topics/1884428)
 - [Livestream](https://www.twitch.tv/osulive)
 - [Tournament listing](https://osu.ppy.sh/community/tournaments/43)

--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -233,7 +233,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/253
    - Hidden + Hard Rock
 8. Failed scores will be counted. To that end, the [No Fail](/wiki/Gameplay/Game_modifier/No_Fail) mod will be enforced on every beatmap.
    - Teams that purposefully disregard this instruction and team fail as a result will lose said game.
-9. The tiebreaker will be played under Free Mod conditions, but players will be exempt from the mod requirement.
+9. The tiebreaker will be played under Free Mod conditions.
 
 ### Scheduling instructions
 


### PR DESCRIPTION
Adds a link to the information spreadsheet. Updates the 9th match rule to reflect the correct mod requirements for tie breaker maps

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
