### PR TITLE
Fix wrong hyperlink in `Project Loved: March 2024`

### DIFF
--- a/news/2024/2024-03-17-project-loved-march-2024.md
+++ b/news/2024/2024-03-17-project-loved-march-2024.md
@@ -220,7 +220,7 @@ The osu!taiko Loved candidates were chosen by [aceticke](https://osu.ppy.sh/user
 🎶But not enough stamina🎶\
 🎶Do you have all of these skills for an FC\~?🎶
 
-Some of you may recognize this map from the [SGTS 2023](https://osu.ppy.sh/community/forums/topics/1471608?n=1) Grand Finals pool, and for those who don't, what are you waiting for?!
+Some of you may recognize this map from the [SGTS 2023](https://osu.ppy.sh/community/forums/topics/1703263?n=1) Grand Finals pool, and for those who don't, what are you waiting for?!
 
 If you like high SV, low SV, tech or speed, make sure to give to map a try. I'm sure you will at least enjoy one of the sections if you said yes to any of these!
 


### PR DESCRIPTION
The current one links to the 2021 version of the tournament. This change links it to the 2023 version of the tournament.

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
