### PR TITLE
Update `Tournament bans` with parity changes.

### DIFF
--- a/wiki/Help_centre/Tournament_bans/de.md
+++ b/wiki/Help_centre/Tournament_bans/de.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 342bb3f3b7dafa4a7d4871e36ceba76c93ad4775
 no_native_review: true
 ---
 

--- a/wiki/Help_centre/Tournament_bans/en.md
+++ b/wiki/Help_centre/Tournament_bans/en.md
@@ -2,7 +2,7 @@
 
 *Main page: [Help centre](/wiki/Help_centre)*
 
-A tournament ban prevents a player from being involved in officially supported tournaments in any capacity. This includes playing and staffing or any other kind of assistance.
+A tournament ban prevents a user from playing in official or officially supported tournaments. It also prohibits a user from staffing or offering assistance in these tournaments in any way other than helping as a streamer, commentator or graphic designer.
 
 Tournament bans are very rarely handed out on their own, but generally speaking almost all players who return under a standard appeal for an [account restriction](/wiki/Help_centre/Account_restrictions) are subject to one of at least a year in length.
 
@@ -43,6 +43,8 @@ In rare situations, the [account support team](/wiki/People/The_Team/Account_sup
 ## What can I do while tournament-banned? {id=while-banned}
 
 You may continue to play in community tournaments that do not request official support or require screening at the discretion of the individuals organising such events.
+
+You may still staff in officially supported tournaments by streaming, commentating, or designing graphics at the host's discretion. If you wish to help with other tasks, the host of the tournament you wish to help in MUST request an exemption in their initial request for support. Depending on the reason and severity of the infringement, and with your history in mind, the [account support team](/wiki/People/The_Team/Account_support_team) may then allow this.
 
 Information about your tournament ban status may be provided to tournament organisers upon request, whether they are benefitting from official support or not.
 

--- a/wiki/Help_centre/Tournament_bans/en.md
+++ b/wiki/Help_centre/Tournament_bans/en.md
@@ -2,7 +2,7 @@
 
 *Main page: [Help centre](/wiki/Help_centre)*
 
-A tournament ban prevents a user from playing in official or officially supported tournaments. It also prohibits a user from staffing or offering assistance in these tournaments in any way other than helping as a streamer, commentator or graphic designer.
+A tournament ban prevents a player from playing in official or officially supported tournaments. It also prohibits a user from staffing or offering assistance in these tournaments in any way other than helping as a streamer, commentator or graphic designer.
 
 Tournament bans are very rarely handed out on their own, but generally speaking almost all players who return under a standard appeal for an [account restriction](/wiki/Help_centre/Account_restrictions) are subject to one of at least a year in length.
 

--- a/wiki/Help_centre/Tournament_bans/en.md
+++ b/wiki/Help_centre/Tournament_bans/en.md
@@ -14,7 +14,7 @@ Any severe violation of the [community rules](/wiki/Rules) that takes place duri
 
 As a real-world example, such behaviour would include drawing or writing hate symbols/slurs (swastika, etc.) using cursor smoke in streamed matches.
 
-All users returning to the game after a restriction under the standard appeal terms are also subject to a [minimum temporary tournament ban of 1 year](/wiki/Help_centre/Account_restrictions#reasons), which may be lengthened at the discretion of the [account support team](/wiki/People/The_Team/Account_support_team).
+All users returning to the game after a restriction under the standard appeal terms are also subject to a [minimum temporary tournament ban of 1 year](/wiki/Help_centre/Account_restrictions#reasons), which may be lengthened at the discretion of the [account support team](/wiki/People/Account_support_team).
 
 ## What causes someone to receive an indefinite tournament ban? {id=why-permanent}
 
@@ -38,13 +38,13 @@ Indefinite tournament bans may be appealed after at least **two years** (24 mont
 
 Though it is possible to appeal indefinite tournament bans as above, it should be stressed that significant effort in the greater community outside writing an appeal should be expected for any earnest chance of success.
 
-In rare situations, the [account support team](/wiki/People/The_Team/Account_support_team) may review individual cases at their discretion and remove or reapply appropriate punishments to ensure they remain consistent with similar instances in the past.
+In rare situations, the [account support team](/wiki/People/Account_support_team) may review individual cases at their discretion and remove or reapply appropriate punishments to ensure they remain consistent with similar instances in the past.
 
 ## What can I do while tournament-banned? {id=while-banned}
 
 You may continue to play in community tournaments that do not request official support or require screening at the discretion of the individuals organising such events.
 
-You may still staff in officially supported tournaments by streaming, commentating, or designing graphics at the host's discretion. If you wish to help with other tasks, the host of the tournament you wish to help in MUST request an exemption in their initial request for support. Depending on the reason and severity of the infringement, and with your history in mind, the [account support team](/wiki/People/The_Team/Account_support_team) may then allow this.
+You may still staff in officially supported tournaments by streaming, commentating, or designing graphics at the host's discretion. If you wish to help with other tasks, the host of the tournament you wish to help in MUST request an exemption in their initial request for support. Depending on the reason and severity of the infringement, and with your history in mind, the [account support team](/wiki/People/Account_support_team) may then allow this.
 
 Information about your tournament ban status may be provided to tournament organisers upon request, whether they are benefitting from official support or not.
 

--- a/wiki/Help_centre/Tournament_bans/en.md
+++ b/wiki/Help_centre/Tournament_bans/en.md
@@ -2,7 +2,7 @@
 
 *Main page: [Help centre](/wiki/Help_centre)*
 
-A tournament ban prevents a player from playing in official or officially supported tournaments. It also prohibits a user from staffing or offering assistance in these tournaments in any way other than helping as a streamer, commentator or graphic designer.
+A tournament ban prevents a player from playing in official or officially supported tournaments. It also limits to what extent a player can staff or otherwise offer assistance in these tournaments.
 
 Tournament bans are very rarely handed out on their own, but generally speaking almost all players who return under a standard appeal for an [account restriction](/wiki/Help_centre/Account_restrictions) are subject to one of at least a year in length.
 

--- a/wiki/Help_centre/Tournament_bans/es.md
+++ b/wiki/Help_centre/Tournament_bans/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 342bb3f3b7dafa4a7d4871e36ceba76c93ad4775
+---
+
 # Vetos de los torneos
 
 *Página principal: [Centro de ayuda](/wiki/Help_centre)*

--- a/wiki/Help_centre/Tournament_bans/fr.md
+++ b/wiki/Help_centre/Tournament_bans/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated_translation: true
+outdated_since: 342bb3f3b7dafa4a7d4871e36ceba76c93ad4775
 no_native_review: true
 ---
 


### PR DESCRIPTION
The [Official tournament support](https://osu.ppy.sh/wiki/en/Tournaments/Official_support#staff) page allows staffing for specific roles whilst tournament banned. This is not reflected on the `Tournament bans` article and has been cause for confusion as a result.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)