### PR TITLE
Add remark rule to check for common country flag mistakes

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -43,6 +43,7 @@ export default {
     ['lint-table-cell-padding', false],
     ['lint-table-pipe-alignment', false],
     ['message-control', { name: 'lint', source: ['remark-lint', 'remark-lint-osu'] }],
+    ['osu/lint-country-flags'],
     ['osu/lint-table-align-style'],
     ['osu/lint-table-cell-padding'],
     ['osu/lint-table-no-missing-cells'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "remark-lint-no-unused-definitions": "3.1.1",
         "remark-lint-osu-links": "github:cl8n/remark-lint-osu-links",
         "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
-        "remark-osu": "^0.1.0",
+        "remark-osu": "^0.2.0",
         "remark-preset-lint-markdown-style-guide": "5.1.2",
         "vfile-reporter-github-action": "^2.0.0"
       }
@@ -3626,9 +3626,9 @@
       }
     },
     "node_modules/remark-osu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/remark-osu/-/remark-osu-0.1.0.tgz",
-      "integrity": "sha512-mJNbRdJE4zQOJtq/+P7zNnT9X97xabiyny8bZz4JbarPfb9fWNWF03wrbJHCpoRwOtdNl3J2JYGQoeqCk4Z1Pw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/remark-osu/-/remark-osu-0.2.0.tgz",
+      "integrity": "sha512-RZtGqKWcaOuGMi/PCJZNehydWynJIM49OeFCFh9/HCcCb3latFbbFvq4EzhFJtGK+d2WmXLJ90QJ4WbspaM+UA==",
       "dependencies": {
         "unified-lint-rule": "^2.1.2",
         "unist-util-position": "^5.0.0",
@@ -6859,9 +6859,9 @@
       }
     },
     "remark-osu": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/remark-osu/-/remark-osu-0.1.0.tgz",
-      "integrity": "sha512-mJNbRdJE4zQOJtq/+P7zNnT9X97xabiyny8bZz4JbarPfb9fWNWF03wrbJHCpoRwOtdNl3J2JYGQoeqCk4Z1Pw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/remark-osu/-/remark-osu-0.2.0.tgz",
+      "integrity": "sha512-RZtGqKWcaOuGMi/PCJZNehydWynJIM49OeFCFh9/HCcCb3latFbbFvq4EzhFJtGK+d2WmXLJ90QJ4WbspaM+UA==",
       "requires": {
         "unified-lint-rule": "^2.1.2",
         "unist-util-position": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "remark-lint-no-unused-definitions": "3.1.1",
     "remark-lint-osu-links": "github:cl8n/remark-lint-osu-links",
     "remark-lint-osu-wiki-links": "github:MegaApplePi/remark-lint-osu-wiki-links",
-    "remark-osu": "^0.1.0",
+    "remark-osu": "^0.2.0",
     "remark-preset-lint-markdown-style-guide": "5.1.2",
     "vfile-reporter-github-action": "^2.0.0"
   },


### PR DESCRIPTION
checks that country code is in valid format, and that the whole flag syntax is standard for osu-wiki

resolves #8135