### PR TITLE
Update ``Release streams`` across multiple articles

### DIFF
--- a/wiki/Client/Options/de.md
+++ b/wiki/Client/Options/de.md
@@ -60,7 +60,7 @@ Du kannst auf dieses Menü durch das Klicken auf deine Benutzerkarte zugreifen, 
 
 | Name | Beschreibung | Typ | Standardwert |
 | :-- | :-- | :-- | :-- |
-| `Updatequelle` | Zeigt eine Liste an Builds an, die du benutzen kannst. | Dropdown-Menü | `Stable` |
+| `Updatequelle` | Zeigt eine Liste an Builds an, die du benutzen kannst. | Dropdown-Menü | `Stabil` |
 | `osu! ist auf dem neuesten Stand!` | Klicke, um den Spiel-Client zu zwingen, nach Updates zu suchen und diese herunterzuladen, falls verfügbar. | Button |  |
 | `osu!-Ordner öffnen` | Öffnet den lokalen osu!-Ordner, der deine Skins, Beatmaps usw. enthält. | Button |  |
 
@@ -70,9 +70,8 @@ Wenn du die Dropdown-Liste unter `Updatequelle` öffnest, hast du folgende Optio
 
 | Name | Beschreibung |
 | :-- | :-- |
-| `Stable` | Stable public release build. |
-| `Beta` | Dev build - erhält neue Funktionen früher, aber möglicherweise leicht fehlerhaft. |
-| `Cutting Edge (Experimentell)` | Dev build - erhält neue Funktionen noch früher, aber möglicherweise mit vielen Fehlern. |
+| `Stabil` | Ofizielle Version von osu!(stable).| <!--Stable public release build. |-->
+| `Cutting Edge (Experimentell)` | Dev build - erhält Updates früher, aber möglicherweise fehlerhaft. |
 
 ## Grafik
 

--- a/wiki/Client/Options/de.md
+++ b/wiki/Client/Options/de.md
@@ -70,7 +70,7 @@ Wenn du die Dropdown-Liste unter `Updatequelle` öffnest, hast du folgende Optio
 
 | Name | Beschreibung |
 | :-- | :-- |
-| `Stabil` | Ofizielle Version von osu!(stable).| <!--Stable public release build. |-->
+| `Stabil` | Ofizielle Version von osu!(stable). |
 | `Cutting Edge (Experimentell)` | Dev build - erhält Updates früher, aber möglicherweise fehlerhaft. |
 
 ## Grafik

--- a/wiki/Client/Options/en.md
+++ b/wiki/Client/Options/en.md
@@ -60,7 +60,7 @@ You can access this menu by clicking on your player card where available.
 
 | Name | Description | Type | Default |
 | :-- | :-- | :-- | :-- |
-| `Release stream` | Display a list of builds that you want to use. | Dropdown | `Stable` |
+| `Release stream` | Display a list of builds that you can use. | Dropdown | `Stable` |
 | `Your osu! is up-to-date!` | Click to force the game client to check for updates again and download them, if any. | Button |  |
 | `Open osu! folder` | Open the local osu! folder, which contains your skins, beatmaps, etc. | Button |  |
 
@@ -71,8 +71,7 @@ If you open the dropdown list for `Release stream`, you will be presented with t
 | Name | Description |
 | :-- | :-- |
 | `Stable` | Stable public release build. |
-| `Beta` | Dev build - gets new features early, but possibly buggier. |
-| `Cutting Edge (Experimental)` | Dev build - gets new features even earlier, but possibly significantly buggier. |
+| `Cutting Edge (Experimental)` | Dev build - receives updates earlier, but possibly buggier. |
 
 ## Graphics
 

--- a/wiki/Client/Release_stream/de.md
+++ b/wiki/Client/Release_stream/de.md
@@ -9,6 +9,6 @@ osu! hat mehrere **Updatequellen** (auch als Version des Spiel-Clients bezeichne
 | Updatequelle | Client | Anmerkungen |
 | :-- | :-- | :-- |
 | `Stabil` | osu!(stable) | Aktuellste Version von osu!(stable); [Code-Freeze](https://de.wikipedia.org/wiki/Code-Freeze); erhält Updates nach `Cutting Edge (Experimentell)`. |
-| `Cutting Edge (Experimentell)` | osu!(stable) | Erhält osu!(stable)-Updates früher; Code-Freeze; enthält gegenüber `Stabil` einige zusätzliche Funktionen; [Mehrspieler](/wiki/Client/Interface/Multiplayer) nur verügbar für [osu!supporter](/wiki/osu!supporter). |
-| [`Lazer`](Lazer) | osu!(lazer) | Vollständig neugeschriebener Spiel-Client; [Open Source](https://github.com/ppy/osu); am aktivsten in der Entwicklung mit [vielen Unterschieden und neuen Funktionen](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| `Cutting Edge (Experimentell)` | osu!(stable) | Erhält osu!(stable)-Updates früher; Code-Freeze; enthält gegenüber `Stabil` einige zusätzliche Funktionen; [Mehrspieler](/wiki/Client/Interface/Multiplayer) nur verfügbar für [osu!supporter](/wiki/osu!supporter). |
+| [`Lazer`](Lazer) | osu!(lazer) | Vollständig neugeschriebener Spiel-Client; [Quelloffen](https://github.com/ppy/osu); am aktivsten in der Entwicklung mit [vielen Unterschieden und neuen Funktionen](/wiki/Help_centre/Upgrading_to_lazer#unterschiede-im-gameplay). |
 | `Tachyon (Unstable)` | osu!(lazer) | Vorabversion von `Lazer`; erhält osu!(lazer)-Updates früher und häufiger. |

--- a/wiki/Client/Release_stream/de.md
+++ b/wiki/Client/Release_stream/de.md
@@ -4,11 +4,11 @@ stub: true
 
 # Updatequelle
 
-osu! hat einige **Updatequellen** (auch als Version des Spiel-Clients bezeichnet), die zu unterschiedlichen Zeiten Aktualisierungen erhalten. Um mögliche Probleme frühzeitig zu erkennen, werden neue Funktionen und Änderungen in Vorabversionen aufgenommen, bevor sie in Stable implementiert werden.
+osu! hat mehrere **Updatequellen** (auch als Version des Spiel-Clients bezeichnet), die zu unterschiedlichen Zeiten Aktualisierungen erhalten. Um mögliche Probleme frühzeitig zu erkennen, werden neue Funktionen und Änderungen in Vorabversionen aufgenommen, bevor sie in die Hauptversion implementiert werden.
 
-| Updatequelle | Anmerkungen |
-| :-- | :-- |
-| Stable | Aktuelle und populärste Version; [Code-Freeze](https://de.wikipedia.org/wiki/Code-Freeze); erhält Updates nach Beta |
-| Beta | Erhält Updates nach Cutting Edge; Code-Freeze |
-| Cutting Edge | Erhält die neuesten Updates; Code-Freeze |
-| [Lazer](Lazer) | Neugeschriebener Spiel-Client; am aktivsten in der Entwicklung mit [vielen Unterschieden und neuen Funktionen](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| Updatequelle | Client | Anmerkungen |
+| :-- | :-- | :-- |
+| `Stabil` | osu!(stable) | Aktuellste Version von osu!(stable); [Code-Freeze](https://de.wikipedia.org/wiki/Code-Freeze); erhält Updates nach `Cutting Edge (Experimentell)`. |
+| `Cutting Edge (Experimentell)` | osu!(stable) | Erhält osu!(stable)-Updates früher; Code-Freeze; enthält gegenüber `Stabil` einige zusätzliche Funktionen; [Mehrspieler](/wiki/Client/Interface/Multiplayer) nur verügbar für [osu!supporter](/wiki/osu!supporter). |
+| [`Lazer`](Lazer) | osu!(lazer) | Vollständig neugeschriebener Spiel-Client; [Open Source](https://github.com/ppy/osu); am aktivsten in der Entwicklung mit [vielen Unterschieden und neuen Funktionen](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| `Tachyon (Unstable)` | osu!(lazer) | Vorabversion von `Lazer`; erhält osu!(lazer)-Updates früher und häufiger. |

--- a/wiki/Client/Release_stream/en.md
+++ b/wiki/Client/Release_stream/en.md
@@ -4,11 +4,11 @@ stub: true
 
 # Release stream
 
-osu! has a few **release streams**, or game client versions, that receive updates at different rates. In order to catch potential issues early, new features and changes are put into preview versions before making their way to the stable client.
+osu! has multiple **release streams**, or game client versions, that receive updates at different rates. In order to catch potential issues early, new features and changes are added into preview versions before making their way to the main client.
 
-| Release stream | Notes |
-| :-- | :-- |
-| Stable | Current, most popular version; [feature-locked](https://en.wikipedia.org/wiki/Freeze_(software_engineering)); receives updates after Beta |
-| Beta | Receives updates after Cutting Edge; feature-locked |
-| Cutting Edge | Receives newest updates; feature-locked |
-| [Lazer](Lazer) | Rewritten game client; most active in development with [many differences and new features](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| Release stream | Client | Notes |
+| :-- | :-- | :-- |
+| `Stable` | osu!(stable) | Most recent full release of osu!(stable); [feature-locked](https://en.wikipedia.org/wiki/Freeze_(software_engineering)); receives updates after `Cutting Edge (Experimental)`. |
+| `Cutting Edge (Experimental)` | osu!(stable) | Receives osu!(stable) updates earlier; feature-locked; contains a few extra features compared to `Stable`; [multiplayer](/wiki/Client/Interface/Multiplayer) only available to [osu!supporters](/wiki/osu!supporter). |
+| [`Lazer`](Lazer) | osu!(lazer) | Completely rewritten game client; [open source](https://github.com/ppy/osu); most active in development with [many differences and new features](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| `Tachyon (Unstable)` | osu!(lazer) | Pre-release version of `Lazer`; receives osu!(lazer) updates earlier and more frequently. |

--- a/wiki/Client/Release_stream/en.md
+++ b/wiki/Client/Release_stream/en.md
@@ -10,5 +10,5 @@ osu! has multiple **release streams**, or game client versions, that receive upd
 | :-- | :-- | :-- |
 | `Stable` | osu!(stable) | Most recent full release of osu!(stable); [feature-locked](https://en.wikipedia.org/wiki/Freeze_(software_engineering)); receives updates after `Cutting Edge (Experimental)`. |
 | `Cutting Edge (Experimental)` | osu!(stable) | Receives osu!(stable) updates earlier; feature-locked; contains a few extra features compared to `Stable`; [multiplayer](/wiki/Client/Interface/Multiplayer) only available to [osu!supporters](/wiki/osu!supporter). |
-| [`Lazer`](Lazer) | osu!(lazer) | Completely rewritten game client; [open source](https://github.com/ppy/osu); most active in development with [many differences and new features](/wiki/Client/Release_stream/Lazer/Feature_comparison). |
+| [`Lazer`](Lazer) | osu!(lazer) | Completely rewritten game client; [open source](https://github.com/ppy/osu); most active in development with [many differences and new features](/wiki/Help_centre/Upgrading_to_lazer#gameplay-differences). |
 | `Tachyon (Unstable)` | osu!(lazer) | Pre-release version of `Lazer`; receives osu!(lazer) updates earlier and more frequently. |

--- a/wiki/Disambiguation/Version/de.md
+++ b/wiki/Disambiguation/Version/de.md
@@ -6,4 +6,6 @@
 - Die Versionsnummer einer [`.osu`-Datei](/wiki/Client/File_formats/osu_(file_format))
 - Die Versionsnummer eines [Skins](/wiki/Skinning)
 - Die Buildnummer oder das Builddatum eines osu!-Clients
-- Die Updatequelle eines osu!-Clients (`Stable`, `Stable (Fallback)`, `Beta`, oder `Cutting Edge (Experimental)`)
+- Die [Updatequelle](/wiki/Client/Release_stream) eines osu!-Clients
+  - `Stabil` oder `Cutting Edge (Experimentell)` in osu!(stable)
+  - `Lazer` oder `Tachyon (Unstable)` in osu!(lazer)

--- a/wiki/Disambiguation/Version/en.md
+++ b/wiki/Disambiguation/Version/en.md
@@ -6,4 +6,6 @@
 - The version number of a [`.osu` file](/wiki/Client/File_formats/osu_(file_format))
 - The version number of a [skin](/wiki/Skinning)
 - The build number or date of an osu! client
-- The release stream of an osu! client (`Stable`, `Stable (Fallback)`, `Beta`, or `Cutting Edge (Experimental)`)
+- The [release stream](/wiki/Client/Release_stream) of an osu! client
+  - `Stable` or `Cutting Edge (Experimental)` for osu!(stable)
+  - `Lazer` or `Tachyon (Unstable)` for osu!(lazer)


### PR DESCRIPTION
I updated every article I could find that contains release streams which don't exist anymore:

- ``Client/Options`` still lists ``Beta`` as a release stream.
- ``Client/Release_stream`` still lists ``Beta``, but is missing ``Tachyon``.
- ``Disambiguation/Version`` still lists ``Beta`` and ``Stable (Fallback)``, but is missing ``Lazer`` and ``Tachyon``.

I also updated the German translations.

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)

<!-- a -->