### PR TITLE
Fix the rest of invalid `outdated_since` hashes

### DIFF
--- a/wiki/Gameplay/Game_modifier/Daycore/es.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/es.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: d8739afa85dd24e508c6ed7b727ed56e82544aae
+outdated_since: 50c5cd66c992ee2ff8b08bf8792a80f8fdd22d1b
 stub: true
 tags:
   - DC

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/es.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: d8739afa85dd24e508c6ed7b727ed56e82544aae
+outdated_since: 50c5cd66c992ee2ff8b08bf8792a80f8fdd22d1b
 stub: true
 tags:
   - EZ

--- a/wiki/History_of_osu!/osu!_wiki/de.md
+++ b/wiki/History_of_osu!/osu!_wiki/de.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: f5a9ad2779ced27751be153b56ead8dffb97c705
+outdated_since: ede52e09b17e9c37acfcdbf6c3b0f18240afa66d
 ---
 
 # Geschichte des osu!-Wikis

--- a/wiki/History_of_osu!/osu!_wiki/fr.md
+++ b/wiki/History_of_osu!/osu!_wiki/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: f5a9ad2779ced27751be153b56ead8dffb97c705
+outdated_since: ede52e09b17e9c37acfcdbf6c3b0f18240afa66d
 no_native_review: true
 needs_cleanup: true
 ---

--- a/wiki/Skinning/de.md
+++ b/wiki/Skinning/de.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # Skinning

--- a/wiki/Skinning/fr.md
+++ b/wiki/Skinning/fr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # Skinning

--- a/wiki/Skinning/ja.md
+++ b/wiki/Skinning/ja.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # スキニング

--- a/wiki/Skinning/pl.md
+++ b/wiki/Skinning/pl.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # Tworzenie skórek

--- a/wiki/Skinning/pt-br.md
+++ b/wiki/Skinning/pt-br.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # Skinning

--- a/wiki/Skinning/ru.md
+++ b/wiki/Skinning/ru.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 needs_cleanup: true
 ---
 

--- a/wiki/Skinning/sv.md
+++ b/wiki/Skinning/sv.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 no_native_review: true
 ---
 

--- a/wiki/Skinning/tr.md
+++ b/wiki/Skinning/tr.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # Tema yapımı

--- a/wiki/Skinning/zh.md
+++ b/wiki/Skinning/zh.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 905eedb0f005b03cb61535b8203b92b0eba8711f
+outdated_since: cd53f694f7e0e700e57857590002cd09e6a07e07
 ---
 
 # 皮肤


### PR DESCRIPTION
apparently I missed a few more cached in the tree -- found them by running `osu-wiki-tools check-outdated-articles --all` on a newly cloned repository, so these should be the last ones.