### PR TITLE
Update nomination rules for hybrid mapsets

### DIFF
--- a/wiki/Beatmap_ranking_procedure/de.md
+++ b/wiki/Beatmap_ranking_procedure/de.md
@@ -9,6 +9,8 @@ tags:
   - Qualifizierung
   - Nominierung
   - gerankt
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Ranking-Verfahren für Beatmaps

--- a/wiki/Beatmap_ranking_procedure/en.md
+++ b/wiki/Beatmap_ranking_procedure/en.md
@@ -38,7 +38,7 @@ It is recommended to receive mods before requesting nominations from BNs, howeve
 
 ## Qualification
 
-Beatmaps that receive two nominations per each available game mode are moved to the [Qualified](/wiki/Beatmap/Category#qualified) beatmap category. Qualified beatmaps have score leaderboards, but do not reward players with [performance points](/wiki/Performance_points). When a beatmap stays in Qualified for at least 7 days, the [ranking queue](Ranking_queue) is able to move it to [Ranked](#ranked).
+Beatmaps that receive two nominations for the primary game mode are moved to the [Qualified](/wiki/Beatmap/Category#qualified) beatmap category.[^hybrid-sets] Qualified beatmaps have score leaderboards, but do not reward players with [performance points](/wiki/Performance_points). When a beatmap stays in Qualified for at least 7 days, the [ranking queue](Ranking_queue) is able to move it to [Ranked](#ranked).
 
 This beatmap category exists to provide beatmaps wider exposure to the osu! community with the hopes of discovering potential problems. Problems can be reported to members of the BN and NAT from a beatmap's discussion page. Unlike Pending beatmaps, Qualified beatmaps cannot be updated by their creators, so feedback can only be applied after requesting a [nomination reset](#nomination-resets).
 
@@ -55,3 +55,7 @@ Members of the BN and NAT occasionally [veto](/wiki/People/Beatmap_Nominators/Be
 Beatmaps that have passed through the qualification stage have completed the ranking procedure. They have [score leaderboards](/wiki/Ranking) and reward players with performance points.
 
 Ranked beatmaps are only unranked under exceptional circumstances when issues are found shortly after they reach Ranked status.
+
+## Annotations
+
+[^hybrid-sets]: For beatmaps with difficulties across multiple game modes, the main game mode is the mode with the most difficulties in total or–if the amount is the same–by the creator. Non-primary game modes require only one nomination by a full BN.

--- a/wiki/Beatmap_ranking_procedure/es.md
+++ b/wiki/Beatmap_ranking_procedure/es.md
@@ -11,6 +11,8 @@ tags:
   - nominaciones
   - clasificación
   - clasificado
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Procedimiento de clasificación de beatmaps

--- a/wiki/Beatmap_ranking_procedure/fr.md
+++ b/wiki/Beatmap_ranking_procedure/fr.md
@@ -9,6 +9,8 @@ tags:
   - classement
   - classé
   - classée
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Procédure de classement des beatmaps

--- a/wiki/Beatmap_ranking_procedure/ru.md
+++ b/wiki/Beatmap_ranking_procedure/ru.md
@@ -14,6 +14,8 @@ tags:
   - ранг
   - ранк
   - рейтинг
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Процедура ранкинга

--- a/wiki/Beatmap_ranking_procedure/zh.md
+++ b/wiki/Beatmap_ranking_procedure/zh.md
@@ -11,6 +11,8 @@ tags:
   - 飞图
   - 提名
   - 上架
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # 谱面审核流程

--- a/wiki/History_of_osu!/Mapping_and_modding_timeline/en.md
+++ b/wiki/History_of_osu!/Mapping_and_modding_timeline/en.md
@@ -595,3 +595,9 @@ Mapping and modding systems are constantly improving. The **Mapping and modding 
   - This batch of evaluators included 12 users.
 - **2022-07-04:** An osu!mania Beatmap Nominator was retroactively added to the [2021 Elite Nominators](https://osu.ppy.sh/home/news/2022-03-22-community-contributors-elite-nominators#osu!mania) after an internal discussion within the Nomination Assessment Team.
 - **2022-07-14:** osu!taiko has also added 2 Beatmap Nominators to the evaluators trial, mimicking osu!'s ongoing trial.
+
+## 2024
+
+### May
+
+- **2024-05-31**: The number of nominations on hybrid sets required for getting a beatmapset qualified, was changed from 2 nominations per each available game mode to 2 nomations on the primary game mode, and 1 nomination for each subsidiary one. The game mode containing the most difficulties in total or–if the amount is the same–by the creator is considered the primary game mode.

--- a/wiki/History_of_osu!/Mapping_and_modding_timeline/es.md
+++ b/wiki/History_of_osu!/Mapping_and_modding_timeline/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
+---
+
 # Cronología de mapping y modding
 
 Los sistemas de mapping y modding están mejorando constantemente. La **cronología de mapping y modding** tiene como objetivo documentar los cambios más grandes del sistema y servir como una herramienta de referencia cuando los usuarios están incorporando nuevos cambios.

--- a/wiki/History_of_osu!/Mapping_and_modding_timeline/fr.md
+++ b/wiki/History_of_osu!/Mapping_and_modding_timeline/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
+---
+
 # Calendrier de mapping et de modding
 
 Les systèmes de mapping et de modding sont en constante amélioration. Le **calendrier de mapping et de modding** vise à documenter les plus grands changements apportés au système et à servir d'outil de référence lorsque les utilisateurs intègrent de nouvelles modifications.

--- a/wiki/History_of_osu!/Mapping_and_modding_timeline/id.md
+++ b/wiki/History_of_osu!/Mapping_and_modding_timeline/id.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Sejarah mapping dan modding

--- a/wiki/People/Beatmap_Nominators/General_Information/en.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/en.md
@@ -18,7 +18,7 @@ Nominations and resetting nominations are the evidence of a BN's efforts when ch
 
 ![nominate button](img/nominate.png)
 
-**This button allows you to nominate beatmaps.** To nominate a beatmap, the mapset must have at least 5 [Hype](/wiki/Beatmap/Hype) and no currently unresolved Problem or Suggestion stamps. Make sure you're satisfied with all difficulties, even other game modes, before placing this. If the beatmap was previously vetoed, you must ensure the veto is resolved before moving a mapset forward. When a beatmap has 2 nominations, it will be [Qualified](/wiki/Beatmap/Category#qualified) and enter the [ranking queue](/wiki/Beatmap_ranking_procedure/Ranking_queue).
+**This button allows you to nominate beatmaps.** To nominate a beatmap, the mapset must have at least 5 [Hype](/wiki/Beatmap/Hype) and no currently unresolved Problem or Suggestion stamps. Make sure you're satisfied with all difficulties, even other game modes, before placing this. If the beatmap was previously vetoed, you must ensure the veto is resolved before moving a mapset forward. When a beatmap has 2 nominations,[^hybrid-sets] it will be [Qualified](/wiki/Beatmap/Category#qualified) and enter the [ranking queue](/wiki/Beatmap_ranking_procedure/Ranking_queue).
 
 ### Disqualify or reset nomination
 
@@ -54,3 +54,7 @@ Any BN can contribute to the moderation of songs and images by either submitting
 ### Mock Evaluations
 
 Full BNs may be assigned at random to do mock evaluations on BN Applications alongside the NAT's real ones. They can choose to opt out of this at any time, and doing assigned evaluations is not required. Mock evaluations are primarily used as information for the NAT to evaluate future NAT candidates, though details presented in mock evaluations may be added to applicant feedback on occasion or serve as tiebreakers if the NAT cannot come to a conclusion on their own.
+
+## Annotations
+
+[^hybrid-sets]: For beatmaps with difficulties across multiple game modes, two nominations are needed for the primary game mode and one is required for each subsidiary one, where the main game mode contains the most difficulties in total, or–if the amount is the same–by the creator.

--- a/wiki/People/Beatmap_Nominators/General_Information/es.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
+---
+
 # Información general para los Beatmap Nominators
 
 ¿Eres un [Beatmap Nominator](/wiki/People/Beatmap_Nominators) *(BN)* o estás interesado en convertirte en uno? Si es así, ¡has venido al lugar adecuado! En este artículo encontrarás toda la información general que necesitas saber como un nuevo Beatmap Nominator.

--- a/wiki/People/Beatmap_Nominators/General_Information/fr.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/fr.md
@@ -1,5 +1,7 @@
 ---
 no_native_review: true
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
 ---
 
 # Informations générales sur les Beatmap Nominators

--- a/wiki/People/Beatmap_Nominators/General_Information/zh.md
+++ b/wiki/People/Beatmap_Nominators/General_Information/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: dcd2a38fb52e9427609446990b0219aa37128dc7
+---
+
 # 谱面审核成员须知
 
 想要成为或者已经成为[谱面审核成员 (*BN*)](/wiki/People/Beatmap_Nominators) 了吗？你来对地方了！本文包含成为新 BN 所需要了解的信息。


### PR DESCRIPTION
From [osu-web#10984](https://github.com/ppy/osu-web/pull/10984):

>The new rules for nomination on hybrid sets are:
>
>2 nominations required for the main ruleset and 1 on every other ruleset.
>There must be one full nominator on every ruleset.
>
>The main ruleset is the one with the most difficulties
>If the number of difficulties are the same, then the one with the most diffs by the host is the main ruleset.
>If 1 and 2 do not result in a clear main ruleset, then any ruleset that satisfies the previous criteria is used.

Closes #12514 

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
