### PR TITLE
Fix wrong link in the `Vocaloid Mapping Contest 2 Results` news post

### DIFF
--- a/news/2024/2024-04-07-vocaloid-mapping-contest-2-results.md
+++ b/news/2024/2024-04-07-vocaloid-mapping-contest-2-results.md
@@ -32,7 +32,7 @@ This contest's submissions were immediately sent to the eyes of our discerning [
 | 2nd | [yaspo](https://osu.ppy.sh/users/4945926) | [14](https://osu.ppy.sh/beatmapsets/2163127#osu/4561861) | - |
 | 3rd | [Meijiro McQueen](https://osu.ppy.sh/users/11555612) | [Devolution](https://osu.ppy.sh/beatmapsets/2163129#osu/4561870) | - |
 | 4th | [celerih](https://osu.ppy.sh/users/4696296) | [Devolution](https://osu.ppy.sh/beatmapsets/2163113#osu/4561840) | - |
-| 5th | [Nijika Ijichi](https://osu.ppy.sh/users/10964252) | [The Cuckoo Bird's Beautiful Youth](https://osu.ppy.sh/beatmapsets/2163129#osu/4561870) | - |
+| 5th | [Nijika Ijichi](https://osu.ppy.sh/users/10964252) | [The Cuckoo Bird's Beautiful Youth](https://osu.ppy.sh/beatmapsets/2163241#osu/4562137) | - |
 
 #### Commentary
 


### PR DESCRIPTION
- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)