### PR TITLE
Update `Storyboard/Scripting/Commands` with proper examples

### DIFF
--- a/wiki/Storyboard/Scripting/Commands/en.md
+++ b/wiki/Storyboard/Scripting/Commands/en.md
@@ -239,11 +239,11 @@ Sprite,Pass,Centre,"Sample.png",320,240
 _C,0,58810,59810,0,0,0,255,255,255
 ```
 
-To make something appear in yellow (`#cccc00`):
+To make something appear in yellow (`255,255,0`):
 
 ```
 Sprite,Pass,Centre,"Sample.png",320,240
-_C,0,58810,59810,CC,CC,0
+_C,0,58810,59810,255,255,0
 ```
 
 ## Extra commands


### PR DESCRIPTION
Change the 2nd example using hexadecimal colors because putting those values in will result in an error. The only way to put hexadecimal colors in is to transform them to RGB (only accepted format).

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
