### PR TITLE
Update `First medal unlocks` to add the first person to unlock Pioneer 

### DIFF
--- a/wiki/Medals/First_medal_unlocks/en.md
+++ b/wiki/Medals/First_medal_unlocks/en.md
@@ -181,7 +181,7 @@ This is a compendium of the first users to unlock each medal in osu! history.
 | ![](/wiki/shared/medals/all-secret-hybrid.png) | Hybrid Hyperion | ::{ flag=MX }:: [Agamalpa](https://osu.ppy.sh/users/15420662) | 31 Dec 2023 (04:25:09) |
 | ![](/wiki/shared/medals/all-secret-divinationbreak.png) | Divination Break | ::{ flag=MX }:: [Riot](https://osu.ppy.sh/users/4256461) | 31 Dec 2023 (21:27:24) |
 | ![](/wiki/shared/medals/all-secret-unwilted.png) | Unwilted | ::{ flag=ID }:: [-Minz-](https://osu.ppy.sh/users/20578672) | 1 Jan 2024 (14:06:48) |
-| ![](/wiki/shared/medals/all-secret-pioneer.png) | Pioneer | - | - |
+| ![](/wiki/shared/medals/all-secret-pioneer.png) | Pioneer | ::{ flag=MX }:: [xtrem3x](https://osu.ppy.sh/users/136385) | 13 Apr 2025 (06:11:57) |
 | ![](/wiki/shared/medals/osu-secret-overcooked.png) | Overcooked? | ::{ flag=CL }:: [GalaxyGaming](https://osu.ppy.sh/users/4587526) | 25 Dec 2024 (05:29:27) |
 | ![](/wiki/shared/medals/taiko-secret-stargazer.png) | Stargazer | ::{ flag=MX }:: [xtrem3x](https://osu.ppy.sh/users/136385) | 18 Jan 2025 (16:09:11) |
 | ![](/wiki/shared/medals/osu-secret-candescence.png) | Candescence | ::{ flag=MX }:: [Riot](https://osu.ppy.sh/users/4256461) | 25 Dec 2024 (04:44:36) |


### PR DESCRIPTION
The Pioneer medal finally got unlocked, so it's finally time to update this.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
