### PR TITLE
Fix hyperlink in `Monthly Beatmapping Contest: May 2024` news post

### DIFF
--- a/news/2024/2024-05-10-monthly-beatmapping-contest-may-2024.md
+++ b/news/2024/2024-05-10-monthly-beatmapping-contest-may-2024.md
@@ -45,7 +45,7 @@ And of course, congrats to [acnozei](https://osu.ppy.sh/users/10141268) for join
 
 ### osu!mania results
 
-[See the full results here.](https://mappersguild.comz/contests/results?contest=65d64ba5b2923e167f793657)
+[See the full results here.](https://mappersguild.com/contests/results?contest=65d64ba5b2923e167f793657)
 
 #### Summary
 


### PR DESCRIPTION
Fixes the hyperlink linking to the MPG result's page, which was currently inaccessible.

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
