### PR TITLE
[ID[ Remove `outdated` tag from main page

### DIFF
--- a/wiki/Main_page/id.md
+++ b/wiki/Main_page/id.md
@@ -1,6 +1,4 @@
 ---
-outdated_translation: true
-outdated_since: 77563f2f23ddf07bc9fc1abbba04b76943364682
 layout: main_page
 ---
 


### PR DESCRIPTION
The main page isn't outdated at all but for some reason it's being tagged as such 🤔 

Apparently the `outdated` tag was added along with [this PR](http://github.com/ppy/osu-wiki/pull/12454), but even then that was already addressed in [#12374](http://github.com/ppy/osu-wiki/pull/12374).

![image](https://github.com/user-attachments/assets/925a23c8-7267-495c-a08a-720188c34b2d)

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
