### PR TITLE
Remove duplicate sentences in `Guides/Starting a beatmap project`

### DIFF
--- a/wiki/Guides/Starting_a_beatmap_project/en.md
+++ b/wiki/Guides/Starting_a_beatmap_project/en.md
@@ -34,7 +34,7 @@ Examples:
 - [\[Album\] Anamanaguchi - Scott Pilgrim vs The World (the game)](https://osu.ppy.sh/community/forums/topics/37908)
 - [\[Album\] Daft Punk - Random Access Memories](https://osu.ppy.sh/community/forums/topics/132592)
 
-**Collab:** Creating a [group-mapping project](/wiki/Beatmap/Beatmap_collaborations) for a certain song. May range from [storyboard](/wiki/Storyboard) request to mapping parts of a [marathon map](/wiki/Beatmap/Marathon). These may range from [storyboard](/wiki/Storyboard) requests to mapping parts of a [marathon map](/wiki/Beatmap/Marathon).
+**Collab:** Creating a [group-mapping project](/wiki/Beatmap/Beatmap_collaborations) for a certain song. May range from [storyboard](/wiki/Storyboard) request to mapping parts of a [marathon map](/wiki/Beatmap/Marathon).
 
 Example:
 

--- a/wiki/Guides/Starting_a_beatmap_project/fr.md
+++ b/wiki/Guides/Starting_a_beatmap_project/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 4e5dda18e70dc4ddb057c93d2ebf1e341996b24f
+---
+
 # Comment démarrer un projet de beatmap
 
 *Remarque : Cet article concerne la section du forum [Beatmap Projects](https://osu.ppy.sh/community/forums/53) et la manière de l'aborder. Assurez-vous de lire les [règles du forum](https://osu.ppy.sh/community/forums/topics/453937) avant de poster vos messages.*


### PR DESCRIPTION
It seems that only the French translation has duplicate sentences, marking it as outdated before we make a decision on the expression.

SKIP_OUTDATED_CHECK

```md
- Cela peut aller d'une demande de [storyboard](/wiki/Storyboard), de mapping de parties d'un [marathon](/wiki/Beatmap/Marathon).
- Cela peut aller d'une demande de [storyboard](/wiki/Storyboard) au mapping de certaines parties d'une [beatmap marathon](/wiki/Beatmap/Marathon).
```

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
