### PR TITLE
Split artist permissions table based on status in `Content usage permissions`

### DIFF
--- a/wiki/Rules/Content_usage_permissions/de.md
+++ b/wiki/Rules/Content_usage_permissions/de.md
@@ -34,388 +34,395 @@ Dieser Abschnitt beschreibt, welche Künstler die Nutzung ihrer Songs in osu! er
 
 Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps/artists)-Seite stehen, sind für die Verwendung in osu!-Beatmaps freigegeben. Songs von einem Featured Artist, die nicht auf seiner Seite erscheinen, sind *nicht* lizenziert und erfordern für die Nutzung möglicherweise zusätzliche Genehmigungen.
 
+#### Erlaubt
+
+| Künstler |  | Status |
+| :-- | :-- | :-- |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |
+
+#### Erlaubt, mit Ausnahmen
+
 | Künstler |  | Status | Bemerkungen |
 | :-- | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
 |  | a\_hisa | ![][partial] | Vor dem Hochladen kontaktieren. Kann über [E-Mail](mailto:hisaweb_info@yahoo.co.jp) oder [Bandcamp](https://a-hisa.bandcamp.com/) erreicht werden. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
@@ -424,16 +431,21 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Songs aus oder rund um *Touhou* sollten nicht hochgeladen oder genutzt werden. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
-|  | 40mP | ![][false] |  |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |  |
-|  | Enter Shikari | ![][false] |  |
-|  | EZFG | ![][false] |  |
-|  | Hatsuki Yura | ![][false] |  |
-|  | Igorrr | ![][false] |  |
-|  | kamome sano | ![][false] |  |
-|  | Kozato | ![][false] |  |
-|  | NOMA | ![][false] |  |
+
+#### Untersagt
+
+| Künstler | Status |
+| :-- | :-- |
+| 40mP | ![][false] |
+| ak+q | ![][false] |
+| Draw the Emotional | ![][false] |
+| Enter Shikari | ![][false] |
+| EZFG | ![][false] |
+| Hatsuki Yura | ![][false] |
+| Igorrr | ![][false] |
+| kamome sano | ![][false] |
+| Kozato | ![][false] |
+| NOMA | ![][false] |
 
 ## Visuell
 

--- a/wiki/Rules/Content_usage_permissions/de.md
+++ b/wiki/Rules/Content_usage_permissions/de.md
@@ -438,6 +438,7 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | :-- | :-- |
 | 40mP | ![][false] |
 | ak+q | ![][false] |
+| DJMax (Neowiz) | ![][false] |
 | Draw the Emotional | ![][false] |
 | Enter Shikari | ![][false] |
 | EZFG | ![][false] |

--- a/wiki/Rules/Content_usage_permissions/de.md
+++ b/wiki/Rules/Content_usage_permissions/de.md
@@ -41,11 +41,9 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-|  | 40mP | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-|  | a\_hisa | ![][partial] | Vor dem Hochladen kontaktieren. Kann über [E-Mail](mailto:hisaweb_info@yahoo.co.jp) oder [Bandcamp](https://a-hisa.bandcamp.com/) erreicht werden. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
@@ -61,8 +59,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-|  | ak+q | ![][false] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
@@ -128,7 +124,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-|  | Draw the Emotional | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
@@ -138,14 +133,12 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-|  | Enter Shikari | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-|  | EZFG | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
@@ -176,21 +169,18 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-|  | Hatsuki Yura | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-|  | Igorrr | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
@@ -202,11 +192,9 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-|  | kamome sano | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
@@ -227,7 +215,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-|  | Kozato | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
@@ -275,7 +262,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
@@ -300,7 +286,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-|  | NOMA | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
@@ -379,7 +364,6 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
@@ -428,12 +412,28 @@ Alle Songs, die auf der jeweiligen [Featured-Artist](https://osu.ppy.sh/beatmaps
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Songs aus oder rund um *Touhou* sollten nicht hochgeladen oder genutzt werden. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
+|  | a\_hisa | ![][partial] | Vor dem Hochladen kontaktieren. Kann über [E-Mail](mailto:hisaweb_info@yahoo.co.jp) oder [Bandcamp](https://a-hisa.bandcamp.com/) erreicht werden. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Songs aus oder rund um *Touhou* sollten nicht hochgeladen oder genutzt werden. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Verwende oder lade keine Songs hoch, die nicht auf der "Featured Artist"-Seite des Künstlers verfügbar sind. |
+|  | 40mP | ![][false] |  |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |  |
+|  | Enter Shikari | ![][false] |  |
+|  | EZFG | ![][false] |  |
+|  | Hatsuki Yura | ![][false] |  |
+|  | Igorrr | ![][false] |  |
+|  | kamome sano | ![][false] |  |
+|  | Kozato | ![][false] |  |
+|  | NOMA | ![][false] |  |
 
 ## Visuell
 

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -36,416 +36,416 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 
 #### Allowed
 
-| Artist |  | Notes |
+| Artist |  | Status |
 | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | [^monstercat-gold] |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |
 
 #### Allowed, with exceptions
 
-| Artist |  | Notes |
-| :-- | :-- | :-- |
-|  | a\_hisa | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | Tracks from or themed around *Touhou* should not be uploaded or used. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| Artist |  | Status | Notes |
+| :-- | :-- | :-- | :-- |
+|  | a\_hisa | ![][partial] | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Tracks from or themed around *Touhou* should not be uploaded or used. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 
 #### Disallowed
 
-| Artist |  | Notes |
+| Artist |  | Status |
 | :-- | :-- | :-- |
-|  | 40mP |  |
-|  | ak+q |  |
-|  | Draw the Emotional |  |
-|  | Enter Shikari |  |
-|  | EZFG |  |
-|  | Hatsuki Yura |  |
-|  | Igorrr |  |
-|  | kamome sano |  |
-|  | Kozato |  |
-|  | NOMA |  |
+|  | 40mP | ![][false] |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |
+|  | Enter Shikari | ![][false] |
+|  | EZFG | ![][false] |
+|  | Hatsuki Yura | ![][false] |
+|  | Igorrr | ![][false] |
+|  | kamome sano | ![][false] |
+|  | Kozato | ![][false] |
+|  | NOMA | ![][false] |
 
 ## Visual
 
@@ -474,3 +474,6 @@ We do not condone submissions featuring gameplay (hit objects) matching those of
 [^monstercat-gold]: This artist is licensed in cooperation with [Monstercat](https://osu.ppy.sh/beatmaps/artists/255), and users may be able to obtain external media usage rights via a [Monstercat Gold](https://www.monstercat.com/gold) subscription. Please consult their site for specific details on this licence.
 
 [FA]: /wiki/shared/group/FA.png "Featured Artist"
+[true]: /wiki/shared/true.png "Allowed"
+[false]: /wiki/shared/false.png "Disallowed"
+[partial]: /wiki/shared/partial.png "Allowed, with exceptions"

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -434,18 +434,18 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 
 #### Disallowed
 
-| Artist |  | Status |
-| :-- | :-- | :-- |
-|  | 40mP | ![][false] |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |
-|  | Enter Shikari | ![][false] |
-|  | EZFG | ![][false] |
-|  | Hatsuki Yura | ![][false] |
-|  | Igorrr | ![][false] |
-|  | kamome sano | ![][false] |
-|  | Kozato | ![][false] |
-|  | NOMA | ![][false] |
+| Artist | Status |
+| :-- | :-- |
+| 40mP | ![][false] |
+| ak+q | ![][false] |
+| Draw the Emotional | ![][false] |
+| Enter Shikari | ![][false] |
+| EZFG | ![][false] |
+| Hatsuki Yura | ![][false] |
+| Igorrr | ![][false] |
+| kamome sano | ![][false] |
+| Kozato | ![][false] |
+| NOMA | ![][false] |
 
 ## Visual
 

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -41,11 +41,9 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-|  | 40mP | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-|  | a\_hisa | ![][partial] | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
@@ -61,8 +59,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-|  | ak+q | ![][false] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
@@ -128,7 +124,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-|  | Draw the Emotional | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
@@ -138,14 +133,12 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-|  | Enter Shikari | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-|  | EZFG | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
@@ -176,21 +169,18 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-|  | Hatsuki Yura | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-|  | Igorrr | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
@@ -202,11 +192,9 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-|  | kamome sano | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
@@ -227,7 +215,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-|  | Kozato | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
@@ -275,7 +262,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
@@ -300,7 +286,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-|  | NOMA | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
@@ -379,7 +364,6 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
@@ -428,12 +412,28 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Tracks from or themed around *Touhou* should not be uploaded or used. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
+|  | a\_hisa | ![][partial] | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Tracks from or themed around *Touhou* should not be uploaded or used. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+|  | 40mP | ![][false] |  |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |  |
+|  | Enter Shikari | ![][false] |  |
+|  | EZFG | ![][false] |  |
+|  | Hatsuki Yura | ![][false] |  |
+|  | Igorrr | ![][false] |  |
+|  | kamome sano | ![][false] |  |
+|  | Kozato | ![][false] |  |
+|  | NOMA | ![][false] |  |
 
 ## Visual
 

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -438,6 +438,7 @@ All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/a
 | :-- | :-- |
 | 40mP | ![][false] |
 | ak+q | ![][false] |
+| DJMax (Neowiz) | ![][false] |
 | Draw the Emotional | ![][false] |
 | Enter Shikari | ![][false] |
 | EZFG | ![][false] |

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -34,406 +34,418 @@ This section details which artists are willing to allow use of their audio works
 
 All tracks listed on any [Featured Artist listing](https://osu.ppy.sh/beatmaps/artists) are approved for use in the creation of osu! beatmaps. Tracks from a Featured Artist that do not appear in their listing are *not* licensed, and additional permissions may be required to use them.
 
-| Artist |  | Status | Notes |
-| :-- | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
-|  | a\_hisa | ![][partial] | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Tracks from or themed around *Touhou* should not be uploaded or used. |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
-|  | 40mP | ![][false] |  |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |  |
-|  | Enter Shikari | ![][false] |  |
-|  | EZFG | ![][false] |  |
-|  | Hatsuki Yura | ![][false] |  |
-|  | Igorrr | ![][false] |  |
-|  | kamome sano | ![][false] |  |
-|  | Kozato | ![][false] |  |
-|  | NOMA | ![][false] |  |
+#### Allowed
+
+| Artist |  | Notes |
+| :-- | :-- | :-- |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) |  |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) |  |
+
+#### Allowed, with exceptions
+
+| Artist |  | Notes |
+| :-- | :-- | :-- |
+|  | a\_hisa | Contact before uploading. Can be reached via [email](mailto:hisaweb_info@yahoo.co.jp) or [Bandcamp](https://a-hisa.bandcamp.com/). |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | Tracks from or themed around *Touhou* should not be uploaded or used. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | Do not use or upload tracks that are not available on the creator's Featured Artist listing. |
+
+#### Disallowed
+
+| Artist |  | Notes |
+| :-- | :-- | :-- |
+|  | 40mP |  |
+|  | ak+q |  |
+|  | Draw the Emotional |  |
+|  | Enter Shikari |  |
+|  | EZFG |  |
+|  | Hatsuki Yura |  |
+|  | Igorrr |  |
+|  | kamome sano |  |
+|  | Kozato |  |
+|  | NOMA |  |
 
 ## Visual
 
@@ -462,6 +474,3 @@ We do not condone submissions featuring gameplay (hit objects) matching those of
 [^monstercat-gold]: This artist is licensed in cooperation with [Monstercat](https://osu.ppy.sh/beatmaps/artists/255), and users may be able to obtain external media usage rights via a [Monstercat Gold](https://www.monstercat.com/gold) subscription. Please consult their site for specific details on this licence.
 
 [FA]: /wiki/shared/group/FA.png "Featured Artist"
-[true]: /wiki/shared/true.png "Allowed"
-[false]: /wiki/shared/false.png "Disallowed"
-[partial]: /wiki/shared/partial.png "Allowed, with exceptions"

--- a/wiki/Rules/Content_usage_permissions/fr.md
+++ b/wiki/Rules/Content_usage_permissions/fr.md
@@ -45,11 +45,9 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-|  | 40mP | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-|  | a\_hisa | ![][partial] | Contacter avant de télécharger. Contact via [email](mailto:hisaweb_info@yahoo.co.jp) ou [Bandcamp](https://a-hisa.bandcamp.com/). |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
@@ -65,8 +63,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-|  | ak+q | ![][false] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
@@ -132,7 +128,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-|  | Draw the Emotional | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
@@ -142,14 +137,12 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-|  | Enter Shikari | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-|  | EZFG | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
@@ -180,21 +173,18 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-|  | Hatsuki Yura | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-|  | Igorrr | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
@@ -206,11 +196,9 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-|  | kamome sano | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
@@ -231,7 +219,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-|  | Kozato | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
@@ -279,7 +266,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
@@ -304,7 +290,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-|  | NOMA | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
@@ -383,7 +368,6 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
@@ -432,12 +416,28 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Les morceaux issus de *Touhou* ou portant sur ce thème ne doivent pas être téléchargés ou utilisés. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
+|  | a\_hisa | ![][partial] | Contacter avant de télécharger. Contact via [email](mailto:hisaweb_info@yahoo.co.jp) ou [Bandcamp](https://a-hisa.bandcamp.com/). |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Les morceaux issus de *Touhou* ou portant sur ce thème ne doivent pas être téléchargés ou utilisés. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
+|  | 40mP | ![][false] |  |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |  |
+|  | Enter Shikari | ![][false] |  |
+|  | EZFG | ![][false] |  |
+|  | Hatsuki Yura | ![][false] |  |
+|  | Igorrr | ![][false] |  |
+|  | kamome sano | ![][false] |  |
+|  | Kozato | ![][false] |  |
+|  | NOMA | ![][false] |  |
 
 ## Visuel
 

--- a/wiki/Rules/Content_usage_permissions/fr.md
+++ b/wiki/Rules/Content_usage_permissions/fr.md
@@ -38,388 +38,395 @@ Cette section indique quels artistes sont prêts à autoriser l'utilisation de l
 
 Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh/beatmaps/artists) sont approuvées pour être utilisées dans la création des beatmaps d'osu!. Les musiques d'un artiste qui n'apparaissent pas dans sa liste ne sont *pas* sous licence, et des autorisations supplémentaires peuvent être nécessaires pour les utiliser.
 
+#### Autorisé
+
+| Artiste |  | Statut |
+| :-- | :-- | :-- |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |
+
+#### Autorisé, avec des exceptions
+
 | Artiste |  | Statut | Notes |
 | :-- | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
 |  | a\_hisa | ![][partial] | Contacter avant de télécharger. Contact via [email](mailto:hisaweb_info@yahoo.co.jp) ou [Bandcamp](https://a-hisa.bandcamp.com/). |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
@@ -428,16 +435,21 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | Les morceaux issus de *Touhou* ou portant sur ce thème ne doivent pas être téléchargés ou utilisés. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | N'utilisez pas ou ne téléchargez pas de titres qui ne sont pas disponibles sur la liste des Featured Artist du créateur. |
-|  | 40mP | ![][false] |  |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |  |
-|  | Enter Shikari | ![][false] |  |
-|  | EZFG | ![][false] |  |
-|  | Hatsuki Yura | ![][false] |  |
-|  | Igorrr | ![][false] |  |
-|  | kamome sano | ![][false] |  |
-|  | Kozato | ![][false] |  |
-|  | NOMA | ![][false] |  |
+
+#### Refusé
+
+| Artiste | Statut |
+| :-- | :-- |
+| 40mP | ![][false] |
+| ak+q | ![][false] |
+| Draw the Emotional | ![][false] |
+| Enter Shikari | ![][false] |
+| EZFG | ![][false] |
+| Hatsuki Yura | ![][false] |
+| Igorrr | ![][false] |
+| kamome sano | ![][false] |
+| Kozato | ![][false] |
+| NOMA | ![][false] |
 
 ## Visuel
 

--- a/wiki/Rules/Content_usage_permissions/fr.md
+++ b/wiki/Rules/Content_usage_permissions/fr.md
@@ -442,6 +442,7 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | :-- | :-- |
 | 40mP | ![][false] |
 | ak+q | ![][false] |
+| DJMax (Neowiz) | ![][false] |
 | Draw the Emotional | ![][false] |
 | Enter Shikari | ![][false] |
 | EZFG | ![][false] |

--- a/wiki/Rules/Content_usage_permissions/ko.md
+++ b/wiki/Rules/Content_usage_permissions/ko.md
@@ -34,388 +34,395 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 
 [공식 아티스트 목록](https://osu.ppy.sh/beatmaps/artists)에 나열된 모든 트랙은 osu! 비트맵 제작에 사용할 수 있도록 승인되어 있습니다. 공식 아티스트 목록에 표시되지 않은 트랙은 라이선스가 부여되지 *않았으며*, 사용 시 추가 권한이 필요할 수 있습니다.
 
+#### 허용됨
+
+| 아티스트 |  | 상태 |
+| :-- | :-- | :-- |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |
+
+#### 조건부 허용됨
+
 | 아티스트 |  | 상태 | 노트 |
 | :-- | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
 |  | a\_hisa | ![][partial] | 업로드 전 [이메일](mailto:hisaweb_info@yahoo.co.jp)이나 [Bandcamp](https://a-hisa.bandcamp.com/)를 통해 문의하세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
@@ -424,16 +431,21 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | *동방프로젝트*를 주제로 한 음악 및 테마곡은 업로드하거나 사용을 금지합니다. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
-|  | 40mP | ![][false] |  |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |  |
-|  | Enter Shikari | ![][false] |  |
-|  | EZFG | ![][false] |  |
-|  | Hatsuki Yura | ![][false] |  |
-|  | Igorrr | ![][false] |  |
-|  | kamome sano | ![][false] |  |
-|  | Kozato | ![][false] |  |
-|  | NOMA | ![][false] |  |
+
+#### 허용되지 않음
+
+| 아티스트 | 상태 |
+| :-- | :-- |
+| 40mP | ![][false] |
+| ak+q | ![][false] |
+| Draw the Emotional | ![][false] |
+| Enter Shikari | ![][false] |
+| EZFG | ![][false] |
+| Hatsuki Yura | ![][false] |
+| Igorrr | ![][false] |
+| kamome sano | ![][false] |
+| Kozato | ![][false] |
+| NOMA | ![][false] |
 
 ## 시각물
 

--- a/wiki/Rules/Content_usage_permissions/ko.md
+++ b/wiki/Rules/Content_usage_permissions/ko.md
@@ -41,11 +41,9 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-|  | 40mP | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-|  | a\_hisa | ![][partial] | 업로드 전 [이메일](mailto:hisaweb_info@yahoo.co.jp)이나 [Bandcamp](https://a-hisa.bandcamp.com/)를 통해 문의하세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
@@ -61,8 +59,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-|  | ak+q | ![][false] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
@@ -128,7 +124,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-|  | Draw the Emotional | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
@@ -138,14 +133,12 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-|  | Enter Shikari | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-|  | EZFG | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
@@ -176,21 +169,18 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-|  | Hatsuki Yura | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-|  | Igorrr | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
@@ -202,11 +192,9 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-|  | kamome sano | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
@@ -227,7 +215,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-|  | Kozato | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
@@ -275,7 +262,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
@@ -300,7 +286,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-|  | NOMA | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
@@ -379,7 +364,6 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
@@ -428,12 +412,28 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | *동방프로젝트*를 주제로 한 음악 및 테마곡은 업로드하거나 사용을 금지합니다. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
+|  | a\_hisa | ![][partial] | 업로드 전 [이메일](mailto:hisaweb_info@yahoo.co.jp)이나 [Bandcamp](https://a-hisa.bandcamp.com/)를 통해 문의하세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | *동방프로젝트*를 주제로 한 음악 및 테마곡은 업로드하거나 사용을 금지합니다. |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 공식 아티스트 목록에 없는 트랙을 사용하거나 업로드하지 마세요. |
+|  | 40mP | ![][false] |  |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |  |
+|  | Enter Shikari | ![][false] |  |
+|  | EZFG | ![][false] |  |
+|  | Hatsuki Yura | ![][false] |  |
+|  | Igorrr | ![][false] |  |
+|  | kamome sano | ![][false] |  |
+|  | Kozato | ![][false] |  |
+|  | NOMA | ![][false] |  |
 
 ## 시각물
 

--- a/wiki/Rules/Content_usage_permissions/ko.md
+++ b/wiki/Rules/Content_usage_permissions/ko.md
@@ -438,6 +438,7 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | :-- | :-- |
 | 40mP | ![][false] |
 | ak+q | ![][false] |
+| DJMax (Neowiz) | ![][false] |
 | Draw the Emotional | ![][false] |
 | Enter Shikari | ![][false] |
 | EZFG | ![][false] |

--- a/wiki/Rules/Content_usage_permissions/zh.md
+++ b/wiki/Rules/Content_usage_permissions/zh.md
@@ -34,388 +34,395 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 
 [精选艺术家列表](https://osu.ppy.sh/beatmaps/artists)中列出的任何曲目都可以用于创作 osu! 谱面。未在列表中列出的，属于精选艺术家创作的歌曲并*没有*获得许可，使用它们创作 osu! 谱面之前，需要额外的授权。
 
+#### 允许
+
+| 艺术家 |  | 可用状态 |
+| :-- | :-- | :-- |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |
+
+#### 部分允许，有例外
+
 | 艺术家 |  | 可用状态 | 备注 |
 | :-- | :-- | :-- | :-- |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/18) | [\*namirin](https://osu.ppy.sh/beatmaps/artists/18) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/297) | [-45](https://osu.ppy.sh/beatmaps/artists/297) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/301) | [AAAA](https://osu.ppy.sh/beatmaps/artists/301) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/179) | [ABSOLUTE CASTAWAY](https://osu.ppy.sh/beatmaps/artists/179) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/294) | [Abuse](https://osu.ppy.sh/beatmaps/artists/294) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/191) | [Aether](https://osu.ppy.sh/beatmaps/artists/191) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/153) | [Aethoro](https://osu.ppy.sh/beatmaps/artists/153) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/259) | [Aethral](https://osu.ppy.sh/beatmaps/artists/259) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/47) | [Æther Realm](https://osu.ppy.sh/beatmaps/artists/47) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/164) | [Agressor Bunx](https://osu.ppy.sh/beatmaps/artists/164) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/360) | [Aice room](https://osu.ppy.sh/beatmaps/artists/360) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/264) | [Allegaeon](https://osu.ppy.sh/beatmaps/artists/264) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/374) | [ALLMYFRIENDS](https://osu.ppy.sh/beatmaps/artists/374) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/151) | [Amidst](https://osu.ppy.sh/beatmaps/artists/151) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/363) | [Andora](https://osu.ppy.sh/beatmaps/artists/363) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/177) | [Andromedik](https://osu.ppy.sh/beatmaps/artists/177) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/302) | [Andy Gillion](https://osu.ppy.sh/beatmaps/artists/302) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/234) | [Annabel](https://osu.ppy.sh/beatmaps/artists/234) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/24) | [antiPLUR / Internet Death Machine](https://osu.ppy.sh/beatmaps/artists/24) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/183) | [Aoi](https://osu.ppy.sh/beatmaps/artists/183) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/380) | [Aquellex](https://osu.ppy.sh/beatmaps/artists/380) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/282) | [aran](https://osu.ppy.sh/beatmaps/artists/282) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/256) | [Archspire](https://osu.ppy.sh/beatmaps/artists/256) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/263) | [Ardolf](https://osu.ppy.sh/beatmaps/artists/263) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/95) | [ARForest](https://osu.ppy.sh/beatmaps/artists/95) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/93) | [Ariabl'eyeS](https://osu.ppy.sh/beatmaps/artists/93) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/352) | [Ashrount](https://osu.ppy.sh/beatmaps/artists/352) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/309) | [Ata](https://osu.ppy.sh/beatmaps/artists/309) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/237) | [Atavistia](https://osu.ppy.sh/beatmaps/artists/237) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/312) | [Au5](https://osu.ppy.sh/beatmaps/artists/312) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/198) | [Avizura](https://osu.ppy.sh/beatmaps/artists/198) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/277) | [Beach Bunny](https://osu.ppy.sh/beatmaps/artists/277) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/377) | [beignet](https://osu.ppy.sh/beatmaps/artists/377) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/11) | [Ben Briggs](https://osu.ppy.sh/beatmaps/artists/11) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/236) | [bill wurtz](https://osu.ppy.sh/beatmaps/artists/236) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/46) | [Billain](https://osu.ppy.sh/beatmaps/artists/46) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/38) | [BilliumMoto](https://osu.ppy.sh/beatmaps/artists/38) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/150) | [BlackY](https://osu.ppy.sh/beatmaps/artists/150) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/80) | [BLANKFIELD](https://osu.ppy.sh/beatmaps/artists/80) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/284) | [Blind Guardian](https://osu.ppy.sh/beatmaps/artists/284) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/115) | [BLOOD CODE](https://osu.ppy.sh/beatmaps/artists/115) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/126) | [BLOOD STAIN CHILD](https://osu.ppy.sh/beatmaps/artists/126) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/65) | [Blue Stahli](https://osu.ppy.sh/beatmaps/artists/65) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/233) | [Boom Kitty](https://osu.ppy.sh/beatmaps/artists/233) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/119) | [Bossfight](https://osu.ppy.sh/beatmaps/artists/119) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/154) | [Boxplot](https://osu.ppy.sh/beatmaps/artists/154) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/378) | [C-Show](https://osu.ppy.sh/beatmaps/artists/378) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/31) | [Camellia](https://osu.ppy.sh/beatmaps/artists/31) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/42) | [Carpool Tunnel](https://osu.ppy.sh/beatmaps/artists/42) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/354) | [CHON](https://osu.ppy.sh/beatmaps/artists/354) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/215) | [Chroma](https://osu.ppy.sh/beatmaps/artists/215) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/341) | [Cinamoro](https://osu.ppy.sh/beatmaps/artists/341) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/78) | [CircusP](https://osu.ppy.sh/beatmaps/artists/78) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/245) | [City Girl](https://osu.ppy.sh/beatmaps/artists/245) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/384) | [ColBreakz](https://osu.ppy.sh/beatmaps/artists/384) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/381) | [Corsace](https://osu.ppy.sh/beatmaps/artists/381) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/23) | [Cranky](https://osu.ppy.sh/beatmaps/artists/23) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/36) | [Creo](https://osu.ppy.sh/beatmaps/artists/36) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/147) | [Cres.](https://osu.ppy.sh/beatmaps/artists/147) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/321) | [Crywolf](https://osu.ppy.sh/beatmaps/artists/321) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/29) | [Culprate](https://osu.ppy.sh/beatmaps/artists/29) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/105) | [cute girls doing cute things](https://osu.ppy.sh/beatmaps/artists/105) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/359) | [cygnus](https://osu.ppy.sh/beatmaps/artists/359) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/2) | [cYsmix](https://osu.ppy.sh/beatmaps/artists/2) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/6) | [dark cat](https://osu.ppy.sh/beatmaps/artists/6) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/290) | [Darkney](https://osu.ppy.sh/beatmaps/artists/290) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/229) | [DGK](https://osu.ppy.sh/beatmaps/artists/229) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/134) | [Dimrain47](https://osu.ppy.sh/beatmaps/artists/134) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/81) | [Disasterpeace](https://osu.ppy.sh/beatmaps/artists/81) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/44) | [Disko Warp](https://osu.ppy.sh/beatmaps/artists/44) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/326) | [Ekcle](https://osu.ppy.sh/beatmaps/artists/326) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/69) | [ELFENSJóN](https://osu.ppy.sh/beatmaps/artists/69) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/160) | [Emille's Moonlight Serenade](https://osu.ppy.sh/beatmaps/artists/160) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/306) | [Feint](https://osu.ppy.sh/beatmaps/artists/306) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/332) | [Fellowship](https://osu.ppy.sh/beatmaps/artists/332) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/156) | [fiend](https://osu.ppy.sh/beatmaps/artists/156) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/170) | [Fleshgod Apocalypse](https://osu.ppy.sh/beatmaps/artists/170) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/313) | [Fractal](https://osu.ppy.sh/beatmaps/artists/313) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/15) | [Fractal Dreamers](https://osu.ppy.sh/beatmaps/artists/15) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/339) | [FRASER EDWARDS](https://osu.ppy.sh/beatmaps/artists/339) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/180) | [Fred V & Grafix](https://osu.ppy.sh/beatmaps/artists/180) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/68) | [Frums](https://osu.ppy.sh/beatmaps/artists/68) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/114) | [Fuki](https://osu.ppy.sh/beatmaps/artists/114) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/212) | [garlagan](https://osu.ppy.sh/beatmaps/artists/212) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/358) | [Genkaku Aria](https://osu.ppy.sh/beatmaps/artists/358) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/133) | [Geoxor](https://osu.ppy.sh/beatmaps/artists/133) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/128) | [Getty](https://osu.ppy.sh/beatmaps/artists/128) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/72) | [ginkiha](https://osu.ppy.sh/beatmaps/artists/72) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/113) | [glass beach](https://osu.ppy.sh/beatmaps/artists/113) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/311) | [GLORYHAMMER](https://osu.ppy.sh/beatmaps/artists/311) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/240) | [Good Kid](https://osu.ppy.sh/beatmaps/artists/240) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/57) | [goreshit](https://osu.ppy.sh/beatmaps/artists/57) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/281) | [Grant](https://osu.ppy.sh/beatmaps/artists/281) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/159) | [Grynpyret](https://osu.ppy.sh/beatmaps/artists/159) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/148) | [GYZE](https://osu.ppy.sh/beatmaps/artists/148) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/368) | [Halv](https://osu.ppy.sh/beatmaps/artists/368) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/289) | [Hamu](https://osu.ppy.sh/beatmaps/artists/289) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/257) | [in love with a ghost](https://osu.ppy.sh/beatmaps/artists/257) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/43) | [Inferi](https://osu.ppy.sh/beatmaps/artists/43) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/323) | [Innocent Key](https://osu.ppy.sh/beatmaps/artists/323) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/135) | [Irreversible Mechanism](https://osu.ppy.sh/beatmaps/artists/135) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/39) | [James Landino](https://osu.ppy.sh/beatmaps/artists/39) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/375) | [Kardashev](https://osu.ppy.sh/beatmaps/artists/375) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/343) | [KASHIWA Daisuke](https://osu.ppy.sh/beatmaps/artists/343) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/176) | [katagiri](https://osu.ppy.sh/beatmaps/artists/176) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/351) | [Kenneyon](https://osu.ppy.sh/beatmaps/artists/351) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/314) | [Kikuo](https://osu.ppy.sh/beatmaps/artists/314) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/222) | [KINEMA106](https://osu.ppy.sh/beatmaps/artists/222) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/27) | [KIRA](https://osu.ppy.sh/beatmaps/artists/27) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/101) | [kiraku](https://osu.ppy.sh/beatmaps/artists/101) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/165) | [Kitazawa Kyouhei](https://osu.ppy.sh/beatmaps/artists/165) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/56) | [Klayton / Celldweller](https://osu.ppy.sh/beatmaps/artists/56) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/48) | [KNOWER](https://osu.ppy.sh/beatmaps/artists/48) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/49) | [KOAN Sound](https://osu.ppy.sh/beatmaps/artists/49) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/96) | [Kobaryo](https://osu.ppy.sh/beatmaps/artists/96) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/67) | [Kola Kid](https://osu.ppy.sh/beatmaps/artists/67) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/58) | [Kurokotei](https://osu.ppy.sh/beatmaps/artists/58) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/217) | [Kurubukko](https://osu.ppy.sh/beatmaps/artists/217) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/174) | [La prière](https://osu.ppy.sh/beatmaps/artists/174) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/327) | [LandRoot](https://osu.ppy.sh/beatmaps/artists/327) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/73) | [LeaF](https://osu.ppy.sh/beatmaps/artists/73) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/88) | [LEAF XCEED Music Division](https://osu.ppy.sh/beatmaps/artists/88) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/208) | [Lexurus](https://osu.ppy.sh/beatmaps/artists/208) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/283) | [Liar-soft](https://osu.ppy.sh/beatmaps/artists/283) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/122) | [Lifetheory](https://osu.ppy.sh/beatmaps/artists/122) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/325) | [LilyPichu](https://osu.ppy.sh/beatmaps/artists/325) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/116) | [Lime / Kankitsu](https://osu.ppy.sh/beatmaps/artists/116) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/213) | [linear ring](https://osu.ppy.sh/beatmaps/artists/213) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/340) | [Liquicity](https://osu.ppy.sh/beatmaps/artists/340) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/201) | [litmus\* / Ester](https://osu.ppy.sh/beatmaps/artists/201) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/7) | [Loki / Thaehan](https://osu.ppy.sh/beatmaps/artists/7) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/171) | [love solfege](https://osu.ppy.sh/beatmaps/artists/171) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/12) | [LukHash](https://osu.ppy.sh/beatmaps/artists/12) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/203) | [Lundy](https://osu.ppy.sh/beatmaps/artists/203) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/250) | [luvlxckdown](https://osu.ppy.sh/beatmaps/artists/250) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/214) | [LV.4](https://osu.ppy.sh/beatmaps/artists/214) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/161) | [m108](https://osu.ppy.sh/beatmaps/artists/161) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/235) | [Maduk](https://osu.ppy.sh/beatmaps/artists/235) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/258) | [Mage](https://osu.ppy.sh/beatmaps/artists/258) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/94) | [Magnetude](https://osu.ppy.sh/beatmaps/artists/94) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/209) | [Mameyudoufu](https://osu.ppy.sh/beatmaps/artists/209) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/220) | [Marmalade butcher](https://osu.ppy.sh/beatmaps/artists/220) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/136) | [Masahiro "Godspeed" Aoki](https://osu.ppy.sh/beatmaps/artists/136) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/318) | [Massive New Krew](https://osu.ppy.sh/beatmaps/artists/318) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/219) | [Matduke](https://osu.ppy.sh/beatmaps/artists/219) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/61) | [MDK](https://osu.ppy.sh/beatmaps/artists/61) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/346) | [Mediks](https://osu.ppy.sh/beatmaps/artists/346) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/75) | [meganeko](https://osu.ppy.sh/beatmaps/artists/75) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/206) | [METAROOM](https://osu.ppy.sh/beatmaps/artists/206) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/182) | [Michael Cera Palin](https://osu.ppy.sh/beatmaps/artists/182) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/331) | [Mili](https://osu.ppy.sh/beatmaps/artists/331) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/77) | [MIMI](https://osu.ppy.sh/beatmaps/artists/77) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/349) | [Minstrel](https://osu.ppy.sh/beatmaps/artists/349) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/162) | [miraie](https://osu.ppy.sh/beatmaps/artists/162) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/239) | [MisoilePunch](https://osu.ppy.sh/beatmaps/artists/239) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/243) | [MisomyL](https://osu.ppy.sh/beatmaps/artists/243) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/262) | [Mitsuki / RINYA](https://osu.ppy.sh/beatmaps/artists/262) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/252) | [my sound life](https://osu.ppy.sh/beatmaps/artists/252) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/62) | [MYLK](https://osu.ppy.sh/beatmaps/artists/62) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/121) | [MYUKKE.](https://osu.ppy.sh/beatmaps/artists/121) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/25) | [Nakanojojo](https://osu.ppy.sh/beatmaps/artists/25) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/10) | [nanobii](https://osu.ppy.sh/beatmaps/artists/10) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/298) | [Nashimoto Ui](https://osu.ppy.sh/beatmaps/artists/298) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/50) | [Native Construct](https://osu.ppy.sh/beatmaps/artists/50) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/189) | [Natsume Itsuki](https://osu.ppy.sh/beatmaps/artists/189) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/86) | [Ne Obliviscaris](https://osu.ppy.sh/beatmaps/artists/86) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/266) | [Neko Hacker](https://osu.ppy.sh/beatmaps/artists/266) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/1) | [nekodex](https://osu.ppy.sh/beatmaps/artists/1) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/53) | [Nekrogoblikon](https://osu.ppy.sh/beatmaps/artists/53) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/251) | [Never Say Die](https://osu.ppy.sh/beatmaps/artists/251) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/260) | [Nile](https://osu.ppy.sh/beatmaps/artists/260) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/278) | [NILFRUITS](https://osu.ppy.sh/beatmaps/artists/278) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/299) | [Nitro Fun](https://osu.ppy.sh/beatmaps/artists/299) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/21) | [niu arx](https://osu.ppy.sh/beatmaps/artists/21) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/228) | [NIWASHI](https://osu.ppy.sh/beatmaps/artists/228) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/74) | [O2i3](https://osu.ppy.sh/beatmaps/artists/74) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/17) | [OISHII](https://osu.ppy.sh/beatmaps/artists/17) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/104) | [Omoi](https://osu.ppy.sh/beatmaps/artists/104) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/32) | [onumi](https://osu.ppy.sh/beatmaps/artists/32) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/118) | [orangentle / Yu\_Asahina](https://osu.ppy.sh/beatmaps/artists/118) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/269) | [Origami Angel](https://osu.ppy.sh/beatmaps/artists/269) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/200) | [Our Stolen Theory](https://osu.ppy.sh/beatmaps/artists/200) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/140) | [ovEnola](https://osu.ppy.sh/beatmaps/artists/140) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/106) | [P4koo](https://osu.ppy.sh/beatmaps/artists/106) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/55) | [Panda Eyes](https://osu.ppy.sh/beatmaps/artists/55) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/366) | [passchooo](https://osu.ppy.sh/beatmaps/artists/366) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/287) | [Pegboard Nerds](https://osu.ppy.sh/beatmaps/artists/287) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/129) | [Phantom Sage](https://osu.ppy.sh/beatmaps/artists/129) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/249) | [Plum](https://osu.ppy.sh/beatmaps/artists/249) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/146) | [polysha](https://osu.ppy.sh/beatmaps/artists/146) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/271) | [Ponchi](https://osu.ppy.sh/beatmaps/artists/271) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/175) | [Pratanallis](https://osu.ppy.sh/beatmaps/artists/175) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/227) | [PTB10](https://osu.ppy.sh/beatmaps/artists/227) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/79) | [PUP](https://osu.ppy.sh/beatmaps/artists/79) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/242) | [Rabbit House](https://osu.ppy.sh/beatmaps/artists/242) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/247) | [Raimukun](https://osu.ppy.sh/beatmaps/artists/247) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/270) | [Rameses B](https://osu.ppy.sh/beatmaps/artists/270) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/91) | [Receptor](https://osu.ppy.sh/beatmaps/artists/91) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/184) | [Redside](https://osu.ppy.sh/beatmaps/artists/184) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/199) | [rejection](https://osu.ppy.sh/beatmaps/artists/199) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/163) | [Reku Mochizuki](https://osu.ppy.sh/beatmaps/artists/163) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/194) | [Release Hallucination](https://osu.ppy.sh/beatmaps/artists/194) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/300) | [Rezonate](https://osu.ppy.sh/beatmaps/artists/300) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/54) | [Ricky Montgomery](https://osu.ppy.sh/beatmaps/artists/54) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/14) | [Rin / Function Phantom](https://osu.ppy.sh/beatmaps/artists/14) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/40) | [RiraN](https://osu.ppy.sh/beatmaps/artists/40) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/211) | [Risa Yuzuki](https://osu.ppy.sh/beatmaps/artists/211) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/181) | [Rish](https://osu.ppy.sh/beatmaps/artists/181) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/41) | [Rising Sun Traxx](https://osu.ppy.sh/beatmaps/artists/41) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/305) | [Ritorikal](https://osu.ppy.sh/beatmaps/artists/305) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/63) | [Rivers of Nihil](https://osu.ppy.sh/beatmaps/artists/63) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/241) | [Riya](https://osu.ppy.sh/beatmaps/artists/241) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/190) | [rN](https://osu.ppy.sh/beatmaps/artists/190) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/82) | [Rohi](https://osu.ppy.sh/beatmaps/artists/82) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/280) | [Rootkit](https://osu.ppy.sh/beatmaps/artists/280) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/370) | [Ruby My Dear](https://osu.ppy.sh/beatmaps/artists/370) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/87) | [Rusty K](https://osu.ppy.sh/beatmaps/artists/87) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/9) | [S3RL](https://osu.ppy.sh/beatmaps/artists/9) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/103) | [Sable Hills](https://osu.ppy.sh/beatmaps/artists/103) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/273) | [SAMString](https://osu.ppy.sh/beatmaps/artists/273) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/231) | [satella](https://osu.ppy.sh/beatmaps/artists/231) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/328) | [Satyr](https://osu.ppy.sh/beatmaps/artists/328) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/112) | [Se-U-Ra](https://osu.ppy.sh/beatmaps/artists/112) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/185) | [seatrus](https://osu.ppy.sh/beatmaps/artists/185) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/186) | [SEBii](https://osu.ppy.sh/beatmaps/artists/186) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/137) | [SECONDWALL](https://osu.ppy.sh/beatmaps/artists/137) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/138) | [seleP](https://osu.ppy.sh/beatmaps/artists/138) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/110) | [Sennzai](https://osu.ppy.sh/beatmaps/artists/110) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/196) | [Sephid](https://osu.ppy.sh/beatmaps/artists/196) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/225) | [Seraph](https://osu.ppy.sh/beatmaps/artists/225) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/169) | [Sewerslvt](https://osu.ppy.sh/beatmaps/artists/169) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/362) | [Shadren](https://osu.ppy.sh/beatmaps/artists/362) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/139) | [Shawn Wasabi](https://osu.ppy.sh/beatmaps/artists/139) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/92) | [Silentroom](https://osu.ppy.sh/beatmaps/artists/92) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/102) | [siqlo](https://osu.ppy.sh/beatmaps/artists/102) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/226) | [siromaru](https://osu.ppy.sh/beatmaps/artists/226) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/338) | [Sobrem](https://osu.ppy.sh/beatmaps/artists/338) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/207) | [solfa](https://osu.ppy.sh/beatmaps/artists/207) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/30) | [SOOOO](https://osu.ppy.sh/beatmaps/artists/30) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/376) | [soowamisu](https://osu.ppy.sh/beatmaps/artists/376) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/334) | [Sound piercer](https://osu.ppy.sh/beatmaps/artists/334) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/70) | [Sound Souler](https://osu.ppy.sh/beatmaps/artists/70) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/353) | [Stars Hollow](https://osu.ppy.sh/beatmaps/artists/353) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/66) | [Station Earth / Blue Marble](https://osu.ppy.sh/beatmaps/artists/66) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/254) | [Stonebank](https://osu.ppy.sh/beatmaps/artists/254) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/89) | [Street](https://osu.ppy.sh/beatmaps/artists/89) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/373) | [Supire](https://osu.ppy.sh/beatmaps/artists/373) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/221) | [Tasty](https://osu.ppy.sh/beatmaps/artists/221) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/193) | [technoplanet](https://osu.ppy.sh/beatmaps/artists/193) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/223) | [Tedjimo yomigY](https://osu.ppy.sh/beatmaps/artists/223) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/64) | [Teminite](https://osu.ppy.sh/beatmaps/artists/64) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/265) | [Tenchio](https://osu.ppy.sh/beatmaps/artists/265) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/361) | [tephe](https://osu.ppy.sh/beatmaps/artists/361) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/83) | [Thank You Scientist](https://osu.ppy.sh/beatmaps/artists/83) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/37) | [The Flashbulb](https://osu.ppy.sh/beatmaps/artists/37) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/142) | [The Gentle Men](https://osu.ppy.sh/beatmaps/artists/142) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/34) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/131) | [Tiny Waves](https://osu.ppy.sh/beatmaps/artists/131) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/202) | [tokiwa](https://osu.ppy.sh/beatmaps/artists/202) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/276) | [Tokyo Machine](https://osu.ppy.sh/beatmaps/artists/276) | ![][true] [^monstercat-gold] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/308) | [Tokyo.MeltiMelt](https://osu.ppy.sh/beatmaps/artists/308) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/279) | [Toromaru](https://osu.ppy.sh/beatmaps/artists/279) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/20) | [Trial & Error](https://osu.ppy.sh/beatmaps/artists/20) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/344) | [True North](https://osu.ppy.sh/beatmaps/artists/344) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/329) | [tsunamix](https://osu.ppy.sh/beatmaps/artists/329) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/98) | [Umeboshi Chazuke](https://osu.ppy.sh/beatmaps/artists/98) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/45) | [UNDEAD CORPORATION](https://osu.ppy.sh/beatmaps/artists/45) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/149) | [URBANGARDE](https://osu.ppy.sh/beatmaps/artists/149) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/248) | [USAO](https://osu.ppy.sh/beatmaps/artists/248) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/232) | [Vansire](https://osu.ppy.sh/beatmaps/artists/232) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/158) | [Vektor](https://osu.ppy.sh/beatmaps/artists/158) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/71) | [Venetian Snares](https://osu.ppy.sh/beatmaps/artists/71) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/22) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/28) | [Virtual Self](https://osu.ppy.sh/beatmaps/artists/28) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/59) | [Voicians](https://osu.ppy.sh/beatmaps/artists/59) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/303) | [Vorso](https://osu.ppy.sh/beatmaps/artists/303) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/291) | [Waterflame](https://osu.ppy.sh/beatmaps/artists/291) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/347) | [Whispered](https://osu.ppy.sh/beatmaps/artists/347) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/192) | [Wiklund](https://osu.ppy.sh/beatmaps/artists/192) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/385) | [Will Stetson](https://osu.ppy.sh/beatmaps/artists/385) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/337) | [WINTERHORDE](https://osu.ppy.sh/beatmaps/artists/337) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/16) | [Wisp X](https://osu.ppy.sh/beatmaps/artists/16) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/178) | [wotoha](https://osu.ppy.sh/beatmaps/artists/178) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/152) | [Xanthochroid](https://osu.ppy.sh/beatmaps/artists/152) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/727) | [xi](https://osu.ppy.sh/beatmaps/artists/727) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/342) | [yaseta](https://osu.ppy.sh/beatmaps/artists/342) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/355) | [Yokomin](https://osu.ppy.sh/beatmaps/artists/355) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/218) | [Yooh](https://osu.ppy.sh/beatmaps/artists/218) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/372) | [YUC'e](https://osu.ppy.sh/beatmaps/artists/372) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
 |  | a\_hisa | ![][partial] | 在上传前请先通过 [email](mailto:hisaweb_info@yahoo.co.jp) 或 [Bandcamp](https://a-hisa.bandcamp.com/) 联系。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
@@ -424,16 +431,21 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | 请勿使用或上传*东方 Project* 主题的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
-|  | 40mP | ![][false] |  |
-|  | ak+q | ![][false] |  |
-|  | Draw the Emotional | ![][false] |  |
-|  | Enter Shikari | ![][false] |  |
-|  | EZFG | ![][false] |  |
-|  | Hatsuki Yura | ![][false] |  |
-|  | Igorrr | ![][false] |  |
-|  | kamome sano | ![][false] |  |
-|  | Kozato | ![][false] |  |
-|  | NOMA | ![][false] |  |
+
+#### 不允许
+
+| 艺术家 | 可用状态 |
+| :-- | :-- |
+| 40mP | ![][false] |
+| ak+q | ![][false] |
+| Draw the Emotional | ![][false] |
+| Enter Shikari | ![][false] |
+| EZFG | ![][false] |
+| Hatsuki Yura | ![][false] |
+| Igorrr | ![][false] |
+| kamome sano | ![][false] |
+| Kozato | ![][false] |
+| NOMA | ![][false] |
 
 ## 视觉内容
 

--- a/wiki/Rules/Content_usage_permissions/zh.md
+++ b/wiki/Rules/Content_usage_permissions/zh.md
@@ -41,11 +41,9 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/382) | [1914](https://osu.ppy.sh/beatmaps/artists/382) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/157) | [2ToneDisco](https://osu.ppy.sh/beatmaps/artists/157) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/187) | [3R2 / DJ Mashiro](https://osu.ppy.sh/beatmaps/artists/187) | ![][true] |  |
-|  | 40mP | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/268) | [69 de 74](https://osu.ppy.sh/beatmaps/artists/268) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/356) | [7\_7](https://osu.ppy.sh/beatmaps/artists/356) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/275) | [:Poin7less](https://osu.ppy.sh/beatmaps/artists/275) | ![][true] |  |
-|  | a\_hisa | ![][partial] | 在上传前请先通过 [email](mailto:hisaweb_info@yahoo.co.jp) 或 [Bandcamp](https://a-hisa.bandcamp.com/) 联系。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/168) | [A-One](https://osu.ppy.sh/beatmaps/artists/168) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/253) | [A.SAKA](https://osu.ppy.sh/beatmaps/artists/253) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/173) | [A?](https://osu.ppy.sh/beatmaps/artists/173) | ![][true] |  |
@@ -61,8 +59,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/166) | [Aiobahn](https://osu.ppy.sh/beatmaps/artists/166) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/127) | [Aitsuki Nakuru](https://osu.ppy.sh/beatmaps/artists/127) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/296) | [Aiyru](https://osu.ppy.sh/beatmaps/artists/296) | ![][true] |  |
-|  | ak+q | ![][false] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/107) | [ALEPH](https://osu.ppy.sh/beatmaps/artists/107) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/304) | [Alestorm](https://osu.ppy.sh/beatmaps/artists/304) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/195) | [Alkome](https://osu.ppy.sh/beatmaps/artists/195) | ![][true] |  |
@@ -128,7 +124,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/295) | [DJ Genki / Gram](https://osu.ppy.sh/beatmaps/artists/295) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/204) | [DJ Raisei](https://osu.ppy.sh/beatmaps/artists/204) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/350) | [Down](https://osu.ppy.sh/beatmaps/artists/350) | ![][true] |  |
-|  | Draw the Emotional | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/111) | [Dual Alter World](https://osu.ppy.sh/beatmaps/artists/111) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/386) | [Dustvoxx](https://osu.ppy.sh/beatmaps/artists/386) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/322) | [E0ri4](https://osu.ppy.sh/beatmaps/artists/322) | ![][true] |  |
@@ -138,14 +133,12 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/246) | [EmoCosine](https://osu.ppy.sh/beatmaps/artists/246) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/145) | [Empty Peperoncino](https://osu.ppy.sh/beatmaps/artists/145) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/320) | [Ensou](https://osu.ppy.sh/beatmaps/artists/320) | ![][true] |  |
-|  | Enter Shikari | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/100) | [EPICA](https://osu.ppy.sh/beatmaps/artists/100) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/125) | [Erik McClure](https://osu.ppy.sh/beatmaps/artists/125) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/335) | [Etherwood](https://osu.ppy.sh/beatmaps/artists/335) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/333) | [Euchaeta](https://osu.ppy.sh/beatmaps/artists/333) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/143) | [Extra Terra](https://osu.ppy.sh/beatmaps/artists/143) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/285) | [Exyl](https://osu.ppy.sh/beatmaps/artists/285) | ![][true] |  |
-|  | EZFG | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/60) | [F-777](https://osu.ppy.sh/beatmaps/artists/60) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/52) | [False Noise](https://osu.ppy.sh/beatmaps/artists/52) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/216) | [FATE GEAR](https://osu.ppy.sh/beatmaps/artists/216) | ![][true] |  |
@@ -176,21 +169,18 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/317) | [happy30](https://osu.ppy.sh/beatmaps/artists/317) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/205) | [HARDCORE UTOPIA](https://osu.ppy.sh/beatmaps/artists/205) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/197) | [Harumaki Gohan](https://osu.ppy.sh/beatmaps/artists/197) | ![][true] |  |
-|  | Hatsuki Yura | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/230) | [Haywyre](https://osu.ppy.sh/beatmaps/artists/230) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/238) | [HEAD PHONES PRESIDENT](https://osu.ppy.sh/beatmaps/artists/238) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/5) | [Helblinde](https://osu.ppy.sh/beatmaps/artists/5) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/26) | [High Tea Music](https://osu.ppy.sh/beatmaps/artists/26) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/315) | [Hinkik](https://osu.ppy.sh/beatmaps/artists/315) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/272) | [Hino Isuka](https://osu.ppy.sh/beatmaps/artists/272) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/310) | [Hybrid Minds](https://osu.ppy.sh/beatmaps/artists/310) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/85) | [Hyper Potions](https://osu.ppy.sh/beatmaps/artists/85) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/33) | [HyuN](https://osu.ppy.sh/beatmaps/artists/33) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/117) | [I love you Orchestra](https://osu.ppy.sh/beatmaps/artists/117) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/3) | [IAHN](https://osu.ppy.sh/beatmaps/artists/3) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/210) | [iFeature](https://osu.ppy.sh/beatmaps/artists/210) | ![][true] |  |
-|  | Igorrr | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/172) | [II-L](https://osu.ppy.sh/beatmaps/artists/172) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/35) | [Imperial Circus Dead Decadence](https://osu.ppy.sh/beatmaps/artists/35) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/99) | [Imy](https://osu.ppy.sh/beatmaps/artists/99) | ![][true] |  |
@@ -202,11 +192,9 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/109) | [Joe Ford](https://osu.ppy.sh/beatmaps/artists/109) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/267) | [JOYLESS](https://osu.ppy.sh/beatmaps/artists/267) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/365) | [Junk](https://osu.ppy.sh/beatmaps/artists/365) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/345) | [Kabocha](https://osu.ppy.sh/beatmaps/artists/345) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/364) | [kaitendaentai](https://osu.ppy.sh/beatmaps/artists/364) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/336) | [kakichoco](https://osu.ppy.sh/beatmaps/artists/336) | ![][true] |  |
-|  | kamome sano | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/367) | [kanemiko](https://osu.ppy.sh/beatmaps/artists/367) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/123) | [kanone](https://osu.ppy.sh/beatmaps/artists/123) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/274) | [Kanpyohgo](https://osu.ppy.sh/beatmaps/artists/274) | ![][true] |  |
@@ -227,7 +215,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/379) | [Kommisar](https://osu.ppy.sh/beatmaps/artists/379) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/383) | [Kou!](https://osu.ppy.sh/beatmaps/artists/383) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/293) | [Koven](https://osu.ppy.sh/beatmaps/artists/293) | ![][true] [^monstercat-gold] |  |
-|  | Kozato | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/371) | [Krimek](https://osu.ppy.sh/beatmaps/artists/371) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/13) | [Kuba Oms](https://osu.ppy.sh/beatmaps/artists/13) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/369) | [kuro](https://osu.ppy.sh/beatmaps/artists/369) | ![][true] |  |
@@ -275,7 +262,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/292) | [Mitsukiyo](https://osu.ppy.sh/beatmaps/artists/292) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/307) | [Mono.](https://osu.ppy.sh/beatmaps/artists/307) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/255) | [Monstercat](https://osu.ppy.sh/beatmaps/artists/255) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/19) | [MOtOLOiD](https://osu.ppy.sh/beatmaps/artists/19) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/120) | [MuryokuP / Powerless](https://osu.ppy.sh/beatmaps/artists/120) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/261) | [MUZZ](https://osu.ppy.sh/beatmaps/artists/261) | ![][true] [^monstercat-gold] |  |
@@ -300,7 +286,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/324) | [Noisestorm](https://osu.ppy.sh/beatmaps/artists/324) | ![][true] [^monstercat-gold] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/84) | [Noisia](https://osu.ppy.sh/beatmaps/artists/84) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/286) | [NOISZ](https://osu.ppy.sh/beatmaps/artists/286) | ![][true] |  |
-|  | NOMA | ![][false] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/141) | [nora2r](https://osu.ppy.sh/beatmaps/artists/141) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/90) | [Numtack05](https://osu.ppy.sh/beatmaps/artists/90) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/330) | [nyankobrq](https://osu.ppy.sh/beatmaps/artists/330) | ![][true] |  |
@@ -379,7 +364,6 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/348) | [SWORD OF JUSTICE](https://osu.ppy.sh/beatmaps/artists/348) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/8) | [Sylvir / sakuraburst](https://osu.ppy.sh/beatmaps/artists/8) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/130) | [Symholic](https://osu.ppy.sh/beatmaps/artists/130) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/188) | [T & Sugah](https://osu.ppy.sh/beatmaps/artists/188) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/144) | [Tanchiky](https://osu.ppy.sh/beatmaps/artists/144) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/97) | [Task Horizon](https://osu.ppy.sh/beatmaps/artists/97) | ![][true] |  |
@@ -428,12 +412,28 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/4) | [yuki.](https://osu.ppy.sh/beatmaps/artists/4) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/167) | [yukitani](https://osu.ppy.sh/beatmaps/artists/167) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/244) | [Yunosuke](https://osu.ppy.sh/beatmaps/artists/244) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | 请勿使用或上传*东方 Project* 主题的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/155) | [YUZUKINGDOM](https://osu.ppy.sh/beatmaps/artists/155) | ![][true] |  |
-| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/316) | [Zenpaku](https://osu.ppy.sh/beatmaps/artists/316) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/224) | [Zomboy](https://osu.ppy.sh/beatmaps/artists/224) | ![][true] |  |
 | [![][FA]](https://osu.ppy.sh/beatmaps/artists/288) | [ZxNX](https://osu.ppy.sh/beatmaps/artists/288) | ![][true] |  |
+|  | a\_hisa | ![][partial] | 在上传前请先通过 [email](mailto:hisaweb_info@yahoo.co.jp) 或 [Bandcamp](https://a-hisa.bandcamp.com/) 联系。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/51) | [Akira Complex](https://osu.ppy.sh/beatmaps/artists/51) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/319) | [HoneyComeBear](https://osu.ppy.sh/beatmaps/artists/319) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/124) | [Jun Kuroda](https://osu.ppy.sh/beatmaps/artists/124) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/108) | [Morimori Atsushi](https://osu.ppy.sh/beatmaps/artists/108) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/357) | [Synthion](https://osu.ppy.sh/beatmaps/artists/357) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/132) | [Yuyoyuppe / DJ'TEKINA//SOMETHING](https://osu.ppy.sh/beatmaps/artists/132) | ![][partial] | 请勿使用或上传*东方 Project* 主题的音频。 |
+| [![][FA]](https://osu.ppy.sh/beatmaps/artists/76) | [Zekk](https://osu.ppy.sh/beatmaps/artists/76) | ![][partial] | 请勿使用或上传在创作者的精选艺术家列表中不可用的音频。 |
+|  | 40mP | ![][false] |  |
+|  | ak+q | ![][false] |  |
+|  | Draw the Emotional | ![][false] |  |
+|  | Enter Shikari | ![][false] |  |
+|  | EZFG | ![][false] |  |
+|  | Hatsuki Yura | ![][false] |  |
+|  | Igorrr | ![][false] |  |
+|  | kamome sano | ![][false] |  |
+|  | Kozato | ![][false] |  |
+|  | NOMA | ![][false] |  |
 
 ## 视觉内容
 

--- a/wiki/Rules/Content_usage_permissions/zh.md
+++ b/wiki/Rules/Content_usage_permissions/zh.md
@@ -438,6 +438,7 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | :-- | :-- |
 | 40mP | ![][false] |
 | ak+q | ![][false] |
+| DJMax (Neowiz) | ![][false] |
 | Draw the Emotional | ![][false] |
 | Enter Shikari | ![][false] |
 | EZFG | ![][false] |


### PR DESCRIPTION
current artist list is a pain to navigate through and it's really hard to see at a glance which artists are disallowed/allowed with exceptions, so i propose to group artists by status while still maintaining alphabetical order when relevant, that way it's much more readable.

[wiki preview](https://osu3.roanh.dev/wiki/en/Rules/Content_usage_permissions)