### PR TITLE
Update schedule in the `Pending Cup 2024` news post

### DIFF
--- a/news/2024/2024-08-25-pending-cup-2024.md
+++ b/news/2024/2024-08-25-pending-cup-2024.md
@@ -24,9 +24,9 @@ For our Chinese contestants: [点击此处查看中文版主题。](https://osu.
 
 | Event | Dates |
 | --: | :-- |
-| Beatmapping (1.5 months) | August 25 to October 10 (15:59 UTC) |
-| Judging (1.5 months) | October 10 to November 25 |
-| Results (1 week) | December 2 |
+| Beatmapping (2 months) | August 25 to October 24 (15:59 UTC) |
+| Judging (1.5 months) | October 24 to December 9 |
+| Results (1 week) | December 16 |
 
 *Beatmapping and judging phase deadlines are subject to change.*
 


### PR DESCRIPTION
the mapping deadline is extended by two weeks