### PR TITLE
Add new Arcaea difficulty to difficulty naming schemes list

### DIFF
--- a/wiki/Ranking_criteria/Difficulty_naming/de.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/de.md
@@ -140,7 +140,8 @@ Beatmapsets von Songs, die von anderen Rhythmusspielen stammen, übernehmen oft 
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/en.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/en.md
@@ -140,7 +140,8 @@ Mapsets of songs that originated from other rhythm games often borrow that game'
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/fr.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/fr.md
@@ -144,7 +144,8 @@ Les mapsets des musiques issues d'autres jeux de rythme empruntent souvent le sy
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/id.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/id.md
@@ -134,7 +134,8 @@ Mapset yang memiliki lagu yang berasal dari game ritme lain sering kali mengguna
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/ja.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/ja.md
@@ -134,7 +134,8 @@ outdated_translation: true
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/ko.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/ko.md
@@ -134,7 +134,8 @@ outdated_translation: true
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/ru.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/ru.md
@@ -134,7 +134,8 @@ outdated_translation: true
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/sv.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/sv.md
@@ -136,7 +136,8 @@ Mapsets av låtar som härstammar från andra rytmspel lånar ofta spelets svår
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/zh-tw.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/zh-tw.md
@@ -135,7 +135,8 @@ outdated_translation: true
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 

--- a/wiki/Ranking_criteria/Difficulty_naming/zh.md
+++ b/wiki/Ranking_criteria/Difficulty_naming/zh.md
@@ -140,7 +140,8 @@
 - ![](/wiki/shared/diff/normal-o.png?20211215) Past
 - ![](/wiki/shared/diff/hard-o.png?20211215) Present
 - ![](/wiki/shared/diff/insane-o.png?20211215) Future
-- ![](/wiki/shared/diff/expert-o.png?20211215) Beyond
+- ![](/wiki/shared/diff/expert-o.png?20211215) Eternal
+- ![](/wiki/shared/diff/expertplus-o.png?20211215) Beyond
 
 ### Lanota
 


### PR DESCRIPTION
- Added the "eternal" difficulty that was recently added in Arcaea, giving it the expert icon and beyond the expert plus icon. Tell me if you think eternal and beyond should be swapped, i.e giving beyond the expert icon and eternal the expert plus icon.