### PR TITLE
Add map links to `New Featured Artist: Kyutatsuki` newspost

### DIFF
--- a/news/2025/2025-05-17-new-featured-artist-kyutatsuki.md
+++ b/news/2025/2025-05-17-new-featured-artist-kyutatsuki.md
@@ -8,7 +8,7 @@ Sound waves from another dimension have been transported directly to our Feature
 
 ![](https://assets.ppy.sh/artists/476/header.jpg)
 
-**Kyutatsuki** first found their way into osu! through community tournaments, especially catching the attention of osu!mania players. That recognition is what led to **Kyutatsuki**'s involvement in the osu!mania 4K World Cup 2024 Grand Finals tiebreaker, [Fractal Vertex](https://osu.ppy.sh/beatmapsets/2253784), so it was only a matter of time before **Kyutatsuki** joined our Featurerd Artists!
+**Kyutatsuki** first found their way into osu! through community tournaments, especially catching the attention of osu!mania players. That recognition is what led to **Kyutatsuki**'s involvement in the osu!mania 4K World Cup 2024 Grand Finals tiebreaker, [Fractal Vertex](https://osu.ppy.sh/beatmapsets/2253784), so it was only a matter of time before **Kyutatsuki** joined our Featured Artists!
 
 **5** tracks are officially part of [**Kyutatsuki**'s Featured Artist listing](https://osu.ppy.sh/beatmaps/artists/476), paired with pre-timed beatmap templates. Map one of them, or map all of them. We'll leave you to it.
 
@@ -16,34 +16,40 @@ Experience what the self-proclaimed *Sound Shaper from Another Dimension* has to
 
 ### [Kyutatsuki - Dimension Wars](https://assets.ppy.sh/artists/476/Dimension%20Wars/Kyutatsuki%20-%20Dimension%20Wars.osz)
 
+Try out [the map from the preview below](https://osu.ppy.sh/beatmapsets/2097269) by [gzdongsheng](https://osu.ppy.sh/users/8660315) or a [shorter cut version](https://osu.ppy.sh/beatmapsets/2029816) hosted by [Polarin](https://osu.ppy.sh/users/15104680)!
+
 <div align="center" class="osu-md__paragraph">
     <video width="95%" controls>
         <source src="https://assets.ppy.sh/artists/476/release_showcase.mp4" type="video/mp4" preload="none">
     </video>
 </div>
 
-### [Kyutatsuki - BLACKLOTUS](https://assets.ppy.sh/artists/476/Dimension%20Wars/Kyutatsuki%20-%20BLACKLOTUS.osz)
+### [kanemiko & Kyutatsuki & Aoi - Fractal Vertex](https://assets.ppy.sh/artists/476/Songs/kanemiko%20%26%20Kyutatsuki%20%26%20Aoi%20-%20Fractal%20Vertex.osz)
+
+Play through [this map](https://osu.ppy.sh/beatmapsets/2253784#mania/4793996) from [osu!mania 4K World Cup 2024](/wiki/Tournaments/MWC/2024_4K) by [-mint-](https://osu.ppy.sh/users/8976576), [guden](https://osu.ppy.sh/users/11626065), [Toaph Daddy](https://osu.ppy.sh/users/7616811), [elexire](https://osu.ppy.sh/users/9206093), and [MyZterioN-](https://osu.ppy.sh/users/8521723)!
 
 <audio controls>
-    <source src="https://assets.ppy.sh/artists/476/Dimension%20Wars/Kyutatsuki%20-%20BLACKLOTUS.mp3">
+    <source src="https://assets.ppy.sh/artists/476/Songs/kanemiko%20%26%20Kyutatsuki%20%26%20Aoi%20-%20Fractal%20Vertex.mp3">
 </audio>
 
 ### [Kyutatsuki - SOUND ARCHITECT](https://assets.ppy.sh/artists/476/Songs/Kyutatsuki%20-%20SOUND%20ARCHITECT.osz)
 
+And if you're still up for more challenge, try [this 8\* tiebreaker map](https://osu.ppy.sh/beatmapsets/2180470) from [Corsace Closed 2024](https://osu.ppy.sh/beatmaps/artists/381) by [9ami](https://osu.ppy.sh/users/1499997) and [oTwinkle](https://osu.ppy.sh/users/15095654) or this [osu!catch map](https://osu.ppy.sh/beatmapsets/2198809#fruits/4653132) by [GiGas](https://osu.ppy.sh/users/7300747) and [Jemzuu](https://osu.ppy.sh/users/7890134)!
+
 <audio controls>
     <source src="https://assets.ppy.sh/artists/476/Songs/Kyutatsuki%20-%20SOUND%20ARCHITECT.mp3">
-</audio>
-
-### [kanemiko & Kyutatsuki & Aoi - Fractal Vertex](https://assets.ppy.sh/artists/476/Songs/kanemiko%20%26%20Kyutatsuki%20%26%20Aoi%20-%20Fractal%20Vertex.osz)
-
-<audio controls>
-    <source src="https://assets.ppy.sh/artists/476/Songs/kanemiko%20%26%20Kyutatsuki%20%26%20Aoi%20-%20Fractal%20Vertex.mp3">
 </audio>
 
 ### [Kyutatsuki - Meteoric Impact](https://assets.ppy.sh/artists/476/Estera%20Starlite/Kyutatsuki%20-%20Meteoric%20Impact.osz)
 
 <audio controls>
     <source src="https://assets.ppy.sh/artists/476/Estera%20Starlite/Kyutatsuki%20-%20Meteoric%20Impact.mp3">
+</audio>
+
+### [Kyutatsuki - BLACKLOTUS](https://assets.ppy.sh/artists/476/Dimension%20Wars/Kyutatsuki%20-%20BLACKLOTUS.osz)
+
+<audio controls>
+    <source src="https://assets.ppy.sh/artists/476/Dimension%20Wars/Kyutatsuki%20-%20BLACKLOTUS.mp3">
 </audio>
 
 ---


### PR DESCRIPTION
Noticed earlier that the newspost didn't feature any map links for some reason, even the one being previewed 😦 

Also fixed a small typo was present elsewhere in the post ("Featurerd" -> "Featured").

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
