### PR TITLE
Update `CWC`/`TWC`/`MWC 4K` 2025 wiki articles

### DIFF
--- a/wiki/Tournaments/CWC/2025/en.md
+++ b/wiki/Tournaments/CWC/2025/en.md
@@ -27,7 +27,7 @@ The **osu!catch World Cup 2025** (***CWC 2025***) was a country-based osu!catch 
 
 ## Prizes
 
-The osu!catch World Cup 2025 offered a $2,000 cash prize pool and limited-edition merch.
+The osu!catch World Cup 2025 offered a $2,300 cash prize pool and limited-edition merch.
 
 | Placing | Prizes |
 | :-: | :-- |

--- a/wiki/Tournaments/MWC/2025_4K/en.md
+++ b/wiki/Tournaments/MWC/2025_4K/en.md
@@ -199,6 +199,12 @@ The complete sign-up list can be found [here](https://gist.github.com/LeoFLT/e07
    - The final team score to be sorted is defined as `Final score = SUM(Map score)`, i.e. the sum of each map's `Map score`.
 9. The top 32 seeded teams will advance to the Round of 32.
 
+The weights for the Qualifiers are as follows:
+
+|  | Stage 1 | Stage 2 | Stage 3 | Stage 4 | Stage 5 | Stage 6 | Stage 7 |
+| --: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+| **Weight** | 1/6 | 1/8 | 1/8 | 1/8 | 1/8 | 1/6 | 1/6 |
+
 ### Stage instructions
 
 1. Following the Qualifiers, a double-elimination bracket will be played — for teams in the winners bracket, the winning country continues in the same bracket, while the losing team gets moved to the losers bracket, where any further defeats will eliminate the team from the competition.

--- a/wiki/Tournaments/TWC/2025/en.md
+++ b/wiki/Tournaments/TWC/2025/en.md
@@ -27,7 +27,7 @@ The **osu!taiko World Cup 2025** (***TWC 2025***) was a country-based osu!taiko 
 
 ## Prizes
 
-The osu!taiko World Cup 2025 offered a $2,000 cash prize pool and limited-edition merch.
+The osu!taiko World Cup 2025 offered a $2,300 cash prize pool and limited-edition merch.
 
 | Placing | Prizes |
 | :-: | :-- |


### PR DESCRIPTION
Adds Qualifiers map weights for `MWC 4K`. Updates final prize pool values for `CWC 2025` and `TWC 2025` to reflect additional revenue from Twitch/banners that was added to the final value given to the players.