### PR TITLE
Update `Official beatmapping contest support`

### DIFF
--- a/wiki/Contests/Official_support/en.md
+++ b/wiki/Contests/Official_support/en.md
@@ -44,6 +44,7 @@ Contests which abide by the following criteria are eligible for official support
 - **A user cannot participate in more than one submission to the contest.**
 - **Submissions to the contest should be anonymised.** This limits judging bias removing name association between a mapper and their map. This rule may be ignored only if a contest has special circumstances that warrant removing anonymity.
 - **The contest's organisers must not participate in the contest.** This includes both submitting a map *and* judging/screening submissions. Anyone with access to judging/screening information or un-anonymised submissions is considered a "contest organiser".
+- **Any staff involved in the operation of a tournament in any capacity must not be currently restricted.**
 
 In addition to the criteria above, contests which abide by these rules are eligible for official support for **[contest points](/wiki/Contests/Contest_points) to earn the *Elite Mapper* user title:**
 

--- a/wiki/Contests/Official_support/en.md
+++ b/wiki/Contests/Official_support/en.md
@@ -14,7 +14,7 @@ tags:
 
 For other contests, email us at [tournaments@ppy.sh](mailto:tournaments@ppy.sh). We'll try to work something out.
 
-This article was last updated on September 7, 2024. For the full changelog, check out the [beatmapping contest support updates thread](https://osu.ppy.sh/community/forums/topics/1907886). For any queries or clarifications, please consult the `#tournaments` channel in the [osu! Discord server](https://discord.com/invite/ppy) or send an email to the [account support team](/wiki/People/Account_support_team) via [tournaments@ppy.sh](mailto:tournaments@ppy.sh).
+This article was last updated on September 30, 2024. For the full changelog, check out the [beatmapping contest support updates thread](https://osu.ppy.sh/community/forums/topics/1907886). For any queries or clarifications, please consult the `#tournaments` channel in the [osu! Discord server](https://discord.com/invite/ppy) or send an email to the [account support team](/wiki/People/Account_support_team) via [tournaments@ppy.sh](mailto:tournaments@ppy.sh).
 
 ## Benefits
 

--- a/wiki/Contests/Official_support/en.md
+++ b/wiki/Contests/Official_support/en.md
@@ -44,7 +44,7 @@ Contests which abide by the following criteria are eligible for official support
 - **A user cannot participate in more than one submission to the contest.**
 - **Submissions to the contest should be anonymised.** This limits judging bias removing name association between a mapper and their map. This rule may be ignored only if a contest has special circumstances that warrant removing anonymity.
 - **The contest's organisers must not participate in the contest.** This includes both submitting a map *and* judging/screening submissions. Anyone with access to judging/screening information or un-anonymised submissions is considered a "contest organiser".
-- **Any staff involved in the operation of a tournament in any capacity must not be currently restricted.**
+- **Any staff involved in the operation of a contest in any capacity must not be currently restricted.**
 
 In addition to the criteria above, contests which abide by these rules are eligible for official support for **[contest points](/wiki/Contests/Contest_points) to earn the *Elite Mapper* user title:**
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

This change aims to keep up with [Tournament support rules in regards to restricted staff members](https://osu.ppy.sh/wiki/en/Tournaments/Official_support#staff).

Currently, there was no explicit mention of whether restricted users were allowed or not to partake in contest as staff members. This change now makes that an impossibility.

[Internal thread](https://discord.com/channels/90072389919997952/1290045749371076618/1290045751111712820)

## Self-check

- [X] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] Reviewed by the Contest Committee
