### PR TITLE
Update `Contest points`

### DIFF
--- a/wiki/Contests/Contest_points/en.md
+++ b/wiki/Contests/Contest_points/en.md
@@ -45,6 +45,7 @@ Contest points have been used in the following contests:
 | ::{ flag=GB }:: [Aistre](https://osu.ppy.sh/users/4879380) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=KR }:: [bIG data](https://osu.ppy.sh/users/17744610) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=DE }:: [0ppInOsu](https://osu.ppy.sh/users/12551840) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
+| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) (1), [Kyoku 2024](/wiki/Contests/Kyoku/2024) (2) |
 | ::{ flag=DK }:: [melon boy](https://osu.ppy.sh/users/3053382) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=RU }:: [Aphestra](https://osu.ppy.sh/users/11949191) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=PL }:: [Kalibe](https://osu.ppy.sh/users/3376777) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
@@ -52,11 +53,9 @@ Contest points have been used in the following contests:
 | ::{ flag=EE }:: [iljaaz](https://osu.ppy.sh/users/8501291) | 2 | [Twin Trials](/wiki/Contests/Twin_Trials_Contest) |
 | ::{ flag=DE }:: [Lulu-](https://osu.ppy.sh/users/4201715) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
 | ::{ flag=DE }:: [Slifer](https://osu.ppy.sh/users/15084122) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
-| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
 | ::{ flag=CN }:: [Moecho](https://osu.ppy.sh/users/5075660) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=GB }:: [Altai](https://osu.ppy.sh/users/5745865) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=CN }:: [fanzhen0019](https://osu.ppy.sh/users/418699) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
-| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=KR }:: [Oriental](https://osu.ppy.sh/users/16142512) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=ID }:: [ScubDomino](https://osu.ppy.sh/users/8972308) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=PH }:: [flake](https://osu.ppy.sh/users/7627157) | 1 | [Twin Trials](/wiki/Contests/Twin_Trials_Contest) |

--- a/wiki/Contests/Contest_points/en.md
+++ b/wiki/Contests/Contest_points/en.md
@@ -24,6 +24,7 @@ Contest points have been used in the following contests:
 - [osu!taiko Featured Artist Cup](/wiki/Contests/o!tFAC) (o!tFAC)
 - [Twin Trials](/wiki/Contests/Twin_Trials_Contest)
 - [Vocaloid Mapping Contest 2](/wiki/Contests/VMC/2) (VMC2)
+- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 
 ## Leaderboard
 

--- a/wiki/Contests/Contest_points/en.md
+++ b/wiki/Contests/Contest_points/en.md
@@ -20,11 +20,11 @@ For team contests, elite mapper points will be evaluated on a case-by-case basis
 
 Contest points have been used in the following contests:
 
+- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 - [Monthly Beatmapping Contest](/wiki/Contests/Monthly_Beatmapping_Contest) (MBC)
 - [osu!taiko Featured Artist Cup](/wiki/Contests/o!tFAC) (o!tFAC)
 - [Twin Trials](/wiki/Contests/Twin_Trials_Contest)
 - [Vocaloid Mapping Contest 2](/wiki/Contests/VMC/2) (VMC2)
-- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 
 ## Leaderboard
 

--- a/wiki/Contests/Contest_points/fr.md
+++ b/wiki/Contests/Contest_points/fr.md
@@ -24,11 +24,11 @@ Pour les concours par équipe, les points des elite mapper seront évalués au c
 
 Les points de concours ont été utilisés pour les concours suivants :
 
+- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 - [Monthly Beatmapping Contest](/wiki/Contests/Monthly_Beatmapping_Contest) (MBC)
 - [osu!taiko Featured Artist Cup](/wiki/Contests/o!tFAC) (o!tFAC)
 - [Twin Trials](/wiki/Contests/Twin_Trials_Contest)
 - [Vocaloid Mapping Contest 2](/wiki/Contests/VMC/2) (VMC2)
-- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 
 ## Classement
 

--- a/wiki/Contests/Contest_points/fr.md
+++ b/wiki/Contests/Contest_points/fr.md
@@ -28,6 +28,7 @@ Les points de concours ont été utilisés pour les concours suivants :
 - [osu!taiko Featured Artist Cup](/wiki/Contests/o!tFAC) (o!tFAC)
 - [Twin Trials](/wiki/Contests/Twin_Trials_Contest)
 - [Vocaloid Mapping Contest 2](/wiki/Contests/VMC/2) (VMC2)
+- [Kyoku 2024](/wiki/Contests/Kyoku/2024)
 
 ## Classement
 

--- a/wiki/Contests/Contest_points/fr.md
+++ b/wiki/Contests/Contest_points/fr.md
@@ -49,6 +49,7 @@ Les points de concours ont été utilisés pour les concours suivants :
 | ::{ flag=GB }:: [Aistre](https://osu.ppy.sh/users/4879380) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=KR }:: [bIG data](https://osu.ppy.sh/users/17744610) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=DE }:: [0ppInOsu](https://osu.ppy.sh/users/12551840) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
+| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 3 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) (1), [Kyoku 2024](/wiki/Contests/Kyoku/2024) (2) |
 | ::{ flag=DK }:: [melon boy](https://osu.ppy.sh/users/3053382) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=RU }:: [Aphestra](https://osu.ppy.sh/users/11949191) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=PL }:: [Kalibe](https://osu.ppy.sh/users/3376777) | 2 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
@@ -56,11 +57,9 @@ Les points de concours ont été utilisés pour les concours suivants :
 | ::{ flag=EE }:: [iljaaz](https://osu.ppy.sh/users/8501291) | 2 | [Twin Trials](/wiki/Contests/Twin_Trials_Contest) |
 | ::{ flag=DE }:: [Lulu-](https://osu.ppy.sh/users/4201715) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
 | ::{ flag=DE }:: [Slifer](https://osu.ppy.sh/users/15084122) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
-| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 2 | [Kyoku 2024](/wiki/Contests/Kyoku/2024) |
 | ::{ flag=CN }:: [Moecho](https://osu.ppy.sh/users/5075660) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=GB }:: [Altai](https://osu.ppy.sh/users/5745865) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=CN }:: [fanzhen0019](https://osu.ppy.sh/users/418699) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
-| ::{ flag=FR }:: [Halgoh](https://osu.ppy.sh/users/4109923) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=KR }:: [Oriental](https://osu.ppy.sh/users/16142512) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=ID }:: [ScubDomino](https://osu.ppy.sh/users/8972308) | 1 | [MBC](/wiki/Contests/Monthly_Beatmapping_Contest) |
 | ::{ flag=PH }:: [flake](https://osu.ppy.sh/users/7627157) | 1 | [Twin Trials](/wiki/Contests/Twin_Trials_Contest) |


### PR DESCRIPTION
## Changes
- **Merged duplicate entries in the leaderboard.** A user had two rows after earning points in two contests.
- **Added "Kyoku 2024" to the list of previous contests.**

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)