### PR TITLE
Update obsolete link in `Past osu!store items`

### DIFF
--- a/wiki/Past_osu!store_items/de.md
+++ b/wiki/Past_osu!store_items/de.md
@@ -76,7 +76,7 @@ Die Kollektion bestand aus einer Breite an Produkten wie zum Beispiel:
 
 Das **osu!tablet** war ein offizielles, von osu! vertriebenes Grafiktablett, das in Zusammenarbeit mit der Elektronikfirma [HUION](https://www.huion.com/) entstand. Es wurde von ::{ flag=MY }:: [flyte](https://osu.ppy.sh/users/3103765) entworfen und als eine erschwingliche Alternative für die, die einfach ein Grafiktablett für osu! haben wollten, herausgebracht.
 
-Das Produkt wurde in zwei Ausführungen angeboten: Das originale "[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)", welches zuerst 2013 verkauft wurde. Das verbesserte [osu!tablet v2](/wiki/Guides/Tablet_purchase#osu!store) kam ab 2016 auf den Markt, bevor es im Jahre 2017 im Rahmen einer [Anpassung der Entwicklungsschwerpunkte](https://twitter.com/ppy/status/846190076853870592) eingestellt wurde.
+Das Produkt wurde in zwei Ausführungen angeboten: Das originale "[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)", welches zuerst 2013 verkauft wurde. Das verbesserte [osu!tablet v2](https://twitter.com/ppy/status/744778218524160000) kam ab 2016 auf den Markt, bevor es im Jahre 2017 im Rahmen einer [Anpassung der Entwicklungsschwerpunkte](https://twitter.com/ppy/status/846190076853870592) eingestellt wurde.
 
 ## osu! beatmap blueprints
 

--- a/wiki/Past_osu!store_items/en.md
+++ b/wiki/Past_osu!store_items/en.md
@@ -73,7 +73,7 @@ The collection featured a range of products such as:
 
 The **osu!tablet** was an official osu!-branded graphic tablet made in partnership with the electronics company [HUION](https://www.huion.com/). It was designed by ::{ flag=MY }:: [flyte](https://osu.ppy.sh/users/3103765) and was released as an affordable alternative for those who wanted to purchase a graphic tablet simply to play osu!.
 
-The product ran for two versions: the original "[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)", which was first sold in 2013, and the updated [osu!tablet v2](/wiki/Guides/Tablet_purchase#osu!store) in 2016 before it was discontinued in 2017 citing [a shift in development focus](https://twitter.com/ppy/status/846190076853870592).
+The product ran for two versions: the original "[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)", which was first sold in 2013, and the updated [osu!tablet v2](https://twitter.com/ppy/status/744778218524160000) in 2016 before it was discontinued in 2017 citing [a shift in development focus](https://twitter.com/ppy/status/846190076853870592).
 
 ![osu! tablet v2](img/osu-tablet-v2.jpg)
 

--- a/wiki/Past_osu!store_items/es.md
+++ b/wiki/Past_osu!store_items/es.md
@@ -78,7 +78,7 @@ La colección presentaba una variedad de productos como:
 
 La **osu!tablet** era una tableta gráfica oficial de la marca osu! fabricada en colaboración con la empresa de electrónica [HUION](https://www.huion.com/). Fue diseñada por ::{ flag=MY }:: [flyte](https://osu.ppy.sh/users/3103765) y se lanzó como una alternativa económica para aquellos que querían comprar una tableta gráfica simplemente para jugar a osu!.
 
-El producto tuvo dos versiones: la original «[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)», que salió a la venta por primera vez en 2013, y la actualizada [osu!tablet v2](/wiki/Guides/Tablet_purchase#osu!store) en 2016 antes de dejar de comercializarse en 2017 citando [un cambio en el enfoque de desarrollo](https://twitter.com/ppy/status/846190076853870592).
+El producto tuvo dos versiones: la original «[osu!tablet v1](https://www.youtube.com/watch?v=27RkPY5lWBw)», que salió a la venta por primera vez en 2013, y la actualizada [osu!tablet v2](https://twitter.com/ppy/status/744778218524160000) en 2016 antes de dejar de comercializarse en 2017 citando [un cambio en el enfoque de desarrollo](https://twitter.com/ppy/status/846190076853870592).
 
 ## Planos para crear beatmaps de osu!
 


### PR DESCRIPTION
Related to the recently merged [#13885](http://github.com/ppy/osu-wiki/pull/13885).

Would be appreciated if this can be merged ASAP, since right now this dead link causes everything to fail the remark test due to the failed wikilink check 🙏 

<img width="909" height="262" alt="image" src="https://github.com/user-attachments/assets/ac173f05-07dc-4f56-ab53-af9d5e84d5ff" />

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
