### PR TITLE
Fix artist capitalisation in `Content usage permissions`

### DIFF
--- a/wiki/Rules/Content_usage_permissions/de.md
+++ b/wiki/Rules/Content_usage_permissions/de.md
@@ -450,7 +450,7 @@ Dieser Abschnitt wurde zuletzt am 30. März 2025 aktualisiert.
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Visuell

--- a/wiki/Rules/Content_usage_permissions/en.md
+++ b/wiki/Rules/Content_usage_permissions/en.md
@@ -450,7 +450,7 @@ This section was last updated on March 30, 2025.
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Visual

--- a/wiki/Rules/Content_usage_permissions/es.md
+++ b/wiki/Rules/Content_usage_permissions/es.md
@@ -450,7 +450,7 @@ Esta sección se actualizó por última vez el 30 de marzo de 2025.
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Visual

--- a/wiki/Rules/Content_usage_permissions/fr.md
+++ b/wiki/Rules/Content_usage_permissions/fr.md
@@ -453,7 +453,7 @@ Toutes les pistes listées sur la liste des [Featured Artist](https://osu.ppy.sh
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Visuel

--- a/wiki/Rules/Content_usage_permissions/it.md
+++ b/wiki/Rules/Content_usage_permissions/it.md
@@ -448,7 +448,7 @@ Tutte le tracce elencate nella [lista brani degli Artisti in Primo Piano](https:
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Visuale

--- a/wiki/Rules/Content_usage_permissions/ko.md
+++ b/wiki/Rules/Content_usage_permissions/ko.md
@@ -452,7 +452,7 @@ osu!의 공식 아티스트 카탈로그 이외의 곡을 사용할 때는 창�
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## 시각물

--- a/wiki/Rules/Content_usage_permissions/ru.md
+++ b/wiki/Rules/Content_usage_permissions/ru.md
@@ -452,7 +452,7 @@ osu! строится вокруг свободы творчества и воз
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## Визуальное содержимое

--- a/wiki/Rules/Content_usage_permissions/zh.md
+++ b/wiki/Rules/Content_usage_permissions/zh.md
@@ -450,7 +450,7 @@ osu! 的核心，是能够让玩家们自由创作，并与其他玩家分享作
 | Hatsuki Yura | ![][false] |
 | Igorrr | ![][false] |
 | kamome sano | ![][false] |
-| Kozato | ![][false] |
+| kozato | ![][false] |
 | NOMA | ![][false] |
 
 ## 视觉内容


### PR DESCRIPTION
Related to the ongoing http://osu.ppy.sh/beatmapsets/2166689/discussion/-/generalAll#/5058349.

Mainly to clear some confusion as the artist officially goes by lowercase "k", not uppercase.

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)