### PR TITLE
Update `Locus 2025` credits

### DIFF
--- a/wiki/Contests/Locus/2025/en.md
+++ b/wiki/Contests/Locus/2025/en.md
@@ -223,7 +223,7 @@ This contest has come to an end and resulted in the following podium:
 |  |  |
 | :-- | :-- |
 | **Team name** | Vocaloid Lovers |
-| **VFX artist / storyboarder / mapper** | ::{ flag=IT }:: [Kuroise](https://osu.ppy.sh/users/14547127) |
+| **GFX artist / storyboarder / mapper** | ::{ flag=IT }:: [Kuroise](https://osu.ppy.sh/users/14547127) |
 | **Musician / mapper** | ::{ flag=ID }:: [ArXe](https://osu.ppy.sh/users/14013313) |
 | **Vocaloid tuning / mapper** | ::{ flag=US }:: [Defy](https://osu.ppy.sh/users/15428357) |
 | **Lyricist / mapper** | ::{ flag=KR }:: [Kawashiro](https://osu.ppy.sh/users/1533796) |
@@ -806,7 +806,7 @@ This contest has come to an end and resulted in the following podium:
 | :-- | :-- |
 | **Team name** | Ocskai |
 | **Musician / mapper** | ::{ flag=HU }:: [RRolanDD](https://osu.ppy.sh/users/12291981) |
-| **Mapper** | ::{ flag=HU }:: [Magor](https://osu.ppy.sh/users/13214099) |
+| **Mapper / hitsounder** | ::{ flag=HU }:: [Magor](https://osu.ppy.sh/users/13214099) |
 | **Storyboarder / illustrator / mapper** | ::{ flag=HU }:: [HyBer](https://osu.ppy.sh/users/15025665) |
 | **Mapper** | ::{ flag=HU }:: [Nyartin](https://osu.ppy.sh/users/3436625) |
 


### PR DESCRIPTION
Update credits for `Kanui` from `Hitsounder` to `Mapper / hitsounder` as previously discussed in osu-locus Discord channel.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
