### PR TITLE
Use `master` instead of HEAD for `--base-commit` in outdated article check

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,6 +76,6 @@ jobs:
         if: ${{ !contains(github.event.pull_request.body, 'SKIP_OUTDATED_CHECK') }}
         run: |
           osu-wiki-tools check-outdated-articles \
-            --base-commit HEAD \
+            --base-commit master \
             --no-recommend-autofix \
             --outdated-since "$(git log --format=%H master.. | tail -n 1)"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,8 +74,4 @@ jobs:
 
       - name: check if translations are marked as outdated
         if: ${{ !contains(github.event.pull_request.body, 'SKIP_OUTDATED_CHECK') }}
-        run: |
-          osu-wiki-tools check-outdated-articles \
-            --base-commit master \
-            --no-recommend-autofix \
-            --outdated-since "$(git log --format=%H master.. | tail -n 1)"
+        run: osu-wiki-tools check-outdated-articles --no-recommend-autofix


### PR DESCRIPTION
fixes issue reported on discord https://discord.com/channels/188630481301012481/218677502141399041/1250894073951289446

turns out i forgot what clayton said in https://github.com/Walavouchey/osu-wiki-tools/pull/22#issuecomment-1872171172 when updating in https://github.com/ppy/osu-wiki/pull/11438