### PR TITLE
Update `CWC 2025` for the Semifinals stage

### DIFF
--- a/wiki/Tournaments/CWC/2025/en.md
+++ b/wiki/Tournaments/CWC/2025/en.md
@@ -42,14 +42,14 @@ The osu!catch World Cup 2025 is run by various community members.
 | Position | Member(s) |
 | :-- | :-- |
 | Manager | ::{ flag=CA }:: [Azer](https://osu.ppy.sh/users/2155578), ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=GB }:: [mangomizer](https://osu.ppy.sh/users/1893718), ::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024) |
-| Mappool selector | ::{ flag=CA }:: **[wwwww](https://osu.ppy.sh/users/8434466)**, ::{ flag=CA }:: **[Yoshi\_green](https://osu.ppy.sh/users/1035891)**, ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114), ::{ flag=PH }:: [Bunnrei](https://osu.ppy.sh/users/829284),::{ flag=PL }:: [Phob](https://osu.ppy.sh/users/6069462), ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598) |
+| Mappool selector | ::{ flag=CA }:: **[wwwww](https://osu.ppy.sh/users/8434466)**, ::{ flag=CA }:: **[Yoshi\_green](https://osu.ppy.sh/users/1035891)**, ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114), ::{ flag=PH }:: [Bunnrei](https://osu.ppy.sh/users/829284), ::{ flag=PL }:: [Phob](https://osu.ppy.sh/users/6069462), ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598) |
 | Mappool playtester | ::{ flag=TN }:: [\-Ken](https://osu.ppy.sh/users/4430811), ::{ flag=AU }:: [Beerus](https://osu.ppy.sh/users/5529199), ::{ flag=US }:: [Blushing](https://osu.ppy.sh/users/5927823), ::{ flag=KR }:: [ExGon](https://osu.ppy.sh/users/214187), ::{ flag=HK }:: [fua](https://osu.ppy.sh/users/21138904), ::{ flag=ID }:: [Haruka Akane](https://osu.ppy.sh/users/1272422), ::{ flag=US }:: [Indy](https://osu.ppy.sh/users/12467500), ::{ flag=VE }:: [Jack Frost](https://osu.ppy.sh/users/6492475), ::{ flag=BR }:: [Laqeramaline](https://osu.ppy.sh/users/4533507), ::{ flag=PL }:: [LaviSorrow](https://osu.ppy.sh/users/9966768), ::{ flag=FR }:: [Noctalium](https://osu.ppy.sh/users/6488167), ::{ flag=US }:: [Trent](https://osu.ppy.sh/users/3438241), ::{ flag=PL }:: [trig0n](https://osu.ppy.sh/users/3704228) |
-| Mapper | ::{ flag=ID }:: [\-Hex\-](https://osu.ppy.sh/users/8630988), ::{ flag=TN }:: [\-Ken](https://osu.ppy.sh/users/4430811), ::{ flag=TH }:: [\-Luminate](https://osu.ppy.sh/users/4778689), ::{ flag=PH }:: [\-Rustyy](https://osu.ppy.sh/users/16355636), ::{ flag=HK }:: [4rcheR\-](https://osu.ppy.sh/users/8846762), ::{ flag=US }:: [Annabel](https://osu.ppy.sh/users/3388410), ::{ flag=US }:: [Ascendance](https://osu.ppy.sh/users/2931883), ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114), ::{ flag=HK }:: [BlackBN](https://osu.ppy.sh/users/6291741), ::{ flag=PH }:: [Bunnrei](https://osu.ppy.sh/users/829284), ::{ flag=PH }:: [Crowley](https://osu.ppy.sh/users/6341006), ::{ flag=AT }:: [Daletto](https://osu.ppy.sh/users/7592136), ::{ flag=ID }:: [Dapulezatos](https://osu.ppy.sh/users/8140944), ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565), ::{ flag=CL }:: [Des9](https://osu.ppy.sh/users/5404711), ::{ flag=DE }:: [Du5t](https://osu.ppy.sh/users/6053071), ::{ flag=CN }:: [F D Flourite](https://osu.ppy.sh/users/2459589), ::{ flag=NL }:: [Greaper](https://osu.ppy.sh/users/2369776), ::{ flag=VE }:: [Jack Frost](https://osu.ppy.sh/users/6492475), ::{ flag=PH }:: [Jemzuu](https://osu.ppy.sh/users/7890134), ::{ flag=TH }:: [Kukkai](https://osu.ppy.sh/users/7811952), ::{ flag=US }:: [Liyac](https://osu.ppy.sh/users/4994598), ::{ flag=PL }:: [Malai](https://osu.ppy.sh/users/4863096), ::{ flag=ID }:: [Mochi \-](https://osu.ppy.sh/users/20424806), ::{ flag=ID }:: [Mochi \-](https://osu.ppy.sh/users/20424806), ::{ flag=RU }:: [Morusya](https://osu.ppy.sh/users/13681464), ::{ flag=PH }:: [Nosuri](https://osu.ppy.sh/users/2150415), ::{ flag=PL }:: [Phob](https://osu.ppy.sh/users/6069462), ::{ flag=ID }:: [Sololiquy](https://osu.ppy.sh/users/4350087), ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598), ::{ flag=PL }:: [Verti](https://osu.ppy.sh/users/10674528), ::{ flag=US }:: [wwwww](https://osu.ppy.sh/users/8434466), ::{ flag=JP }:: [Xinnoh](https://osu.ppy.sh/users/4236057), ::{ flag=CA }:: [Yoshi\_green](https://osu.ppy.sh/users/1035891), ::{ flag=RU }:: [yuinn](https://osu.ppy.sh/users/11239593), ::{ flag=US }:: [Zileni](https://osu.ppy.sh/users/23525574), ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768), *more TBA* |
+| Mapper | ::{ flag=ID }:: [\-Hex\-](https://osu.ppy.sh/users/8630988), ::{ flag=TN }:: [\-Ken](https://osu.ppy.sh/users/4430811), ::{ flag=TH }:: [\-Luminate](https://osu.ppy.sh/users/4778689), ::{ flag=PH }:: [\-Rustyy](https://osu.ppy.sh/users/16355636), ::{ flag=HK }:: [4rcheR\-](https://osu.ppy.sh/users/8846762), ::{ flag=US }:: [Annabel](https://osu.ppy.sh/users/3388410), ::{ flag=US }:: [Ascendance](https://osu.ppy.sh/users/2931883), ::{ flag=HK }:: [autofanboy](https://osu.ppy.sh/users/636114), ::{ flag=HK }:: [BlackBN](https://osu.ppy.sh/users/6291741), ::{ flag=PH }:: [Bunnrei](https://osu.ppy.sh/users/829284), ::{ flag=PH }:: [Crowley](https://osu.ppy.sh/users/6341006), ::{ flag=FR }:: [Cruwev](https://osu.ppy.sh/users/12195994), ::{ flag=AT }:: [Daletto](https://osu.ppy.sh/users/7592136), ::{ flag=ID }:: [Dapulezatos](https://osu.ppy.sh/users/8140944), ::{ flag=RU }:: [Daycore](https://osu.ppy.sh/users/5596337), ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565), ::{ flag=CL }:: [Des9](https://osu.ppy.sh/users/5404711), ::{ flag=DE }:: [Du5t](https://osu.ppy.sh/users/6053071), ::{ flag=KR }:: [ExGon](https://osu.ppy.sh/users/214187), ::{ flag=CN }:: [F D Flourite](https://osu.ppy.sh/users/2459589), ::{ flag=NL }:: [Greaper](https://osu.ppy.sh/users/2369776), ::{ flag=VE }:: [Jack Frost](https://osu.ppy.sh/users/6492475), ::{ flag=PH }:: [Jemzuu](https://osu.ppy.sh/users/7890134), ::{ flag=TH }:: [Kukkai](https://osu.ppy.sh/users/7811952), ::{ flag=US }:: [Liyac](https://osu.ppy.sh/users/4994598), ::{ flag=PL }:: [Malai](https://osu.ppy.sh/users/4863096), ::{ flag=PL }:: [Mniam](https://osu.ppy.sh/users/6050530), ::{ flag=ID }:: [Mochi \-](https://osu.ppy.sh/users/20424806), ::{ flag=ID }:: [Mochi \-](https://osu.ppy.sh/users/20424806), ::{ flag=RU }:: [Morusya](https://osu.ppy.sh/users/13681464), ::{ flag=PH }:: [Nosuri](https://osu.ppy.sh/users/2150415), ::{ flag=PL }:: [Phob](https://osu.ppy.sh/users/6069462), ::{ flag=RU }:: [skill issue lol](https://osu.ppy.sh/users/12498861), ::{ flag=ID }:: [Sololiquy](https://osu.ppy.sh/users/4350087), ::{ flag=KR }:: [Spectator](https://osu.ppy.sh/users/702598), ::{ flag=PL }:: [Verti](https://osu.ppy.sh/users/10674528), ::{ flag=US }:: [wwwww](https://osu.ppy.sh/users/8434466), ::{ flag=JP }:: [Xinnoh](https://osu.ppy.sh/users/4236057), ::{ flag=CA }:: [Yoshi\_green](https://osu.ppy.sh/users/1035891), ::{ flag=RU }:: [yuinn](https://osu.ppy.sh/users/11239593), ::{ flag=US }:: [Zileni](https://osu.ppy.sh/users/23525574), ::{ flag=CL }:: [ZiRoX](https://osu.ppy.sh/users/200768), ::{ flag=ID }:: [Zyzyx](https://osu.ppy.sh/users/2888013), *more TBA* |
 | Commentator | ::{ flag=IS }:: [Ash Ketchum](https://osu.ppy.sh/users/7297777), ::{ flag=US }:: [ChillierPear](https://osu.ppy.sh/users/9501251), ::{ flag=US }:: [Dohland](https://osu.ppy.sh/users/5220511), ::{ flag=BE }:: [ElSkeffe](https://osu.ppy.sh/users/6283136), ::{ flag=US }:: [Elux](https://osu.ppy.sh/users/12004983), ::{ flag=AU }:: [KWYJIBO](https://osu.ppy.sh/users/7178386), ::{ flag=AU }:: [Maitoo](https://osu.ppy.sh/users/16899553), ::{ flag=FR }:: [Realmaas](https://osu.ppy.sh/users/6567640), ::{ flag=US }:: [Secre](https://osu.ppy.sh/users/2306637), ::{ flag=US }:: [Snowleopard](https://osu.ppy.sh/users/3790227), ::{ flag=US }:: [Toaph Daddy](https://osu.ppy.sh/users/7616811), ::{ flag=SE }:: [Wonder Stella](https://osu.ppy.sh/users/1352257), ::{ flag=US }:: [wwwww](https://osu.ppy.sh/users/8434466) |
 | Referee | ::{ flag=IN }:: [\-Space](https://osu.ppy.sh/users/7720204), ::{ flag=US }:: [akace100](https://osu.ppy.sh/users/9308128), ::{ flag=NL }:: [Albionthegreat](https://osu.ppy.sh/users/9853595), ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779), ::{ flag=NL }:: [nik](https://osu.ppy.sh/users/10077264), ::{ flag=FI }:: [shdewz](https://osu.ppy.sh/users/10000899), ::{ flag=US }:: [Suicune3](https://osu.ppy.sh/users/6895187), ::{ flag=US }:: [tigereyes144](https://osu.ppy.sh/users/6499811), ::{ flag=GB }:: [Yazzehh](https://osu.ppy.sh/users/7068973) |
 | Statistician | ::{ flag=FI }:: **[shdewz](https://osu.ppy.sh/users/10000899)**, ::{ flag=BR }:: [LeoFLT](https://osu.ppy.sh/users/3668779) |
 | Design coordinator | ::{ flag=CN }:: [Sakura006](https://osu.ppy.sh/users/10365024) |
-| Musician | [Symholic / Rina Komatsu](https://osu.ppy.sh/beatmaps/artists/130), [Vorso](https://osu.ppy.sh/beatmaps/artists/303), [XenjeS](https://linktr.ee/XenjeS), *more TBA* |
+| Musician | [A-One](https://lit.link/en/aonejp), [Ice](https://osu.ppy.sh/beatmaps/artists/484), [Symholic / Rina Komatsu](https://osu.ppy.sh/beatmaps/artists/130), [Vorso](https://osu.ppy.sh/beatmaps/artists/303), [XenjeS](https://linktr.ee/XenjeS), *more TBA* |
 
 ## Links
 
@@ -112,36 +112,63 @@ The osu!catch World Cup 2025 is run by various community members.
 
 The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/19a8df801dc4c99f192694621928b231).
 
-## Match schedule: Quarterfinals
+## Match schedule: Semifinals
 
-### Saturday, 28 June 2025
+### Saturday, 5 July 2025
 
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Colombia ::{ flag=CO }:: | ::{ flag=TW }:: Taiwan | [Jun 28 (Sat) 03:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T030000&p1=1440&p2=41&p3=241) | [osulive](https://twitch.tv/osulive) |
-| Indonesia ::{ flag=ID }:: | ::{ flag=SG }:: Singapore | [Jun 28 (Sat) 08:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T083000&p1=1440&p2=108&p3=236) | [osulive](https://twitch.tv/osulive) |
-| Sweden ::{ flag=SE }:: | ::{ flag=AU }:: Australia | [Jun 28 (Sat) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T100000&p1=1440&p2=239&p3=57) | [osulive](https://twitch.tv/osulive) |
-| Belgium ::{ flag=BE }:: | ::{ flag=ES }:: Spain | [Jun 28 (Sat) 13:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T130000&p1=1440&p2=48&p3=141) | [osulive](https://twitch.tv/osulive) |
-| Germany ::{ flag=DE }:: | ::{ flag=HK }:: Hong Kong | [Jun 28 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T140000&p1=1440&p2=37&p3=102) | [osulive_2](https://twitch.tv/osulive_2) |
-| Italy ::{ flag=IT }:: | ::{ flag=FR }:: France | [Jun 28 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T140000&p1=1440&p2=215&p3=195) | [osulive](https://twitch.tv/osulive) |
-| Chile ::{ flag=CL }:: | ::{ flag=CN }:: China | [Jun 28 (Sat) 15:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T150000&p1=1440&p2=232&p3=33) | [osulive](https://twitch.tv/osulive) |
-| Canada ::{ flag=CA }:: | ::{ flag=MX }:: Mexico | [Jun 28 (Sat) 17:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T173000&p1=1440&p2=188&p3=155) | [osulive](https://twitch.tv/osulive) |
-| United Kingdom ::{ flag=GB }:: | ::{ flag=PE }:: Peru | [Jun 28 (Sat) 19:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250628T190000&p1=1440&p2=136&p3=131) | [osulive](https://twitch.tv/osulive) |
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| Japan ::{ flag=JP }:: | ::{ flag=ID }:: Indonesia | [Jul 05 (Sat) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250705T140000&p1=1440&p2=248&p3=108) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| Argentina ::{ flag=AR }:: | ::{ flag=FI }:: Finland | [Jul 05 (Sat) 15:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250705T153000&p1=1440&p2=51&p3=101) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| Poland ::{ flag=PL }:: | ::{ flag=CL }:: Chile | [Jul 05 (Sat) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250705T170000&p1=1440&p2=262&p3=232) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=CA }:: Canada | [Jul 05 (Sat) 18:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250705T183000&p1=1440&p2=166&p3=188) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
+| France ::{ flag=FR }:: | ::{ flag=PE }:: Peru | [Jul 05 (Sat) 20:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250705T200000&p1=1440&p2=195&p3=131) | [osulive](https://twitch.tv/osulive) | [^losers-bracket] |
 
-### Sunday, 29 June 2025
+### Sunday, 6 July 2025
 
-| Team A | Team B | Match time | Twitch stream |
-| --: | :-- | :-- | :-: |
-| Indonesia ::{ flag=ID }:: | ::{ flag=TW }:: Taiwan | [Jun 29 (Sun) 10:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T100000&p1=1440&p2=108&p3=241) | [osulive](https://twitch.tv/osulive) |
-| Russian Federation ::{ flag=RU }:: | ::{ flag=FI }:: Finland | [Jun 29 (Sun) 13:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T133000&p1=1440&p2=166&p3=101) | [osulive](https://twitch.tv/osulive) |
-| United States ::{ flag=US }:: | ::{ flag=JP }:: Japan | [Jun 29 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T140000&p1=1440&p2=263&p3=248) | [osulive](https://twitch.tv/osulive) |
-| Argentina ::{ flag=AR }:: | ::{ flag=PL }:: Poland | [Jun 29 (Sun) 14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T140000&p1=1440&p2=51&p3=262) | [osulive_2](https://twitch.tv/osulive_2) |
-| Chile ::{ flag=CL }:: | ::{ flag=SE }:: Sweden | [Jun 29 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T160000&p1=1440&p2=232&p3=239) | [osulive](https://twitch.tv/osulive) |
-| Canada ::{ flag=CA }:: | ::{ flag=DE }:: Germany | [Jun 29 (Sun) 17:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T170000&p1=1440&p2=188&p3=37) | [osulive](https://twitch.tv/osulive) |
-| Peru ::{ flag=PE }:: | ::{ flag=BE }:: Belgium | [Jun 29 (Sun) 18:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T180000&p1=1440&p2=131&p3=48) | [osulive](https://twitch.tv/osulive) |
-| Semifinals | mappool showcase | [Jun 29 (Sun) 20:00 UTC (estimated)](https://www.timeanddate.com/worldclock/converter.html?iso=20250629T200000&p1=1440) | [osulive](https://twitch.tv/osulive) |
+| Team A | Team B | Match time | Twitch stream |  |
+| --: | :-- | :-- | :-: | :-: |
+| Peru ::{ flag=PE }:: | ::{ flag=JP }:: Japan | [Jul 06 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T040000&p1=1440&p2=131&p3=248) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Peru ::{ flag=PE }:: | ::{ flag=ID }:: Indonesia | [Jul 06 (Sun) 04:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T040000&p1=1440&p2=131&p3=108) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| France ::{ flag=FR }:: | ::{ flag=JP }:: Japan | [Jul 06 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T120000&p1=1440&p2=195&p3=248) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| France ::{ flag=FR }:: | ::{ flag=ID }:: Indonesia | [Jul 06 (Sun) 12:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T120000&p1=1440&p2=195&p3=108) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=PL }:: Poland | [Jul 06 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T160000&p1=1440&p2=166&p3=262) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Russian Federation ::{ flag=RU }:: | ::{ flag=CL }:: Chile | [Jul 06 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T160000&p1=1440&p2=166&p3=232) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Canada ::{ flag=CA }:: | ::{ flag=PL }:: Poland | [Jul 06 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T160000&p1=1440&p2=188&p3=262) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| Canada ::{ flag=CA }:: | ::{ flag=CL }:: Chile | [Jul 06 (Sun) 16:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T160000&p1=1440&p2=188&p3=232) | [osulive](https://twitch.tv/osulive) | [^potential-match] |
+| United States ::{ flag=US }:: | ::{ flag=IT }:: Italy | [Jul 06 (Sun) 17:30 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T173000&p1=1440&p2=263&p3=215) | [osulive](https://twitch.tv/osulive) | [^winners-bracket] |
+| Finals | mappool showcase | [Jul 06 (Sun) 19:00 UTC (estimated)](https://www.timeanddate.com/worldclock/converter.html?iso=20250706T190000&p1=1440) | [osulive](https://twitch.tv/osulive) | [^mappool-showcase] |
 
 ## Mappools
+
+### Semifinals
+
+[View the showcase VOD here](https://www.twitch.tv/videos/2499196622?t=4h6m5s)
+
+- No Mod
+  1. *youman feat. GUMI - R.I.P. (Zyzyx, Yoshi\_green) \[Yoshyx's Painful Memory\] (link pending)*
+  2. [Jouxl Eterna (JinoBeats) - Resonance of Ice Stalactites (-Ken) \[Absolute Zero\]](https://osu.ppy.sh/beatmapsets/2395295#fruits/5188102)
+  3. [USAO - Big Daddy (Cut ver.) (Cruwev) \[showdown\]](https://osu.ppy.sh/beatmapsets/2395283#fruits/5188079)
+  4. [MetaHumanBoi - Solar Strike (Daycore) \[Cataclysm (CWC Ver.)\]](https://osu.ppy.sh/beatmapsets/2343774#osu/5188108)
+- Hidden
+  1. [Marmalade butcher - SUTEGORO (Mniam) \[Alpha Tag Team\]](https://osu.ppy.sh/beatmapsets/2395265#fruits/5187955)
+  2. [O-LIFE.JP - Yakujinsama no Couple Dance (Phob) \[I'm not an Angel, Honey\]](https://osu.ppy.sh/beatmapsets/2395303#fruits/5188114)
+  3. [COR!S - Xabon (ExGon) \[CWC 2025 Semifinals HD3\]](https://osu.ppy.sh/beatmapsets/2395292#fruits/5188099)
+- Hard Rock
+  1. *FRASER EDWARDS - The Haymaker (-Rustyy) \[Farmin'\] (link pending)*
+  2. [cygnus - Sacred Connection (skill issue lol) \[534B4942494449544F494C455452495A5A\]](https://osu.ppy.sh/beatmapsets/2395286#fruits/5188085)
+  3. [Xeven - Deglaciation (Zileni) \[Permafrost\]](https://osu.ppy.sh/beatmapsets/2395287#fruits/5188086)
+- Double Time
+  1. *Kano - Dear Brave (Ascendance) \[Resolute Love\] (link pending)*
+  2. [F-777 - Deadlocked (Yoshi\_green) \[It would seem we have reached an impasse.\]](https://osu.ppy.sh/beatmapsets/2395290#fruits/5188096)
+  3. [xi - d e a t h  p i a n o \~for four pianos\~ (Kukkai) \[L I G H T O V E R D O S E\]](https://osu.ppy.sh/beatmapsets/2395291#fruits/5188098)
+  4. [Creo - Idolize (Phob) \[Idealize\]](https://osu.ppy.sh/beatmapsets/2395304#fruits/5188115)
+- Mixed Mod
+  1. [A-One - Side by Side (Bunnrei) \[Our Native Faith\]](https://osu.ppy.sh/beatmapsets/2395293#fruits/5188100)
+  2. *Zenpaku - Blast+ (feat. DEMONDICE) (autofanboy) \[Momentum+\] (link pending)*
+  3. *Ice - Nostalgia Sonatina Op.3 (Ascendance) \[Ascenzuu's Opus Memoria\] (link pending)*
+- Tiebreaker
+  1. ***celtix - Necrotopia (Spectator, ExGon) \[ExSpec's Afterworld\] (link pending)***
 
 ### Quarterfinals
 
@@ -248,6 +275,8 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/19a
 
 ### Quarterfinals
 
+Detailed statistics for this round can be found [here](https://docs.google.com/spreadsheets/d/19DyXtBXqcuO59oV-1IUnbJ0qQ7qJWnyZajDbhh0AgNE?rm=minimal).
+
 Saturday, 28 June 2025:
 
 | Team A |  |  | Team B | Match link | VOD link |
@@ -261,6 +290,18 @@ Saturday, 28 June 2025:
 | **Chile** ::{ flag=CL }:: | **6** | 3 | ::{ flag=CN }:: China | [#1](https://osu.ppy.sh/community/matches/118528988) | [#1](https://www.twitch.tv/videos/2498193185?t=2h2m35s) |
 | **Canada** ::{ flag=CA }:: | **6** | 2 | ::{ flag=MX }:: Mexico | [#1](https://osu.ppy.sh/community/matches/118530439) | [#1](https://www.twitch.tv/videos/2498368392?t=0h5m30s) |
 | United Kingdom ::{ flag=GB }:: | 2 | **6** | ::{ flag=PE }:: **Peru** | [#1](https://osu.ppy.sh/community/matches/118531170) | [#1](https://www.twitch.tv/videos/2498368392?t=1h35m29s) |
+
+Sunday, 29 June 2025:
+
+| Team A |  |  | Team B | Match link | VOD link |
+| --: | :-: | :-: | :-- | :-- | :-- |
+| **Indonesia** ::{ flag=ID }:: | **6** | 4 | ::{ flag=TW }:: Taiwan | [#1](https://osu.ppy.sh/community/matches/118536756) | [#1](https://www.twitch.tv/videos/2499005113?t=0h4m49s) |
+| Russian Federation ::{ flag=RU }:: | 3 | **6** | ::{ flag=FI }:: **Finland** | [#1](https://osu.ppy.sh/community/matches/118538200) | [#1](https://www.twitch.tv/videos/2499104106?t=0h5m45s) |
+| **United States** ::{ flag=US }:: | **6** | 1 | ::{ flag=JP }:: Japan | [#1](https://osu.ppy.sh/community/matches/118538491) | [#1](https://www.twitch.tv/videos/2499104106?t=1h3m10s) |
+| **Argentina** ::{ flag=AR }:: | **6** | 0 | ::{ flag=PL }:: Poland | [#1](https://osu.ppy.sh/community/matches/118538470) | [#1](https://www.twitch.tv/videos/2499151053) |
+| **Chile** ::{ flag=CL }:: | **6** | 0 | ::{ flag=SE }:: Sweden | [#1](https://osu.ppy.sh/community/matches/118539528) | [#1](https://www.twitch.tv/videos/2499196622?t=0h5m52s) |
+| **Canada** ::{ flag=CA }:: | **6** | 4 | ::{ flag=DE }:: Germany | [#1](https://osu.ppy.sh/community/matches/118540024) | [#1](https://www.twitch.tv/videos/2499196622?t=1h5m57s) |
+| **Peru** ::{ flag=PE }:: | **6** | 3 | ::{ flag=BE }:: Belgium | [#1](https://osu.ppy.sh/community/matches/118540582) | [#1](https://www.twitch.tv/videos/2499196622?t=2h21m41s) |
 
 ### Round of 16
 
@@ -528,3 +569,7 @@ The final standings for the Qualifier stage can be found in the following [sprea
 
 [^qualifiers-seeding]: Used as the main seeding method
 [^qualifiers-tiebreaker]: Used as a tiebreaker when two teams have the same MAX% sum
+[^winners-bracket]: Winners bracket match
+[^losers-bracket]: Losers bracket match
+[^potential-match]: Potential match — final matchup depends on the results of the preceding losers bracket matches
+[^mappool-showcase]: Mappool showcase — schedule subject to rescheduling without prior notice, depending on preceding matches


### PR DESCRIPTION
Adds remaining Quarterfinals results, Semifinals mappool and schedules. Updates the staff listing with new mappers and artists.
