### PR TITLE
Reformat "Areas of focus" in `People/Global_Moderation_Team`

### DIFF
--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -82,6 +82,7 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 | ::{ flag=HU }:: [[ Another ]](https://osu.ppy.sh/users/3416573) | Hungarian |
 | ::{ flag=CH }:: [\[ryuu\]](https://osu.ppy.sh/users/5698467) | Russian |
 | ::{ flag=MY }:: [bibitaru](https://osu.ppy.sh/users/4482419) | Chinese, Malay |
+| ::{ flag=US }:: [Blushing](https://osu.ppy.sh/users/5927823) |  |
 | ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish |
 | ::{ flag=GB }:: [chromb](https://osu.ppy.sh/users/10238680) |  |
 | ::{ flag=KR }:: [Civil oath](https://osu.ppy.sh/users/3216107) | Korean, Japanese |
@@ -246,7 +247,7 @@ The following users don't have a specific area of focus.
 | `#spanish` | [Español](https://osu.ppy.sh/community/forums/33) | ::{ flag=AR }:: [Darksonic](https://osu.ppy.sh/users/570042), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=MX }:: [Repflez](https://osu.ppy.sh/users/201392) |
 | `#thai` | [ภาษาไทย](https://osu.ppy.sh/community/forums/54) | ::{ flag=TH }:: [Trigonoculus](https://osu.ppy.sh/users/7627013) |
 | `#turkish` | [Türkçe](https://osu.ppy.sh/community/forums/93) |  |
-| `#ukrainian` |  | ::{ flag=RU }:: [Kobold84](https://osu.ppy.sh/users/3227533) |
+| `#ukrainian` |  |  |
 | `#vietnamese` |  | ::{ flag=VN }:: [My Angel Chino](https://osu.ppy.sh/users/20547597), ::{ flag=ID }:: [Sies](https://osu.ppy.sh/users/6491991) |
 
 <!-- TODO: History section wanted (Chat operators/GreenBAT, etc, etc) -->

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -70,6 +70,8 @@ Once a Global Moderator chooses to depart from the team, they may be granted the
 
 The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all of the team members. In addition to areas mentioned below, all GMT members take part in [reviewing visual and aural content included in beatmaps](/wiki/Rules/Visual_content_considerations#getting-your-image-assessed).
 
+**A member of the GMT can engage with any tasks within any category that they choose, despite their listed primary responsibilities.** For example, a GMT member primarily responsible for chat moderation may also help with forum moderation, or vice versa.
+
 <!-- NOTE FOR TRANSLATORS: Translating this section is different from other parts of the osu! wiki. See https://github.com/ppy/osu-wiki/blob/master/meta/group-info/TRANSLATING.md#group-articles. -->
 
 ### Chat moderation

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -174,7 +174,7 @@ Small intro paragraph to explain what exactly tournament management is, or what 
 | :-- | :-- |
 | ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish |
 | ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) | Portuguese, Spanish |
-| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) |
+| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) | German |
 
 ### Technical support
 

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -132,6 +132,7 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 | ::{ flag=US }:: [abraker](https://osu.ppy.sh/users/4635891) |  |
 | ::{ flag=FR }:: [Corne2Plum3](https://osu.ppy.sh/users/15646039) | French |
 | ::{ flag=US }:: [Death](https://osu.ppy.sh/users/3242450) |  |
+| ::{ flag=RU }:: [Kobold84](https://osu.ppy.sh/users/3227533) | Russian |
 | ::{ flag=DE }:: [Lyawi](https://osu.ppy.sh/users/5851253) | German |
 | ::{ flag=PH }:: [Nathanael](https://osu.ppy.sh/users/2295078) | Filipino |
 | ::{ flag=DE }:: [RockRoller](https://osu.ppy.sh/users/8388854) | German |
@@ -172,9 +173,10 @@ Small intro paragraph to explain what exactly tournament management is, or what 
 
 | Name | Additional languages |
 | :-- | :-- |
+| ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595) | Dutch, some German |
 | ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish |
+| ::{ flag=CA }:: [D I O](https://osu.ppy.sh/users/3958619) | Some Spanish |
 | ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) | Portuguese, Spanish |
-| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) | German |
 
 ### Technical support
 
@@ -198,6 +200,7 @@ The following users have very specific use cases in the team. The role provides 
 | ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718) | Cantonese, Chinese | [^task-mangomizer] |
 | ::{ flag=NO }:: [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu! development |
 | ::{ flag=AU }:: [osu!team](https://osu.ppy.sh/users/4341397) |  | Official team presence |
+| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) | German | Tournament management |
 | ::{ flag=CH }:: [TicClick](https://osu.ppy.sh/users/672931) | Russian | Wiki administration |
 | ::{ flag=PL }:: [Venix](https://osu.ppy.sh/users/5999631) | Polish | Team leadership |
 
@@ -208,8 +211,6 @@ The following users don't have a specific area of focus.
 | Name | Additional languages |
 | :-- | :-- |
 | ::{ flag=RS }:: [0x84f](https://osu.ppy.sh/users/7944724) | Serbian |
-| ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595) | Dutch, some German |
-| ::{ flag=CA }:: [D I O](https://osu.ppy.sh/users/3958619) | Some Spanish |
 
 ### Grouped by languages moderated
 

--- a/wiki/People/Global_Moderation_Team/en.md
+++ b/wiki/People/Global_Moderation_Team/en.md
@@ -72,85 +72,144 @@ The [Global Moderation Team group page](https://osu.ppy.sh/groups/4) lists all o
 
 <!-- NOTE FOR TRANSLATORS: Translating this section is different from other parts of the osu! wiki. See https://github.com/ppy/osu-wiki/blob/master/meta/group-info/TRANSLATING.md#group-articles. -->
 
+### Chat moderation
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=DE }:: [- Felix](https://osu.ppy.sh/users/8503985) | German |
+| ::{ flag=HU }:: [[ Another ]](https://osu.ppy.sh/users/3416573) | Hungarian |
+| ::{ flag=CH }:: [\[ryuu\]](https://osu.ppy.sh/users/5698467) | Russian |
+| ::{ flag=MY }:: [bibitaru](https://osu.ppy.sh/users/4482419) | Chinese, Malay |
+| ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish |
+| ::{ flag=GB }:: [chromb](https://osu.ppy.sh/users/10238680) |  |
+| ::{ flag=KR }:: [Civil oath](https://osu.ppy.sh/users/3216107) | Korean, Japanese |
+| ::{ flag=AR }:: [Darksonic](https://osu.ppy.sh/users/570042) | Spanish |
+| ::{ flag=BR }:: [Edward](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese |
+| ::{ flag=FI }:: [Flutteh](https://osu.ppy.sh/users/5042507) | Finnish, some Swedish |
+| ::{ flag=CN }:: [Fycho](https://osu.ppy.sh/users/1876867) | Chinese |
+| ::{ flag=PL }:: [Galkan](https://osu.ppy.sh/users/169570) | Polish |
+| ::{ flag=FR }:: [Ganondorf](https://osu.ppy.sh/users/10660738) | French |
+| ::{ flag=FR }:: [Imakuri](https://osu.ppy.sh/users/6100837) | French, Spanish |
+| ::{ flag=HK }:: [kanpakyin](https://osu.ppy.sh/users/394326) | Cantonese, Chinese, Japanese |
+| ::{ flag=RU }:: [Kobold84](https://osu.ppy.sh/users/3227533) | Russian |
+| ::{ flag=JP }:: [KSHR](https://osu.ppy.sh/users/409957) | Japanese |
+| ::{ flag=RU }:: [Kudou Chitose](https://osu.ppy.sh/users/9936528) | Russian |
+| ::{ flag=FI }:: [Laurakko](https://osu.ppy.sh/users/7253731) | Finnish, some Swedish |
+| ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) | Portuguese, Spanish |
+| ::{ flag=DE }:: [Lyawi](https://osu.ppy.sh/users/5851253) | German |
+| ::{ flag=VN }:: [My Angel Chino](https://osu.ppy.sh/users/20547597) | Vietnamese |
+| ::{ flag=PH }:: [Nathanael](https://osu.ppy.sh/users/2295078) | Filipino |
+| ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805) | Indonesian |
+| ::{ flag=FR }:: [Nozhomi](https://osu.ppy.sh/users/2716981) | French |
+| ::{ flag=BR }:: [Nukrid](https://osu.ppy.sh/users/2307484) | Portuguese, Spanish |
+| ::{ flag=DE }:: [OnosakiHito](https://osu.ppy.sh/users/290128) | German, Serbian |
+| ::{ flag=KR }:: [Petit](https://osu.ppy.sh/users/4637369) | Korean, Japanese |
+| ::{ flag=MY }:: [QHideaki13](https://osu.ppy.sh/users/733998) | Malay |
+| ::{ flag=MX }:: [Repflez](https://osu.ppy.sh/users/201392) | Spanish |
+| ::{ flag=KR }:: [ruexia](https://osu.ppy.sh/users/385069) | Korean |
+| ::{ flag=JP }:: [S o h](https://osu.ppy.sh/users/2234772) | Japanese |
+| ::{ flag=SE }:: [Saten](https://osu.ppy.sh/users/444506) | Swedish, Spanish |
+| ::{ flag=FR }:: [Shiro](https://osu.ppy.sh/users/113005) | French, Spanish |
+| ::{ flag=ID }:: [Shurelia](https://osu.ppy.sh/users/3807986) | Indonesian |
+| ::{ flag=ID }:: [Sies](https://osu.ppy.sh/users/6491991) | Indonesian, some Vietnamese |
+| ::{ flag=TW }:: [spboxer3](https://osu.ppy.sh/users/197974) | Chinese |
+| ::{ flag=FI }:: [terho](https://osu.ppy.sh/users/6090105) | Finnish |
+| ::{ flag=NZ }:: [THAT_otaku](https://osu.ppy.sh/users/11798717) |  |
+| ::{ flag=CH }:: [TicClick](https://osu.ppy.sh/users/672931) | Russian |
+| ::{ flag=KR }:: [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese, Filipino |
+| ::{ flag=PH }:: [topecnz](https://osu.ppy.sh/users/2103927) | Filipino |
+| ::{ flag=TH }:: [Trigonoculus](https://osu.ppy.sh/users/7627013) | Thai |
+| ::{ flag=PL }:: [Venix](https://osu.ppy.sh/users/5999631) | Polish |
+| ::{ flag=NL }:: [Uni](https://osu.ppy.sh/users/617106) | Dutch |
+| ::{ flag=ID }:: [wowcake](https://osu.ppy.sh/users/16121851) | Indonesian |
+| ::{ flag=PL }:: [Yason](https://osu.ppy.sh/users/2574392) | Polish |
+| ::{ flag=HM }:: [Zallius](https://osu.ppy.sh/users/55) | <!-- TODO --> |
+
+### Forum moderation
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=US }:: [abraker](https://osu.ppy.sh/users/4635891) |  |
+| ::{ flag=FR }:: [Corne2Plum3](https://osu.ppy.sh/users/15646039) | French |
+| ::{ flag=US }:: [Death](https://osu.ppy.sh/users/3242450) |  |
+| ::{ flag=DE }:: [Lyawi](https://osu.ppy.sh/users/5851253) | German |
+| ::{ flag=PH }:: [Nathanael](https://osu.ppy.sh/users/2295078) | Filipino |
+| ::{ flag=DE }:: [RockRoller](https://osu.ppy.sh/users/8388854) | German |
+| ::{ flag=ID }:: [Sies](https://osu.ppy.sh/users/6491991) | Indonesian, some Vietnamese |
+| ::{ flag=AT }:: [Stefan](https://osu.ppy.sh/users/626907) | German, Serbian |
+| ::{ flag=NZ }:: [THAT_otaku](https://osu.ppy.sh/users/11798717) |  |
+
+### Mapping/modding community moderation
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=MY }:: [\_Kobii](https://osu.ppy.sh/users/6209713) | Chinese, Malay, Cantonese, some Japanese |
+| ::{ flag=CN }:: [Fycho](https://osu.ppy.sh/users/1876867) | Chinese |
+| ::{ flag=US }:: [Halfslashed](https://osu.ppy.sh/users/4598899) |  |
+| ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154) | Indonesian |
+| ::{ flag=MY }:: [Jerry](https://osu.ppy.sh/users/605973) | Malay, some Chinese |
+| ::{ flag=DE }:: [Loctav](https://osu.ppy.sh/users/71366) | German |
+| ::{ flag=BR }:: [maot](https://osu.ppy.sh/users/3914271) | Portuguese |
+| ::{ flag=US }:: [Nevo](https://osu.ppy.sh/users/7451883) |  |
+| ::{ flag=DE }:: [OnosakiHito](https://osu.ppy.sh/users/290128) | German, Serbian |
+| ::{ flag=CA }:: [Shad0wStar](https://osu.ppy.sh/users/16866460) |  |
+| ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598) | Korean |
+| ::{ flag=JP }:: [TKS](https://osu.ppy.sh/users/940878) | Japanese |
+| ::{ flag=PL }:: [Venix](https://osu.ppy.sh/users/5999631) | Polish |
+| ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768) | Spanish |
+
+### Skinning community moderation
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=PL }:: [Redo_](https://osu.ppy.sh/users/7122165) | Polish |
+| ::{ flag=NL }:: [Roan](https://osu.ppy.sh/users/8214639) | Dutch, Japanese |
+| ::{ flag=DE }:: [RockRoller](https://osu.ppy.sh/users/8388854) | German |
+
+### Tournament management
+
+Small intro paragraph to explain what exactly tournament management is, or what it needs GMT for (?)
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish |
+| ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) | Portuguese, Spanish |
+| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) |
+
+### Technical support
+
+*See also: [Technical Support Team](/wiki/People/Technical_Support_Team).*
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=US }:: [Death](https://osu.ppy.sh/users/3242450) |  |
+| ::{ flag=US }:: [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  |
+| ::{ flag=PH }:: [Nathanael](https://osu.ppy.sh/users/2295078) | Filipino |
+| ::{ flag=ES }:: [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish |
+
+### Miscellaneous
+
+The following users have very specific use cases in the team. The role provides them tools and visibility over internal affairs, but don't necessarily moderate like other members do.
+
 | Name | Additional languages | Area of focus |
 | :-- | :-- | :-- |
-| ::{ flag=MY }:: [\_Kobii](https://osu.ppy.sh/users/6209713) | Chinese, Malay, Cantonese, some Japanese | Mapping/modding community moderation |
-| ::{ flag=DE }:: [- Felix](https://osu.ppy.sh/users/8503985) | German | Chat moderation |
-| ::{ flag=HU }:: [[ Another ]](https://osu.ppy.sh/users/3416573) | Hungarian | Chat moderation |
-| ::{ flag=CH }:: [\[ryuu\]](https://osu.ppy.sh/users/5698467) | Russian | Chat moderation |
-| ::{ flag=RS }:: [0x84f](https://osu.ppy.sh/users/7944724) | Serbian |  |
-| ::{ flag=US }:: [abraker](https://osu.ppy.sh/users/4635891) |  | Forum moderation |
-| ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595) | Dutch, some German |  |
 | ::{ flag=CA }:: [Azer](https://osu.ppy.sh/users/2155578) |  | Tournament management[^task-Azer] |
-| ::{ flag=MY }:: [bibitaru](https://osu.ppy.sh/users/4482419) | Chinese, Malay | Chat moderation |
-| ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251) | Swedish, Spanish | Chat moderation, tournament management |
-| ::{ flag=GB }:: [chromb](https://osu.ppy.sh/users/10238680) |  | Chat moderation |
-| ::{ flag=KR }:: [Civil oath](https://osu.ppy.sh/users/3216107) | Korean, Japanese | Chat moderation |
-| ::{ flag=FR }:: [Corne2Plum3](https://osu.ppy.sh/users/15646039) | French | Forum moderation |
-| ::{ flag=CA }:: [D I O](https://osu.ppy.sh/users/3958619) | Some Spanish |  |
-| ::{ flag=AR }:: [Darksonic](https://osu.ppy.sh/users/570042) | Spanish | Chat moderation |
-| ::{ flag=US }:: [Death](https://osu.ppy.sh/users/3242450) |  | Forum moderation, technical support |
-| ::{ flag=US }:: [Dntm8kmeeatu](https://osu.ppy.sh/users/5428812) |  | Technical support |
-| ::{ flag=BR }:: [Edward](https://osu.ppy.sh/users/5618109) | Portuguese, Japanese | Chat moderation |
 | ::{ flag=AU }:: [Ephemeral](https://osu.ppy.sh/users/102335) |  | Player support, wiki administration |
-| ::{ flag=FI }:: [Flutteh](https://osu.ppy.sh/users/5042507) | Finnish, some Swedish | Chat moderation |
-| ::{ flag=CN }:: [Fycho](https://osu.ppy.sh/users/1876867) | Chinese | Chat moderation, mapping/modding community moderation |
-| ::{ flag=PL }:: [Galkan](https://osu.ppy.sh/users/169570) | Polish | Chat moderation |
-| ::{ flag=FR }:: [Ganondorf](https://osu.ppy.sh/users/10660738) | French | Chat moderation |
-| ::{ flag=US }:: [Halfslashed](https://osu.ppy.sh/users/4598899) |  | Mapping/modding community moderation |
-| ::{ flag=ID }:: [Ilham](https://osu.ppy.sh/users/3057154) | Indonesian | Mapping/modding community moderation |
-| ::{ flag=FR }:: [Imakuri](https://osu.ppy.sh/users/6100837) | French, Spanish | Chat moderation |
-| ::{ flag=MY }:: [Jerry](https://osu.ppy.sh/users/605973) | Malay, some Chinese | Mapping/modding community moderation |
-| ::{ flag=HK }:: [kanpakyin](https://osu.ppy.sh/users/394326) | Cantonese, Chinese, Japanese | Chat moderation |
-| ::{ flag=RU }:: [Kobold84](https://osu.ppy.sh/users/3227533) | Russian | Chat moderation |
-| ::{ flag=JP }:: [KSHR](https://osu.ppy.sh/users/409957) | Japanese | Chat moderation |
-| ::{ flag=RU }:: [Kudou Chitose](https://osu.ppy.sh/users/9936528) | Russian | Chat moderation |
-| ::{ flag=FI }:: [Laurakko](https://osu.ppy.sh/users/7253731) | Finnish, some Swedish | Chat moderation |
-| ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) | Portuguese, Spanish | Chat moderation, tournament management |
-| ::{ flag=DE }:: [Loctav](https://osu.ppy.sh/users/71366) | German | Mapping/modding community moderation |
-| ::{ flag=DE }:: [Lyawi](https://osu.ppy.sh/users/5851253) | German | Chat moderation, forum moderation |
 | ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718) | Cantonese, Chinese | [^task-mangomizer] |
-| ::{ flag=BR }:: [maot](https://osu.ppy.sh/users/3914271) | Portuguese | Mapping/modding community moderation |
 | ::{ flag=NO }:: [MillhioreF](https://osu.ppy.sh/users/941094) |  | osu! development |
-| ::{ flag=VN }:: [My Angel Chino](https://osu.ppy.sh/users/20547597) | Vietnamese | Chat moderation |
-| ::{ flag=PH }:: [Nathanael](https://osu.ppy.sh/users/2295078) | Filipino | Chat moderation, forum moderation, technical support |
-| ::{ flag=US }:: [Nevo](https://osu.ppy.sh/users/7451883) |  | Mapping/modding community moderation |
-| ::{ flag=ID }:: [Niva](https://osu.ppy.sh/users/197805) | Indonesian | Chat moderation |
-| ::{ flag=FR }:: [Nozhomi](https://osu.ppy.sh/users/2716981) | French | Chat moderation |
-| ::{ flag=BR }:: [Nukrid](https://osu.ppy.sh/users/2307484) | Portuguese, Spanish | Chat moderation |
-| ::{ flag=DE }:: [OnosakiHito](https://osu.ppy.sh/users/290128) | German, Serbian | Chat moderation, mapping/modding community moderation |
 | ::{ flag=AU }:: [osu!team](https://osu.ppy.sh/users/4341397) |  | Official team presence |
-| ::{ flag=DE }:: [p3n](https://osu.ppy.sh/users/123703) | German | Tournament management |
-| ::{ flag=KR }:: [Petit](https://osu.ppy.sh/users/4637369) | Korean, Japanese | Chat moderation |
-| ::{ flag=MY }:: [QHideaki13](https://osu.ppy.sh/users/733998) | Malay | Chat moderation |
-| ::{ flag=PL }:: [Redo_](https://osu.ppy.sh/users/7122165) | Polish | Skinning community moderation |
-| ::{ flag=MX }:: [Repflez](https://osu.ppy.sh/users/201392) | Spanish | Chat moderation |
-| ::{ flag=NL }:: [Roan](https://osu.ppy.sh/users/8214639) | Dutch, Japanese | Skinning community moderation |
-| ::{ flag=DE }:: [RockRoller](https://osu.ppy.sh/users/8388854) | German | Skinning community moderation, forum moderation |
-| ::{ flag=KR }:: [ruexia](https://osu.ppy.sh/users/385069) | Korean | Chat moderation |
-| ::{ flag=JP }:: [S o h](https://osu.ppy.sh/users/2234772) | Japanese | Chat moderation |
-| ::{ flag=SE }:: [Saten](https://osu.ppy.sh/users/444506) | Swedish, Spanish | Chat moderation |
-| ::{ flag=CA }:: [Shad0wStar](https://osu.ppy.sh/users/16866460) |  | Mapping/modding community moderation |
-| ::{ flag=FR }:: [Shiro](https://osu.ppy.sh/users/113005) | French, Spanish | Chat moderation |
-| ::{ flag=ID }:: [Shurelia](https://osu.ppy.sh/users/3807986) | Indonesian | Chat moderation |
-| ::{ flag=ID }:: [Sies](https://osu.ppy.sh/users/6491991) | Indonesian, some Vietnamese | Chat moderation, forum moderation |
-| ::{ flag=AT }:: [Stefan](https://osu.ppy.sh/users/626907) | German, Serbian | Forum moderation |
-| ::{ flag=TW }:: [spboxer3](https://osu.ppy.sh/users/197974) | Chinese | Chat moderation |
-| ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598) | Korean | Mapping/modding community moderation |
-| ::{ flag=FI }:: [terho](https://osu.ppy.sh/users/6090105) | Finnish | Chat moderation |
-| ::{ flag=NZ }:: [THAT_otaku](https://osu.ppy.sh/users/11798717) |  | Forum moderation, chat moderation |
-| ::{ flag=CH }:: [TicClick](https://osu.ppy.sh/users/672931) | Russian | Chat moderation, wiki administration |
-| ::{ flag=JP }:: [TKS](https://osu.ppy.sh/users/940878) | Japanese | Mapping/modding community moderation |
-| ::{ flag=KR }:: [ToGlette](https://osu.ppy.sh/users/1076236) | Korean, Japanese, Filipino | Chat moderation |
-| ::{ flag=PH }:: [topecnz](https://osu.ppy.sh/users/2103927) | Filipino | Chat moderation |
-| ::{ flag=TH }:: [Trigonoculus](https://osu.ppy.sh/users/7627013) | Thai | Chat moderation |
-| ::{ flag=ES }:: [Trosk-](https://osu.ppy.sh/users/3469385) | Spanish | Technical support |
-| ::{ flag=NL }:: [Uni](https://osu.ppy.sh/users/617106) | Dutch | Chat moderation |
-| ::{ flag=PL }:: [Venix](https://osu.ppy.sh/users/5999631) | Polish | Team leadership, chat moderation, mapping/modding community moderation |
-| ::{ flag=ID }:: [wowcake](https://osu.ppy.sh/users/16121851) | Indonesian | Chat moderation |
-| ::{ flag=PL }:: [Yason](https://osu.ppy.sh/users/2574392) | Polish | Chat moderation |
-| ::{ flag=HM }:: [Zallius](https://osu.ppy.sh/users/55) | <!-- TODO --> | Chat moderation |
-| ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768) | Spanish | Mapping/modding community moderation |
+| ::{ flag=CH }:: [TicClick](https://osu.ppy.sh/users/672931) | Russian | Wiki administration |
+| ::{ flag=PL }:: [Venix](https://osu.ppy.sh/users/5999631) | Polish | Team leadership |
+
+### Undefined
+
+The following users don't have a specific area of focus.
+
+| Name | Additional languages |
+| :-- | :-- |
+| ::{ flag=RS }:: [0x84f](https://osu.ppy.sh/users/7944724) | Serbian |
+| ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595) | Dutch, some German |
+| ::{ flag=CA }:: [D I O](https://osu.ppy.sh/users/3958619) | Some Spanish |
 
 ### Grouped by languages moderated
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

The team wanted to try a new format to make it easier to find members of the GMT working in a specific area of focus.

Discussed in [the GMT channel](https://discord.com/channels/90072389919997952/276296389519081472/1250871956354629663)

Drafting so we have a live preview. This is subject to either change or be scrapped right away.

[--> PREVIEW <--](https://osu1.roanh.dev/wiki/en/People/Global_Moderation_Team)

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] The GMT has checked the stuff
- [ ] *(translations only)* Do the whatevermathing that needs to be done for translations.
