### PR TITLE
Update `People/Tournament Committee` with application links, new member info, and more

### DIFF
--- a/wiki/People/Tournament_Committee/en.md
+++ b/wiki/People/Tournament_Committee/en.md
@@ -13,7 +13,7 @@ The Tournament Committee's responsibilities include advising the [account suppor
 
 - Responding to general inquiries sent to the tournaments email.
 - Determining the necessity and duration of tournament and staffing bans on a case-by-case basis.
-- Reviewing recently concluded officially supported tournaments for badge eligibility.
+- Reviewing recently concluded [officially supported](/wiki/Tournaments/Official_support) tournaments for badge eligibility.
 - Determining which tournaments are eligible to award badges to the top three finalists.
 
 Additionally, the Tournament Committee performs the following roles independent of the account support team:
@@ -39,7 +39,7 @@ The panel was first announced to the public on February 28, 2024 through the [Ma
 
 ### Tournament reports
 
-Tournament reports are the preferred way for players and tournament staff to report infringements of the [official tournament support](/wiki/Tournaments/Official_support) expectations and eligibility. When a new report is sent in, all Tournament Committee members are automatically notified. Members will read the report and determine whether to pursue action based on the report's contents. Such action includes but is not limited to:
+[Tournament reports](https://tcomm.hivie.tn/reports/create) are the preferred way for players and tournament staff to report infringements of the [official tournament support](/wiki/Tournaments/Official_support) expectations and eligibility. When a new report is sent in, all Tournament Committee members are automatically notified. Members will read the report and determine whether to pursue action based on the report's contents. Such action includes but is not limited to:
 
 - Marking the tournament for investigation pending further reports if this report alone is not sufficient to warrant further action.
 - Further investigation and context gathering.
@@ -82,11 +82,13 @@ If a tournament host believes their tournament has achieved the highest level of
 
 Public communication by the Tournament Committee is handled through several channels. The purposes for these sometimes overlap, but all are official sources of information kept up to date by the Tournament Committee.
 
-The Tournament Committee maintains an [account on Twitter](https://twitter.com/osu_tcomm) where the committee broadcasts major changes and updates of various types. Not all changes are communicated here, but many of the most important changes are communicated and clarified through this channel.
+The primary method of communicating with the public is via the [osu! Discord server](https://discord.gg/ppy)'s `#tournaments` and `#tournament-news` channels. The `#tournaments` channel is a great place to ask quick questions which don't require extensive internal deliberation. For complex topics, please open a [ticket](https://tcomm.hivie.tn/tickets).
 
-The [Community Tournament Status Tracker](https://docs.google.com/spreadsheets/d/1bV5MyrJZI0F52Bx9EcYxdfRu8qGnhWRBKdXHK9uPbO0/edit?usp=sharing) is a publicly viewable spreadsheet detailing the status of all tournaments that have requested official support. This sheet shows all tournaments dating back to June 20th, 2023 and displays their status through the official support process, including whether a badge was applied or denied.
+The [Tournament Committee website](https://tcomm.hivie.tn/) is a resource users may use to contact the committee directly via reports and tickets. The website also has a [tool](https://tcomm.hivie.tn/mappool-compliance) to check whether beatmaps are cleared in terms of [Content usage permissions](/wiki/Rules/Content_usage_permissions). The committee uses this site to host votes, maintain community resources, conduct reviews, and maintain official support statuses.
 
 The [Official Tournament Support Updates thread](https://osu.ppy.sh/community/forums/topics/1715676) is a pinned thread in the [Tournaments & Contests forum](https://osu.ppy.sh/community/forums/126) which contains an up-to-date list of updates to the [official tournament support wiki article](/wiki/Tournaments/Official_support) dating back to February 1st, 2023. It also links to all the aforementioned resources.
+
+The Tournament Committee maintains an [account on Twitter](https://twitter.com/osu_tcomm) where updates and changes of various types may be broadcast. Note that this method of communication is a supplement to the above sources and has largely been superseded by the `#tournament-news` channel.
 
 ### Adding new members
 
@@ -95,9 +97,19 @@ New members to the Tournament Committee must meet the following basic criteria b
 - Be at least 18 years old
 - Pass a check for recent account infringements
 
-Once a prospective member applies by sending an email to [tournaments@ppy.sh](mailto:tournaments@ppy.sh), the Tournament Committee holds an in-depth discussion on the candidate. Special attention is paid towards their activity in the tournament scene, stature, community contributions, and how they would benefit the committee. Following said discussion, a vote is held to determine whether to add the candidate to the committee.
+Successful applicants have most of these qualities:
 
-Applicants that fail to gather enough positive votes will be denied, and won't be able to apply again for 6 months from the time of response to their application. The response will be sent no later than 2 weeks from the day the application was submitted.
+- Is heavily involved in official tournaments and/or the community tournament scene
+- Provides a unique perspective which the committee currently lacks
+- Demonstrates expertise in a particular area of the tournament scene
+- Maintains excellent behaviour and conduct online
+- Generally has an excellent reputation within the community
+
+Applicants may apply online by completing the [application form](https://forms.gle/3c51xGd3DzW2JCqV6) or by submitting an email to [tournaments@ppy.sh](mailto:tournaments@ppy.sh). All applicants applying via email are expected to extensively detail their contributions, impact, and involvement in the tournament scene. The application form is preferred by the committee as it provides much more context than an email.
+
+Once a prospective member applies by sending an email to [tournaments@ppy.sh](mailto:tournaments@ppy.sh) or [applying online](https://forms.gle/3c51xGd3DzW2JCqV6), the committee holds an in-depth discussion on the candidate. Special attention is paid towards their activity in the tournament scene, stature, community contributions, and how they would benefit the committee. Following said discussion, a vote is held to determine whether to add the candidate to the committee.
+
+Applicants that fail to gather enough positive votes will be denied, and won't be able to apply again for 6 months from the time of response to their application. The committee aims to return an answer to applicants within 2 weeks of the application date.
 
 ### Votes
 
@@ -131,7 +143,11 @@ The account support team applies profile badges. While the Tournament Committee 
 
 ### Can the Tournament Committee see emails?
 
-The Tournament Committee can only see the content of emails to [tournaments@ppy.sh](mailto:tournaments@ppy.sh). They cannot write or send emails, nor can they see metadata such as the sender's email address or name, only email content.
+The Tournament Committee can only see the content of emails to [tournaments@ppy.sh](mailto:tournaments@ppy.sh). Emails are drafted internally by committee members before being reviewed and sent by the account support team. They cannot send emails, nor can they see metadata such as the sender's email address or name, only email content.
+
+### I need help immediately! What do I do?
+
+For immediate assistance, join the [osu! Discord server](https://discord.gg/ppy) and ping the `@tournament-committee` role in the `#tournaments` channel. This should be used in emergencies requiring immediate intervention only. For other urgent inquiries, please open a [ticket](https://tcomm.hivie.tn/tickets) and note the urgency there.
 
 ## How can I help contribute?
 

--- a/wiki/People/Tournament_Committee/en.md
+++ b/wiki/People/Tournament_Committee/en.md
@@ -151,9 +151,9 @@ For immediate assistance, join the [osu! Discord server](https://discord.gg/ppy)
 
 ## How can I help contribute?
 
-You can help the Tournament Committee by continuing to run excellent tournaments! If you have any issues or concerns regarding any aspect of a community tournament, we encourage you to bring these to our attention via the tournament reports form.
+You can help the Tournament Committee by continuing to run excellent tournaments! If you have any issues or concerns regarding any aspect of a community tournament, we encourage you to bring these to our attention via the [tournament reports form](https://tcomm.hivie.tn/reports/create).
 
-Those who are interested in joining the Tournament Committee may express their interest by sending an email to the [account support team](/wiki/People/Account_support_team) via [tournaments@ppy.sh](mailto:tournaments@ppy.sh), where requests are forwarded to the committee. Successful candidates are expected to have a significant breadth of experience in the tournament scene, either as a player or staff.
+Those who are interested in joining the committee should read through [adding new members](#adding-new-members) to learn about the team's expectations and application process.
 
 ## Benefits
 

--- a/wiki/People/Tournament_Committee/en.md
+++ b/wiki/People/Tournament_Committee/en.md
@@ -20,6 +20,7 @@ Additionally, the Tournament Committee performs the following roles independent 
 
 - Regularly reviewing the [Official tournament support](/wiki/Tournaments/Official_support) page for necessary revisions.
 - Investigating reports from the [tournament reports form](https://tcomm.hivie.tn/reports/create).
+- Processing tickets submitted through the [Tournament Committee website](https://tcomm.hivie.tn/tickets/create).
 - Checking whether concluded tournaments requesting official support meet its criteria.
 - Advising the osu! news team on whether to grant [news post support](/wiki/Tournaments/Official_support#requesting-in-game-banner-and-news-post-support) for tournaments.
 - Maintaining communications with the general playerbase regarding changes to official support criteria and the status of all tournaments that have requested official support.
@@ -48,9 +49,13 @@ The panel was first announced to the public on February 28, 2024 through the [Ma
 - Voting on whether to administer a tournament ban.
 - Voting on whether to administer a tournament staffing ban.
 
+### Tickets
+
+[Tickets](https://tcomm.hivie.tn/tickets/create) are the preferred way for players and tournament staff to ask the committee questions which require group discussion. Tickets enable the committee to respond without going through the [account support team](/wiki/People/Account_support_team), resulting in much faster response times compared to email. Official support requests still must **always** be sent via email. Note that any ticket submitted here is **public**. For private or anonymous inquiries, email is the recommended method of contact.
+
 ### Tournament review
 
-Once a tournament has concluded and has requested a badge prize, two random members from the Tournament Committee are assigned to review the tournament. If either of those members have a conflict of interest, they are required to state it so that someone else may be assigned in their place. The assigned members will ensure the following:
+Once a tournament has concluded and has requested a badge prize, two random members from the Tournament Committee are assigned to review the tournament. If either of those members have a conflict of interest, they are required to state it so that someone else may be assigned in their place. Assigned members will ensure the tournament abides by all [official support](/wiki/Tournaments/Official_support) criteria, including:
 
 - The format adheres to [official support](/wiki/Tournaments/Official_support) guidelines or received an official approval.
 - The tournament theme does not violate [community rules](/wiki/Rules).
@@ -58,8 +63,9 @@ Once a tournament has concluded and has requested a badge prize, two random memb
 - The existence of a publicly viewable catalogue of the tournament's match history.
 - Any staff and player lists are publicly available and the staff list is up to date.
 - The badge meets relevant [design criteria](/wiki/Tournaments/Official_support#profile-badges).
+- The tournament's mappools are public with no [content usage permissions](/wiki/Rules/Content_usage_permissions) violations.
 
-Assigned members will indicate tournaments that pass the review process as eligible for badges. The account support team will apply the badges at a later time to the winners' profiles. If a tournament fails the review process, the reviewing members may advise the account support team on what changes need to be communicated to the tournament hosts. If these changes are not possible after the tournament's conclusion, the Tournament Committee will hold a vote on whether to withdraw official support.
+Assigned members will indicate tournaments that pass the review process as eligible for badges. The account support team will apply the badges at a later time to the winners' profiles. If a tournament fails the review process, the reviewing members may advise the account support team on what changes need to be communicated to the tournament hosts. If these changes are not possible after the tournament's conclusion, the Tournament Committee will hold a vote on whether to withdraw official support or issue a punishment to the tournament organisers.
 
 Tournaments may be reported for violations of official support criteria via the [tournament reports form](https://tcomm.hivie.tn/reports/create). For concluded tournaments that have sent a support email, the Tournament Committee will take the following course of action if there are actionable reports:
 
@@ -115,13 +121,13 @@ Applicants that fail to gather enough positive votes will be denied, and won't b
 
 The Tournament Committee frequently makes use of voting when making important decisions. Typical uses are listed above, but those are not fully inclusive. The voting requirements also differ based on the use case. All typical votes also require "strict participation", meaning that if 75% of the Tournament Committee does not participate by the vote deadline, voting is extended by 24 hours. Furthermore, all votes require at least an absolute majority, at least 50%, for action to be taken. Votes on many topics have the same requirements, but there are slight differences on some common topics listed below.
 
-| Vote type | Minimum length (days) | Approval threshold |
-| :-- | --: | --: |
-| Withholding badge support | 3 | 50% |
-| Tournament bans | 3 | 50% |
-| Tournament staffing bans | 3 | 50% |
-| Top three badge support | 4 | 80% |
-| Adding new members | 4 | 80% |
+| Vote type | Minimum length (days) | Approval threshold | Participation |
+| :-- | --: | --: | --: |
+| Withholding badge support | 3 | 50% | 75% |
+| Tournament bans | 3 | 50% | 75% |
+| Tournament hosting & staffing bans | 3 | 50% | 75% |
+| Top three badge support | 4 | 80% | 100%[^abstinence] |
+| Adding new members | 4 | 80% | 100% |
 
 ## Tournament ban lengths
 
@@ -164,7 +170,7 @@ Tournament Committee members are granted the following benefits:
 
 ## Committee members
 
-The [Tournament Committee group page](https://osu.ppy.sh/groups/50) lists all of the current committee members.
+The [Tournament Committee group page](https://osu.ppy.sh/groups/50) lists all of the current tournament and contest committee members.
 
 ### Tournament Committee
 
@@ -204,3 +210,29 @@ The [Tournament Committee group page](https://osu.ppy.sh/groups/50) lists all of
 - ::{ flag=NL }:: [n0ah](https://osu.ppy.sh/users/3086393)
 - ::{ flag=CL }:: [WalterToro](https://osu.ppy.sh/users/5281416)
 - ::{ flag=NL }:: [Wesley](https://osu.ppy.sh/users/2407265)
+
+## History
+
+### Voting
+
+The voting method used by the Tournament and Contest Committees has seen sweeping changes in recent years. When the committee was first formed, votes would take place by reacting to chat messages internally. Eventually, tools were created to host votes online, where a [plurality vote](https://en.wikipedia.org/wiki/Plurality_voting) method of voting was used. This vote type allows members to select a single option among many. As time went on, it became clear that something needed to change due to these issues:
+
+- No clear way to break ties
+- No way to rank or weigh multiple options against each other
+- Ambiguity on close results (60%/40% on complex topics)
+
+In October 2024, a proposal was raised by [Stage](https://osu.ppy.sh/users/8191845) to allow each option to be graded from a -5 to +5 scale. The idea was simple: if an outcome receives a score greater than 0, the committee is in favour of it. The option with the highest score would be the winner. It sounded great on paper, but in reality, these issues arose internally:
+
+- It was very difficult to pick between two options that scored closely to each other. This often resulted in delays in action by the committee.
+- It failed to account for the fact that member opinions do not translate to the same numeric score equally. Two members may agree on something to the same degree but rank them differently due to [response bias](https://en.wikipedia.org/wiki/Response_bias).
+- For topics such as new member additions, the threshold of score needed to be approved by the team became difficult to discern.
+
+As a result, in May 2025, [Stage](https://osu.ppy.sh/users/8191845) wrote an even more thorough proposal to switch the voting method once again. This time, the [Schulze method](https://en.wikipedia.org/wiki/Schulze_method) was proposed. This voting method allows members to rank each option from "Strongly Disagree" to "Strongly Agree" using a radio-buttion selector. This provides the following benefits:
+
+- Members can rank multiple options as equally favorable.
+- Members can express how much more they like specific options over others.
+- It is very unlikely for ties to occur.
+
+To avoid deadlocks after the vote takes place, members can now see the outcomes in order from most to least preferred, but cannot see exactly how close these options are to each other. Members can see each other's votes in detail, but with no comparison to be made beyond final ranking, little room is left for overturning the result after the vote concludes (which was a problem with the prior methods).
+
+[^abstinence]: Members who have a conflict of interest are instructed to abstain from voting.

--- a/wiki/Tournaments/README.md
+++ b/wiki/Tournaments/README.md
@@ -4,7 +4,7 @@
 
 This is where wiki articles for tournaments live, both official and community-run. You are welcome to add new tournaments here, but you should have approval from the tournaments' host(s) before doing so.
 
-[Learn how to contribute](/CONTRIBUTING.md) if you are new to the osu! wiki. If you have any questions about tournament articles, ask in the `#osu-wiki` channel of the [osu!dev Discord server](https://discord.gg/ppy) or [open an issue](https://github.com/ppy/osu-wiki/issues/new).
+[Learn how to contribute](/CONTRIBUTING.md) if you are new to the osu! wiki. If you have any questions about tournament articles, ask in the `#osu-wiki` channel of the [osu! Discord server](https://discord.gg/ppy) or [open an issue](https://github.com/ppy/osu-wiki/issues/new).
 
 ## Adding a new tournament
 


### PR DESCRIPTION
Updates `People/Tournament_Committee` with:

- New application URL
- Desired qualities in new members
- Linked some unlinked text
- Rewrite & update of public communication section which more accurately reflects how we use various platforms
- Clarified that we can draft emails without sending them
- Add new FAQ question for immediate help
- Update existing FAQ to match new updates
- Adds a new history section on the bottom which covers the history of voting methods used by the committees

Tasks:
- [ ] TC Review