### PR TITLE
Fix misleading deprecation notice in skin.ini version 2.6

### DIFF
--- a/wiki/Skinning/skin.ini/en.md
+++ b/wiki/Skinning/skin.ini/en.md
@@ -89,7 +89,7 @@ If your `skin.ini` does not specify a `Version`, it will default to this version
 **Allow per-type skinning of arrows**
 
 - Adds `arrow-generic.png`, `arrow-warning.png` and `arrow-pause.png`.
-- Removes `play-warningarrow.png`.
+- Deprecates `play-warningarrow.png` in favor of the above.
 
 ### 2.7
 

--- a/wiki/Skinning/skin.ini/es.md
+++ b/wiki/Skinning/skin.ini/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: a5a4d44b66fbe6446aefb341d712d1623b1aac80
+---
+
 # Archivo skin.ini
 
 *Véase también: [skin.ini en blanco](/wiki/Skinning/skin.ini/Blank)*

--- a/wiki/Skinning/skin.ini/fr.md
+++ b/wiki/Skinning/skin.ini/fr.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated_translation: true
+outdated_since: a5a4d44b66fbe6446aefb341d712d1623b1aac80
 ---
 
 # skin.ini

--- a/wiki/Skinning/skin.ini/zh.md
+++ b/wiki/Skinning/skin.ini/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: a5a4d44b66fbe6446aefb341d712d1623b1aac80
+---
+
 # skin.ini
 
 *另见：[skin.ini / 空白 skin.ini 文件](/wiki/Skinning/skin.ini/Blank)*


### PR DESCRIPTION
resolves #3176 (min effort)

the whole skin ini changelog needs to be rewritten to properly explain what behavior each version causes, rather than what skin features were introduced at the same time as each version (which are often backward and forward compatible). I have some other skin.ini updates to get back to at some point and I'll probably revisit this at that time