### PR TITLE
Fix English title and remove outdated mark in translation of `Reporting bad behaviour/Abuse`

### DIFF
--- a/wiki/Reporting_bad_behaviour/Abuse/en.md
+++ b/wiki/Reporting_bad_behaviour/Abuse/en.md
@@ -1,4 +1,4 @@
-# Reporting Abuse
+# Reporting abuse
 
 ## I don't know if I should report this or not
 

--- a/wiki/Reporting_bad_behaviour/Abuse/it.md
+++ b/wiki/Reporting_bad_behaviour/Abuse/it.md
@@ -1,8 +1,3 @@
----
-outdated_since: 8b45559ddf7fab47f5aac78e524abc158ccab574
-outdated_translation: true
----
-
 # Denunciare un abuso
 
 ## Non so se dovrei segnalarlo o meno


### PR DESCRIPTION
mistakenly applied in https://github.com/ppy/osu-wiki/pull/11460 (spanish translation is already updated)

noticed a title-cased title too

SKIP_OUTDATED_CHECK