### PR TITLE
Clarify probation activity requirements in `Beatmap Nominators`

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -28,7 +28,7 @@ Approximately every three months, full Beatmap Nominators have their behaviour a
 
 Probation is used to monitor new Beatmap Nominators more closely. The main role for probationary Beatmap Nominators is to establish a foundation as a Beatmap Nominator through exclusively promoting beatmaps in the ranking process. At least one full nominator must be involved in the ranking process for each game mode of a beatmap, so probationary members cannot give the final nomination to a beatmap which has only received nominations from other probationary members for their game mode.
 
-Probationary Beatmap Nominators are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after meeting double their [activity requirements](/wiki/People/Beatmap_Nominators/Rules#activity), or after one month from being placed there, whichever comes first.
+Probationary Beatmap Nominators are required to have at least **3** nominated beatmaps that were ranked. They are [evaluated](/wiki/People/Nomination_Assessment_Team/Evaluations) after one month, and the evaluation may happen early if they have **6** ranked nominations early in the month.
 
 New members of the Beatmap Nominators will be assigned an NAT buddy who they are encouraged to directly contact for questions or guidance. After their first evaluation, they will be either promoted to the full Beatmap Nominators following a positive evaluation, or removed from the Beatmap Nominators.
 

--- a/wiki/People/Beatmap_Nominators/es.md
+++ b/wiki/People/Beatmap_Nominators/es.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 32b8cbe53f7b9a5ee6408f6e905d6b5f7557bb7c
 tags:
   - BN
   - BNG

--- a/wiki/People/Beatmap_Nominators/fr.md
+++ b/wiki/People/Beatmap_Nominators/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 32b8cbe53f7b9a5ee6408f6e905d6b5f7557bb7c
 no_native_review: true
 tags:
   - BN

--- a/wiki/People/Beatmap_Nominators/vi.md
+++ b/wiki/People/Beatmap_Nominators/vi.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 32b8cbe53f7b9a5ee6408f6e905d6b5f7557bb7c
 no_native_review_since: 303f8823b527327f34a55f39074ed308da98e4b3 Avariation
 tags:
   - BN

--- a/wiki/People/Beatmap_Nominators/zh.md
+++ b/wiki/People/Beatmap_Nominators/zh.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 32b8cbe53f7b9a5ee6408f6e905d6b5f7557bb7c
 tags:
   - BN
   - BNG


### PR DESCRIPTION
a consequence of #12381 no longer specifying monthly activity.

numbers are intentional because probations need slightly higher activity to be better evaluated.