### PR TITLE
Corrected text in "sliderendcircle" and "sliderendcircleoverlay" sections

### DIFF
--- a/wiki/Skinning/osu!/en.md
+++ b/wiki/Skinning/osu!/en.md
@@ -345,7 +345,7 @@ Notes:
 
 Notes:
 
-- Overrides `hitcircle.png` for the start of the slider, if skinned.
+- Overrides `hitcircle.png` for the end of the slider, if skinned.
 - This element is the hitcircle for the end of the slider.
 - This element fades in before completing and expands when completed.
   - If [Hidden](/wiki/Gameplay/Game_modifier/Hidden) mod is enabled, this will fade in before completing and only fade out.
@@ -365,7 +365,7 @@ Notes:
   - If [Hidden](/wiki/Gameplay/Game_modifier/Hidden) mod is enabled, this will fade in before completing and only fade out.
 - This can either overlay or underlay the combo number, by default this will always overlay.
   - To make this underlay the combo number, set `HitCircleOverlayAboveNumber` to `0`.
-- Overrides the `hitcircle.png` image for the start of the slider.
+- Overrides the `hitcircleoverlay.png` image for the end of the slider.
 - `sliderendcircle.png` is required for this to work.
 - Should be a circle.
 - This element was animatable in the past. For full details, see [skinning history](/wiki/Skinning/History).

--- a/wiki/Skinning/osu!/es.md
+++ b/wiki/Skinning/osu!/es.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 0e4f0c847059bf3a4e350040939b18b193704bce
+outdated_translation: true
+---
+
 # Skinning de osu!
 
 ## Combo bursts

--- a/wiki/Skinning/osu!/fr.md
+++ b/wiki/Skinning/osu!/fr.md
@@ -1,4 +1,6 @@
 ---
+outdated_since: 0e4f0c847059bf3a4e350040939b18b193704bce
+outdated_translation: true
 no_native_review: true
 ---
 

--- a/wiki/Skinning/osu!/zh.md
+++ b/wiki/Skinning/osu!/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_since: 0e4f0c847059bf3a4e350040939b18b193704bce
+outdated_translation: true
+---
+
 # osu! 自定义皮肤
 
 ## 连击提示图


### PR DESCRIPTION
- The sliderendcircle and sliderendcircleoverlay entries say that their images override the hit circle at the beginning of the slider.
- The wiki says that both will override the start of the slider, which is incorrect before this change.
