### PR TITLE
update-discord-invite

### DIFF
--- a/news/2024/2024-03-05-community-mentorship-program-spring-2024-signups-now-open.md
+++ b/news/2024/2024-03-05-community-mentorship-program-spring-2024-signups-now-open.md
@@ -10,7 +10,7 @@ The 26th cycle of the Community Mentorship program is on its way! Get ready to d
 
 The Community Mentorship program serves as a place for upcoming mappers, modders, and storyboarders to develop their skills under the guidance of more experienced members in the community. If you've ever found yourself wanting to expand your current knowledge, this might just be the opportunity you need.
 
-Over the course of a cycle, you'll have the opportunity to learn from your mentor, participate in various mentorship events (like contests), hang out with fellow mentees, and more! Even guests can take part in the learning process. [Our Discord server](https://discord.gg/EvHqwvD) has feedback and question channels dedicated to helping newcomers to our community.
+Over the course of a cycle, you'll have the opportunity to learn from your mentor, participate in various mentorship events (like contests), hang out with fellow mentees, and more! Even guests can take part in the learning process. [Our Discord server](https://discord.gg/Ft2FtXmBgx) has feedback and question channels dedicated to helping newcomers to our community.
 
 If you're experienced in mapping, modding, or storyboarding, and have a desire to take those who are new under your wing, then consider joining us as a mentor! In the [forum announcement and rule thread](https://osu.ppy.sh/community/forums/topics/1892036?n=1), you'll be able to apply right away. If you're only just getting started and are eager to hone your skills, then signing up as a mentee might be what you need!
 
@@ -26,7 +26,7 @@ Throughout this cycle, the organisation team will host various events on the Men
 
 If you or a friend are curious about the rules and which mentors you can apply for, please go to our [forum announcement and rules thread](https://osu.ppy.sh/community/forums/topics/1892036?n=1) for more information.
 
-Otherwise: [join our Discord server!](https://discord.gg/EvHqwvD)
+Otherwise: [join our Discord server!](https://discord.gg/Ft2FtXmBgx)
 
 We're looking forward to the mappers, modders and storyboarders of tomorrow!
 


### PR DESCRIPTION
The old invite link expired because we deleted a very old "verify"-type channel which had just been sitting there since 2017, which in turn deleted the invite....

