### PR TITLE
Update soft deletion scores for `Migrating to lazer`

### DIFF
--- a/wiki/Help_centre/Upgrading_to_lazer/en.md
+++ b/wiki/Help_centre/Upgrading_to_lazer/en.md
@@ -44,7 +44,7 @@ The following is a comprehensive list of the **current state** of lazer in compa
 | Storyboards in main menu | ![No][false] | ![Yes][true][^supporter] |
 | Hiding difficulties | ![No][false] | ![Yes][true] |
 | First-run setup wizard | ![No][false] | ![Yes][true] |
-| Soft deletion | ![True][true][^recycling-bin] | ![Partial][partial][^soft-deletion] |
+| Soft deletion | ![Yes][true][^recycling-bin] | ![Partial][partial][^soft-deletion] |
 | Immediate setting changes during gameplay | ![No][false] | ![Yes][true] |
 
 ### Gameplay


### PR DESCRIPTION
Stable: No ❌ ---> Yes ✅
Lazer: Yes ✅ ---> Partial ⚠️

Stable redirects all deleted beatmaps to the recycling bin. This is basically soft deletion and I don't see why stable should be marked as a "no".

Lazer does not soft delete skins. The lazer soft deletion is more aggressive than the stable one - you only have time to restore your stuff until you close the client. You also only have the option to restore everything, which is likely a lot of junk if you were mass deleting stuff. On stable you have by default 30 days, can be customized in Windows Settings and have the option to restore only what you want. That's why this PR is downgrading the lazer score to partial. 

[x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)