### PR TITLE
Use precise formula in `Beatmap/Circle_size`

### DIFF
--- a/wiki/Beatmap/Circle_size/de.md
+++ b/wiki/Beatmap/Circle_size/de.md
@@ -15,7 +15,7 @@ Die **Circle Size** (***CS***) ist eine Schwierigkeitseinstellung einer [Beatmap
 
 In [osu!](/wiki/Game_mode/osu!) bestimmt die Circle Size die Größe der [Hit-Circles](/wiki/Gameplay/Hit_object/Hit_circle) und [Sliders](/wiki/Gameplay/Hit_object/Slider). Je höher der CS-Wert ist, desto kleiner sind die Hit-Objekte. Die [Spinner](/wiki/Gameplay/Hit_object/Spinner)-Größe wird nicht von der Circle Size beeinflusst. Die Größe der Hit-Circles wird durch folgende Formel bestimmt:
 
-`r = 54.4 - 4.48 * CS`
+`r = (54.4 - 4.48 * CS) * 1.00041`
 
 Dabei ist `r` der Kreisradius in [osu!-Pixeln](/wiki/Client/Beatmap_editor/osu!_pixel) und `CS` die eingestellte Circle Size.
 

--- a/wiki/Beatmap/Circle_size/en.md
+++ b/wiki/Beatmap/Circle_size/en.md
@@ -15,7 +15,7 @@ tags:
 
 In [osu!](/wiki/Game_mode/osu!), circle size changes the size of [hit circles](/wiki/Gameplay/Hit_object/Hit_circle) and [sliders](/wiki/Gameplay/Hit_object/Slider), with higher values creating smaller hit objects. [Spinners](/wiki/Gameplay/Hit_object/Spinner) are unaffected by circle size. Circle size is derived through the following formula:
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
 
 Where `r` is the radius measured in [osu!pixels](/wiki/Client/Beatmap_editor/osu!_pixel), and `CS` is the circle size value.
 

--- a/wiki/Beatmap/Circle_size/es.md
+++ b/wiki/Beatmap/Circle_size/es.md
@@ -17,7 +17,7 @@ El **tamaño del círculo** (***CS***) es una configuración de dificultad de un
 
 En [osu!](/wiki/Game_mode/osu!), el tamaño del círculo cambia el tamaño de los [círculos](/wiki/Gameplay/Hit_object/Hit_circle) y los [sliders](/wiki/Gameplay/Hit_object/Slider), con valores más altos creando objetos más pequeños. Los [spinners](/wiki/Gameplay/Hit_object/Spinner) no se ven afectados por el tamaño del círculo. El tamaño del círculo se obtiene mediante la siguiente fórmula:
 
-`r = 54.4 - 4.48 * CS`
+`r = (54.4 - 4.48 * CS) * 1.00041`
 
 Donde `r` es el radio medido en [osu!pixels](/wiki/Client/Beatmap_editor/osu!_pixel), y `CS` es el valor del tamaño del círculo.
 

--- a/wiki/Beatmap/Circle_size/fr.md
+++ b/wiki/Beatmap/Circle_size/fr.md
@@ -15,7 +15,7 @@ Le **circle size** (***CS***) est un paramètre de difficulté d'une [beatmap](/
 
 Dans le mode [osu!](/wiki/Game_mode/osu!), le circle size modifie la taille des [cercles](/wiki/Gameplay/Hit_object/Hit_circle) et des [sliders](/wiki/Gameplay/Hit_object/Slider), les valeurs les plus élevées créant des objets plus petits. Les [spinners](/wiki/Gameplay/Hit_object/Spinner) ne sont pas affectés par ce paramètre. Le circle size est calculé à l'aide de la formule suivante :
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
 
 Où `r` est le rayon mesuré en [osu!pixels](/wiki/Client/Beatmap_editor/osu!_pixel), et `CS` est la valeur du circle size.
 

--- a/wiki/Beatmap/Circle_size/id.md
+++ b/wiki/Beatmap/Circle_size/id.md
@@ -15,7 +15,7 @@ tags:
 
 Di [osu!](/wiki/Game_mode/osu!), circle size mengubah ukuran dari [hit circle](/wiki/Gameplay/Hit_object/Hit_circle) dan [slider](/wiki/Gameplay/Hit_object/Slider), dengan nilai yang tinggi akan membuat hit object yang kecil. [Spinner](/wiki/Gameplay/Hit_object/Spinner) tidak terpengaruh oleh circle size. Circle size dihasilkan melalui rumus dibawah ini:
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
 
 Di mana `r` adalah radius ukur dalam satuan [osu!pixels](/wiki/Client/Beatmap_editor/osu!_pixel), dan `CS` adalah nilai dari circle size.
 

--- a/wiki/Beatmap/Circle_size/it.md
+++ b/wiki/Beatmap/Circle_size/it.md
@@ -15,7 +15,7 @@ La **Dimensione cerchi** (***CS per Circle Size***) è un'impostazione di diffic
 
 In [osu!](/wiki/Game_mode/osu!), la dimensione cerchi cambia la grandezza dei [cerchi](/wiki/Gameplay/Hit_object/Hit_circle) e degli [slider](/wiki/Gameplay/Hit_object/Slider), con risultato a valori più alti, oggetti da cliccare più piccoli. Gli [spinner](/wiki/Gameplay/Hit_object/Spinner) non sono influenzati dalla dimensione cerchi. La dimensione effettiva dei cerchi è calcolata attraverso la seguente formula:
 
-`r = 54.4 - 4.48 * CS`
+`r = (54.4 - 4.48 * CS) * 1.00041`
 
 Dove `r` è il raggio misurato in [osu!pixel](/wiki/Client/Beatmap_editor/osu!_pixel), e `CS` è il valore della dimensione cerchi.
 

--- a/wiki/Beatmap/Circle_size/ja.md
+++ b/wiki/Beatmap/Circle_size/ja.md
@@ -15,7 +15,7 @@ tags:
 
 [osu!](/wiki/Game_mode/osu!)では、サークルサイズは[サークル](/wiki/Gameplay/Hit_object/Hit_circle)と[スライダー](/wiki/Gameplay/Hit_object/Slider)のサイズを変更し、値を大きくするとヒットオブジェクトが小さくなります。[スピナー](/wiki/Gameplay/Hit_object/Spinner)はサークルサイズの影響を受けません。ヒットオブジェクトの大きさは次の式で求められます。
 
-`r = 54.4 - 4.48 * CS`<!-- 古いリプレイのバグを解消するためには最後に 1.00041 を掛けます -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- 古いリプレイのバグを解消するためには最後に 1.00041 を掛けます -->
 
 `r`は[osu!pixels](/wiki/Client/Beatmap_editor/osu!_pixel)あたりのピクセル数を表し、`CS`はサークルサイズを表します。
 

--- a/wiki/Beatmap/Circle_size/ru.md
+++ b/wiki/Beatmap/Circle_size/ru.md
@@ -16,7 +16,7 @@ tags:
 
 В [osu!](/wiki/Game_mode/osu!) данный параметр задаёт размер [нот](/wiki/Gameplay/Hit_object/Hit_circle) и [слайдеров](/wiki/Gameplay/Hit_object/Slider), причём чем больше само значение, тем меньше размер объектов (на [спиннеры](/wiki/Gameplay/Hit_object/Spinner) он не влияет). Вычислить радиус нот можно по следующей формуле:
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->,
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->,
 
 где `r` — радиус, измеренный в [osu!пикселях](/wiki/Client/Beatmap_editor/osu!_pixel), а `CS` — значение параметра.
 

--- a/wiki/Beatmap/Circle_size/sk.md
+++ b/wiki/Beatmap/Circle_size/sk.md
@@ -16,7 +16,7 @@ no_native_review: true
 
 V [osu!](/wiki/Game_mode/osu!), veľkosť kruhov mení veľkosť [kruhov](/wiki/Gameplay/Hit_object/Hit_circle) a [sliderov](/wiki/Gameplay/Hit_object/Slider), kde väčšie hodnotu robia tieto objekty menšie. [Spinnery](/wiki/Gameplay/Hit_object/Spinner) nie sú afektované veľkosťou kruhov. Veľkosť kruhov sa vypočíta pomocou tohto vzorca:
 
-`r = 54.4 - 4.48 * CS`
+`r = (54.4 - 4.48 * CS) * 1.00041`
 
 Kde `r` je polomer meraný v [osu!pixeloch](/wiki/Client/Beatmap_editor/osu!_pixel), a `CS` ja hodnota veľkosti kruhu.
 

--- a/wiki/Beatmap/Circle_size/zh-tw.md
+++ b/wiki/Beatmap/Circle_size/zh-tw.md
@@ -16,7 +16,7 @@ tags:
 
 在 [osu!](/wiki/Game_mode/osu!) 中，圓圈大小將改變[打擊圈圈](/wiki/Gameplay/Hit_object/Hit_circle)和[滑條](/wiki/Gameplay/Hit_object/Slider)的大小。數值越大，物件越小。[轉盤](/wiki/Gameplay/Hit_object/Spinner)不會被影響。以下是計算公式：
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
 
 `r` 為半徑，以[osu!pixel](/wiki/Client/Beatmap_editor/osu!_pixel)為單位。`CS` 為圓圈大小的值。
 

--- a/wiki/Beatmap/Circle_size/zh.md
+++ b/wiki/Beatmap/Circle_size/zh.md
@@ -16,7 +16,7 @@ tags:
 
 在 [osu!](/wiki/Game_mode/osu!) 中，圆圈大小改变[打击圈](/wiki/Gameplay/Hit_object/Hit_circle)与[滑条](/wiki/Gameplay/Hit_object/Slider)的大小，CS 值越高，打击物件越小。[转盘](/wiki/Gameplay/Hit_object/Spinner)不受 CS 值影响。圆圈大小由以下公式得出：
 
-`r = 54.4 - 4.48 * CS`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
+`r = (54.4 - 4.48 * CS) * 1.00041`<!-- multiplied by 1.00041 in the end to account for some bug in old replays -->
 
 其中，`r` 是以 [osu! 像素](/wiki/Client/Beatmap_editor/osu!_pixel)为单位的半径，`CS` 是 CS 值。
 


### PR DESCRIPTION
`Beatmap/Circle_size` says circle radius equals `54.4 - 4.48 * CS` osu pixels. at CS=5, that would equal `32`, but the correct value (in both stable and lazer) is actually `32.01312`. both clients also display the (rounded) correct value when hovering over difficulty numbers.

the correct formula is: `(54.4 - 4.48 * CS) * 1.00041`. ([a comment in lazer's source code](https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs#L48) explains why)

alternatively, `* 1.00041` could be said in a footnote.

rationale:
i don't think the wiki should say "Circle size is derived through the following formula", when the following formula is actually an approximation, because that's misleading.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
