### PR TITLE
Archive osu! Completionists and separate completionist badge from completionist accomplishment

### DIFF
--- a/wiki/People/Completionists/en.md
+++ b/wiki/People/Completionists/en.md
@@ -6,16 +6,25 @@ tags:
 
 # Completionists
 
-**Completionists** are players who have completed every [Ranked](/wiki/Beatmap/Category#ranked) [beatmap](/wiki/Beatmap) of a given [game mode](/wiki/Game_mode). Because the amount of Ranked beatmaps increases every day, this feat becomes progressively more difficult to achieve.
+**Completionists** are players who have completed every [Ranked](/wiki/Beatmap/Category#ranked) [beatmap](/wiki/Beatmap) of a given [ruleset](/wiki/Game_mode). Because the amount of Ranked beatmaps increases every day, this feat becomes progressively more difficult to achieve.
 
-As of September 2023, this achievement is recognised through a [profile badge](/wiki/Community/Profile_badge) handed out at the discretion of the [osu! team](/wiki/People/osu!_team):
+As of September 2023, this achievement is recognised through a [profile badge](/wiki/Community/Profile_badge).
 
-![osu!](img/osu.png?20230902 "osu! completionist badge") ![osu!taiko](img/taiko.png?20230902 "osu!taiko completionist badge") ![osu!catch](img/catch.png?20230902 "osu!catch completionist badge") ![osu!mania](img/mania.png?20230902 "osu!mania completionist badge")
+# Completionist badge
 
-## Confirmed completionists
+The **completionist** badge was an official award granted to users for setting a score on every ranked beatmap. The badge was discontinued by the osu! team for unknown reasons.
 
-These people have been verified by the osu! team as completionists:
+**Used badges:**
 
+![osu!](img/osu.png?20230902 "osu! completionist badge") ![osu!taiko](img/taiko.png?20230902 "osu!taiko completionist badge") 
+
+**Unused badges**: The following rulesets have never had a single badge awarded despite multiple users meeting the criteria, and will likely never be granted.
+
+![osu!catch](img/catch.png?20230902 "osu!catch completionist badge") ![osu!mania](img/mania.png?20230902 "osu!mania completionist badge")
+
+## Approved completionists
+
+These people have been declared completionists by the osu! team. Note that this list does not include all completionists.
 ### osu!
 
 | Player | Date of completion | Total played difficulties |
@@ -31,8 +40,10 @@ These people have been verified by the osu! team as completionists:
 | ::{ flag=AU }:: [Jaye](https://osu.ppy.sh/users/4841352) | 2019-11-03 | 8,841 |
 | ::{ flag=MY }:: [\[Zeth\]](https://osu.ppy.sh/users/9912966) | 2023-08-14 | 22,170 |
 
+
 ## Trivia
 
 - ::{ flag=US }:: [xasuma](https://osu.ppy.sh/users/3172980) was awarded the [user title](/wiki/Community/User_title) *The First Completionist* for being the first player to ever achieve this feat.
-- ::{ flag=AU }:: [Jaye](https://osu.ppy.sh/users/4841352) was awarded the user title *Drum Decimator* for being the first osu!taiko completionist and scoring full combos on every Ranked osu!taiko beatmap.
+- ::{ flag=AU }:: [Jaye](https://osu.ppy.sh/users/4841352) was awarded the user title *Drum Decimator* for being the first declared osu!taiko completionist and scoring full combos on every Ranked osu!taiko beatmap.
+- The last user to ever become an officially approved completionist is [\[Zeth\]](https://osu.ppy.sh/users/9912966). The team has never granted completionist badges to any user since, despite multiple users meeting the criteria.
 - Prior to September 2023, players used to earn an *osu!completionist* user title, which was discontinued in favour of profile badges.


### PR DESCRIPTION
The badge has not been awarded to any users since 2023 despite multiple users meeting the criteria. Not even users like osu420 for which malicious intentions were not suspected by anyone have failed to get the badge on osu!std. Archiving the badge is best to avoid scenarios where users complete a ruleset and are told at the very end that they don't deserve it.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
