### PR TITLE
Bump osu-wiki-tools to version `2.3.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-osu-wiki-tools==2.3.0
+osu-wiki-tools==2.3.2


### PR DESCRIPTION
view changes at
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.3.0...v2.3.2

fixes link checking for redirects that point to nonexistent sections, and adds specific errors for them

![image](https://github.com/user-attachments/assets/65d82989-a7a3-4e24-86d1-448bfafb26d4)

[reported as broken on discord](https://discord.com/channels/188630481301012481/218677502141399041/1273260591636549707). if it did ever check them then it probably broke back in [november last year](https://github.com/Walavouchey/osu-wiki-tools/commit/02a93da6f962b7b281be0be5ee02bc0e5e80b582), but i haven't bisected

no such redirects seem to have slipped by in that time