### PR TITLE
Add link to the original SICK ROCK CRAZY map in `New Featured Artist: ikaruga_nex` newspost

### DIFF
--- a/news/2024/2024-11-16-new-featured-artist-ikaruga-nex.md
+++ b/news/2024/2024-11-16-new-featured-artist-ikaruga-nex.md
@@ -40,7 +40,7 @@ Or experience [this 4K Loved map](https://osu.ppy.sh/beatmapsets/486877) hosted 
 
 ### [ikaruga_nex - SICK ROCK CRAZY](https://assets.ppy.sh/artists/446/SICK%20ROCK%20CRAZY/ikaruga%27nex%20-%20SICK%20ROCK%20CRAZY.osz)
 
-Try [this this 4K marathon](https://osu.ppy.sh/beatmapsets/2044131) hosted by [-mint-](https://osu.ppy.sh/users/8976576)!
+Try [this tiebreaker map](https://osu.ppy.sh/beatmapsets/1838305) hosted by [JeZag](https://osu.ppy.sh/users/3087506) from [Corsace Open 2022](https://osu.ppy.sh/beatmaps/artists/381) (where the song originated) or [this 4K marathon](https://osu.ppy.sh/beatmapsets/2044131) hosted by [-mint-](https://osu.ppy.sh/users/8976576)!
 
 <audio controls>
     <source src="https://assets.ppy.sh/artists/446/SICK%20ROCK%20CRAZY/ikaruga%27nex%20-%20SICK%20ROCK%20CRAZY.mp3">


### PR DESCRIPTION
was done to fix this typo that i noticed at first :

![image](https://github.com/user-attachments/assets/a6980297-47c5-4d82-ae5a-2df017534a2d)

but then i figured that it would be nice to link the og Corsace map to the newspost as well since the song was commissioned for that in the first place

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
