### PR TITLE
Fix results in `TWC 2025: Round of 32 recap`

### DIFF
--- a/news/2025/2025-03-28-osutaiko-world-cup-2025-round-of-32-recap.md
+++ b/news/2025/2025-03-28-osutaiko-world-cup-2025-round-of-32-recap.md
@@ -52,7 +52,6 @@ We've tallied up the scores, and let's roll the drumrolls...
 | Philippines ::{ flag=PH }:: | 1 | **5** | ::{ flag=NL }:: **Netherlands** |
 | **Taiwan** ::{ flag=TW }:: | **5** | 0 | ::{ flag=PE }:: Peru |
 | **Türkiye** ::{ flag=TR }:: | **5** | 0 | ::{ flag=SK }:: Slovakia |
-| **United Kingdom** ::{ flag=GB }:: | **5** | 0 | ::{ flag=CA }:: Canada |
 | **Chile** ::{ flag=CL }:: | **5** | 0 | ::{ flag=AR }:: Argentina |
 | **China** ::{ flag=CN }:: | **5** | 0 | ::{ flag=BR }:: Brazil |
 | **South Korea** ::{ flag=KR }:: | **5** | 0 | ::{ flag=CO }:: Colombia |
@@ -86,7 +85,7 @@ Confidently, Finland went with [Nishino Kana - Darling](https://osu.ppy.sh/beatm
 
 Needless to say, it was a very intense match, both for the teams playing and the viewers and casters spectating live. How they're going to perform in the upcoming matches will definitely be something to look forward to.
 
-### ::{ flag=VN }:: Vietnam vs. ::{ flag=PL }:: Poland
+### ::{ flag=PL }:: Poland vs. ::{ flag=VN }:: Vietnam
 
 **[View the match information here!](https://osu.ppy.sh/community/matches/117570281)**
 
@@ -94,7 +93,7 @@ Needless to say, it was a very intense match, both for the teams playing and the
     <iframe width="95%" style="aspect-ratio: 16 / 9;" src="https://player.twitch.tv/?video=2413275301&time=0h5m28s&parent=osu.ppy.sh&autoplay=false" frameborder="0" allowfullscreen="true" scrolling="no"></iframe>
 </div>
 
-One of the closer matches of this week, Vietnam (#18) and Poland (#15) have definitely held their own in this match.
+One of the closer matches of this week, Poland (#15) and Vietnam (#18) have definitely held their own in this match.
 
 Vietnam had a very strong start, scoring themselves a 4–0 lead before Poland could even get on the board with solid sweeps on [Nishino Kana - Darling](https://osu.ppy.sh/beatmapsets/2288836#taiko/4884307) (DT2) [Kobaryo & Matatabi Sound System + DJ NECOJITA + Shinonome I/F + blaxervant - HARD-COREMATA (HVS VER.)](https://osu.ppy.sh/beatmapsets/2193212#taiko/4672708) (HR2), [Sound Souler - Eternalism 3](https://osu.ppy.sh/beatmapsets/2340352#taiko/5028105) (HD1), and [MetaHumanBoi - Speed Bomb](https://osu.ppy.sh/beatmapsets/2340349#taiko/5028101) (NM3).
 


### PR DESCRIPTION
United Kingdom vs. Canada was mentioned twice in the results.
Poland vs. Vietnam was confusingly listed as Vietnam vs. Poland in a couple places.