### PR TITLE
[Typo] update osu RC

### DIFF
--- a/wiki/Ranking_criteria/osu!/en.md
+++ b/wiki/Ranking_criteria/osu!/en.md
@@ -127,7 +127,7 @@ If a Normal difficulty is required and used as the *lowest difficulty* of a beat
 - **Avoid more than three actively clicked 1/2 rhythms in a row.**
 - **Include a 1/1 or longer gap in rhythm for every two measures of gameplay.** Leniency is permitted for sections of beatmaps with extremely long sliders, such as sliders longer than 2 measures.
 - **Avoid more than four consecutive 1/2 sliders.** This includes 1/2 reversing sliders.
-- **Objects making up actively clicked 1/2 rhythms should [overlap](/wiki/Beatmapping/Mapping_techniques/Overlap) each other on the playfield.** Passively played 1/2 rhythms that do not overlap, such a sliderend followed by a circle, are acceptable.
+- **Objects making up actively clicked 1/2 rhythms should [overlap](/wiki/Beatmapping/Mapping_techniques/Overlap) each other on the playfield.** Passively played 1/2 rhythms that do not overlap, such as sliderends followed by a circle, are acceptable.
 - **Avoid [slider velocity](/wiki/Gameplay/Hit_object/Slider/Slider_velocity) above 1.3.**
 
 #### Difficulty setting guidelines


### PR DESCRIPTION
fixes the normal guideline to actually be syntactically correct? 

This only affects the english base, i assume i dont need to outdate the translations unless they specifically translated this error?