### PR TITLE
Fix switched audio previews in `osu!taiko World Cup 2024: Semifinals Recap` news post

### DIFF
--- a/news/2024/2024-04-17-osutaiko-world-cup-2024-semifinals-recap.md
+++ b/news/2024/2024-04-17-osutaiko-world-cup-2024-semifinals-recap.md
@@ -32,7 +32,7 @@ The heat is slowly being turned up, and the mappool is starting to transform int
 
 <div class="osu-md__paragraph">
     <audio controls>
-        <source src="https://assets.ppy.sh/artists/398/Songs/Sparxe_-_Switcheroo.mp3">
+        <source src="https://assets.ppy.sh/artists/415/Songs/lemm%20-%20Algorithm%2054.mp3">
     </audio>
 </div>
 
@@ -40,7 +40,7 @@ The heat is slowly being turned up, and the mappool is starting to transform int
 
 <div class="osu-md__paragraph">
     <audio controls>
-        <source src="https://assets.ppy.sh/artists/415/Songs/lemm%20-%20Algorithm%2054.mp3">
+        <source src="https://assets.ppy.sh/artists/398/Songs/Sparxe_-_Switcheroo.mp3">
     </audio>
 </div>
 


### PR DESCRIPTION
the switcheroo