### PR TITLE
Update `LGA 2025` wiki post, news article with partial Week 2 results/redate

### DIFF
--- a/news/2025/2025-05-02-the-lazer-grand-arena-returns.md
+++ b/news/2025/2025-05-02-the-lazer-grand-arena-returns.md
@@ -20,7 +20,7 @@ As always, for more details pertaining to the tournament, please refer to the **
 | Qualifier stage | May 4 (19:00 UTC) – May 11 (19:00 UTC) |
 | Bracket stage (single elimination) | May 17 & May 18 |
 | Top 8 (double elimination) | May 24 & May 25 |
-| Top 3 | May 31 & June 1 |
+| Top 3 | May 30 & May 31 |
 
 ## Tournament format showcase
 

--- a/news/2025/2025-05-02-the-lazer-grand-arena-returns.md
+++ b/news/2025/2025-05-02-the-lazer-grand-arena-returns.md
@@ -16,10 +16,11 @@ As always, for more details pertaining to the tournament, please refer to the **
 
 | Event | Timestamp |
 | --: | :-- |
-| Qualifier and tournament format showcase | 2025-05-04 (15:00 UTC) |
-| Qualifier stage | 2025-05-04 (19:00 UTC) – 2025-05-11 (19:00 UTC) |
-| Bracket stage (single elimination) | 2025-05-17 & 2025-05-18 |
-| Top 8 (double elimination) | 2025-05-24 & 2025-05-25 |
+| Qualifier and tournament format showcase | May 4 (15:00 UTC) |
+| Qualifier stage | May 4 (19:00 UTC) – May 11 (19:00 UTC) |
+| Bracket stage (single elimination) | May 17 & May 18 |
+| Top 8 (double elimination) | May 24 & May 25 |
+| Top 3 | May 31 & June 1 |
 
 ## Tournament format showcase
 

--- a/wiki/Tournaments/LGA/2025/en.md
+++ b/wiki/Tournaments/LGA/2025/en.md
@@ -55,7 +55,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 
 ### Saturday, 31 May 2025
 
-| ID | Round | Team A | Team B | Match time | Twitch stream |  |
+| ID | Round | High seed| Low seed | Match time | Twitch stream |  |
 | :-: | :-- | --: | :-- | :-- | :-: | :-: |
 | 36 | F | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T130000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^winners-finals] |
 | 37a | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=AU }:: [mrekk](https://osu.ppy.sh/users/7562902) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
@@ -183,13 +183,13 @@ Saturday, 24 May 2025:
 
 Wednesday, 21 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | QF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1374325) | [#1](https://www.twitch.tv/videos/2464791551?t=0h4m7s) |
 
 Thursday, 22 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | QF | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [#1](https://osu.ppy.sh/multiplayer/rooms/1375373) | [#1](https://www.twitch.tv/videos/2465313605?t=0h4m47s) |
 
@@ -199,7 +199,7 @@ Thursday, 22 May 2025:
 
 Friday, 23 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | QF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | 2 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1376863) | [#1](https://www.twitch.tv/videos/2465902753?t=0h4m38s) |
 | QF | [Lexu3S](https://osu.ppy.sh/users/11552867) ::{ flag=RU }:: | 1 | **3** | ::{ flag=AU }:: **[aknzx](https://osu.ppy.sh/users/9938943)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1377693) | [#1](https://www.twitch.tv/videos/2466222700?t=0h4m50s) |
@@ -208,7 +208,7 @@ Friday, 23 May 2025:
 
 Saturday, 24 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | LR1 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1379178) | [#1](https://www.twitch.tv/videos/2466762236?t=0h4m56s) |
 | LR1 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=RU }:: [Lexu3S](https://osu.ppy.sh/users/11552867) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380145) | [#1](https://www.twitch.tv/videos/2467125549?t=0h5m11s) |
@@ -218,7 +218,7 @@ Saturday, 24 May 2025:
 
 Sunday, 25 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | LR2 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 2 | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [#1](https://osu.ppy.sh/multiplayer/rooms/1382174) | [#1](https://www.twitch.tv/videos/2467904057?t=0h4m55s) |
 | LR3 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [#1](https://osu.ppy.sh/multiplayer/rooms/1382384) | [#1](https://www.twitch.tv/videos/2467904057?t=2h5m4s) |
@@ -229,7 +229,7 @@ Detailed statistics for this round can be found [here](https://docs.google.com/s
 
 Saturday, 17 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | RO32 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 0 | ::{ flag=US }:: [synchromic](https://osu.ppy.sh/users/14201221) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364116) | [#1](https://youtu.be/Pux_RC4P8Ik?si=S1yVFIZwkF9z-zbd&t=276) |
 | RO32 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [gilgamesh815](https://osu.ppy.sh/users/14040810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364219) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=3860) |
@@ -249,7 +249,7 @@ Saturday, 17 May 2025:
 
 Sunday, 18 May 2025:
 
-| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | RO32 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NO }:: [nanolini](https://osu.ppy.sh/users/12353810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367207) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=10922) |
 | RO16 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [decaten](https://osu.ppy.sh/users/5645231) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368095) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=18112) |
@@ -471,7 +471,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 ### Match procedures
 
 1. A referee will create a multiplayer room 10 minutes before the scheduled match time. Players must join the lobby in that period.
-   - The room settings are `Ruleset: "osu!"` and `Game type: "Team Vs"`. The room name must follow the pattern of `LGA2025: ({Red Player}) VS ({Blue Player})`. The player mentioned first in the room name must be the red player, and the player mentioned second in the room name must be the blue player.
+   - The room settings are `Ruleset: "osu!"` and `Game type: "Team Vs"`. The room name must follow the pattern of `LGA2025: ({High seed}) VS ({Low seed})`. The player mentioned first in the room name must be the High seed, and the player mentioned second in the room name must be the Low seed.
 2. Each player will receive one "tactical timeout" of 2 minutes, to be used as extra time to ban, pick, or ready for a beatmap. The tactical timeout may not be called on the opposing player's pick or ban phase.
 3. Players will be allowed 2 minutes for each pick/ban phase (as described on the [bracket stage instructions](#bracket-stage-information) section), and an additional 2 minutes to press the `Ready` button on their client before play commences. If a player takes more time than allotted for either action, the procedures adopted will be as follows:
    - For the first occurrence:

--- a/wiki/Tournaments/LGA/2025/en.md
+++ b/wiki/Tournaments/LGA/2025/en.md
@@ -55,7 +55,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 
 ### Saturday, 31 May 2025
 
-| ID | Round | High seed| Low seed | Match time | Twitch stream |  |
+| ID | Round | High seed | Low seed | Match time | Twitch stream |  |
 | :-: | :-- | --: | :-- | :-- | :-: | :-: |
 | 36 | F | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T130000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^winners-finals] |
 | 37a | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=AU }:: [mrekk](https://osu.ppy.sh/users/7562902) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
@@ -63,7 +63,6 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 | 37c | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=AU }:: [mrekk](https://osu.ppy.sh/users/7562902) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
 | 37d | LF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
 | 38 | GF | Winner of 36 | Winner of 37 | [May 31 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T150000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^grand-finals] |
-
 
 ## Mappools
 
@@ -166,45 +165,6 @@ Friday, 23 May 2025:
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
 | QF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | 2 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1376863) | [#1](https://www.twitch.tv/videos/2465902753?t=0h4m38s) |
 | QF | [Lexu3S](https://osu.ppy.sh/users/11552867) ::{ flag=RU }:: | 1 | **3** | ::{ flag=AU }:: **[aknzx](https://osu.ppy.sh/users/9938943)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1377693) | [#1](https://www.twitch.tv/videos/2466222700?t=0h4m50s) |
-
-Saturday, 24 May 2025:
-
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
-| :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| LR1 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1379178) | [#1](https://www.twitch.tv/videos/2466762236?t=0h4m56s) |
-| SF | [aknzx](https://osu.ppy.sh/users/9938943) ::{ flag=AU }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1379254) | [#1](https://www.twitch.tv/videos/2466762236?t=1h5m0s) |
-| LR2 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=AU }:: [aknzx](https://osu.ppy.sh/users/9938943) | [#1](https://osu.ppy.sh/multiplayer/rooms/1379334) | [#1](https://www.twitch.tv/videos/2466762236?t=2h4m57s) |
-| LR1 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=RU }:: [Lexu3S](https://osu.ppy.sh/users/11552867) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380145) | [#1](https://www.twitch.tv/videos/2467125549?t=0h5m11s) |
-| SF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380255) | [#1](https://www.twitch.tv/videos/2467125549?t=1h4m37s) |
-
-## Match results
-
-### Week 2
-
-Wednesday, 21 May 2025:
-
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
-| :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| QF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1374325) | [#1](https://www.twitch.tv/videos/2464791551?t=0h4m7s) |
-
-Thursday, 22 May 2025:
-
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
-| :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| QF | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [#1](https://osu.ppy.sh/multiplayer/rooms/1375373) | [#1](https://www.twitch.tv/videos/2465313605?t=0h4m47s) |
-
-## Match results
-
-### Week 2
-
-Friday, 23 May 2025:
-
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
-| :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| QF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | 2 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1376863) | [#1](https://www.twitch.tv/videos/2465902753?t=0h4m38s) |
-| QF | [Lexu3S](https://osu.ppy.sh/users/11552867) ::{ flag=RU }:: | 1 | **3** | ::{ flag=AU }:: **[aknzx](https://osu.ppy.sh/users/9938943)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1377693) | [#1](https://www.twitch.tv/videos/2466222700?t=0h4m50s) |
-
-### Week 2
 
 Saturday, 24 May 2025:
 

--- a/wiki/Tournaments/LGA/2025/en.md
+++ b/wiki/Tournaments/LGA/2025/en.md
@@ -22,6 +22,7 @@ The **Lazer Grand Arena 2025** (***LGA 2025***) is an osu!(lazer) tournament hos
 | Qualifier stage | 2025-05-04 (19:00 UTC) – 2025-05-11 (19:00 UTC) |
 | Bracket stage (single elimination) | 2025-05-17/2025-05-18 |
 | Top 8 (double elimination) | 2025-05-24/2025-05-25 |
+| Top 3 | 2025-05-31/2025-06-01 |
 
 ## Organisation
 
@@ -178,43 +179,89 @@ Saturday, 24 May 2025:
 | LR1 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=RU }:: [Lexu3S](https://osu.ppy.sh/users/11552867) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380145) | [#1](https://www.twitch.tv/videos/2467125549?t=0h5m11s) |
 | SF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380255) | [#1](https://www.twitch.tv/videos/2467125549?t=1h4m37s) |
 
+## Match results
+
+### Week 2
+
+Wednesday, 21 May 2025:
+
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| :-- | --: | :-: | :-: | :-- | :-- | :-- |
+| QF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1374325) | [#1](https://www.twitch.tv/videos/2464791551?t=0h4m7s) |
+
+Thursday, 22 May 2025:
+
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| :-- | --: | :-: | :-: | :-- | :-- | :-- |
+| QF | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [#1](https://osu.ppy.sh/multiplayer/rooms/1375373) | [#1](https://www.twitch.tv/videos/2465313605?t=0h4m47s) |
+
+## Match results
+
+### Week 2
+
+Friday, 23 May 2025:
+
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| :-- | --: | :-: | :-: | :-- | :-- | :-- |
+| QF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | 2 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1376863) | [#1](https://www.twitch.tv/videos/2465902753?t=0h4m38s) |
+| QF | [Lexu3S](https://osu.ppy.sh/users/11552867) ::{ flag=RU }:: | 1 | **3** | ::{ flag=AU }:: **[aknzx](https://osu.ppy.sh/users/9938943)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1377693) | [#1](https://www.twitch.tv/videos/2466222700?t=0h4m50s) |
+
+### Week 2
+
+Saturday, 24 May 2025:
+
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| :-- | --: | :-: | :-: | :-- | :-- | :-- |
+| LR1 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [tekkito](https://osu.ppy.sh/users/7075211) | [#1](https://osu.ppy.sh/multiplayer/rooms/1379178) | [#1](https://www.twitch.tv/videos/2466762236?t=0h4m56s) |
+| LR1 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=RU }:: [Lexu3S](https://osu.ppy.sh/users/11552867) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380145) | [#1](https://www.twitch.tv/videos/2467125549?t=0h5m11s) |
+| SF | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [#1](https://osu.ppy.sh/multiplayer/rooms/1380255) | [#1](https://www.twitch.tv/videos/2467125549?t=1h4m37s) |
+| SF | [aknzx](https://osu.ppy.sh/users/9938943) ::{ flag=AU }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1379254) | [#1](https://www.twitch.tv/videos/2466762236?t=1h5m0s) |
+| LR2 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=AU }:: [aknzx](https://osu.ppy.sh/users/9938943) | [#1](https://osu.ppy.sh/multiplayer/rooms/1379334) | [#1](https://www.twitch.tv/videos/2466762236?t=2h4m57s) |
+
+Sunday, 25 May 2025:
+
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
+| :-- | --: | :-: | :-: | :-- | :-- | :-- |
+| LR2 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 2 | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [#1](https://osu.ppy.sh/multiplayer/rooms/1382174) | [#1](https://www.twitch.tv/videos/2467904057?t=0h4m55s) |
+| LR3 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [#1](https://osu.ppy.sh/multiplayer/rooms/1382384) | [#1](https://www.twitch.tv/videos/2467904057?t=2h5m4s) |
+
 ### Week 1
 
 Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/1Erb5JlSWdy0dGFHdbw0rXrTZYbEKIv-ICTBM8HruuZ4?rm=minimal).
 
 Saturday, 17 May 2025:
 
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| RO32 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 0 | ::{ flag=US }:: [synchromic](https://osu.ppy.sh/users/14201221) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364116) | [#1](https://www.twitch.tv/videos/2460815628?t=0h4m38s) |
-| RO32 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [gilgamesh815](https://osu.ppy.sh/users/14040810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364219) | [#1](https://www.twitch.tv/videos/2460815628?t=1h4m13s) |
-| RO32 | **[Emilbus](https://osu.ppy.sh/users/11141578)** ::{ flag=NZ }:: | **3** | 2 | ::{ flag=US }:: [Jakson](https://osu.ppy.sh/users/8788058) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364301) | [#1](https://www.twitch.tv/videos/2460815628?t=2h4m16s) |
-| RO32 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=PL }:: [hedayo](https://osu.ppy.sh/users/9323821) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364971) | [#1](https://www.twitch.tv/videos/2461097135?t=0h5m19s) |
-| RO32 | [fedoragoose](https://osu.ppy.sh/users/2323131) ::{ flag=AT }:: | 1 | **3** | ::{ flag=PL }:: **[Kosiarek](https://osu.ppy.sh/users/9086565)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365028) | [#1](https://www.twitch.tv/videos/2461097135?t=0h37m26s) |
+| RO32 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 0 | ::{ flag=US }:: [synchromic](https://osu.ppy.sh/users/14201221) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364116) | [#1](https://youtu.be/Pux_RC4P8Ik?si=S1yVFIZwkF9z-zbd&t=276) |
+| RO32 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [gilgamesh815](https://osu.ppy.sh/users/14040810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364219) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=3860) |
+| RO32 | **[Emilbus](https://osu.ppy.sh/users/11141578)** ::{ flag=NZ }:: | **3** | 2 | ::{ flag=US }:: [Jakson](https://osu.ppy.sh/users/8788058) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364301) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=7450) |
+| RO32 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=PL }:: [hedayo](https://osu.ppy.sh/users/9323821) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364971) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=11991) |
+| RO32 | [fedoragoose](https://osu.ppy.sh/users/2323131) ::{ flag=AT }:: | 1 | **3** | ::{ flag=PL }:: **[Kosiarek](https://osu.ppy.sh/users/9086565)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365028) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=13922) |
 | RO32 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 0 | ::{ flag=SE }:: [trumpatino69](https://osu.ppy.sh/users/10903510) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365122) | [#1](https://www.twitch.tv/videos/2461097135?t=1h21m58s) |
-| RO32 | **[nnamoe](https://osu.ppy.sh/users/11215030)** ::{ flag=SM }:: | **3** | 2 | ::{ flag=CA }:: [Juan Dario](https://osu.ppy.sh/users/16529875) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365358) | [#1](https://www.twitch.tv/videos/2461213237?t=0h3m50s) |
-| RO32 | **[tekkito](https://osu.ppy.sh/users/7075211)** ::{ flag=US }:: | **3** | 0 | ::{ flag=MN }:: [seegii](https://osu.ppy.sh/users/4659319) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365363) | [#1](https://www.twitch.tv/videos/2461209887?t=0h8m28s) |
-| RO32 | **[decaten](https://osu.ppy.sh/users/5645231)** ::{ flag=US }:: | **3** | 1 | ::{ flag=FI }:: [Amasetic](https://osu.ppy.sh/users/11375251) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365538) | [#1](https://www.twitch.tv/videos/2461213237?t=1h4m00s) |
-| RO32 | **[SERBIATRUCKER13](https://osu.ppy.sh/users/15339747)** ::{ flag=DE }:: | **3** | 0 | ::{ flag=GB }:: [rudj](https://osu.ppy.sh/users/11592896) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365531) | [#1](https://www.twitch.tv/videos/2461209887?t=1h8m31s) |
-| RO32 | **[Riot](https://osu.ppy.sh/users/4256461)** ::{ flag=MX }:: | **3** | 0 | ::{ flag=FR }:: [Musty](https://osu.ppy.sh/users/251683) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365680) | [#1](https://www.twitch.tv/videos/2461209887?t=2h7m45s) |
-| RO32 | [RafGPio](https://osu.ppy.sh/users/13705417) ::{ flag=UA }:: | 1 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365810) | [#1](https://www.twitch.tv/videos/2461209887?t=3h8m32s) |
-| RO32 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [rinse](https://osu.ppy.sh/users/11962818) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365934) | [#1](https://www.twitch.tv/videos/2461409635?t=0h6m35s) |
-| RO32 | [LUNAISTABBY](https://osu.ppy.sh/users/4673649) ::{ flag=US }:: | 2 | **3** | ::{ flag=PL }:: **[eniu](https://osu.ppy.sh/users/5472693)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365937) | [#1](https://www.twitch.tv/videos/2461409635?t=0h6m35s) |
-| RO32 | **[alfiu](https://osu.ppy.sh/users/17724014)** ::{ flag=CL }:: | **3** | 2 | ::{ flag=US }:: [Flameztear](https://osu.ppy.sh/users/13207763) | [#1](https://osu.ppy.sh/multiplayer/rooms/1366079) | [#1](https://www.twitch.tv/videos/2461209887?t=5h8m40s) |
+| RO32 | **[nnamoe](https://osu.ppy.sh/users/11215030)** ::{ flag=SM }:: | **3** | 2 | ::{ flag=CA }:: [Juan Dario](https://osu.ppy.sh/users/16529875) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365358) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=4236) |
+| RO32 | **[tekkito](https://osu.ppy.sh/users/7075211)** ::{ flag=US }:: | **3** | 0 | ::{ flag=MN }:: [seegii](https://osu.ppy.sh/users/4659319) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365363) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=18827) |
+| RO32 | **[decaten](https://osu.ppy.sh/users/5645231)** ::{ flag=US }:: | **3** | 1 | ::{ flag=FI }:: [Amasetic](https://osu.ppy.sh/users/11375251) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365538) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=7847) |
+| RO32 | **[SERBIATRUCKER13](https://osu.ppy.sh/users/15339747)** ::{ flag=DE }:: | **3** | 0 | ::{ flag=GB }:: [rudj](https://osu.ppy.sh/users/11592896) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365531) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=22428) |
+| RO32 | **[Riot](https://osu.ppy.sh/users/4256461)** ::{ flag=MX }:: | **3** | 0 | ::{ flag=FR }:: [Musty](https://osu.ppy.sh/users/251683) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365680) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=25985) |
+| RO32 | [RafGPio](https://osu.ppy.sh/users/13705417) ::{ flag=UA }:: | 1 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365810) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=29623) |
+| RO32 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [rinse](https://osu.ppy.sh/users/11962818) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365934) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=33239) |
+| RO32 | [LUNAISTABBY](https://osu.ppy.sh/users/4673649) ::{ flag=US }:: | 2 | **3** | ::{ flag=PL }:: **[eniu](https://osu.ppy.sh/users/5472693)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365937) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=393) |
+| RO32 | **[alfiu](https://osu.ppy.sh/users/17724014)** ::{ flag=CL }:: | **3** | 2 | ::{ flag=US }:: [Flameztear](https://osu.ppy.sh/users/13207763) | [#1](https://osu.ppy.sh/multiplayer/rooms/1366079) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=36834) |
 
 Sunday, 18 May 2025:
 
-| Stage | High seed |  |  | Low seed | Match link | VOD link |
+| Stage | Red Player |  |  | Blue Player | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| RO32 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NO }:: [nanolini](https://osu.ppy.sh/users/12353810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367207) | [#1](https://www.twitch.tv/videos/2461935882?t=0h4m54s) |
-| RO16 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [decaten](https://osu.ppy.sh/users/5645231) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368095) | [#1](https://www.twitch.tv/videos/2462159940?t=1h5m43s) |
-| RO16 | [nnamoe](https://osu.ppy.sh/users/11215030) ::{ flag=SM }:: | 1 | **3** | ::{ flag=US }:: **[tekkito](https://osu.ppy.sh/users/7075211)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367689) | [#1](https://www.twitch.tv/videos/2462034092?t=1h4m24s) |
-| RO16 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=DE }:: [SERBIATRUCKER13](https://osu.ppy.sh/users/15339747) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367557) | [#1](https://www.twitch.tv/videos/2462034092?t=0h4m27s) |
-| RO16 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NZ }:: [Emilbus](https://osu.ppy.sh/users/11141578) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367562) | [#1](https://www.twitch.tv/videos/2462034176?t=0h4m15s) |
+| RO32 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NO }:: [nanolini](https://osu.ppy.sh/users/12353810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367207) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=10922) |
+| RO16 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [decaten](https://osu.ppy.sh/users/5645231) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368095) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=18112) |
+| RO16 | [nnamoe](https://osu.ppy.sh/users/11215030) ::{ flag=SM }:: | 1 | **3** | ::{ flag=US }:: **[tekkito](https://osu.ppy.sh/users/7075211)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367689) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=6246) |
+| RO16 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=DE }:: [SERBIATRUCKER13](https://osu.ppy.sh/users/15339747) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367557) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=2648) |
+| RO16 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NZ }:: [Emilbus](https://osu.ppy.sh/users/11141578) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367562) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=259) |
 | RO16 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=CL }:: [alfiu](https://osu.ppy.sh/users/17724014) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367580) |  |
-| RO16 | [Riot](https://osu.ppy.sh/users/4256461) ::{ flag=MX }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367960) | [#1](https://www.twitch.tv/videos/2462159940?t=0h5m38s) |
-| RO16 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 2 | ::{ flag=PL }:: [eniu](https://osu.ppy.sh/users/5472693) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368105) | [#1](https://www.twitch.tv/videos/2462298024) |
-| RO16 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 1 | ::{ flag=PL }:: [Kosiarek](https://osu.ppy.sh/users/9086565) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367302) | [#1](https://www.twitch.tv/videos/2461935882?t=1h5m11s) |
+| RO16 | [Riot](https://osu.ppy.sh/users/4256461) ::{ flag=MX }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367960) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=14512) |
+| RO16 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 2 | ::{ flag=PL }:: [eniu](https://osu.ppy.sh/users/5472693) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368105) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=9253) |
+| RO16 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 1 | ::{ flag=PL }:: [Kosiarek](https://osu.ppy.sh/users/9086565) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367302) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=14536) |
 
 ### Qualifiers
 

--- a/wiki/Tournaments/LGA/2025/en.md
+++ b/wiki/Tournaments/LGA/2025/en.md
@@ -22,7 +22,7 @@ The **Lazer Grand Arena 2025** (***LGA 2025***) is an osu!(lazer) tournament hos
 | Qualifier stage | 2025-05-04 (19:00 UTC) – 2025-05-11 (19:00 UTC) |
 | Bracket stage (single elimination) | 2025-05-17/2025-05-18 |
 | Top 8 (double elimination) | 2025-05-24/2025-05-25 |
-| Top 3 | 2025-05-31/2025-06-01 |
+| Top 3 | 2025-05-30/2025-05-31 |
 
 ## Organisation
 
@@ -49,30 +49,28 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 - [Pick'ems page](https://pickem.hwc.hr/tournaments/172) hosted by ::{ flag=DE }:: [hallowatcher](https://osu.ppy.sh/users/1874761)
 - [Challonge bracket](https://challonge.com/LGA2025)
 
-## Match schedule: Week 2
+## Match schedule: Week 3
 
 *Notice: The schedule is tentative and subject to change based on the availability of the players.*
 
-### Sunday, 25 May 2025
+### Saturday, 31 May 2025
 
-| ID | Round | High seed | Low seed | Match time | Twitch stream |  |
+| ID | Round | Team A | Team B | Match time | Twitch stream |  |
 | :-: | :-- | --: | :-- | :-- | :-: | :-: |
-| 33 | LR2 | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | ::{ flag=KR }:: [FlyingTuna](https://osu.ppy.sh/users/9224078) | [May 25 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T100000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
-| 35a | LR3 | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [May 25 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T120000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 33, 34[^potential-match] |
-| 35b | LR3 | [FlyingTuna](https://osu.ppy.sh/users/9224078) ::{ flag=KR }:: | ::{ flag=AU }:: [ASecretBox](https://osu.ppy.sh/users/7341183) | [May 25 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T120000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 33, 34[^potential-match] |
-| 36 | F | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 25 (Sun) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T130000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
-| 37a | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | Winner of 35 | [May 25 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 36, 35[^potential-match] |
-| 37b | LF | Winner of 35 | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 25 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 36, 35[^potential-match] |
-| 37c | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | Winner of 35 | [May 25 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 36, 35[^potential-match] |
-| 37d | LF | Winner of 35 | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 25 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | depends on: 36, 35[^potential-match] |
-| 38 | GF | Winner of 36 | Winner of 37 | [May 25 (Sun) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250525T150000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| 36 | F | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T130000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^winners-finals] |
+| 37a | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=AU }:: [mrekk](https://osu.ppy.sh/users/7562902) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
+| 37b | LF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
+| 37c | LF | [MALISZEWSKI](https://osu.ppy.sh/users/12408961) ::{ flag=PL }:: | ::{ flag=AU }:: [mrekk](https://osu.ppy.sh/users/7562902) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
+| 37d | LF | [mrekk](https://osu.ppy.sh/users/7562902) ::{ flag=AU }:: | ::{ flag=CA }:: [Zylice](https://osu.ppy.sh/users/5033077) | [May 31 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T140000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^losers-finals] |
+| 38 | GF | Winner of 36 | Winner of 37 | [May 31 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250531T150000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^grand-finals] |
+
 
 ## Mappools
 
 ### Week 2
 
 **[Download the mappack here (114 MB)](https://packs.ppy.sh/P286%20-%20Lazer%20Grand%20Arena%202025%3A%20Week%202.zip)**\
-[View the showcase VOD here](https://www.twitch.tv/videos/2456368092?t=0h44m30s)
+[View the showcase VOD here](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=23293)
 
 - No Mod
   1. [Falcom Sound Team jdk - GENS D'ARMES (jonathanlfj) \[CONQUEROR\]](https://osu.ppy.sh/beatmapsets/1078344#osu/2256387)
@@ -99,7 +97,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 ### Week 1
 
 **[Download the mappack here (104 MB)](https://packs.ppy.sh/P285%20-%20Lazer%20Grand%20Arena%202025%3A%20Week%201.zip?1747460209)**\
-[View the showcase VOD here](https://www.twitch.tv/videos/2456368092?t=0h44m30s)
+[View the showcase VOD here](https://youtu.be/3Q3VXkmWa7c?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=2670)
 
 - No Mod
   1. [Nanahoshi Kangengakudan - FREEDMAN (-Links) \[Imitadores de la Libertad\]](https://osu.ppy.sh/beatmapsets/2369572#osu/5112574)
@@ -126,7 +124,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 ### Qualifiers
 
 **[Download the mappack here (114 MB)](https://packs.ppy.sh/P284%20-%20Lazer%20Grand%20Arena%202025%3A%20Qualifiers.zip?1747006157)**\
-[View the showcase VOD here](https://www.youtube.com/watch?v=52W_cvU-ajU)
+[View the showcase VOD here](https://youtu.be/52W_cvU-ajU?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK)
 
 - No Mod
   1. [Wagakki Band - Kagerou Days (-Kirigiri) \[Heaven\]](https://osu.ppy.sh/beatmapsets/1865260#osu/3836604)
@@ -499,7 +497,8 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 ## Notes
 
-[^winners-bracket]: Winners bracket match
-[^potential-match]: Potential match — final matchup depends on the results of the preceding matches
+[^winners-finals]: Winners bracket Finals match
+[^losers-finals]: Losers bracket Finals match — final matchup depends on the results of the preceding Winners bracket Finals match
+[^grand-finals]: Grand Finals match — final matchup depends on the results of the preceding Losers bracket Finals match
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two players have the same MAX sum

--- a/wiki/Tournaments/LGA/2025/en.md
+++ b/wiki/Tournaments/LGA/2025/en.md
@@ -69,7 +69,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 ### Week 2
 
 **[Download the mappack here (114 MB)](https://packs.ppy.sh/P286%20-%20Lazer%20Grand%20Arena%202025%3A%20Week%202.zip)**\
-[View the showcase VOD here](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=23293)
+[View the showcase VOD here](https://www.youtube.com/watch?v=qpd2DPddsKs&t=23293)
 
 - No Mod
   1. [Falcom Sound Team jdk - GENS D'ARMES (jonathanlfj) \[CONQUEROR\]](https://osu.ppy.sh/beatmapsets/1078344#osu/2256387)
@@ -96,7 +96,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 ### Week 1
 
 **[Download the mappack here (104 MB)](https://packs.ppy.sh/P285%20-%20Lazer%20Grand%20Arena%202025%3A%20Week%201.zip?1747460209)**\
-[View the showcase VOD here](https://youtu.be/3Q3VXkmWa7c?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=2670)
+[View the showcase VOD here](https://www.youtube.com/watch?v=3Q3VXkmWa7c&t=2670)
 
 - No Mod
   1. [Nanahoshi Kangengakudan - FREEDMAN (-Links) \[Imitadores de la Libertad\]](https://osu.ppy.sh/beatmapsets/2369572#osu/5112574)
@@ -123,7 +123,7 @@ The Lazer Grand Arena is run by the [osu! team](/wiki/People/osu!_team) and vari
 ### Qualifiers
 
 **[Download the mappack here (114 MB)](https://packs.ppy.sh/P284%20-%20Lazer%20Grand%20Arena%202025%3A%20Qualifiers.zip?1747006157)**\
-[View the showcase VOD here](https://youtu.be/52W_cvU-ajU?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK)
+[View the showcase VOD here](https://www.youtube.com/watch?v=52W_cvU-ajU)
 
 - No Mod
   1. [Wagakki Band - Kagerou Days (-Kirigiri) \[Heaven\]](https://osu.ppy.sh/beatmapsets/1865260#osu/3836604)
@@ -191,40 +191,40 @@ Saturday, 17 May 2025:
 
 | Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| RO32 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 0 | ::{ flag=US }:: [synchromic](https://osu.ppy.sh/users/14201221) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364116) | [#1](https://youtu.be/Pux_RC4P8Ik?si=S1yVFIZwkF9z-zbd&t=276) |
-| RO32 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [gilgamesh815](https://osu.ppy.sh/users/14040810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364219) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=3860) |
-| RO32 | **[Emilbus](https://osu.ppy.sh/users/11141578)** ::{ flag=NZ }:: | **3** | 2 | ::{ flag=US }:: [Jakson](https://osu.ppy.sh/users/8788058) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364301) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=7450) |
-| RO32 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=PL }:: [hedayo](https://osu.ppy.sh/users/9323821) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364971) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=11991) |
-| RO32 | [fedoragoose](https://osu.ppy.sh/users/2323131) ::{ flag=AT }:: | 1 | **3** | ::{ flag=PL }:: **[Kosiarek](https://osu.ppy.sh/users/9086565)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365028) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=13922) |
+| RO32 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 0 | ::{ flag=US }:: [synchromic](https://osu.ppy.sh/users/14201221) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364116) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=276) |
+| RO32 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=US }:: [gilgamesh815](https://osu.ppy.sh/users/14040810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364219) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=3860) |
+| RO32 | **[Emilbus](https://osu.ppy.sh/users/11141578)** ::{ flag=NZ }:: | **3** | 2 | ::{ flag=US }:: [Jakson](https://osu.ppy.sh/users/8788058) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364301) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=7450) |
+| RO32 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=PL }:: [hedayo](https://osu.ppy.sh/users/9323821) | [#1](https://osu.ppy.sh/multiplayer/rooms/1364971) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=11991) |
+| RO32 | [fedoragoose](https://osu.ppy.sh/users/2323131) ::{ flag=AT }:: | 1 | **3** | ::{ flag=PL }:: **[Kosiarek](https://osu.ppy.sh/users/9086565)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365028) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=13922) |
 | RO32 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 0 | ::{ flag=SE }:: [trumpatino69](https://osu.ppy.sh/users/10903510) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365122) | [#1](https://www.twitch.tv/videos/2461097135?t=1h21m58s) |
-| RO32 | **[nnamoe](https://osu.ppy.sh/users/11215030)** ::{ flag=SM }:: | **3** | 2 | ::{ flag=CA }:: [Juan Dario](https://osu.ppy.sh/users/16529875) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365358) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=4236) |
-| RO32 | **[tekkito](https://osu.ppy.sh/users/7075211)** ::{ flag=US }:: | **3** | 0 | ::{ flag=MN }:: [seegii](https://osu.ppy.sh/users/4659319) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365363) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=18827) |
-| RO32 | **[decaten](https://osu.ppy.sh/users/5645231)** ::{ flag=US }:: | **3** | 1 | ::{ flag=FI }:: [Amasetic](https://osu.ppy.sh/users/11375251) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365538) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=7847) |
-| RO32 | **[SERBIATRUCKER13](https://osu.ppy.sh/users/15339747)** ::{ flag=DE }:: | **3** | 0 | ::{ flag=GB }:: [rudj](https://osu.ppy.sh/users/11592896) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365531) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=22428) |
-| RO32 | **[Riot](https://osu.ppy.sh/users/4256461)** ::{ flag=MX }:: | **3** | 0 | ::{ flag=FR }:: [Musty](https://osu.ppy.sh/users/251683) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365680) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=25985) |
-| RO32 | [RafGPio](https://osu.ppy.sh/users/13705417) ::{ flag=UA }:: | 1 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365810) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=29623) |
-| RO32 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [rinse](https://osu.ppy.sh/users/11962818) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365934) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=33239) |
-| RO32 | [LUNAISTABBY](https://osu.ppy.sh/users/4673649) ::{ flag=US }:: | 2 | **3** | ::{ flag=PL }:: **[eniu](https://osu.ppy.sh/users/5472693)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365937) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=393) |
-| RO32 | **[alfiu](https://osu.ppy.sh/users/17724014)** ::{ flag=CL }:: | **3** | 2 | ::{ flag=US }:: [Flameztear](https://osu.ppy.sh/users/13207763) | [#1](https://osu.ppy.sh/multiplayer/rooms/1366079) | [#1](https://youtu.be/Pux_RC4P8Ik?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=36834) |
+| RO32 | **[nnamoe](https://osu.ppy.sh/users/11215030)** ::{ flag=SM }:: | **3** | 2 | ::{ flag=CA }:: [Juan Dario](https://osu.ppy.sh/users/16529875) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365358) | [#1](https://www.youtube.com/watch?v=eSPa3jMFcKs&t=4236) |
+| RO32 | **[tekkito](https://osu.ppy.sh/users/7075211)** ::{ flag=US }:: | **3** | 0 | ::{ flag=MN }:: [seegii](https://osu.ppy.sh/users/4659319) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365363) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=18827) |
+| RO32 | **[decaten](https://osu.ppy.sh/users/5645231)** ::{ flag=US }:: | **3** | 1 | ::{ flag=FI }:: [Amasetic](https://osu.ppy.sh/users/11375251) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365538) | [#1](https://www.youtube.com/watch?v=eSPa3jMFcKs&t=7847) |
+| RO32 | **[SERBIATRUCKER13](https://osu.ppy.sh/users/15339747)** ::{ flag=DE }:: | **3** | 0 | ::{ flag=GB }:: [rudj](https://osu.ppy.sh/users/11592896) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365531) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=22428) |
+| RO32 | **[Riot](https://osu.ppy.sh/users/4256461)** ::{ flag=MX }:: | **3** | 0 | ::{ flag=FR }:: [Musty](https://osu.ppy.sh/users/251683) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365680) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=25985) |
+| RO32 | [RafGPio](https://osu.ppy.sh/users/13705417) ::{ flag=UA }:: | 1 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365810) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=29623) |
+| RO32 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [rinse](https://osu.ppy.sh/users/11962818) | [#1](https://osu.ppy.sh/multiplayer/rooms/1365934) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=33239) |
+| RO32 | [LUNAISTABBY](https://osu.ppy.sh/users/4673649) ::{ flag=US }:: | 2 | **3** | ::{ flag=PL }:: **[eniu](https://osu.ppy.sh/users/5472693)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1365937) | [#1](https://www.youtube.com/watch?v=eSPa3jMFcKs&t=393) |
+| RO32 | **[alfiu](https://osu.ppy.sh/users/17724014)** ::{ flag=CL }:: | **3** | 2 | ::{ flag=US }:: [Flameztear](https://osu.ppy.sh/users/13207763) | [#1](https://osu.ppy.sh/multiplayer/rooms/1366079) | [#1](https://www.youtube.com/watch?v=Pux_RC4P8Ik&t=36834) |
 
 Sunday, 18 May 2025:
 
 | Stage | High seed |  |  | Low seed | Match link | VOD link |
 | :-- | --: | :-: | :-: | :-- | :-- | :-- |
-| RO32 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NO }:: [nanolini](https://osu.ppy.sh/users/12353810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367207) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=10922) |
-| RO16 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [decaten](https://osu.ppy.sh/users/5645231) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368095) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=18112) |
-| RO16 | [nnamoe](https://osu.ppy.sh/users/11215030) ::{ flag=SM }:: | 1 | **3** | ::{ flag=US }:: **[tekkito](https://osu.ppy.sh/users/7075211)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367689) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=6246) |
-| RO16 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=DE }:: [SERBIATRUCKER13](https://osu.ppy.sh/users/15339747) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367557) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=2648) |
-| RO16 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NZ }:: [Emilbus](https://osu.ppy.sh/users/11141578) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367562) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=259) |
+| RO32 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NO }:: [nanolini](https://osu.ppy.sh/users/12353810) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367207) | [#1](https://www.youtube.com/watch?v=eSPa3jMFcKs&t=10922) |
+| RO16 | **[MALISZEWSKI](https://osu.ppy.sh/users/12408961)** ::{ flag=PL }:: | **3** | 0 | ::{ flag=US }:: [decaten](https://osu.ppy.sh/users/5645231) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368095) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=18112) |
+| RO16 | [nnamoe](https://osu.ppy.sh/users/11215030) ::{ flag=SM }:: | 1 | **3** | ::{ flag=US }:: **[tekkito](https://osu.ppy.sh/users/7075211)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367689) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=6246) |
+| RO16 | **[FlyingTuna](https://osu.ppy.sh/users/9224078)** ::{ flag=KR }:: | **3** | 1 | ::{ flag=DE }:: [SERBIATRUCKER13](https://osu.ppy.sh/users/15339747) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367557) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=2648) |
+| RO16 | **[ASecretBox](https://osu.ppy.sh/users/7341183)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=NZ }:: [Emilbus](https://osu.ppy.sh/users/11141578) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367562) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=259) |
 | RO16 | **[mrekk](https://osu.ppy.sh/users/7562902)** ::{ flag=AU }:: | **3** | 0 | ::{ flag=CL }:: [alfiu](https://osu.ppy.sh/users/17724014) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367580) |  |
-| RO16 | [Riot](https://osu.ppy.sh/users/4256461) ::{ flag=MX }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367960) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=14512) |
-| RO16 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 2 | ::{ flag=PL }:: [eniu](https://osu.ppy.sh/users/5472693) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368105) | [#1](https://youtu.be/qpd2DPddsKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=9253) |
-| RO16 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 1 | ::{ flag=PL }:: [Kosiarek](https://osu.ppy.sh/users/9086565) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367302) | [#1](https://youtu.be/eSPa3jMFcKs?list=PLIYfYZCsR-6GbBNYQUJwUOkweHnF10QfK&t=14536) |
+| RO16 | [Riot](https://osu.ppy.sh/users/4256461) ::{ flag=MX }:: | 0 | **3** | ::{ flag=CA }:: **[Zylice](https://osu.ppy.sh/users/5033077)** | [#1](https://osu.ppy.sh/multiplayer/rooms/1367960) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=14512) |
+| RO16 | **[Lexu3S](https://osu.ppy.sh/users/11552867)** ::{ flag=RU }:: | **3** | 2 | ::{ flag=PL }:: [eniu](https://osu.ppy.sh/users/5472693) | [#1](https://osu.ppy.sh/multiplayer/rooms/1368105) | [#1](https://www.youtube.com/watch?v=qpd2DPddsKs&t=9253) |
+| RO16 | **[aknzx](https://osu.ppy.sh/users/9938943)** ::{ flag=AU }:: | **3** | 1 | ::{ flag=PL }:: [Kosiarek](https://osu.ppy.sh/users/9086565) | [#1](https://osu.ppy.sh/multiplayer/rooms/1367302) | [#1](https://www.youtube.com/watch?v=eSPa3jMFcKs&t=14536) |
 
 ### Qualifiers
 
 The final standings for the Qualifier stage can be found in the following [spreadsheet](https://docs.google.com/spreadsheets/d/1OR01k8dPK5n01LzxrM1lpZLetKx9Kb-2yx42EQvhMwA?rm=minimal).\
-[View the Qualifier seed reveal VOD here](https://www.twitch.tv/videos/2456368092?t=0h4m54s).
+[View the Qualifier seed reveal VOD here](https://www.youtube.com/watch?v=3Q3VXkmWa7c).
 
 | Seed | Country | %MAX[^qualifiers-seeding] | Avg. score[^qualifiers-tiebreaker] |
 | :-: | :-- | --: | --: |


### PR DESCRIPTION
We've decided to extend the tournament by an extra week to better accommodate the remaining player's schedules. This PR amends the dates for both the news post and the wiki article to reflect that, in addition to updating the results for Sat/Sun, swapping Twitch VOD links to YouTube (where applicable). 