### PR TITLE
Update visibility duration for tournament bans

### DIFF
--- a/wiki/Help_centre/Tournament_sanctions/en.md
+++ b/wiki/Help_centre/Tournament_sanctions/en.md
@@ -95,4 +95,4 @@ In rare situations, the [account support team](/wiki/People/Account_support_team
 ![](img/tourney-ban-profile.png "A tournament ban on a user's profile")
 :::
 
-Indefinite tournament bans and tournament bans that have been applied via means other than [standard appeal terms](/wiki/Help_centre/Account_restrictions#appeal-granted) are visible on a user's profile for the entire duration of the ban in question, plus an additional **28 days** after the it expires. Other tournament sanctions (i.e. hosting probations, hosting bans and staffing bans) are not publicly visible in this way.
+Indefinite tournament bans and tournament bans that have been applied via means other than [standard appeal terms](/wiki/Help_centre/Account_restrictions#appeal-granted) are visible on a user's profile for the entire duration of the ban in question, plus an additional **28 days** after it expires. Other tournament sanctions (i.e. hosting probations, hosting bans and staffing bans) are not publicly visible in this way.

--- a/wiki/Help_centre/Tournament_sanctions/en.md
+++ b/wiki/Help_centre/Tournament_sanctions/en.md
@@ -95,4 +95,4 @@ In rare situations, the [account support team](/wiki/People/Account_support_team
 ![](img/tourney-ban-profile.png "A tournament ban on a user's profile")
 :::
 
-Indefinite tournament bans and tournament bans that have been applied via means other than [standard appeal terms](/wiki/Help_centre/Account_restrictions#appeal-granted) are visible on a user's profile while active. Other tournament sanctions (i.e. hosting probations, hosting bans and staffing bans) are not publicly visible in this way.
+Indefinite tournament bans and tournament bans that have been applied via means other than [standard appeal terms](/wiki/Help_centre/Account_restrictions#appeal-granted) are visible on a user's profile for the entire duration of the ban in question, plus an additional **28 days** after the it expires. Other tournament sanctions (i.e. hosting probations, hosting bans and staffing bans) are not publicly visible in this way.


### PR DESCRIPTION
https://github.com/ppy/osu-web/pull/12699 changed the duration infringements are displayed on user profiles so that they always remain visible for 28 days past their expiration.

This commit updates the tournament sanctions page to reflect that change.

(see [discord conversation](https://discord.com/channels/90072389919997952/1479189706708091031/1490737419404841000) for reasoning why this information is being surfaced on the wiki)

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
