### PR TITLE
Correct date that MAT was first able to bubble maps

### DIFF
--- a/wiki/Modding/Bubble/en.md
+++ b/wiki/Modding/Bubble/en.md
@@ -23,7 +23,7 @@ In the modern [beatmap ranking procedure](/wiki/Beatmap_ranking_procedure), the 
 
 Bubbles were introduced by ::{ flag=AU }:: [peppy](/wiki/People/peppy) on October 29, 2007, for "beatmaps that are being considered for ranked play (pending further moderator's feedback)". Setting a beatmap thread's icon to a bubble was a way for BAT members to indicate that the beatmap was of good quality and had followed the [ranking criteria](/wiki/Ranking_criteria)<!-- internal reference: https://osu.ppy.sh/community/forums/topics/619 -->.
 
-On October 3, 2010, the MAT received the permissions to use the bubble icon, alongside the BAT<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->. This essentially deprecated the [proto-bubbles](/wiki/Modding/Proto-bubble), and both teams had been primarily using regular bubbles since.
+On October 4, 2010, the MAT received the permissions to use the bubble icon, alongside the BAT<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->. This essentially deprecated the [proto-bubbles](/wiki/Modding/Proto-bubble), and both teams had been primarily using regular bubbles since.
 
 After the [beatmap discussion system](/wiki/Beatmap_discussion) was fully implemented and became the main interface for modding in November 2017, the forum-based beatmap management controls were phased out, with bubbles being naturally replaced by nominations.
 

--- a/wiki/Modding/Bubble/es.md
+++ b/wiki/Modding/Bubble/es.md
@@ -25,7 +25,7 @@ En el [procedimiento de clasificación de los beatmaps](/wiki/Beatmap_ranking_pr
 
 Las burbujas fueron introducidas por ::{ flag=AU }:: [peppy](/wiki/People/peppy) el 29 de octubre de 2007, para los «beatmaps que estén siendo considerados para el juego clasificado (dependiendo de la opinión de los moderadores)». Para los miembros del BAT, poner una burbuja en el icono de un hilo de un beatmap era una forma de indicar que el beatmap era de buena calidad y había seguido los [criterios de clasificación](/wiki/Ranking_criteria).
 
-El 3 de octubre de 2010, el MAT recibió los permisos para usar el icono de la burbuja, junto con el BAT. De este modo, las [proto-burbujas](/wiki/Modding/Proto-bubble) quedaron obsoletas, y desde entonces ambos equipos usaban principalmente burbujas normales.
+El 4 de octubre de 2010, el MAT recibió los permisos para usar el icono de la burbuja, junto con el BAT. De este modo, las [proto-burbujas](/wiki/Modding/Proto-bubble) quedaron obsoletas, y desde entonces ambos equipos usaban principalmente burbujas normales.
 
 Después de que el [sistema de discusiones de los beatmaps](/wiki/Beatmap_discussion) se implementara por completo y se convirtiera en la interfaz principal para el modding en noviembre de 2017, los controles de gestión de los beatmaps basados ​​en los foros se eliminaron gradualmente y las burbujas fueron naturalmente reemplazadas por nominaciones.
 

--- a/wiki/Modding/Bubble/fr.md
+++ b/wiki/Modding/Bubble/fr.md
@@ -23,7 +23,7 @@ Dans la [procédure de classement du beatmap](/wiki/Beatmap_ranking_procedure) m
 
 Les bubbles ont été introduites par ::{ flag=AU }:: [peppy](/wiki/People/peppy) le 29 octobre 2007, pour les "beatmaps qui sont considérés pour le jeu classé (en attendant les commentaires des modérateurs)". Le fait de transformer l'icône d'un fil de discussion d'une beatmap en une bubble était un moyen pour les membres de la BAT d'indiquer que la beatmap était de bonne qualité et qu'elle avait respecté les [critères de classement](/wiki/Ranking_criteria).
 
-Le 3 octobre 2010, la MAT a reçu l'autorisation d'utiliser l'icône de bubble, aux côtés de la BAT. Cela a essentiellement déprécié les [proto-bubbles](/wiki/Modding/Proto-bubble), et les deux équipes ont principalement utilisé des bubbles ordinaires depuis.
+Le 4 octobre 2010, la MAT a reçu l'autorisation d'utiliser l'icône de bubble, aux côtés de la BAT. Cela a essentiellement déprécié les [proto-bubbles](/wiki/Modding/Proto-bubble), et les deux équipes ont principalement utilisé des bubbles ordinaires depuis.
 
 Après la mise en place complète du [système de discussion d'une beatmap](/wiki/Beatmap_discussion), devenu l'interface principale pour le modding en novembre 2017, les contrôles de gestion des beatmap sur le forum ont été progressivement supprimés, les bubbles étant naturellement remplacées par les nominations.
 

--- a/wiki/Modding/Bubble/id.md
+++ b/wiki/Modding/Bubble/id.md
@@ -23,7 +23,7 @@ Pada [prosedur ranking beatmap](/wiki/Beatmap_ranking_procedure) modern, ekuival
 
 Bubble pada awalnya diperkenalkan oleh ::{ flag=AU }:: peppy pada 29 Oktober 2007 untuk menandai "beatmap-beatmap yang dianggap sudah layak untuk di-rank (walaupun masih perlu untuk dikaji lebih lanjut oleh para moderator lainnya)". Memberikan ikon bubble pada utas beatmap adalah cara anggota BAT untuk menunjukkan bahwa beatmap memiliki kualitas yang baik dan telah mengikuti [ranking criteria](/wiki/Ranking_criteria).
 
-Pada 3 Oktober 2010, MAT mendapatkan izin untuk menggunakan ikon bubble bersama BAT<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->. Hal ini menyebabkan [proto-bubbles](/wiki/Modding/Proto-bubble) menjadi usang dan kedua tim telah menggunakan bubble sejak itu.
+Pada 4 Oktober 2010, MAT mendapatkan izin untuk menggunakan ikon bubble bersama BAT<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->. Hal ini menyebabkan [proto-bubbles](/wiki/Modding/Proto-bubble) menjadi usang dan kedua tim telah menggunakan bubble sejak itu.
 
 Setelah [sistem diskusi beatmap](/wiki/Beatmap_discussion) telah diimplementasi sepenuhnya dan menjadi *interface* utama untuk modding pada November 2017, kontrol manajemen beatmap berbasis forum dikeluarkan, dengan bubble yang secara alami digantikan oleh nominasi.
 

--- a/wiki/Modding/Bubble/vi.md
+++ b/wiki/Modding/Bubble/vi.md
@@ -23,7 +23,7 @@ Trong [quy trình xếp hạng beatmap](/wiki/Beatmap_ranking_procedure) hiện 
 
 Bubble được giới thiệu bởi ::{ flag=AU }:: [peppy](/wiki/People/peppy) vào ngày 29 tháng 10 năm 2007, dành cho "những beatmap đang xem xét để có thể xếp hạng (trong trạng thái chờ thêm phản hồi từ mod)". Đặt biểu tượng cho thread của beatmap qua bubble là một cách cho thành viên BAT biết rằng beatmap có chất lượng tốt và tuân thủ [tiêu chuẩn xếp hạng](/wiki/Ranking_criteria)<!-- internal reference: https://osu.ppy.sh/community/forums/topics/619 -->.
 
-Vào ngày 3 tháng 10 năm 2010, MAT được sử dụng biểu tượng bubble cùng với BAT. Việc này gần như loại bỏ proto-bubble, và kể từ đó cả hai nhóm chủ yếu sử dụng bubbles.
+Vào ngày 4 tháng 10 năm 2010, MAT được sử dụng biểu tượng bubble cùng với BAT. Việc này gần như loại bỏ proto-bubble, và kể từ đó cả hai nhóm chủ yếu sử dụng bubbles.
 
 Sau khi [hệ thống thảo luận beatmap](/wiki/Beatmap_discussion) được hoàn thiện và trở thành giao diện chính cho việc modding vào tháng 11 năm 2017, quản lý beatmap thông qua diễn đàn đã bị loại bỏ dần, và bubble được thay bằng đề cử.
 

--- a/wiki/Modding/Bubble/zh.md
+++ b/wiki/Modding/Bubble/zh.md
@@ -26,7 +26,7 @@ tags:
 
 泡泡最初由 ::{ flag=AU }:: [peppy](/wiki/People/peppy) 在 2007 年 10 月 29 日提出，用于“正在考虑上架游玩（等待摸图员的进一步反馈）”的谱面。他将讨论串的图标设为一个泡泡，并用于 BAT 成员表示谱面质量良好，符合[谱面上架标准 (RC)](/wiki/Ranking_criteria)。<!-- internal reference: https://osu.ppy.sh/community/forums/topics/619 -->
 
-在 2010 年 10 月 3 日，MAT 获得了和 BAT 一样的泡图（给谱面赋予泡泡）权限。<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->这基本上宣告了[原型泡泡](/wiki/Modding/Proto-bubble)系统的死亡。从那以后，两个团队都主要使用普通泡泡。
+在 2010 年 10 月 4 日，MAT 获得了和 BAT 一样的泡图（给谱面赋予泡泡）权限。<!-- internal reference: https://osu.ppy.sh/community/forums/topics/38403 -->这基本上宣告了[原型泡泡](/wiki/Modding/Proto-bubble)系统的死亡。从那以后，两个团队都主要使用普通泡泡。
 
 在 2017 年 11 月，[谱面讨论系统](/wiki/Beatmap_discussion)全面实装并成为摸图的主要界面后，基于论坛的谱面管理控制被逐步淘汰，泡泡系统也被提名系统所取代。
 


### PR DESCRIPTION
MAT gained permission to use bubbles on October 4, not the 3rd. Source: https://osu.ppy.sh/community/forums/topics/38405?n=1

Not a fluent speaker of the languages except spanish, but its just changing a single number.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
