### PR TITLE
Fix wrong name designation in `History of osu!/2015`

### DIFF
--- a/wiki/History_of_osu!/2015/en.md
+++ b/wiki/History_of_osu!/2015/en.md
@@ -139,7 +139,7 @@ A few days later (19 November 2015), peppy updated users on the situation in [an
 [^osu-weekly-8]: [News post by Tasha (2015-05-01) "osu!weekly #8"](https://osu.ppy.sh/home/news/2015-05-01-osuweekly-8)
 [^realtime-bn-ranking]: [Forum thread by p3n (2015-06-04) "Realtime Beatmap Nominator Ranking"](https://osu.ppy.sh/community/forums/topics/334994)
 [^osu-weekly-14]: [News post by Tasha (2015-06-13) "osu!weekly #14"](https://osu.ppy.sh/home/news/2015-06-13-osuweekly-14)
-[^osu-weekly-9]: [News post by Tahsa (2015-05-08) "osu!weekly #9"](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
+[^osu-weekly-9]: [News post by Tasha (2015-05-08) "osu!weekly #9"](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
 [^osu-news-welcome]: [YouTube video by osu!news (2015-05-08) "Welcome to the osu!news"](https://www.youtube.com/watch?v=iAhKcQK5Iw8)
 [^osu-weekly-12]: [News post by Tasha (2015-05-30) "osu!weekly 12"](https://osu.ppy.sh/home/news/2015-05-30-osuweekly-12)
 [^ppy-tweet-osu-keyboards]: [Tweet by @ppy (2015-05-28)](https://twitter.com/ppy/status/603797988742336512)

--- a/wiki/History_of_osu!/2015/es.md
+++ b/wiki/History_of_osu!/2015/es.md
@@ -141,7 +141,7 @@ Unos días después (19 de noviembre de 2015), peppy actualizó a los usuarios s
 [^osu-weekly-8]: [Publicación de noticia por Tasha (1/5/2015) «osu!weekly #8»](https://osu.ppy.sh/home/news/2015-05-01-osuweekly-8)
 [^realtime-bn-ranking]: [Hilo del foro por p3n (4/6/2015) «Realtime Beatmap Nominator Ranking»](https://osu.ppy.sh/community/forums/topics/334994)
 [^osu-weekly-14]: [Publicación de noticia por Tasha (13/6/2015) «osu!weekly #14»](https://osu.ppy.sh/home/news/2015-06-13-osuweekly-14)
-[^osu-weekly-9]: [Publicación de noticia por Tahsa (8/5/2015) «osu!weekly #9»](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
+[^osu-weekly-9]: [Publicación de noticia por Tasha (8/5/2015) «osu!weekly #9»](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
 [^osu-news-welcome]: [Vídeo de YouTube por osu!news (8/5/2015) «Welcome to the osu!news»](https://www.youtube.com/watch?v=iAhKcQK5Iw8)
 [^osu-weekly-12]: [Publicación de noticia por Tasha (30/5/2015) «osu!weekly 12»](https://osu.ppy.sh/home/news/2015-05-30-osuweekly-12)
 [^ppy-tweet-osu-keyboards]: [Tuit de @ppy (28/5/2015)](https://twitter.com/ppy/status/603797988742336512)

--- a/wiki/History_of_osu!/2015/fr.md
+++ b/wiki/History_of_osu!/2015/fr.md
@@ -142,7 +142,7 @@ Quelques jours plus tard (19 novembre 2015), peppy a mis à jour les utilisateur
 [^osu-weekly-8]: [Article de news par Tasha (01/05/2015) "osu!weekly #8"](https://osu.ppy.sh/home/news/2015-05-01-osuweekly-8)
 [^realtime-bn-ranking]: [Fil de discussion par p3n (04/06/2015) "Realtime Beatmap Nominator Ranking"](https://osu.ppy.sh/community/forums/topics/334994)
 [^osu-weekly-14]: [Article de news par Tasha (13/06/2015) "osu!weekly #14"](https://osu.ppy.sh/home/news/2015-06-13-osuweekly-14)
-[^osu-weekly-9]: [Article de news par Tahsa (08/05/2015) "osu!weekly #9"](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
+[^osu-weekly-9]: [Article de news par Tasha (08/05/2015) "osu!weekly #9"](https://osu.ppy.sh/home/news/2015-05-08-osuweekly-9)
 [^osu-news-welcome]: [Vidéo YouTube par osu!news (08/05/2015) "Welcome to the osu!news"](https://www.youtube.com/watch?v=iAhKcQK5Iw8)
 [^osu-weekly-12]: [Article de news par Tasha (30/05/2015) "osu!weekly 12"](https://osu.ppy.sh/home/news/2015-05-30-osuweekly-12)
 [^ppy-tweet-osu-keyboards]: [Tweet par @ppy (28/05/2015)](https://twitter.com/ppy/status/603797988742336512)


### PR DESCRIPTION
quick fix for a very minor error that i happened to notice, should be safe to be merged right away

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~ (*shouldn't be required*)
