### PR TITLE
Update Lazer migration page to specify that certain medals are unobtainable on Stable

### DIFF
--- a/wiki/Help_centre/Upgrading_to_lazer/de.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/de.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: b9df3013ed6661bb01dfbf1f499b46b680dab3e4
+outdated_translation: true
 no_native_review: true
 ---
 

--- a/wiki/Help_centre/Upgrading_to_lazer/en.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/en.md
@@ -72,7 +72,7 @@ The following is a comprehensive list of the **current state** of lazer in compa
 | Score submission | ![Yes][true] | ![Yes][true] |
 | Beatmap leaderboards | ![Yes][true] | ![Yes][true] |
 | Profile statistics | ![Yes][true] | ![Yes][true] |
-| Medals | ![Yes][true] | ![Partial][partial][^medals-lazer] |
+| Medals | ![Partial][partial][^medals-stable] | ![Partial][partial][^medals-lazer] |
 | Performance points | ![Yes][true] | ![Yes][true] |
 | Real-time chat | ![Partial][partial][^stable-chat] | ![Yes][true] |
 | Wiki / news / changelog / rankings | ![No][false] | ![Yes][true][^online-content] |
@@ -345,6 +345,7 @@ You're likely thinking of another game.
 [^freestyle]: Turn on in song select to allow players to select any difficulty of the current beatmap.
 [^difficulty-adjust]: Change CS/AR/OD/HP of a beatmap directly from song select via the Difficulty Adjust mod.
 [^medals-lazer]: Some [Hush-Hush medals](/wiki/Medals#hush-hush) are not yet obtainable.
+[^medals-stable]: Certain medals are Lazer exclusive.
 
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png

--- a/wiki/Help_centre/Upgrading_to_lazer/en.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/en.md
@@ -345,7 +345,7 @@ You're likely thinking of another game.
 [^freestyle]: Turn on in song select to allow players to select any difficulty of the current beatmap.
 [^difficulty-adjust]: Change CS/AR/OD/HP of a beatmap directly from song select via the Difficulty Adjust mod.
 [^medals-lazer]: Some [Hush-Hush medals](/wiki/Medals#hush-hush) are not yet obtainable.
-[^medals-stable]: Certain medals are Lazer exclusive.
+[^medals-stable]: Certain medals are lazer-exclusive.
 
 [true]: /wiki/shared/true.png
 [false]: /wiki/shared/false.png

--- a/wiki/Help_centre/Upgrading_to_lazer/es.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/es.md
@@ -1,3 +1,8 @@
+---
+outdated_since: b9df3013ed6661bb01dfbf1f499b46b680dab3e4
+outdated_translation: true
+---
+
 # Actualizar a lazer
 
 osu!(lazer) es la próxima gran actualización del juego. Es la culminación de varios años de trabajo detrás de escena para relanzar laboriosamente el juego.

--- a/wiki/Help_centre/Upgrading_to_lazer/id.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/id.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: b9df3013ed6661bb01dfbf1f499b46b680dab3e4
+outdated_translation: true
 no_native_review: true
 tags:
   - game client

--- a/wiki/Help_centre/Upgrading_to_lazer/it.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/it.md
@@ -1,3 +1,8 @@
+---
+outdated_since: b9df3013ed6661bb01dfbf1f499b46b680dab3e4
+outdated_translation: true
+---
+
 # Aggiornare a lazer
 
 osu!(lazer) è il prossimo grande aggiornamento al client di osu!. È il frutto di diversi anni di lavoro dietro le quinte per reimplementare osu!.


### PR DESCRIPTION
## Description

Certain medals are exclusive to Lazer. This clarifies it by replacing stable's medal score from true to partial.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)