### PR TITLE
Update `TWC 2025` for the Semifinals stage

### DIFF
--- a/wiki/Tournaments/TWC/2025/en.md
+++ b/wiki/Tournaments/TWC/2025/en.md
@@ -44,7 +44,7 @@ The osu!taiko World Cup 2025 is run by the [osu! team](/wiki/People/osu!_team) a
 | Manager | ::{ flag=CA }:: [Azer](https://osu.ppy.sh/users/2155578), ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718), ::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024) |
 | Mappool selector | ::{ flag=SE }:: **[Nurend](https://osu.ppy.sh/users/9905079)**, ::{ flag=SE }:: **[Raphalge](https://osu.ppy.sh/users/3918650)**, ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417) |
 | Mappool playtester | ::{ flag=US }:: [Backfire](https://osu.ppy.sh/users/263110), ::{ flag=BR }:: [Foxeru](https://osu.ppy.sh/users/7479684), ::{ flag=DE }:: [frz](https://osu.ppy.sh/users/6956922), ::{ flag=DE }:: [Greenshell](https://osu.ppy.sh/users/8693851), ::{ flag=BR }:: [Kyoumo](https://osu.ppy.sh/users/8145223), ::{ flag=BR }:: [miwoo](https://osu.ppy.sh/users/12630336), ::{ flag=IT }:: [ndrrr](https://osu.ppy.sh/users/4609767), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=US }:: [Shyguy](https://osu.ppy.sh/users/178038) |
-| Mapper | ::{ flag=JP }:: [\_Rise](https://osu.ppy.sh/users/5217107), ::{ flag=IT }:: [D 3](https://osu.ppy.sh/users/7807444), ::{ flag=DE }:: [DarkVortex](https://osu.ppy.sh/users/1940325), ::{ flag=PH }:: [Eyenine](https://osu.ppy.sh/users/1259391), ::{ flag=DE }:: [frz](https://osu.ppy.sh/users/6956922), ::{ flag=DE }:: [Greenshell](https://osu.ppy.sh/users/8693851), ::{ flag=BR }:: [HiroK](https://osu.ppy.sh/users/4050738), ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976), ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649), ::{ flag=US }:: [Jayceko](https://osu.ppy.sh/users/19951350), ::{ flag=TW }:: [K a y o k o](https://osu.ppy.sh/users/17664300), ::{ flag=MY }:: [ler1211](https://osu.ppy.sh/users/19901680), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=SE }:: [Raphalge](https://osu.ppy.sh/users/3918650), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=CA }:: [rubies87](https://osu.ppy.sh/users/4949934), ::{ flag=BR }:: [Skid](https://osu.ppy.sh/users/3044264), ::{ flag=GB }:: [Skidooskei](https://osu.ppy.sh/users/10079029), ::{ flag=US }:: [Wadsy](https://osu.ppy.sh/users/2598555), ::{ flag=JP }:: [Waribashi](https://osu.ppy.sh/users/2250574), ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417), ::{ flag=AT }:: [Yasuho](https://osu.ppy.sh/users/8458835), *more TBA* |
+| Mapper | ::{ flag=JP }:: [\_Rise](https://osu.ppy.sh/users/5217107), ::{ flag=IT }:: [D 3](https://osu.ppy.sh/users/7807444), ::{ flag=DE }:: [DarkVortex](https://osu.ppy.sh/users/1940325), ::{ flag=PH }:: [Eyenine](https://osu.ppy.sh/users/1259391), ::{ flag=DE }:: [frz](https://osu.ppy.sh/users/6956922), ::{ flag=DE }:: [Greenshell](https://osu.ppy.sh/users/8693851), ::{ flag=BR }:: [HiroK](https://osu.ppy.sh/users/4050738), ::{ flag=TN }:: [Hivie](https://osu.ppy.sh/users/14102976), ::{ flag=NL }:: [ikin5050](https://osu.ppy.sh/users/4007649), ::{ flag=US }:: [Jayceko](https://osu.ppy.sh/users/19951350), ::{ flag=TW }:: [K a y o k o](https://osu.ppy.sh/users/17664300), ::{ flag=MY }:: [ler1211](https://osu.ppy.sh/users/19901680), ::{ flag=IT }:: [ndrrr](https://osu.ppy.sh/users/4609767), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=IT }:: [Quorum](https://osu.ppy.sh/users/5200775), ::{ flag=SE }:: [Raphalge](https://osu.ppy.sh/users/3918650), ::{ flag=NO }:: [roufou](https://osu.ppy.sh/users/1109122), ::{ flag=CA }:: [rubies87](https://osu.ppy.sh/users/4949934), ::{ flag=BR }:: [Skid](https://osu.ppy.sh/users/3044264), ::{ flag=GB }:: [Skidooskei](https://osu.ppy.sh/users/10079029), ::{ flag=JP }:: [tasuke912](https://osu.ppy.sh/users/2774767), ::{ flag=US }:: [Wadsy](https://osu.ppy.sh/users/2598555), ::{ flag=JP }:: [Waribashi](https://osu.ppy.sh/users/2250574), ::{ flag=DE }:: [Xay](https://osu.ppy.sh/users/961417), ::{ flag=AT }:: [Yasuho](https://osu.ppy.sh/users/8458835), ::{ flag=DE }:: [Zetera](https://osu.ppy.sh/users/587737), *more TBA* |
 | Commentator | ::{ flag=AU }:: [Beat43210](https://osu.ppy.sh/users/5664171), ::{ flag=US }:: [Bronzecrank](https://osu.ppy.sh/users/14173115), ::{ flag=US }:: [driodx](https://osu.ppy.sh/users/9709548), ::{ flag=US }:: [ETHN](https://osu.ppy.sh/users/9536977), ::{ flag=CA }:: [janitore](https://osu.ppy.sh/users/3307897), ::{ flag=AU }:: [Jaye](https://osu.ppy.sh/users/4841352), ::{ flag=DE }:: [Joogs](https://osu.ppy.sh/users/8844167), ::{ flag=DE }:: [Nwolf](https://osu.ppy.sh/users/1910766), ::{ flag=GB }:: [overdahedge2015](https://osu.ppy.sh/users/9864847), ::{ flag=GB }:: [Teezel](https://osu.ppy.sh/users/7528639), ::{ flag=HK }:: [YonGin](https://osu.ppy.sh/users/7109317) |
 | Referee | ::{ flag=IN }:: [\-Space](https://osu.ppy.sh/users/7720204), ::{ flag=FI }:: [Aetherian](https://osu.ppy.sh/users/6263040), ::{ flag=US }:: [akace100](https://osu.ppy.sh/users/9308128), ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=NL }:: [nik](https://osu.ppy.sh/users/10077264), ::{ flag=FI }:: [shdewz](https://osu.ppy.sh/users/10000899), ::{ flag=US }:: [Suicune3](https://osu.ppy.sh/users/6895187), ::{ flag=US }:: [tigereyes144](https://osu.ppy.sh/users/6499811), ::{ flag=GB }:: [Yazzehh](https://osu.ppy.sh/users/7068973) |
 | Statistician | ::{ flag=FI }:: **[shdewz](https://osu.ppy.sh/users/10000899)**, ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) |
@@ -103,21 +103,61 @@ The osu!taiko World Cup 2025 is run by the [osu! team](/wiki/People/osu!_team) a
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/bcaab51028b74dee27c483e54fc7f251).
 
-## Match schedule: Quarterfinals
+## Match schedule: Semifinals
 
-### Sunday, 6 April 2025
+### Saturday, 12 April 2025
 
 | Team A | Team B | Match time | Twitch stream |  |
 | --: | :-- | :-- | :-: | :-: |
-| United States ::{ flag=US }:: | ::{ flag=CL }:: Chile | [Apr 06 (Sun) 01:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T010000&p1=1440&p2=263&p3=232) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-| France ::{ flag=FR }:: | ::{ flag=NZ }:: New Zealand | [Apr 06 (Sun) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T090000&p1=1440&p2=195&p3=264) | [osulive_2](https://twitch.tv/osulive_2) | [^losers-bracket] |
-| Japan ::{ flag=JP }:: | ::{ flag=MY }:: Malaysia | [Apr 06 (Sun) 09:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T090000&p1=1440&p2=248&p3=122) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-| Türkiye ::{ flag=TR }:: | ::{ flag=ID }:: Indonesia | [Apr 06 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T140000&p1=1440&p3=108) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=FI }:: Finland | [Apr 06 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T160000&p1=1440&p2=166&p3=101) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| United Kingdom ::{ flag=GB }:: | ::{ flag=SK }:: Slovakia | [Apr 06 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T170000&p1=1440&p2=136) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| Semifinals | mappool showcase | [Apr 06 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250406T180000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
+| Singapore ::{ flag=SG }:: | ::{ flag=RU }:: Russian Federation | [Apr 12 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250412T100000&p1=1440&p2=236&p3=166) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| China ::{ flag=CN }:: | ::{ flag=FR }:: France | [Apr 12 (Sat) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250412T120000&p1=1440&p2=33&p3=195) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| Malaysia ::{ flag=MY }:: | ::{ flag=GB }:: United Kingdom | [Apr 12 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250412T140000&p1=1440&p2=122&p3=136) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| South Korea ::{ flag=KR }:: | ::{ flag=CL }:: Chile | [Apr 12 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250412T150000&p1=1440&p2=235&p3=232) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| United States ::{ flag=US }:: | ::{ flag=TR }:: Türkiye | [Apr 12 (Sat) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250412T180000&p1=1440&p2=263) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+
+### Sunday, 13 April 2025
+
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| United States ::{ flag=US }:: | ::{ flag=CN }:: China | [Apr 13 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T040000&p1=1440&p2=263&p3=33) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Türkiye ::{ flag=TR }:: | ::{ flag=CN }:: China | [Apr 13 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T040000&p1=1440&p3=33) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Japan ::{ flag=JP }:: | ::{ flag=TW }:: Taiwan | [Apr 13 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T100000&p1=1440&p2=248&p3=241) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| Singapore ::{ flag=SG }:: | ::{ flag=MY }:: Malaysia | [Apr 13 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T120000&p1=1440&p2=236&p3=122) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Singapore ::{ flag=SG }:: | ::{ flag=GB }:: United Kingdom | [Apr 13 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T120000&p1=1440&p2=236&p3=136) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=MY }:: Malaysia | [Apr 13 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T120000&p1=1440&p2=166&p3=122) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=GB }:: United Kingdom | [Apr 13 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T120000&p1=1440&p2=166&p3=136) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| United States ::{ flag=US }:: | ::{ flag=FR }:: France | [Apr 13 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T180000&p1=1440&p2=263&p3=195) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Türkiye ::{ flag=TR }:: | ::{ flag=FR }:: France | [Apr 13 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T180000&p1=1440&p3=195) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Finals | mappool showcase | [Apr 13 (Sun) 19:00 UTC (estimated)](https://www.timeanddate.com/worldclock/converter.html?iso=20250413T190000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
 
 ## Mappools
+
+### Semifinals
+
+**[Download the mappack here (113 MB)](https://leoflt.com/s/twc2025-semifinals-mappack)**\
+[View the showcase VOD here](https://www.twitch.tv/videos/2425712130?t=2h4m42s)
+
+- No Mod
+  1. [isonosuke - Baka Tsuushin (feat. Chis-A) (Skidooskei) \[Terminally Online\]](https://osu.ppy.sh/beatmapsets/1998016#taiko/4152878)
+  2. [P4koo - Hyperlight. (feat. Tsuyuri Karin) (Raphalge) \[Inner Oni\] *(temporary link)*](https://leoflt.com/s/4kE0O)
+  3. [WyvernP - White Devil (Alchyr) \[-\]](https://osu.ppy.sh/beatmapsets/2194042#taiko/4641645)
+  4. [aoi08 - j9fqo80fdgcr (roufou) \[just what the doctor ordered, more dariacore\]](https://osu.ppy.sh/beatmapsets/2350992#taiko/5059144)
+  5. [Quarkee - HYPER PSY2K (Zetera) \[COSMIC RAY BITFLIP\] *(temporary link)*](https://leoflt.com/s/JlCPX)
+  6. [tv room - Know It All (Raphalge) \[Inner Oni (Edit)\]](https://osu.ppy.sh/beatmapsets/2149103#taiko/4527330)
+- Hidden
+  1. [cluli - they besties (D 3) \[Relae\]](https://osu.ppy.sh/beatmapsets/2350993#taiko/5059153)
+  2. [The Ghost Of 3.13 - Forgotten (ndrrr) \[poggatura\] *(temporary link)*](https://leoflt.com/s/Y0c49)
+- Hard Rock
+  1. [Kaitendaentai - Aether (ikin5050) \[Ritual Oni\]](https://osu.ppy.sh/beatmapsets/2351002#taiko/5059170)
+  2. [tn-shi - Annihilation in F# Minor (Raphalge) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2351018#taiko/5059245)
+- Double Time
+  1. [MiddleIsland - Frailness (Quorum) \[Inner Oni \[TWC Edit\]\]](https://osu.ppy.sh/beatmapsets/2183900#taiko/5059168)
+  2. [Yousei Teikoku - Senketsu no Chikai (gaston\_2199) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2168439#taiko/4575475)
+- Free Mod
+  1. [Rabbit House & Evin a'k - optimal solution (Irone OSU) \[inequality\]](https://osu.ppy.sh/beatmapsets/2321605#taiko/4973868)
+  2. [Tonari no Niwa wa Aoi (NIWASHI+Aoi) - Polacro (sendol) \[Inner Oni\]](https://osu.ppy.sh/beatmapsets/2140365#taiko/4504718)
+- Tiebreaker
+  1. **[Sydosys - Partition (tasuke912) \[Finem\] *(temporary link)*](https://leoflt.com/s/nitRj)**
 
 ### Quarterfinals
 
@@ -234,6 +274,17 @@ Saturday, 5 April 2025:
 | **Indonesia** ::{ flag=ID }:: | **6** | 2 | ::{ flag=CA }:: Canada | [#1](https://osu.ppy.sh/community/matches/117701961) | [#1](https://www.twitch.tv/videos/2424643241?t=3h20m26s) |
 | **Türkiye** ::{ flag=TR }:: | **6** | -1 | ::{ flag=PL }:: Poland | *[win by default](https://osu.ppy.sh/community/matches/117703394)* |  |
 | **Finland** ::{ flag=FI }:: | **6** | 0 | ::{ flag=CH }:: Switzerland | [#1](https://osu.ppy.sh/community/matches/117704091) | [#1](https://www.twitch.tv/videos/2424918464?t=0h2m49s) |
+
+Sunday, 6 April 2025:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| United States ::{ flag=US }:: | 5 | **6** | ::{ flag=CL }:: **Chile** | [#1](https://osu.ppy.sh/community/matches/117707419) | [#1](https://www.twitch.tv/videos/2425207564?t=0h4m40s) |
+| **France** ::{ flag=FR }:: | **6** | 1 | ::{ flag=NZ }:: New Zealand | [#1](https://osu.ppy.sh/community/matches/117710212) | [#1](https://www.twitch.tv/videos/2425501211) |
+| **Japan** ::{ flag=JP }:: | **6** | 0 | ::{ flag=MY }:: Malaysia | [#1](https://osu.ppy.sh/community/matches/117710213) | [#1](https://www.twitch.tv/videos/2425480498?t=0h3m8s) |
+| **Türkiye** ::{ flag=TR }:: | **6** | 1 | ::{ flag=ID }:: Indonesia | [#1](https://osu.ppy.sh/community/matches/117712738) | [#1](https://www.twitch.tv/videos/2425627870?t=0h7m34s) |
+| **Russian Federation** ::{ flag=RU }:: | **6** | 1 | ::{ flag=FI }:: Finland | [#1](https://osu.ppy.sh/community/matches/117714077) | [#1](https://www.twitch.tv/videos/2425712130?t=0h4m52s) |
+| **United Kingdom** ::{ flag=GB }:: | **6** | 0 | ::{ flag=SK }:: Slovakia | [#1](https://osu.ppy.sh/community/matches/117714679) | [#1](https://www.twitch.tv/videos/2425712130?t=1h4m53s) |
 
 ### Round of 16
 
@@ -491,6 +542,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 [^winners-bracket]: Winners bracket match
 [^losers-bracket]: Losers bracket match
+[^potential-match]: Potential match — final matchup depends on the results of the preceding losers bracket matches
 [^mappool-showcase]: Mappool showcase — schedule subject to rescheduling without prior notice, depending on preceding matches
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same rank sum. For this statistic the Hidden, Hard Rock, and Double Time bracket scores are normalised (but Free Mod is not).


### PR DESCRIPTION
Adds remaining Quarterfinals results. Adds Semifinals schedules/mappool. Updates the staff listing with more mappers.
