### PR TITLE
Change Outstanding Oldies description in `Project Loved` wiki page

### DIFF
--- a/wiki/Community/Project_Loved/en.md
+++ b/wiki/Community/Project_Loved/en.md
@@ -50,7 +50,7 @@ Every month, beatmaps are chosen according to 9 categories, with the goal of ens
 | Category | Explanation |
 | :-: | :-- |
 | Popular Playcounts | Popular beatmaps in the community, with at least 100,000 playcount. |
-| Outstanding Oldies | Beatmaps submitted more than six years ago. |
+| Outstanding Oldies | Beatmaps submitted in the first half of osu!'s lifespan. |
 | Small Spectacles | Outstanding beatmaps as determined by the captains, with less than 5,000 playcount. |
 | Daredevil Difficulties | Beatmaps known for extreme difficulty, nominated with the goal of fostering competition among top players. |
 | Ranked Rejects | Beatmaps with full spreads that follow ranking criteria, yet never reached Ranked status. |


### PR DESCRIPTION
The osu!standard captains wanted the Outstanding Oldies description on the Project Loved wiki page to be changed since they agreed on changing what Outstanding Oldies mean back in November, but the wiki page was never changed.

Discussion regarding wanting the wiki page updated can be found here: https://discord.com/channels/833130067462717451/1140077143007690842/1338380613031432222

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
