### PR TITLE
Update `TWC 2024` Finals mappool

### DIFF
--- a/wiki/Tournaments/TWC/2024/en.md
+++ b/wiki/Tournaments/TWC/2024/en.md
@@ -133,8 +133,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/253
 
 ### Finals
 
-**[Download the mappack here (168 MB)](https://packs.ppy.sh/P244%20-%20osu!taiko%20World%20Cup%202024%3A%20Finals.zip)**\
-[View the showcase VOD here](https://www.twitch.tv/videos/2119951003)
+**[Download the mappack here (167 MB)](https://packs.ppy.sh/P244%20-%20osu!taiko%20World%20Cup%202024%3A%20Finals.zip?1713511023)**
 
 - No Mod
   1. [SatapanP ft. Hatsune Miku - Bagooon!!!!! (Skidooskei) \[NO MISS!!!!! (TWC EDIT!!!!!)\]](https://osu.ppy.sh/beatmapsets/2112567#taiko/4570747)
@@ -142,7 +141,7 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/253
   3. [kessoku band - Seishun Complex (Kirairi Bootleg) (Seren58) \[Quartet\]](https://osu.ppy.sh/beatmapsets/1901991#taiko/3921191)
   4. [Ruby My Dear - Ecureuil (SolaEclipse) \[Don't Blink\]](https://osu.ppy.sh/beatmapsets/2166520#taiko/4570829)
   5. [Rivers of Nihil - Reign of Dreams (Xay) \[Perpetuity\]](https://osu.ppy.sh/beatmapsets/2166485#taiko/4570764)
-  6. [Sobrem - Carrot Carrot (Nurend) \[Carrot\]](https://osu.ppy.sh/beatmapsets/2166484#taiko/4570763)
+  6. [Frums - Remnants of Turing (Ulqui) \[Alto Hospicio\]](https://osu.ppy.sh/beatmapsets/2019618#taiko/4205872)
   7. [Sydosys - Serrate (\_Rise) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2166563#taiko/4570945)
 - Hidden
   1. [flatt - Agitato (miyagishima) \[Inner Oni (TWC Edit)\]](https://osu.ppy.sh/beatmapsets/2024995#taiko/4570745)

--- a/wiki/Tournaments/TWC/2024/ko.md
+++ b/wiki/Tournaments/TWC/2024/ko.md
@@ -133,8 +133,7 @@ osu!taiko 월드컵 2024는 osu!팀과 여러명의 커뮤니티 멤버들로 �
 
 ### 파이널
 
-**[맵팩은 여기서 다운로드가 가능합니다  (168 MB)](https://packs.ppy.sh/P244%20-%20osu!taiko%20World%20Cup%202024%3A%20Finals.zip)**\
-[쇼케이스 VOD는 여기서 볼 수 있습니다](https://www.twitch.tv/videos/2119951003)
+**[맵팩은 여기서 다운로드가 가능합니다  (167 MB)](https://packs.ppy.sh/P244%20-%20osu!taiko%20World%20Cup%202024%3A%20Finals.zip?1713511023)**
 
 - No Mod
   1. [SatapanP ft. Hatsune Miku - Bagooon!!!!! (Skidooskei) \[NO MISS!!!!! (TWC EDIT!!!!!)\]](https://osu.ppy.sh/beatmapsets/2112567#taiko/4570747)
@@ -142,7 +141,7 @@ osu!taiko 월드컵 2024는 osu!팀과 여러명의 커뮤니티 멤버들로 �
   3. [kessoku band - Seishun Complex (Kirairi Bootleg) (Seren58) \[Quartet\]](https://osu.ppy.sh/beatmapsets/1901991#taiko/3921191)
   4. [Ruby My Dear - Ecureuil (SolaEclipse) \[Don't Blink\]](https://osu.ppy.sh/beatmapsets/2166520#taiko/4570829)
   5. [Rivers of Nihil - Reign of Dreams (Xay) \[Perpetuity\]](https://osu.ppy.sh/beatmapsets/2166485#taiko/4570764)
-  6. [Sobrem - Carrot Carrot (Nurend) \[Carrot\]](https://osu.ppy.sh/beatmapsets/2166484#taiko/4570763)
+  6. [Frums - Remnants of Turing (Ulqui) \[Alto Hospicio\]](https://osu.ppy.sh/beatmapsets/2019618#taiko/4205872)
   7. [Sydosys - Serrate (\_Rise) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2166563#taiko/4570945)
 - Hidden
   1. [flatt - Agitato (miyagishima) \[Inner Oni (TWC Edit)\]](https://osu.ppy.sh/beatmapsets/2024995#taiko/4570745)


### PR DESCRIPTION
Replaces Finals NM6 since the current track breaks the content usage guidelines.