### PR TITLE
Update `People/Beatmap_Nominators` 

### DIFF
--- a/wiki/People/Beatmap_Nominators/en.md
+++ b/wiki/People/Beatmap_Nominators/en.md
@@ -207,6 +207,7 @@ The tables listed below indicate the game mode(s) in which each Beatmap Nominato
 | :-- | :-- |
 | ::{ flag=RU }:: [222222222222222](https://osu.ppy.sh/users/12498861) | Russian |
 | ::{ flag=HK }:: [4rcheR-](https://osu.ppy.sh/users/8846762) | Cantonese, Chinese |
+| ::{ flag=HK }:: [BlackBN](https://osu.ppy.sh/users/6291741) | Cantonese, Chinese |
 | ::{ flag=ES }:: [Deif](https://osu.ppy.sh/users/318565) | Spanish, German |
 | ::{ flag=DE }:: [DizzyOracel](https://osu.ppy.sh/users/32159666) | German |
 | ::{ flag=PH }:: [JierYagtama](https://osu.ppy.sh/users/7483452) |  |


### PR DESCRIPTION
after [this PR](https://github.com/ppy/osu-wiki/pull/14667), user [BlackBN](https://osu.ppy.sh/users/6291741) was removed from the osu!catch Beatmap Nominators listing on the respective wiki page. This PR fixes that and adds him back. The BN site markdown copy paste didn't include him, was already pointed out to Hivie. (Likely a multimode BN + NAT issue)

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
