### PR TITLE
Fix commit hash in `Beatmap/Packs`

### DIFF
--- a/wiki/Beatmap/Packs/de.md
+++ b/wiki/Beatmap/Packs/de.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 7f3ac2254866625e3837a2a7ddab76a0e935ca8b
+outdated_since: 322adbb5c9e8e17fc68e6e7f019e8ca93bd53544
 no_native_review: true
 ---
 

--- a/wiki/Beatmap/Packs/es.md
+++ b/wiki/Beatmap/Packs/es.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 7f3ac2254866625e3837a2a7ddab76a0e935ca8b
+outdated_since: 322adbb5c9e8e17fc68e6e7f019e8ca93bd53544
 ---
 
 # Paquetes de beatmaps

--- a/wiki/Beatmap/Packs/it.md
+++ b/wiki/Beatmap/Packs/it.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 7f3ac2254866625e3837a2a7ddab76a0e935ca8b
+outdated_since: 322adbb5c9e8e17fc68e6e7f019e8ca93bd53544
 ---
 
 # Pacchetti di beatmap

--- a/wiki/Beatmap/Packs/ru.md
+++ b/wiki/Beatmap/Packs/ru.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 7f3ac2254866625e3837a2a7ddab76a0e935ca8b
+outdated_since: 322adbb5c9e8e17fc68e6e7f019e8ca93bd53544
 ---
 
 # Наборы карт

--- a/wiki/Beatmap/Packs/zh.md
+++ b/wiki/Beatmap/Packs/zh.md
@@ -1,6 +1,6 @@
 ---
 outdated_translation: true
-outdated_since: 7f3ac2254866625e3837a2a7ddab76a0e935ca8b
+outdated_since: 322adbb5c9e8e17fc68e6e7f019e8ca93bd53544
 tags:
   - beatmap packs
   - pack


### PR DESCRIPTION
Related to #14589

When merged, every commit is squashed into one, new commit. The `outdated_since` tag needs to reference this new commit hash.

This is why translation *must not* be outdated manually.

cc @Sitoria @Nivalyx 

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
