### PR TITLE
Bump osu-wiki-tools to version `2.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.2.1
+osu-wiki-tools==2.3.0


### PR DESCRIPTION
view changes at https://github.com/Walavouchey/osu-wiki-tools/compare/v2.2.1...v2.3.0

- `--base-commit` now defaults to `master` and behaves as a true base commit, not one-commit-after-the-base-commit
- `--outdated-since` now defaults to first commit diverging from `master` (i.e. the old `--base-commit` default)
- allows "series" yaml tag, for future use in news posts
