### PR TITLE
(Compose tab) Note how to create reverse sliders

### DIFF
--- a/wiki/Client/Beatmap_editor/Compose/en.md
+++ b/wiki/Client/Beatmap_editor/Compose/en.md
@@ -22,6 +22,8 @@ The editor shares the same tools between osu!, osu!taiko, and osu!catch, while o
 
 The timeline can be zoomed in and out with the `+`/`-` buttons to the left, or alternatively scrolling with the `Alt` key held. The two white lines in the middle indicate the current timestamp. Additionally, hit objects on the timeline can be selected and moved around with the left mouse button, or removed by right-clicking.
 
+Click and drag a slidertail on the timeline right to create [reverse sliders](/wiki/Gameplay/Hit_object/Slider/Reverse_slider).
+
 ### Beat snap divisor
 
 ![](img/beat-snap-divisor.jpg "Beat snap divisor")


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

Based on the navigation I landed on what seems to be the main editor page describing all the controls (https://osu.ppy.sh/wiki/en/Client/Beatmap_editor/Compose). But I couldn't find how to create a reverse slider. So I searched it up and found https://osu.ppy.sh/community/forums/topics/115403?n=1 and then made this

## Drawbacks

- It seems a bit out of place to be honest, but it doesn't really go in the "left sidebar" section.
- When making this pr I noticed https://osu.ppy.sh/wiki/en/Gameplay/Hit_object/Slider/Reverse_slider already had the editor information, so it's a bit redundant...
