### PR TITLE
Update `unfeeling`'s country in Featured Artists lists

### DIFF
--- a/wiki/People/Featured_Artists/de.md
+++ b/wiki/People/Featured_Artists/de.md
@@ -132,7 +132,7 @@ Die [Gruppenseite für Featured Artists](https://osu.ppy.sh/groups/35) listet al
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |

--- a/wiki/People/Featured_Artists/en.md
+++ b/wiki/People/Featured_Artists/en.md
@@ -132,7 +132,7 @@ The [Featured Artist group page](https://osu.ppy.sh/groups/35) lists all such ac
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |

--- a/wiki/People/Featured_Artists/es.md
+++ b/wiki/People/Featured_Artists/es.md
@@ -132,7 +132,7 @@ La [página de grupo de los artistas destacados](https://osu.ppy.sh/groups/35) e
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |

--- a/wiki/People/Featured_Artists/fr.md
+++ b/wiki/People/Featured_Artists/fr.md
@@ -133,7 +133,7 @@ La [page du groupe des Featured Artist](https://osu.ppy.sh/groups/35) répertori
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |

--- a/wiki/People/Featured_Artists/ru.md
+++ b/wiki/People/Featured_Artists/ru.md
@@ -133,7 +133,7 @@ tags:
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |

--- a/wiki/People/Featured_Artists/zh.md
+++ b/wiki/People/Featured_Artists/zh.md
@@ -134,7 +134,7 @@ tags:
 | ::{ flag=RU }:: [tieff](https://osu.ppy.sh/users/89619) | [tieff](https://osu.ppy.sh/beatmaps/artists/34) |
 | ::{ flag=AU }:: [tomspicy](https://osu.ppy.sh/users/13210748) | [tomspicy](https://osu.ppy.sh/beatmaps/artists/437) |
 | ::{ flag=HK }:: [Trainer LOLXD](https://osu.ppy.sh/users/14817071) | [Trina Lydia](https://osu.ppy.sh/beatmaps/artists/440) |
-| ::{ flag=RU }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
+| ::{ flag=UA }:: [un_feeling](https://osu.ppy.sh/users/7100478) | [unfeeling](https://osu.ppy.sh/beatmaps/artists/509) |
 | ::{ flag=RU }:: [uselet](https://osu.ppy.sh/users/5256300) | [uselet](https://osu.ppy.sh/beatmaps/artists/402) |
 | ::{ flag=CA }:: [VINXIS](https://osu.ppy.sh/users/4323406) | [VINXIS](https://osu.ppy.sh/beatmaps/artists/22) |
 | ::{ flag=DE }:: [WangleLine](https://osu.ppy.sh/users/7994819) | [WangleLine](https://osu.ppy.sh/beatmaps/artists/427) |


### PR DESCRIPTION
Updated country of `unfeeling` artist as it was incorrectly stated in the wiki pages

unfeeling's osu! profile:
https://osu.ppy.sh/users/7100478

Here is stated that he is Ukrainian artist, but was added as Russian in the lists:
https://github.com/ppy/osu-wiki/commit/4232413a2f9111edc1cfd78d94ef1b0f826822a3#diff-b56008d840e29222eb11b2ae3554b082f16f46a62489e55a34777142b90345ffR11

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
