### PR TITLE
Change triggers for labeler and welcome github actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: Label pull request
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
     types:

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -1,7 +1,7 @@
 name: Welcome new contributors
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 


### PR DESCRIPTION
even though [both](https://github.com/garg3133/welcome-new-contributors) [readmes](https://github.com/actions/labeler?tab=readme-ov-file) include it in the examples, apparently `pull_request_target` might not be required? works when testing in https://github.com/Walavouchey/osu-wiki/pull/38, with my fork's `master` branch having this change applied. the action logs don't complain anything and it seems to apply labels correctly

of course, that's a pr on the same repo, but if that isn't a significant detail then it'd be pretty great since `pull_request` [isn't as privileged](https://github.com/actions/labeler?tab=readme-ov-file) (but note that neither of the workflows check out any files anyway). i dunno what the easiest way to test this would be other than trying it here