### PR TITLE
add release ver to changelog link in `osu!(lazer) Updates: September 6, 2024` news post

### DIFF
--- a/news/2024/2024-09-06-osu-lazer-updates-september-6-2024.md
+++ b/news/2024/2024-09-06-osu-lazer-updates-september-6-2024.md
@@ -59,7 +59,7 @@ Here's what the [Rewind](https://osu.ppy.sh/community/forums/topics/1451845)-ins
 
 ---
 
-Did reading all of this pique your interest for osu!(lazer)? [Download it here](https://osu.ppy.sh/home/download) and give it a try! Already have osu!(lazer) and want to check out all the juicy details from this update? View out the [full changelog](https://osu.ppy.sh/home/changelog/lazer/) here.
+Did reading all of this pique your interest for osu!(lazer)? [Download it here](https://osu.ppy.sh/home/download) and give it a try! Already have osu!(lazer) and want to check out all the juicy details from this update? View out the [full changelog](https://osu.ppy.sh/home/changelog/lazer/2024.906.1) here.
 
 See ya next time!
 


### PR DESCRIPTION
coincidentally this worked out just fine for the end user because it would just go to the latest lazer update (which was the september one), but going forward it'll be incorrect