### PR TITLE
Update `TWC 2024` with partial RO16 results

### DIFF
--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -110,19 +110,6 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/253
 
 ## Match Schedule: Round of 16
 
-### Saturday, 30 March 2024
-
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Japan ::{ flag=JP }:: | ::{ flag=PH }:: Philippines | [Mar 30 (Sat) 06:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T060000&p1=1440&p2=248&p3=145) | [osulive](https://twitch.tv/osulive) |
-| Denmark ::{ flag=DK }:: | ::{ flag=AU }:: Australia | [Mar 30 (Sat) 11:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T110000&p1=1440&p2=69&p3=57) | [osulive](https://twitch.tv/osulive) |
-| Brazil ::{ flag=BR }:: | ::{ flag=FI }:: Finland | [Mar 30 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T140000&p1=1440&p2=45&p3=101) | [osulive](https://twitch.tv/osulive) |
-| Hong Kong ::{ flag=HK }:: | ::{ flag=TH }:: Thailand | [Mar 30 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T150000&p1=1440&p2=102&p3=28) | [osulive](https://twitch.tv/osulive) |
-| Italy ::{ flag=IT }:: | ::{ flag=DE }:: Germany | [Mar 30 (Sat) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T160000&p1=1440&p2=215&p3=37) | [osulive](https://twitch.tv/osulive) |
-| Peru ::{ flag=PE }:: | ::{ flag=PL }:: Poland | [Mar 30 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T170000&p1=1440&p2=131&p3=262) | [osulive](https://twitch.tv/osulive) |
-| Czechia ::{ flag=CZ }:: | ::{ flag=RU }:: Russian Federation | [Mar 30 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T180000&p1=1440&p2=204&p3=166) | [osulive](https://twitch.tv/osulive) |
-| Chile ::{ flag=CL }:: | ::{ flag=CA }:: Canada | [Mar 30 (Sat) 23:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20240330T230000&p1=1440&p2=232&p3=188) | [osulive](https://twitch.tv/osulive) |
-
 ### Sunday, 31 March 2024
 
 | Team A | Team B | Match time | Twitch stream |

--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -211,6 +211,21 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/253
 
 ## Match results
 
+### Round of 16
+
+Saturday, 30 March 2024:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **Japan** ::{ flag=JP }:: | **5** | 0 | ::{ flag=PH }:: Philippines | [#1](https://osu.ppy.sh/community/matches/113289025) | [#1](https://www.twitch.tv/videos/2105887871) |
+| Denmark ::{ flag=DK }:: | 0 | **5** | ::{ flag=AU }:: **Australia** | [#1](https://osu.ppy.sh/community/matches/113291144) | [#1](https://www.twitch.tv/videos/2105889387) |
+| **Brazil** ::{ flag=BR }:: | **5** | 0 | ::{ flag=FI }:: Finland | [#1](https://osu.ppy.sh/community/matches/113293395) | [#1](https://www.twitch.tv/videos/2105891423) |
+| Hong Kong ::{ flag=HK }:: | 0 | **5** | ::{ flag=TH }:: **Thailand** | [#1](https://osu.ppy.sh/community/matches/113294179) | [#1](https://www.twitch.tv/videos/2105925815) |
+| Italy ::{ flag=IT }:: | 0 | **5** | ::{ flag=DE }:: **Germany** | [#1](https://osu.ppy.sh/community/matches/113295134) | [#1](https://www.twitch.tv/videos/2105968607) |
+| Peru ::{ flag=PE }:: | 0 | **5** | ::{ flag=PL }:: **Poland** | [#1](https://osu.ppy.sh/community/matches/113296025) | [#1](https://www.twitch.tv/videos/2106021865) |
+| Czechia ::{ flag=CZ }:: | 0 | **5** | ::{ flag=RU }:: **Russian Federation** | [#1](https://osu.ppy.sh/community/matches/113296934) | [#1](https://www.twitch.tv/videos/2106075246) |
+| **Chile** ::{ flag=CL }:: | **5** | 1 | ::{ flag=CA }:: Canada | [#1](https://osu.ppy.sh/community/matches/113301124) | [#1](https://www.twitch.tv/videos/2106335145) |
+
 ### Round of 32
 
 Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1Ik9AOAkdUBKwGi6qYNsAIwhlYG1vVKjP6SXH67in6pk?rm=minimal).


### PR DESCRIPTION
Adds results from this saturday/removes past matches from the RO16 schedule table.
