### PR TITLE
[ID] Further cleanup/Fix typos on `Chat console`

### DIFF
--- a/wiki/Client/Interface/Chat_console/id.md
+++ b/wiki/Client/Interface/Chat_console/id.md
@@ -6,12 +6,12 @@ no_native_review: true
 
 # Konsol chat
 
-Dari hampir seluruh jendela yang ada di osu!, kamu dapat menekan `F8` atau mengeklik tombol `Show Chat` yang terdapat pada pojok kanan bawah untuk menampilkan Konsol Chat pada sepertiga bawah jendela permainan.
+Dari hampir seluruh layar yang ada di osu!, kamu dapat menekan `F8` atau mengeklik tombol `Show Chat` yang terdapat pada pojok kanan bawah untuk menampilkan Konsol Chat pada sepertiga bawah jendela permainan.
 
 ![Konsol Chat](img/Chatconsole1.png "Chat Console")
 
-- Tab yang terbentang menunjukkan kanal percakapan mana saja yang saat ini sedang terbuka. Cukup klik pada suatu tab untuk berpindah ke kanal yang bersangkutan. Klik tombol plus berwarna kuning untuk menampilkan daftar berbagai kanal baru yang dapat kamu masuki.
-- Warna dari masing-masing pengguna memiliki arti yang berbeda.
+- Tab yang terbentang menunjukkan kanal percakapan mana saja yang saat ini sedang terbuka. Cukup klik pada salah satu tab untuk berpindah ke kanal yang bersangkutan. Klik tombol plus berwarna kuning untuk menampilkan berbagai kanal baru yang dapat kamu masuki.
+- Masing-masing warna nama pengguna memiliki artinya tersendiri.
 
 | Warna | Siapa? |
 | :-- | :-- |
@@ -19,45 +19,45 @@ Dari hampir seluruh jendela yang ada di osu!, kamu dapat menekan `F8` atau menge
 | **Kuning pucat** | Pengguna tanpa osu!supporter |
 | **Kuning cerah** | Pengguna dengan [osu!supporter](/wiki/osu!supporter) |
 | **Merah** | Anggota [Global Moderation Team](/wiki/People/Global_Moderation_Team) atau [Nomination Assessment Team](/wiki/People/The_Team/Nomination_Assessment_Team) |
-| **Hijau** | Baris percakapan yang mengandung kata kunci tertentu yang telah kamu tambahkan untuk meng-*[highlight](Highlight)* dirimu. Salinan dari pesan ini akan turut muncul pada kanal `#highlight`, yang khusus ditujukan untuk menampung seluruh *highlight* yang masuk. |
+| **Hijau** | Baris percakapan yang mengandung namamu atau kata kunci yang telah kamu tambahkan untuk meng-*[highlight](Highlight)* dirimu. Salinan dari pesan ini akan turut muncul pada kanal `#highlight`, yang menampung seluruh *highlight* yang masuk. |
 | **Biru** | Pesan pribadi |
 | **Biru muda** | [peppy](https://osu.ppy.sh/users/2), pencipta osu! |
 | **Merah jambu** | [BanchoBot](/wiki/BanchoBot) |
 
 - Klik boks `Show Ticker` untuk menampilkan pesan chat terbaru di bagian bawah layar pada saat konsol chat sedang tidak aktif.
 - Klik boks `Auto-Hide` untuk menyembunyikan konsol chat secara otomatis di dalam permainan (kecuali pada saat intro, outro, dan jeda rehat/*break* pada beatmap)
-- Klik boks `HIde Chat` atau tekan `F8` sekali lagi untuk kembali menyembunyikan konsol chat.
+- Klik boks `Hide Chat` atau tekan `F8` sekali lagi untuk kembali menyembunyikan konsol chat.
 
 ## Konsol chat yang diperluas
 
 *Topik berikut ini telah diliput oleh [osu!academy](/wiki/Community/Video_series/osu!academy) pada [Episode 6 (6:52)](https://www.youtube.com/watch?v=cyYRl-a5xII) bersama dengan [Multiplayer](/wiki/Client/Interface/Multiplayer).*
 
-Dari hampir seluruh layar yang ada di osu!, kamu dapat menekan `F9` atau mengeklik tombol `Online Users` yang terdapat pada pojok kanan bawah menu intro untuk menampilkan konsol chat yang diperluas. Di samping konsol chat utama, konsol chat yang diperluas juga menampilkan berbagai panel yang berisi informasi seputar pengguna yang sedang terhubung masuk ke osu!.
+Dari hampir seluruh layar yang ada di osu!, kamu dapat menekan `F9` atau mengeklik tombol `Online Users` yang terdapat pada pojok kanan bawah untuk menampilkan konsol chat yang diperluas. Di samping konsol chat utama, konsol chat ini juga akan menampilkan berbagai informasi seputar pengguna yang sedang terhubung masuk ke osu!.
 
 ![Konsol chat yang diperluas](img/Chat_Console-Extended.png "Konsol chat yang diperluas")
 
-Setiap pengguna yang terhubung masuk ke osu! akan memiliki panel penggunanya tersendiri pada konsol chat yang diperluas. Secara bawaan, panel ini menampilkan berbagai informasi umum seputar pengguna (seperti nama pengguna, total skor ranked, peringkat, akurasi, jumlah permainan, dan avatar apabila ada). Meskipun demikian, pada saat kursor mouse dilayangkan ke atasnya, panel ini akan menampilkan set informasi yang berbeda (yang meliputi nama pengguna, peringkat, avatar apabila ada, waktu lokal, zona waktu, negara dan kota apabila diperkenankan, serta kegiatan apa yang sedang mereka lakukan).
+Setiap pengguna yang terhubung masuk ke osu! akan memiliki panel penggunanya tersendiri pada konsol chat yang diperluas. Secara bawaan, panel ini menampilkan berbagai informasi umum seputar pengguna (seperti nama pengguna, total skor Ranked, peringkat, akurasi, jumlah permainan, dan avatar apabila ada). Panel ini akan menampilkan set informasi yang berbeda pada saat kamu melayangkan kursormu ke atas panel (yang meliputi nama pengguna, peringkat, avatar apabila ada, waktu lokal, zona waktu, negara dan kota apabila diizinkan, serta kegiatan apa yang sedang mereka lakukan).
 
 - Filter "Friends" akan membatasi tampilan hanya pada pengguna yang telah kamu tambahkan sebagai teman.
 - Pilihan "Lock Panels" akan mengunci panel pada tempatnya. Pilihan ini juga akan mencegah pengguna baru untuk muncul pada konsol chat.
-- Klik pada salah satu tab untuk menyunting panel pengguna berdasarkan atribut yang dipilih.
-- Klik pada tab World Map untuk menampilkan peta dunia yang menunjukkan lokasi keseluruhan pengguna.
+- Klik salah satu tab untuk menyunting panel pengguna berdasarkan atribut yang dipilih.
+- Klik tab World Map untuk menampilkan peta dunia yang menunjukkan lokasi keseluruhan pengguna.
 - Kamu dapat mengeklik dan menyeret kotak putih yang terdapat pada sisi kanan layar atau menggunakan roda mouse untuk menggulirkan daftar panel.
-- Pengguna yang tidak memiliki statistik pada panelnya menandakan bahwa pengguna tersebut sedang terhubung melalui klien IRC yang terpisah.
+- Pengguna yang tidak memiliki statistik pada panelnya menandakan bahwa pengguna ini sedang terhubung melalui klien IRC yang terpisah.
 
 | Warna panel | Keterangan |
 | :-- | :-- |
-| ![Pemain sedang senggang](img/Chat_Console-Idle.png "Pemain sedang senggang") | Biru Tua - Pengguna saat ini sedang senggang, sedang tidak melakukan hal apa pun, atau hanya sedang mengobrol. |
+| ![Pemain sedang senggang](img/Chat_Console-Idle.png "Pemain sedang senggang") | Biru Tua - Pengguna sedang senggang, sedang tidak melakukan hal apa pun, atau hanya sedang mengobrol. |
 | ![Pemain sedang bermain](img/Chat_Console-Playing.png "Pemain sedang bermain") | Abu-abu - Pengguna sedang memainkan beatmap secara solo. |
-| ![Pemain sedang menonton](img/Chat_Console-Watching.png "Pemain sedang menonton") | Biru Muda - Pengguna sedang menonton tayangan ulang atau pemain lain. |
-| ![Pemain sedang menyunting beatmap](img/Chat_Console-Editing.png "Pemain sedang menyunting beatmap") | Merah - Pengguna sedang menyunting beatmap milik mereka sendiri. |
-| ![Pemain sedang menguji beatmap](img/Chat_Console-Testing.png "Pemain sedang menguji beatmap") | Ungu - Pengguna sedang menguji suatu beatmap di editor. |
-| ![Pemain sedang mengirim beatmap](img/Chat_Console-Submitting.png "Pemain sedang mengirim beatmap") | Biru Kehijauan - Pengguna sedang mengirim (baik itu mengunggah atau memperbarui) beatmap yang telah mereka buat. |
-| ![Pemain sedang me-mod beatmap](img/Chat_Console-Modding.png "Pemain sedang me-mod beatmap") | Hijau - Pengguna sedang memberikan mod atau menyunting beatmap milik pemain lain. |
-| ![Pemain sedang berada di Multiplayer](img/Chat_Console-Multiplayer.png "Pemain sedang berada di Multiplayer") | Coklat - Pengguna sedang berada pada lobi multiplayer, namun tidak sedang bermain. |
+| ![Pemain sedang menonton](img/Chat_Console-Watching.png "Pemain sedang menonton") | Biru Muda - Pengguna sedang menonton tayangan ulang atau pengguna lain. |
+| ![Pemain sedang menyunting beatmap](img/Chat_Console-Editing.png "Pemain sedang menyunting beatmap") | Merah - Pengguna sedang menyunting beatmap mereka. |
+| ![Pemain sedang menguji beatmap](img/Chat_Console-Testing.png "Pemain sedang menguji beatmap") | Ungu - Pengguna sedang menguji beatmap di editor. |
+| ![Pemain sedang mengirim beatmap](img/Chat_Console-Submitting.png "Pemain sedang mengirim beatmap") | Biru Kehijauan - Pengguna sedang mengirim (baik itu mengunggah atau memperbarui) beatmap mereka. |
+| ![Pemain sedang memberikan mod pada beatmap](img/Chat_Console-Modding.png "Pemain sedang memberikan mod pada beatmap") | Hijau - Pengguna sedang menyunting atau memberikan mod pada beatmap milik pengguna lain. |
+| ![Pemain sedang berada di Multiplayer](img/Chat_Console-Multiplayer.png "Pemain sedang berada di Multiplayer") | Coklat - Pengguna sedang berada pada lobi/ruang multiplayer, namun tidak sedang bermain. |
 | ![Pemain sedang bermain di Multiplayer](img/Chat_Console-Multiplaying.png "Pemain sedang bermain di Multiplayer") | Kuning - Pengguna sedang bermain di ruang multiplayer. |
 | ![Pemain sedang AFK](img/Chat_Console-Afk.png "Pemain sedang AFK") | Hitam - Pengguna sedang tidak berada di depan keyboard (AFK). |
-| ![Pemain sedang terhubung via IRC](img/Chat_Console-IRC.png "Pemain sedang terhubung via IRC") | Biru Gelap tanpa konten - Pengguna tidak berada di dalam permainan, namun sedang terhubung masuk ke klien IRC atau statistik pengguna tidak tersedia. |
+| ![Pemain sedang terhubung via IRC](img/Chat_Console-IRC.png "Pemain sedang terhubung via IRC") | Biru Gelap tanpa konten - Pengguna tidak berada di dalam permainan, namun sedang terhubung masuk via klien IRC atau statistik pengguna tidak tersedia. |
 
 Mengeklik panel pengguna mana pun akan membuka layar pilihan sebagai berikut.
 
@@ -65,7 +65,7 @@ Mengeklik panel pengguna mana pun akan membuka layar pilihan sebagai berikut.
 
 Tekan tombol angka yang sesuai pada keyboard atau klik pada bilah pilihan yang bersangkutan untuk:
 
-1. `Mulai Menonton`: Apabila pengguna yang dipilih sedang bermain dan kamu memiliki beatmap yang sedang dimainkan, kamu dapat menonton mereka selagi mereka bermain. Namamu akan tertera dalam daftar Penonton mereka.
+1. `Mulai Menonton`: Apabila pengguna yang dipilih sedang bermain dan kamu memiliki beatmap yang dimainkan, kamu dapat menonton mereka selagi mereka bermain. Namamu akan tampil dalam daftar Penonton mereka.
 2. `Lihat Profil`: Membuka halaman profil pengguna pada browser milikmu.
 3. `Mulai Percakapan`: Membuka tab pesan pribadi dengan pengguna.
 4. `Undang ke Permainan`: Meminta pengguna untuk bergabung ke ruang permainanmu (apabila kamu sedang berada pada ruang multiplayer).
@@ -82,20 +82,20 @@ Tekan tombol angka yang sesuai pada keyboard atau klik pada bilah pilihan yang b
 | :-- | :-- | :-- | :-- |
 | `/addfriend [nama pengguna]` | Menambahkan `[nama pengguna]` ke dalam daftar temanmu. | `/addfriend Amigo` | Kamu kini berteman dengan Amigo. |
 | `/delfriend [nama pengguna]` | Menghapus `[user]` dari daftar temanmu. | `/delfriend Amigo` | Kamu kini tidak lagi berteman dengan Amigo. |
-| `/away [pesan]` | Mengatur pesan sibuk (yang akan dikirim kepada pengguna yang mengirimkan PM kepadamu). Kosongkan isi pesan untuk membatalkan perintah ini. | `/away Saya adalah John Smith.` | Kamu telah ditandai sebagai sedang sibuk: Saya adalah John Smith. Pada saat Amigo mengirimkan pesan (/msg) kepadamu "John, di manakah dirimu?~" BanchoBot akan membalas dengan: Saya adalah John Smith. |
+| `/away [pesan]` | Mengatur pesan sibuk (yang akan dikirimkan kepada pengguna yang mengirim PM kepadamu). Kosongkan isi pesan untuk membatalkan perintah ini. | `/away Saya adalah John Smith.` | Kamu telah ditandai sebagai sedang sibuk: Saya adalah John Smith. Pada saat Amigo mengirimkan pesan (/msg) kepadamu "John, di manakah dirimu?~" BanchoBot akan membalas dengan: Saya adalah John Smith. |
 | `/bb` | Mengirimkan pesan ke Bancho untuk menjalankan perintah seperti `!stats [nama pengguna]`. | `/bb !stats Uan` | \[15/11/12\] Statistik untuk [Uan](https://osu.ppy.sh/users/147623): Skor: 47,323,299,680 (#1) Jumlah Permainan: 176293 (lv102) Akurasi: 98.95% |
 | `/chat [nama pengguna]`, `/msg [nama pengguna]`, atau `/query [nama pengguna]` | Membuka tab percakapan baru dengan pengguna yang ditentukan. | `/chat Amigo` | (tab Amigo akan terbuka) |
-| `/clear` | Menghapus chat yang termuat pada tab yang sedang aktif. | `/clear` | (Menghapus seluruh teks chat pada tab saat ini) |
-| `/ignore [nama pengguna][@chp]` | Mengabaikan seluruh pesan dari pengguna yang ditentukan untuk sesi saat ini. Dengan menambahkan karakter "@" yang disertai dengan huruf "c", "h", dan/atau "p", kamu dapat mengabaikan pengguna ini di chat, [highlight](Highlight), atau PM. | `/ignore Amigo@chp` | BanchoBot: Kamu tidak lagi akan mendengar percakapan dari Amigo {chat} {highlights} {PM} (Konsol chat kamu akan dikondisikan untuk: mengabaikan teks apa pun yang dikirim oleh Amigo \[c\], teks apa pun yang meng-highlight dirimu oleh Amigo \[h\], serta pesan pribadi mana pun yang berasal dari Amigo \[p\]) |
+| `/clear` | Menghapus chat pada tab yang sedang aktif. | `/clear` | (Menghapus seluruh teks chat pada tab saat ini) |
+| `/ignore [nama pengguna][@chp]` | Mengabaikan seluruh pesan dari pengguna yang ditentukan untuk sesi saat ini. Dengan menambahkan karakter "@" yang disertai dengan huruf "c", "h", dan/atau "p", kamu dapat secara khusus mengabaikan pengguna ini di chat, [highlight](Highlight), atau PM. | `/ignore Amigo@chp` | BanchoBot: Kamu tidak lagi akan mendengar percakapan dari Amigo {chat} {highlights} {PM} (Konsol chat kamu akan diatur untuk: mengabaikan teks apa pun yang dikirim oleh Amigo \[c\], teks apa pun yang meng-highlight dirimu oleh Amigo \[h\], serta pesan pribadi mana pun yang berasal dari Amigo \[p\]) |
 | `/j [kanal percakapan]` or `/join [kanal percakapan]` | Bergabung ke kanal percakapan yang ditentukan. | `/join #lobby` | (tab #lobby akan terbuka) |
 | `/p` or `/part` | Meninggalkan kanal percakapan saat ini. | `/part` | n/a |
 | `/unignore [nama pengguna]` | Menghentikan pengabaian pesan dari pengguna yang ditentukan untuk sesi saat ini. | `/unignore Amigo` | Kamu kini akan dapat mendengar percakapan dari Amigo. (Konsol chat milikmu akan mengizinkan segala baris percakapan yang ditulis oleh Amigo untuk kembali muncul) |
 | `/me [tindakan]` | Melangsungkan tindakan dari sudut pandang orang ketiga. | `/me sedang berada di rumah` | - John sedang berada di rumah |
 | `/np` | Menulis judul lagu yang sedang kamu dengarkan atau mainkan ke kolom chat. | `/np` | (apabila sedang bermain) \* John sedang memainkan [Peter Lambert - osu! tutorial \[Gameplay Basics\]](https://osu.ppy.sh/beatmapsets/3756#osu/22538) |
 | `/reply` atau `/r` | Membalas pesan pribadi yang terakhir diterima. | `/r: Apakah kamu tahu dokter yang bagus?` | (Pada tab Amigo) \[Kiriman sebelumnya\] John: Saya sedang sakit di rumah. Amigo: Benarkah? John: Apakah kamu tahu dokter yang bagus? |
-| `/savelog` | Menyimpan isi tab chat saat ini ke dalam berkas teks. | `/savelog` | (Folder dengan nama "Chat" akan dibuat pada direktori osu!, di mana folder ini ke depannya akan berisikan seluruh tab chat yang disimpan) |
-| `/watch [user]` | Mulai menonton `[user]`. | `/watch Amigo` | * Kamu mulai menonton Amigo. (Pada saat Amigo memainkan beatmap yang kamu miliki, kamu akan menonton permainan Amigo dengan namamu yang terpajang di sisi kiri layar dan \[jeda buffer selama beberapa detik\]) |
-| `/nopm` | Mengatur apakah pesan pribadi yang masuk dapat berasal dari semua orang atau hanya terbatas dari teman. | `/nopm` | (Sebuah banner pop-up akan muncul pada sisi tengah layar yang merincikan bahwa kamu saat ini sedang mengizinkan pribadi dari seluruh pengguna/hanya dari teman) |
+| `/savelog` | Menyimpan isi tab chat saat ini ke dalam berkas teks. | `/savelog` | (Folder dengan nama "Chat" akan dibuat pada direktori osu!, yang berisikan seluruh tab chat yang disimpan) |
+| `/watch [user]` | Mulai menonton `[user]`. | `/watch Amigo` | * Kamu mulai menonton Amigo. (Pada saat Amigo memainkan beatmap yang kamu miliki, kamu akan menonton permainan Amigo dengan namamu yang terpajang di sisi kiri layar dan dengan jeda buffer selama beberapa detik) |
+| `/nopm` | Mengatur apakah pesan pribadi yang masuk dapat berasal dari semua orang atau hanya terbatas dari teman. | `/nopm` | (Banner pop-up akan muncul pada sisi tengah layar yang menjelaskan bahwa kamu saat ini sedang mengizinkan pesan pribadi dari seluruh pengguna/hanya dari teman) |
 | `/invite [nama pengguna]` | Mengirim undangan kepada `[nama pengguna]` ke ruang multiplayer beserta dengan tautan ruang yang bersangkutan. | `/invite Nathanael` | - Nathanael telah diundang ke dalam permainan |
 
 ### /keys


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/10af4ed2-6e5c-41ad-8a53-1839c0423247)

Follow-up to [#12166](http://github.com/ppy/osu-wiki/pull/12166). Was initially intended to fix the typo above among some others, but I decided to further improve the writing on this as well while I'm on it.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
