### PR TITLE
Fix incorrect flag code in `osu!mania 4K World Cup 2025: Round of 16 Recap`

### DIFF
--- a/news/2025/2025-09-07-osumania-4k-world-cup-2025-round-of-16-recap.md
+++ b/news/2025/2025-09-07-osumania-4k-world-cup-2025-round-of-16-recap.md
@@ -68,7 +68,7 @@ Another round, another [osu! original](/wiki/Community/Bespoke_music)! This time
 | Germany ::{ flag=DE }:: | 0 | **5** | ::{ flag=ID }:: **Indonesia** |
 | **China** ::{ flag=CN }:: | **5** | 1 | ::{ flag=MY }:: Malaysia |
 | Venezuela ::{ flag=VE }:: | 0 | **5** | ::{ flag=JP }:: **Japan** |
-| Denmark ::{ flag=DE }:: | 0 | **5** | ::{ flag=ES }:: **Spain** |
+| Denmark ::{ flag=DK }:: | 0 | **5** | ::{ flag=ES }:: **Spain** |
 | **Hong Kong** ::{ flag=HK }:: | **5** | 1 | ::{ flag=PE }:: Peru |
 | **United Kingdom** ::{ flag=GB }:: | **5** | 2 | ::{ flag=AR }:: Argentina |
 | **Chile** ::{ flag=CL }:: | **5** | 1 | ::{ flag=IT }:: Italy |


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

Title.

[Preview](https://osu2.roanh.dev/home/news/2025-09-07-osumania-4k-world-cup-2025-round-of-16-recap).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
