### PR TITLE
Update `Content voting process` with new process

### DIFF
--- a/wiki/Rules/Content_voting_process/en.md
+++ b/wiki/Rules/Content_voting_process/en.md
@@ -47,7 +47,7 @@ As this does not reach the 70% threshold required for the image to pass, the ima
 
 A user reports a Qualified beatmap made by StableStreamer because they believe its background is inappropriate. They report it as described above.
 
-The report is deemed valid by an NAT member. A member of the GMT disqualifies the map, and the voting process starts.
+The report is reviewed by the GMT and NAT. After reaching a mixed consensus, the content is sent through the voting process and a suggestion is posted in the beatmap's discussion to block the map from being ranked.
 
 After 7 days, the vote concludes. 71% of the GMT and NAT agree that the image is acceptable. 29% do not.
 

--- a/wiki/Rules/Content_voting_process/en.md
+++ b/wiki/Rules/Content_voting_process/en.md
@@ -31,7 +31,7 @@ Once a result has been achieved, the outcome is **final** and cannot be conteste
 
 #### Example 1
 
-Ultralazer420 finds a background for their new beatmap that they wants to use, but is unsure if it is allowed. Following the process above, they put it up for a vote.
+Ultralazer420 finds a background for their new beatmap that they want to use, but is unsure if it is allowed. Following the process above, they put it up for a vote.
 
 After 3 days, the vote has concluded, and the results come back.
 

--- a/wiki/Rules/Content_voting_process/en.md
+++ b/wiki/Rules/Content_voting_process/en.md
@@ -10,8 +10,8 @@ Content submitted to the [Beatmap Nominators](/wiki/People/Beatmap_Nominators) (
 ## Process
 
 1. A mapper, modder or concerned member of the community raises any visual element in a beatmap for review under the [Visual Content Considerations](/wiki/Rules/Visual_content_considerations) by reporting it via the [BN website](https://bn.mappersguild.com/reports).
-2. The report is assessed by the NAT and for all but the most obvious situations, a new "content case" is made live and available for voting as soon as possible. All members of the BN, GMT and NAT are eligible to vote.
-3. While the vote is active, any map containing said visual element cannot be nominated or qualified. If the map is qualified, it is temporarily disqualified while the discussion continues.
+2. The report is then assessed by the NAT and GMT[^beatmap-nominators]. For all but the most obvious situations, a new "content case" is made live and available for voting as soon as possible. All members of the BN, GMT and NAT are eligible to vote.
+3. While the vote is active, any map containing said visual element cannot be nominated or qualified. If the map is qualified, a suggestion will be posted on the modding discussion, halting the map from being ranked until voting ends.
 4. The vote concludes after a period of 3 days without any new votes, or 7 days since the vote began, whichever comes first.
 
 ## Outcome
@@ -38,3 +38,7 @@ This means that the BN votes are now merged into the total votes, and those are 
 After factoring in the BN votes with the GMT and NAT votes, 67% of the vote agrees that the image is okay, 33% do not.
 
 As this does not reach the 70% threshold required for the image to pass, the image is considered unacceptable and Ultralazer420 is asked to find another one to use instead.
+
+## Notes
+
+[^beatmap-nominators]: [Beatmap Nominators](/wiki/People/Beatmap_Nominators) who submit content for voting will skip the review process and start a new vote immediately.

--- a/wiki/Rules/Content_voting_process/en.md
+++ b/wiki/Rules/Content_voting_process/en.md
@@ -57,4 +57,4 @@ The discussion on the beatmap is resolved, and StableStreamer is told their beat
 
 ## Notes
 
-[^beatmap-nominators]: [Beatmap Nominators](/wiki/People/Beatmap_Nominators) who submit content for voting will skip the review process and start a new vote immediately.
+[^beatmap-nominators]: [Beatmap Nominators](/wiki/People/Beatmap_Nominators) who submit content for voting may skip the review process and start a new vote immediately.


### PR DESCRIPTION
[Preview](https://osu2.roanh.dev/wiki/en/Rules/Content_voting_process).

Discussed by the Moderation team in [internal](https://discord.com/channels/90072389919997952/1415439493183574076/1415439507494535270).

The old process was left unmodified even after the newest changes to blocking suggestion/problem stamps were added to the osu!web. This will now be in line with how Vetos are handled by blocking maps with a suggestion which is overall less disruptive than a full-on disqualification for something that may not need to be changed.

Additionally, I've taken the liberty to add two miscellaneous changes to keep the process further up to date:
- Content reports are handled by both the NAT *and* GMT.
- Beatmap Nominators skip the report review process. Moderators are not involved in those reports as they straight up get sent to Content Review.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] Reviewed by the GMT
- [x] Merged [the other PR](https://github.com/ppy/osu-wiki/pull/13702)
