### PR TITLE
Bump osu-wiki-tools to version `2.5.1` and add yaml lint rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,14 @@
-"area:help centre":
+area:help centre:
   - changed-files:
       - any-glob-to-any-file:
           - wiki/Help_centre/**
 
-"area:legal":
+area:legal:
   - changed-files:
       - any-glob-to-any-file:
           - wiki/Legal/**
 
-"area:meta":
+area:meta:
   - changed-files:
       - any-glob-to-any-file:
           - "*"
@@ -20,23 +20,23 @@
           - wiki/Tournaments/TEMPLATE.md
           - wiki/Tournaments/TEMPLATE-SERIES.md
 
-"area:news":
+area:news:
   - changed-files:
       - any-glob-to-any-file:
           - news/**/*.md
           - wiki/shared/news/**
 
-"area:ranking criteria":
+area:ranking criteria:
   - changed-files:
       - any-glob-to-any-file:
           - wiki/Ranking_criteria/**
 
-"area:tournaments":
+area:tournaments:
   - changed-files:
       - any-glob-to-any-file:
           - wiki/Tournaments/**
 
-"area:translations":
+area:translations:
   - all:
       - changed-files:
           - any-glob-to-any-file:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -30,6 +30,7 @@ rules:
     allow-quoted-quotes: true
     quote-type: double
     required: only-when-needed
+    check-keys: true
   truthy:
     check-keys: false
     level: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ name = "osu-wiki"
 version = "0.1.0"
 requires-python = ">=3.14.3"
 dependencies = [
-    "osu-wiki-tools==2.5.0",
+    "osu-wiki-tools==2.5.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -20,11 +20,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "osu-wiki-tools", specifier = "==2.5.0" }]
+requires-dist = [{ name = "osu-wiki-tools", specifier = "==2.5.1" }]
 
 [[package]]
 name = "osu-wiki-tools"
-version = "2.5.0"
+version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "braceexpand" },
@@ -32,9 +32,9 @@ dependencies = [
     { name = "types-pyyaml" },
     { name = "yamllint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/10/5e536e669dd1e3551645a4465218a81ccd64c1f6759a04b2271c9b9d2f14/osu_wiki_tools-2.5.0.tar.gz", hash = "sha256:ed5f70cc2fccfbd860d22aed0fda682b0fa2f0427888ff0c648bf9669cac8d5a", size = 46372, upload-time = "2026-03-07T14:35:49.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/41/080f2a406313e09c000c9afc27e5c809c6a4d22708e8d699db19a116c2cd/osu_wiki_tools-2.5.1.tar.gz", hash = "sha256:ab26e8745ad8b77db1b19e49f541704f69dfdcad133fec5e15eafb926a3fd7a2", size = 46788, upload-time = "2026-04-29T12:49:47.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/13/b774ab1d0277db2dc4140c0101ff95d62024ff2cfa16ccd8ca2e22745195/osu_wiki_tools-2.5.0-py3-none-any.whl", hash = "sha256:771d306e18da6db0d7d7732b9e5bc9e111710d3ca643b247021b8116793b086e", size = 37437, upload-time = "2026-03-07T14:35:47.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/64/fa7747d62221e71c8ac78864d327047f270e7f9be2b2148eb95a659b9f29/osu_wiki_tools-2.5.1-py3-none-any.whl", hash = "sha256:1f59f2597d0ead989ee6ef12470440d66debffed594a9c2714507f27db96a6f3", size = 37582, upload-time = "2026-04-29T12:49:46.345Z" },
 ]
 
 [[package]]

--- a/wiki/Community/Bespoke_music/es.md
+++ b/wiki/Community/Bespoke_music/es.md
@@ -52,7 +52,7 @@ translation_keys:
     Livestream BGM: Música de fondo de la transmisión en vivo
     Main theme: Tema principal
     Trailer music: Música del tráiler
-    'Finals & Last Chance Bracket Pool #1 (.+)': "\\1 de las finales y del bracket\
+    "Finals & Last Chance Bracket Pool #1 (.+)": "\\1 de las finales y del bracket\
       \ de última oportunidad \\#1"
     Finals HD3 \(osu!\), finals NM1 \(osu!catch\): HD3 de las finales (osu!), NM1
       de las finales (osu!catch)

--- a/wiki/Community/Bespoke_music/zh.md
+++ b/wiki/Community/Bespoke_music/zh.md
@@ -35,10 +35,10 @@ translation_keys:
     osu!\(lazer\) main theme: osu!(lazer) 主主题曲
     osu! theme: osu! 主题曲
     osu!\(lazer\) "ranked play" theme: osu!(lazer) 排位模式主题曲
-    ' tutorial song': 教程歌曲
-    'Christmas/Winter (\d{4}) ': "\\1 年圣诞节/冬季 "
-    'Halloween 2016 ': "2016 年万圣节 "
-    'Summer 2023 ': "2023 年夏季 "
+    " tutorial song": 教程歌曲
+    "Christmas/Winter (\\d{4}) ": "\\1 年圣诞节/冬季 "
+    "Halloween 2016 ": "2016 年万圣节 "
+    "Summer 2023 ": "2023 年夏季 "
     Original composition for \[osu!stream\]\(/wiki/osu!stream\): 为 [osu!stream](/wiki/osu!stream)
       原创的作品
     \[osu!stream\]\(/wiki/osu!stream\) main theme: "[osu!stream](/wiki/osu!stream)
@@ -49,12 +49,12 @@ translation_keys:
     Main theme: 主主题曲
     Trailer music: 预告片音乐
     (osu!(?:taiko|catch|mania)?) and (osu!(?:taiko|catch|mania)?): \1 和 \2
-    '(\d+)\s+Pool #?(\w+)': \1 图池 \2 中的
-    '(\w+?)\s+Pool #?(\w+)': \1图池 \2 中的
-    '^Pool #?(\w+)': 图池 \1 中的
+    "(\\d+)\\s+Pool #?(\\w+)": \1 图池 \2 中的
+    "(\\w+?)\\s+Pool #?(\\w+)": \1图池 \2 中的
+    "^Pool #?(\\w+)": 图池 \1 中的
     Day (\d+): 第 \1 天
     5k division: 5K 组
-    ' & ': 与
+    " & ": 与
     LAN: 线下赛
     Swiss Week (\d+) (.+): 瑞士轮第 \1 周 \2
     Swiss Stage (\d+) (.+): 瑞士轮阶段 \1 \2
@@ -72,7 +72,7 @@ translation_keys:
     Grand [Ff]inals: 总决赛
     Semifinals: 半决赛
     Quarterfinals: 四分之一决赛
-    '[Ff]inals': 决赛
+    "[Ff]inals": 决赛
     Round of (\d+): \1 强赛
     Qualifiers? Stage (\d+): 资格赛阶段 \1
     Qualifiers: 资格赛
@@ -80,8 +80,8 @@ translation_keys:
     ^Runoff Bracket: 附加名次赛
     ^Tier (\d) (.+): Tier \1 \2
     tiebreaker: TB
-    ' wildcard': 外卡
-    ' pick': " 选图"
+    " wildcard": 外卡
+    " pick": " 选图"
 ---
 
 <!-- “统计”部分和“列表”部分的所有内容都是自动化翻译的。如果一条翻译有误、格式不正确或需要更新，请通过开发服务器上的 `#osu-wiki` 频道联系 wiki 维护者。 -->


### PR DESCRIPTION
view changes at
https://github.com/Walavouchey/osu-wiki-tools/compare/v2.5.0...v2.5.1

- fixed yaml dumper using single quotes in some cases and wrapping long  lines

basically, some of the generated changes in https://github.com/ppy/osu-wiki/commit/0fff0997cf916ee1e313644d4c86f4376dae864e caused ci errors:

- removed comments (ok)
- used single quotes (lint error, fixed here)
- wrapped long lines (not an error, but fixed here)
- removed redundant quotes from keys (not an error, but added linting in e4560b7735d2bb6c0c22228842e6dba42064ef53)