### PR TITLE
Fix auto-play in embedded videos in `Kyoku 2024 Results`

### DIFF
--- a/news/2024/2024-09-19-kyoku-2024-results.md
+++ b/news/2024/2024-09-19-kyoku-2024-results.md
@@ -19,7 +19,9 @@ With 33 total entries, the competition was fierce and the judges had a lot of wo
 Drum and bass enjoyers can rejoice as Team RGB harnessed the full power of neurofunk. Featuring music by [Artackni](https://artackni.newgrounds.com/) and craftsmanship of [Amon-](https://osu.ppy.sh/users/18161041) and ballsmaster69, [*Encaged*](https://osu.ppy.sh/beatmapsets/2242804#osu/4767104) is a slider-heavy tech map that is bound to get the adrenaline pumping and keep your attention throughout its course.
 
 <div align="center" class="osu-md__paragraph">
-    <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://assets.ppy.sh/media/news/kyoku-2024-3rd-place.mp4" frameborder="0" allowfullscreen></iframe>
+    <video width="95%" controls>
+        <source src="https://assets.ppy.sh/media/news/kyoku-2024-3rd-place.mp4" type="video/mp4" preload="none">
+    </video>
 </div>
 
 Congratulations to Team RGB as they scored themselves 3rd place with a final score of **84.50**!
@@ -29,7 +31,9 @@ Congratulations to Team RGB as they scored themselves 3rd place with a final sco
 Team Zero Blunders has put their best foot forward in this contest with a genre mash-up song featuring many osu! references. [*who's afraid?*](https://osu.ppy.sh/beatmapsets/2242420#osu/4766280) by fur:trash (a.k.a. [Nihkee](https://osu.ppy.sh/users/14244740) on osu!) offers many chances for [Mysty](https://osu.ppy.sh/users/10210657), [Le Mirai](https://osu.ppy.sh/users/13646997), [hakashii](https://osu.ppy.sh/users/11688893), [Omekyu](https://osu.ppy.sh/users/14348073s) and [[-Evil-]](https://osu.ppy.sh/users/10234313) to express their mapping ideas via music genres such as dariacore, dubstep and hyperpop, creating a balanced map that is both fun to look at and play.
 
 <div align="center" class="osu-md__paragraph">
-    <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://assets.ppy.sh/media/news/kyoku-2024-2nd-place.mp4" frameborder="0" allowfullscreen></iframe>
+    <video width="95%" controls>
+        <source src="https://assets.ppy.sh/media/news/kyoku-2024-2nd-place.mp4" type="video/mp4" preload="none">
+    </video>
 </div>
 
 Congratulations to Zero Blunders for managing to lock in a total score of **86.00**, securing 2nd place and 1 contest point for all team members.
@@ -39,7 +43,9 @@ Congratulations to Zero Blunders for managing to lock in a total score of **86.0
 Team cosmo/LOGIΛ have managed to concoct what can best be described as a Grand Finals Tiebreaker map on steroids. [Stellar Evolution](https://osu.ppy.sh/beatmapsets/2242303) from [airlemoneX](https://soundcloud.com/airlemonex) has hints of [Camellia](https://osu.ppy.sh/beatmaps/artists/31) as the inspiration behind the track, with expert mappers [Lulu-](https://osu.ppy.sh/users/4201715), [Slifer](https://osu.ppy.sh/users/15084122) and [Halgoh](https://osu.ppy.sh/users/4109923) fully playing into it with a focus on visuals that complement gameplay.
 
 <div align="center" class="osu-md__paragraph">
-    <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://assets.ppy.sh/media/news/kyoku-2024-1st-place.mp4" frameborder="0" allowfullscreen></iframe>
+    <video width="95%" controls>
+        <source src="https://assets.ppy.sh/media/news/kyoku-2024-1st-place.mp4" type="video/mp4" preload="none">
+    </video>
 </div>
 
 With a final score of **88.25**, cosmo/LOGIΛ have managed to achieve first place, earning badges, $100 to distribute and 2 contest points per person. Congratulations!


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

The way the videos were embedded differed from how it's done in posts such as https://osu.ppy.sh/home/news/2024-09-14-new-featured-artist-tomspicy and caused all of the 3 videos to auto-play, at least on chromium browser.

Not sure if this would be the intended fix, or if there's a reason these were embedded differently. I just embedded them the way they were in the last news post, but these changes are untested.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
