### PR TITLE
Update `Help_centre/Account_restrictions`

### DIFF
--- a/wiki/Help_centre/Account_restrictions/en.md
+++ b/wiki/Help_centre/Account_restrictions/en.md
@@ -9,7 +9,7 @@ When an account is restricted, it is unable to interact with the community until
 The following features are disabled for restricted accounts:
 
 - ability to enter official contests
-- ability to participate in and staff for officially supported tournaments
+- ability to participate in and staff for officially supported tournaments and contests
 - ability to participate in multiplayer rooms
 - in-game chat
 - private messaging

--- a/wiki/Help_centre/Account_restrictions/es.md
+++ b/wiki/Help_centre/Account_restrictions/es.md
@@ -9,7 +9,7 @@ Cuando una cuenta es restringida, es incapaz de interactuar con la comunidad has
 Las siguientes funciones están desactivadas para las cuentas restringidas:
 
 - posibilidad de participar en concursos oficiales
-- posibilidad de participar y ser parte del personal en torneos patrocinados oficialmente
+- posibilidad de participar y ser parte del personal en torneos y concursos patrocinados oficialmente
 - posibilidad de participar en salas multijugador
 - chat dentro del juego
 - mensajes privados

--- a/wiki/Help_centre/Account_restrictions/fr.md
+++ b/wiki/Help_centre/Account_restrictions/fr.md
@@ -13,7 +13,7 @@ Lorsqu'un compte est soumis à des restrictions, il ne peut pas interagir avec l
 Les fonctions suivantes sont désactivées pour les comptes soumis à des restrictions :
 
 - La possibilité de participer à des concours officiels
-- La possibilité de participer à des tournois et des conours bénéficiant d'un soutien officiel et d'être membre du personnel de ces tournois
+- La possibilité de participer à des tournois et des concours bénéficiant d'un soutien officiel et d'être membre du personnel de ces tournois
 - La possibilité de participer à des salons multijoueurs
 - La possibilité de discuter dans le tchat en jeu
 - La possibilité d''envoyer des messages privé

--- a/wiki/Help_centre/Account_restrictions/fr.md
+++ b/wiki/Help_centre/Account_restrictions/fr.md
@@ -13,7 +13,7 @@ Lorsqu'un compte est soumis à des restrictions, il ne peut pas interagir avec l
 Les fonctions suivantes sont désactivées pour les comptes soumis à des restrictions :
 
 - La possibilité de participer à des concours officiels
-- La possibilité de participer à des tournois bénéficiant d'un soutien officiel et d'être membre du personnel de ces tournois
+- La possibilité de participer à des tournois et des conours bénéficiant d'un soutien officiel et d'être membre du personnel de ces tournois
 - La possibilité de participer à des salons multijoueurs
 - La possibilité de discuter dans le tchat en jeu
 - La possibilité d''envoyer des messages privé


### PR DESCRIPTION
It is now explicitly mentioned that restricted users may not participate or staff for officially supported contests. This was previously added for tournaments in #9200 and mirrors the recent changes to the `Contests/Official_support` page found in #12243.

[Internal discussion thread](https://discord.com/channels/90072389919997952/1290045749371076618/1290045751111712820)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
