### PR TITLE
Fix wrong image link in `Pending Cup 2025`

### DIFF
--- a/wiki/Contests/PDC/2025/en.md
+++ b/wiki/Contests/PDC/2025/en.md
@@ -32,7 +32,7 @@ This contest currently offers a cash prize pool of $400, distributed among the t
 | 2nd | 9% of the cash prize pool, 6 months of osu!supporter, [contest points](/wiki/Contests/Contest_points) |
 | 3rd | 6% of the cash prize pool, 4 months of osu!supporter, [contest points](/wiki/Contests/Contest_points) |
 
-![Pending Cup 2025 badge prizes](img/grand-prize.jpg "Pending Cup 2025 badge prize")
+![Pending Cup 2025 badge prizes](img/track-prize.jpg "Pending Cup 2025 badge prize")
 
 ### Grand prize
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

Current image is showing grand prize winner instead of badges

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
