### PR TITLE
add table of timings

### DIFF
--- a/wiki/Gameplay/Judgement/osu!taiko/en.md
+++ b/wiki/Gameplay/Judgement/osu!taiko/en.md
@@ -10,6 +10,12 @@ A **judgement**, or **hit result**, is the outcome of interacting with a [hit ob
 | ![](/wiki/shared/judgement/osu!taiko/taiko-hit100k.png) ![](/wiki/shared/judgement/osu!taiko/taiko-hit100.png) | OK | 150 | 50% | `120 - 8 × OD` if OD ≤ 5, and `110 - 6 × OD` if OD ≥ 5 |
 | ![](/wiki/shared/judgement/osu!taiko/taiko-hit0.png) | MISS | 0 | 0% | `135 - 8 × OD` if OD ≤ 5, and `120 - 5 × OD` if OD ≥ 5 |
 
+|           | 0   | 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8   | 9   | 10  |
+|-----------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
+| Great     | 50 ms | 47 ms | 44 ms | 41 ms | 38 ms | 35 ms | 32 ms | 29 ms | 26 ms | 23 ms | 20 ms |
+| Ok        | 120 ms | 112 ms | 104 ms | 96 ms | 88 ms | 80 ms | 74 ms | 68 ms | 62 ms | 56 ms | 50 ms |
+| Miss      | 135 ms | 127 ms | 119 ms | 111 ms | 103 ms | 95 ms | 90 ms | 85 ms | 80 ms | 75 ms | 70 ms |
+
 The hit window depends on the beatmap's [overall difficulty (OD)](/wiki/Beatmap/Overall_difficulty). A hit is then considered inside a hit window if `hit error < max hit error`, meaning the value listed is half of the hit window width. The MISS window by exception compares `hit error ≤ max hit error`<!-- internal reference: https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/HitObjects/Taiko/HitCircleTaiko.cs#L187, https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/HitObjects/Taiko/HitCircleTaiko.cs#L151 --> instead.
 
 The hit error is rounded and the max hit error values are truncated to the nearest integer<!-- see corresponding reference in wiki/Gameplay/Judgement/osu!/en.md -->, meaning that for GREATs and OKs, hit windows may be up to 1.5 ms shorter on both sides, while miss windows may be up to 0.5 ms shorter or longer on both sides, than what the formulas suggest.


### PR DESCRIPTION
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

I can't do math in my head and thought maybe some other players would appreciate a simple table of hit window timings too. It might also be good to also add the same table to https://osu.ppy.sh/wiki/en/Beatmap/Overall_difficulty