### PR TITLE
[DE] Fix incorrect phrase in `Beatmapping/Beatmap submission`

### DIFF
--- a/wiki/Beatmapping/Beatmap_submission/de.md
+++ b/wiki/Beatmapping/Beatmap_submission/de.md
@@ -20,7 +20,7 @@ Am unteren Ende des Fensters sind zwei Checkboxen erkennbar. Die erste trägt de
 
 ## Limitierungen
 
-Beatmaps werden nicht eingereicht, wenn sie das Online-Dateigrößen- oder Schwierigkeitslimit überschreiten. Die Beschränkung der Dateigröße liegt bei 5 MB sowie zusätzliche 10 MB für jede Minute an Beatmap-Länge. Das Maximum beträgt 100 MB. Die Schwierigkeitsgrenze ist aktuell 128 Sterne.
+Beatmaps werden nicht eingereicht, wenn sie das Online-Dateigrößen- oder Schwierigkeitslimit überschreiten. Die Beschränkung der Dateigröße liegt bei 5 MB sowie zusätzliche 10 MB für jede Minute an Beatmap-Länge. Das Maximum beträgt 100 MB. Aktuell können maximal 128 Schwierigkeitsgrade einer Beatmap hinzugefügt werden.
 
 Benutzern wird es erlaubt, eine limitierte Anzahl an ausstehenden Beatmaps gleichzeitig auf der Webseite zu haben. Die Beschränkung variiert, abhängig davon, wie viele gerankte Beatmaps ein Nutzer hat und ob er gerade ein [osu!supporter](/wiki/osu!supporter) ist. Benutzer ohne osu!supporter können 4 ausstehende Beatmaps plus 1 pro gerankter Beatmap haben (bis zu 4). Mit osu!supporter wird die Grenze auf 8 ausstehende Beatmaps plus 1 pro gerankter Beatmap erhöht (bis zu 12), also insgesamt 20.
 


### PR DESCRIPTION
The BSS allows the submission of maximum 128 playable beatmap levels in a beatmapset and not 128 stars in a beatmap difficulty.

I don't know when this was exactly, but I was made aware of this mistake some time ago.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
