### PR TITLE
Fix incorrect Discord invite in `osu! indonesia Tournament #14 (2024)`

### DIFF
--- a/wiki/Tournaments/OIT/2024/en.md
+++ b/wiki/Tournaments/OIT/2024/en.md
@@ -60,7 +60,7 @@ The osu! Indonesia Tournament #14 (2024) was run by various osu! community membe
 
 - **[Master spreadsheet](https://docs.google.com/spreadsheets/d/1zSjTQYN_9qG_bZTnw89k-H3AV_mhZrVJdTP5_Z9crYE/edit?usp=sharing)**
 - [Forum thread](https://osu.ppy.sh/community/forums/topics/1968598)
-- [Discord server](https://discord.gg/nKthrPUahJ)
+- [Discord server](https://discord.gg/FJgtKEqypY)
 - [Challonge brackets](https://challonge.com/oit14)
 - [Livestream channel](https://www.twitch.tv/osumalaysia)
 


### PR DESCRIPTION
was told that the current one links out to another tournament instead whoops

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
