### PR TITLE
Remove incorrect clause in hush-hush medal requirements

### DIFF
--- a/wiki/Medals/Unlock_requirements/Hush-hush/en.md
+++ b/wiki/Medals/Unlock_requirements/Hush-hush/en.md
@@ -7,4 +7,4 @@ There are, however, some general rules that the solutions tend to follow:
 - A medal only appears in the profile of [game modes](/wiki/Game_mode) it can be obtained in.
 - Medals can only be obtained on beatmaps that are either [Ranked](/wiki/Beatmap/Category#ranked), [Loved](/wiki/Beatmap/Category#loved), [Approved](/wiki/Beatmap/Category#approved) or [Qualified](/wiki/Beatmap/Category#qualified).
 - Beatmap-specific medals are always related to songs from [Featured Artists](/wiki/People/Featured_Artists). This is a convention which has been emphasised more recently, so some older medals may be an exception to this rule.
-- Medals in the "Hush-Hush (Expert)" subcategory do not allow usage of any [difficulty reduction](/wiki/Gameplay/Game_modifier#difficulty-reduction) or unranked mods.
+- Medals in the "Hush-Hush (Expert)" subcategory do not allow usage of any [difficulty reduction](/wiki/Gameplay/Game_modifier#difficulty-reduction) mods.

--- a/wiki/Medals/Unlock_requirements/Hush-hush/es.md
+++ b/wiki/Medals/Unlock_requirements/Hush-hush/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 28f66b88547dc9468350e5d84580b9cc32128832
+---
+
 # Requisitos para desbloquear las medallas Hush-Hush
 
 Las soluciones reales de las medallas [Hush-Hush](/wiki/Medals#hush-hush) se omiten intencionalmente en este artículo para ayudar a preservar sus secretos. Se anima a la comunidad a colaborar entre sí para encontrar las soluciones.
@@ -7,4 +12,4 @@ Sin embargo, hay algunas reglas generales que suelen seguir las soluciones:
 - Una medalla solo aparece en el perfil según el [modo de juego](/wiki/Game_mode) en la que se pueda obtener.
 - Las medallas solo se pueden obtener en mapas que estén [clasificados](/wiki/Beatmap/Category#ranked), [amados](/wiki/Beatmap/Category#loved), [aprobados](/wiki/Beatmap/Category#approved) o [calificados](/wiki/Beatmap/Category#qualified).
 - Las medallas específicas de los beatmaps siempre están relacionadas con canciones de los [artistas destacados](/wiki/People/Featured_Artists). Esta regla se ha puesto en práctica recientemente, por lo que algunas medallas antiguas pueden ser una excepción.
-- Las medallas de la subcategoría «Hush-Hush (Expert)» no permiten el uso de ningún mod que [reduzca la dificultad](/wiki/Gameplay/Game_modifier#reducción-de-dificultad) o mods no clasificados.
+- Las medallas de la subcategoría «Hush-Hush (Expert)» no permiten el uso de ningún mod que [reduzca la dificultad](/wiki/Gameplay/Game_modifier#reducción-de-dificultad).

--- a/wiki/Medals/Unlock_requirements/Hush-hush/es.md
+++ b/wiki/Medals/Unlock_requirements/Hush-hush/es.md
@@ -1,8 +1,3 @@
----
-outdated_translation: true
-outdated_since: 28f66b88547dc9468350e5d84580b9cc32128832
----
-
 # Requisitos para desbloquear las medallas Hush-Hush
 
 Las soluciones reales de las medallas [Hush-Hush](/wiki/Medals#hush-hush) se omiten intencionalmente en este artículo para ayudar a preservar sus secretos. Se anima a la comunidad a colaborar entre sí para encontrar las soluciones.


### PR DESCRIPTION
This reverts https://github.com/ppy/osu-wiki/pull/12314 and https://github.com/ppy/osu-wiki/pull/12316.

The statements added in those pulls are not universally true, cannot be elaborated on without giving solutions away, and the medal hunter people keep annoying me about them, so I want them gone.

(Edit: I'm not sure what's up with the french translation, it wasn't outdated in https://github.com/ppy/osu-wiki/pull/12314, and the content seems to match to my cursory understanding of the language, so SKIP_OUTDATED_CHECK)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)