### PR TITLE
[ZH] fix(/wiki/Help_centre/zh.md): nothing outdated

### DIFF
--- a/wiki/Help_centre/zh.md
+++ b/wiki/Help_centre/zh.md
@@ -7,8 +7,6 @@ tags:
   - missing
   - 帮助
   - 问题
-outdated_translation: true
-outdated_since: 712bbdeb6c5c3e1c40c7d6b44cf61df76a6ab8ff
 ---
 
 # 帮助中心


### PR DESCRIPTION
English version only change plural format for a English word, but Chinese don't use such way to express plural so nothing need change. So I remove outdated tag. 

https://github.com/ppy/osu-wiki/commit/b4207575b7ba29a8456d3bd762278fae68e0131f#diff-83ac327018a86174fde156b2791d6ef7c64a8f538ff96e802d907c606c17cc44L1

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [ ] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
