### PR TITLE
Fix typo in `SEV rating` article

### DIFF
--- a/wiki/People/Nomination_Assessment_Team/SEV_rating/en.md
+++ b/wiki/People/Nomination_Assessment_Team/SEV_rating/en.md
@@ -167,5 +167,5 @@ Resets related to beatmap files almost never have a severity above 0, as they us
 ## History
 
 - SEV ratings were introduced in 20 May 2020 and were publicly visible.<!-- internal reference: https://discord.com/channels/316154420591067136/316586967171203075/712448434770018424 -->
-- In 16 December 2023, SEV ratings were deprecated in favor if a simpler impact system that assigned a "minor", "notable" or "severe" label to each reset.<!-- internal reference: https://discord.com/channels/90072389919997952/299846395031060480/1184280021448273930 -->
+- In 16 December 2023, SEV ratings were deprecated in favor of a simpler impact system that assigned a "minor", "notable" or "severe" label to each reset.<!-- internal reference: https://discord.com/channels/90072389919997952/299846395031060480/1184280021448273930 -->
 - The SEV rating system was reintroduced on 19 April 2025<!-- internal reference: https://discord.com/channels/90072389919997952/299846395031060480/1363112346272272484 --> following concerns about impact ratings being too vague. However, it was not made public again given its main purpose is to serve as internal documentation.


### PR DESCRIPTION
I was reading through this and spotted the typo in "In 16 December 2023, SEV ratings were deprecated in favor if a simpler impact system that assigned a "minor", "notable" or "severe" label to each reset." where "if" in "in favor if" should be "of", so I just decided to do a pr. very very minor thing

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

DO_NOT_OUTDATE: wiki/People/Nomination_Assessment_Team/SEV_rating
