### PR TITLE
Update `osu! ranking criteria` with revised slider rule on Expert difficulties

### DIFF
--- a/wiki/Ranking_criteria/osu!/en.md
+++ b/wiki/Ranking_criteria/osu!/en.md
@@ -191,7 +191,7 @@ If a Normal difficulty is required and used as the *lowest difficulty* of a beat
 #### Rules
 
 - **Every slider must have a clear and visible path of movement to follow from start to end.** Sliders that overlap themselves without straightforward slider borders and sliders whose individual sections are unreadable cannot be used. A slider's end position must be clear under the assumption that a player has a skin which makes slider end circles fully transparent.
-  - The slider path is allowed to be ambiguous if the cursor can stay inside the slider's follow circle without any movement away from the slider head.
+  - Ambiguous slider paths are allowed if a 300 can be achieved on the slider without any movement away from the slider head.
 
 #### Guidelines
 


### PR DESCRIPTION
This was approved and even allowed in a ranked map following the proposal, but fell through for making it into the actual wiki. This PR simply fixes that to provide clarity for future maps.

Relevant RC thread: https://osu.ppy.sh/community/forums/topics/1979244?n=1

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
