### PR TITLE
Recommend VSCode osu! markdown preview extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@ node_modules/
 /.osu-wiki-bin*
 
 # local vscode config files
-.vscode
+/.vscode/*
+
+# un-ignore vscode extension recommendations
+!/.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "cl8n.osu-wiki-markdown-preview"
+  ]
+}


### PR DESCRIPTION
it's not perfect or matching osu-web in every way, but it's at least a lot better than vscode's default previewer. https://marketplace.visualstudio.com/items?itemName=cl8n.osu-wiki-markdown-preview

thanks @agatemosu for half of the work on that