### PR TITLE
Remove false `outdated_since` attribution from a few translations of `Community Contributors`

### DIFF
--- a/wiki/People/Community_Contributors/pl.md
+++ b/wiki/People/Community_Contributors/pl.md
@@ -1,6 +1,5 @@
 ---
 outdated_translation: true
-outdated_since: 776e337b5ed79c751285d76678634b6f0291ce1d
 no_native_review: true
 ---
 

--- a/wiki/People/Community_Contributors/pt-br.md
+++ b/wiki/People/Community_Contributors/pt-br.md
@@ -1,6 +1,5 @@
 ---
 outdated_translation: true
-outdated_since: 776e337b5ed79c751285d76678634b6f0291ce1d
 ---
 
 # Colaboradores da Comunidade

--- a/wiki/People/Community_Contributors/pt.md
+++ b/wiki/People/Community_Contributors/pt.md
@@ -1,6 +1,5 @@
 ---
 outdated_translation: true
-outdated_since: 776e337b5ed79c751285d76678634b6f0291ce1d
 ---
 
 # Contribuidores da Comunidade


### PR DESCRIPTION
https://github.com/ppy/osu-wiki/pull/13040/files#r2016103730 explains why