### PR TITLE
Update grading system heading in `Gameplay differences in osu!(lazer)`

### DIFF
--- a/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
+++ b/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
@@ -17,7 +17,7 @@ Instead of pausing gameplay while filling up the health bar, health is restored 
 | Intentionally changed | ![No][false] |
 | Needs further consideration | ![Yes][true] |
 
-### All game modes except osu!catch use the same grading system
+### Differences in grading system
 
 In stable, the accuracy (and judgement) requirements for each [grade](/wiki/Gameplay/Grade) are as follows:
 

--- a/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
+++ b/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md
@@ -17,7 +17,7 @@ Instead of pausing gameplay while filling up the health bar, health is restored 
 | Intentionally changed | ![No][false] |
 | Needs further consideration | ![Yes][true] |
 
-### Differences in grading system
+### Differences in grading systems
 
 In stable, the accuracy (and judgement) requirements for each [grade](/wiki/Gameplay/Grade) are as follows:
 


### PR DESCRIPTION
opted for consistent wording with https://github.com/ppy/osu-wiki/blob/a1d6efbb2f2ed80a1f6da7fb7018a5a2d1f2db45/wiki/Client/Release_stream/Lazer/Gameplay_differences_in_osu!(lazer)/en.md?plain=1#L66

Couldn't really figure something that encapsulates both the acc threshold changes and the removal of judgments while not being too wordy. Open for suggestions.