### PR TITLE
Update "Game modifier (lazer)" to match June 2026 Mod Multipliers: Survey Results

### DIFF
--- a/wiki/Gameplay/Game_modifier/Adaptive_Speed/en.md
+++ b/wiki/Gameplay/Game_modifier/Adaptive_Speed/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | AS |
 | Type | Fun |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!mania] |
-| Score multiplier | 0.50x |
+| Score multiplier | 0.10x |
 | Status | Unranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Autoplay (AT)](/wiki/Gameplay/Game_modifier/Autoplay_(lazer)), [Cinema (CN)](/wiki/Gameplay/Game_modifier/Cinema_(lazer)), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) |
 

--- a/wiki/Gameplay/Game_modifier/Approach_Different/en.md
+++ b/wiki/Gameplay/Game_modifier/Approach_Different/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | AD |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow), [Deflate (DF)](/wiki/Gameplay/Game_modifier/Deflate), [Freeze Frame (FR)](/wiki/Gameplay/Game_modifier/Freeze_Frame) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Blinds/en.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/en.md
@@ -32,8 +32,10 @@ tags:
 
 The **Blinds** mod covers the entire screen with [shoji doors](https://en.wikipedia.org/wiki/Shoji) without the possibility to see the objects behind. The more successive misses the player gets, the more the doors open. Building up a combo will have the opposite effect.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
-
 **This mod can't be customised through Customisation.**
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Blinds/en.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/en.md
@@ -22,15 +22,17 @@ tags:
 | Type | Difficulty Increase |
 | Default shortcut key | `K` |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.12x |
+| Score multiplier | 1.24x* |
 | Status | Ranked |
-| Incompatible mods | [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)) |
+| Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)) |
 
 :::
 
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Blinds** mod covers the entire screen with [shoji doors](https://en.wikipedia.org/wiki/Shoji) without the possibility to see the objects behind. The more successive misses the player gets, the more the doors open. Building up a combo will have the opposite effect.
+
+*Score multiplier depends on other factors such as mod combinations or mod settings.
 
 **This mod can't be customised through Customisation.**
 

--- a/wiki/Gameplay/Game_modifier/Blinds/en.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/en.md
@@ -24,7 +24,7 @@ tags:
 | Game modes | ![][osu!] |
 | Score multiplier | 1.24x* |
 | Status | Ranked |
-| Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)) |
+| Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable) |
 
 :::
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -38,7 +38,7 @@ The **Classic** mod emulates gameplay mechanics from osu!stable that have since 
 
 When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!stable have this mod enabled with default settings. The mod's unranked status does not affect the scores in this case.
 
-*Score multiplier goes from 0.985x to 0.96x if "Apply classic notelock" is disabled
+*Score multiplier goes from 0.985x to 0.96x if "Apply classic notelock" is disabled.
 
 <!-- TODO settings -->
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -38,9 +38,9 @@ The **Classic** mod emulates gameplay mechanics from osu!stable that have since 
 
 When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!stable have this mod enabled with default settings. The mod's unranked status does not affect the scores in this case.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
+*Score multiplier depends on other factors such as mod combinations or mod settings:
 
-- Reduced to 0.96x if the "Apply classic notelock" setting is disabled.
+- The multiplier is reduced to 0.96x if the `Apply classic notelock` setting is disabled.
 
 <!-- TODO settings -->
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -38,7 +38,9 @@ The **Classic** mod emulates gameplay mechanics from osu!stable that have since 
 
 When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!stable have this mod enabled with default settings. The mod's unranked status does not affect the scores in this case.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Decreases from 0.985x to 0.96x if the `Apply classic notelock` setting is disabled.
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -20,11 +20,13 @@ tags:
 | :-- | :-- |
 | Acronym | CL |
 | Type | Conversion |
-| Game modes | ![][osu!] ![][osu!taiko] |
-| Score multiplier | 0.96x |
+| Game modes | ![][osu!] ![][osu!taiko] ![][osu!mania] |
+| Score multiplier ![][osu!] | 0.985x* |
+| Score multiplier ![][osu!taiko] ![][osu!mania] | 1.0x |
 | Status | Unranked |
 | Incompatible mods ![][osu!] | [Strict Tracking (ST)](/wiki/Gameplay/Game_modifier/Strict_Tracking) |
 | Incompatible mods ![][osu!taiko] | None |
+| Incompatible mods ![][osu!mania] | None |
 
 :::
 
@@ -36,9 +38,12 @@ The **Classic** mod emulates gameplay mechanics from osu!stable that have since 
 
 When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!stable have this mod enabled with default settings. The mod's unranked status does not affect the scores in this case.
 
+*Score multiplier goes from 0.985x to 0.96x if "Apply classic notelock" is disabled
+
 <!-- TODO settings -->
 
 <!-- explanation of why this is unranked could be interesting to write about here -clayton -->
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"
+[osu!mania]: /wiki/shared/mode/mania.png "osu!mania"

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -40,7 +40,7 @@ When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!s
 
 *Score multiplier depends on other factors such as mod combinations or mod settings:
 
-- The multiplier is reduced to 0.96x if the `Apply classic notelock` setting is disabled.
+- Decreases from 0.985x to 0.96x if the `Apply classic notelock` setting is disabled.
 
 <!-- TODO settings -->
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -38,7 +38,9 @@ The **Classic** mod emulates gameplay mechanics from osu!stable that have since 
 
 When viewed from osu!(lazer) or "Lazer mode" on the website, scores set on osu!stable have this mod enabled with default settings. The mod's unranked status does not affect the scores in this case.
 
-*Score multiplier goes from 0.985x to 0.96x if "Apply classic notelock" is disabled.
+*Score multiplier depends on other factors such as mod combinations or mod settings.
+
+- Reduced to 0.96x if the "Apply classic notelock" setting is disabled.
 
 <!-- TODO settings -->
 

--- a/wiki/Gameplay/Game_modifier/Daycore/en.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/en.md
@@ -22,7 +22,7 @@ tags:
 | Type | Difficulty Reduction |
 | Default shortcut key | `R` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.30x\* <!-- TODO --> |
+| Score multiplier | 0.55x* <!-- TODO --> |
 | Status | Ranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) |
 
@@ -31,6 +31,24 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Daycore** mod behaves exactly like [Half Time](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)) when it comes to speed change and difficulty settings modification. It only lowers the audio frequency by 75% without the possibility of adjusting the pitch through customisation.
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Calculated in steps of 0.05 rate, the final value scales linearly using the formula `rate * 1.4 - 0.5`.
+### 
+| Rate | Before | After |
+| :--- | :---: | :---: |
+| 0.95x | 0.5x | 0.83x |
+| 0.90x | 0.5x | 0.76x |
+| 0.85x | 0.4x | 0.69x |
+| 0.80x | 0.4x | 0.62x |
+| 0.75x | 0.3x | 0.55x |
+| 0.70x | 0.3x | 0.48x |
+| 0.65x | 0.2x | 0.41x |
+| 0.60x | 0.2x | 0.34x |
+| 0.55x | 0.1x | 0.27x |
+| 0.50x | 0.1x | 0.20x |
+- No custom rate penalty applies to this modifier, unlike [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)) and [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)).
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Daycore/en.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/en.md
@@ -32,7 +32,9 @@ tags:
 
 The **Daycore** mod behaves exactly like [Half Time](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)) when it comes to speed change and difficulty settings modification. It only lowers the audio frequency by 75% without the possibility of adjusting the pitch through customisation.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Calculated in steps of 0.05 rate, the final value scales linearly using the formula `rate * 1.4 - 0.5`.
 ### 

--- a/wiki/Gameplay/Game_modifier/Deflate/en.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/en.md
@@ -33,6 +33,6 @@ tags:
 
 *Score multiplier depends on other factors such as mod combinations or mod settings.
 
-- Reduced by 0.02x per step in the "Starting size" setting.
+- Decreases by 0.02x per step increment applied to the `Starting size` setting.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Deflate/en.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/en.md
@@ -36,5 +36,6 @@ tags:
 Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Decreases by 0.02x per step increment applied to the `Starting size` setting.
+- It also reduces the [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)) score multiplier by 0.02x if enabled.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Deflate/en.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/en.md
@@ -31,7 +31,9 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Decreases by 0.02x per step increment applied to the `Starting size` setting.
 

--- a/wiki/Gameplay/Game_modifier/Deflate/en.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | DF |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+*Score multiplier depends on other factors such as mod combinations or mod settings.
+
+- Reduced by 0.02x per step in the "Starting size" setting.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Depth/en.md
+++ b/wiki/Gameplay/Game_modifier/Depth/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | DP |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)), [Transform (TR)](/wiki/Gameplay/Game_modifier/Transform), [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow), [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Magnetised (MG)](/wiki/Gameplay/Game_modifier/Magnetised), [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel), [Freeze Frame (FR)](/wiki/Gameplay/Game_modifier/Freeze_Frame) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Depth/en.md
+++ b/wiki/Gameplay/Game_modifier/Depth/en.md
@@ -33,6 +33,8 @@ tags:
 
 ## Score multiplier
 
-Score multiplier depends on other factors such as mod combinations or mod settings.
+Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Decreases the [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)) score multiplier by 0.02x if enabled.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | DA |
 | Type | Conversion |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.50x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Easy (EZ)](/wiki/Gameplay/Game_modifier/Easy_(lazer)), [Hard Rock (HR)](/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)) |
 
@@ -30,6 +30,10 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+*Score multiplier depends on other factors such as mod combinations or mod settings.
+
+- Reduced by 0.05x per 0.1 step change made to any original map parameter (CS, HP, OD and AR) down to a strict minimum of 0.1x.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
@@ -31,9 +31,11 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
 
-- Starts at 1.00x and decreases by 0.05x for every 0.1 step change made to any original map parameter (CS, HP, OD, AR), down to a strict minimum of 0.10x.
+Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Decreases by 0.05x for every 0.1 step change made to any original map parameter (CS, HP, OD, AR), down to a strict minimum of 0.10x.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
@@ -31,9 +31,9 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
+*Score multiplier depends on other factors such as mod combinations or mod settings:
 
-- Reduced by 0.05x per 0.1 step change made to any original map parameter (CS, HP, OD and AR) down to a strict minimum of 0.1x.
+- Starts at 1.00x and decreases by 0.05x for every 0.1 step change made to any original map parameter (CS, HP, OD, AR), down to a strict minimum of 0.10x.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
@@ -23,7 +23,7 @@ tags:
 | Type | Difficulty Increase |
 | Default shortcut key | `F` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.10x\* <!-- TODO --> |
+| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.23x* <!-- TODO --> |
 | Score multiplier ![][osu!mania] | 1.00x |
 | Status | Ranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) |
@@ -34,6 +34,24 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Double Time** mod increases the BPM of any beatmap by 150% as well as decreasing the length of the song by 33%. It also increases the [approach rate (AR)](/wiki/Beatmap/Approach_rate), [overall difficulty (OD)](/wiki/Beatmap/Overall_difficulty) or both at once according to the [game mode](/wiki/Game_mode).
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Calculated in steps of 0.1 rate, the final value scales linearly using the formula `(rate - 1) * 0.46 + 1`.
+### 
+| Rate | Before | After |
+| :--- | :---: | :---: |
+| 1.1x | 1.02x | 1.036x |
+| 1.2x | 1.04x | 1.082x |
+| 1.3x | 1.06x | 1.128x |
+| 1.4x | 1.08x | 1.174x |
+| 1.5x | 1.1x | 1.23x |
+| 1.6x | 1.12x | 1.266x |
+| 1.7x | 1.14x | 1.312x |
+| 1.8x | 1.16x | 1.358x |
+| 1.9x | 1.18x | 1.404x |
+| 2.0x | 1.2x | 1.45x |
+- A penalty of 0.01x is added if a custom rate other than the default 1.5x is selected. This ensures that legacy Double Time scores preserve their positions on the leaderboards.
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
@@ -35,7 +35,9 @@ tags:
 
 The **Double Time** mod increases the BPM of any beatmap by 150% as well as decreasing the length of the song by 33%. It also increases the [approach rate (AR)](/wiki/Beatmap/Approach_rate), [overall difficulty (OD)](/wiki/Beatmap/Overall_difficulty) or both at once according to the [game mode](/wiki/Game_mode).
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Calculated in steps of 0.1 rate, the final value scales linearly using the formula `(rate - 1) * 0.46 + 1`.
 ### 

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/en.md
@@ -25,7 +25,7 @@ tags:
 | Type | Difficulty Reduction |
 | Default shortcut key | `Q` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.50x |
+| Score multiplier | 0.80x* |
 | Status | Ranked |
 | Incompatible mods ![][osu!] ![][osu!catch] ![][osu!mania] | [Hard Rock (HR)](/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)), [Accuracy Challenge (AC)](/wiki/Gameplay/Game_modifier/Accuracy_Challenge), [Difficulty Adjust (DA)](/wiki/Gameplay/Game_modifier/Difficulty_Adjust) |
 | Incompatible mods ![][osu!taiko] | [Hard Rock (HR)](/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)), [Difficulty Adjust (DA)](/wiki/Gameplay/Game_modifier/Difficulty_Adjust) |
@@ -36,6 +36,10 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Easy** mod attempts to make the gameplay on any [beatmap](/wiki/Beatmap) played easier by halving each difficulty setting. In all [game modes](/wiki/Game_mode) except [osu!taiko](/wiki/Game_mode/osu!taiko), the mod gives two extra lives in case the [health bar](/wiki/Client/Interface/Health_bar) drops to zero, which instead refills it instantly.
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
@@ -37,7 +37,9 @@ tags:
 
 The **Flashlight** mod restricts visibility of the playfield to a small illuminated area, as if viewed through a flashlight. As the player's combo increases, this visible area progressively shrinks until it reaches a minimum size, which varies depending on the [game mode](/wiki/Game_mode).
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Decreases by 0.02x for every 0.1 increase applied to the `Flashlight size` setting.
 - It is reduced to 1.04x if the `Change size based on combo` setting is disabled.

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
@@ -24,7 +24,7 @@ tags:
 | Default shortcut key ![][osu!] ![][osu!taiko] ![][osu!catch] | `J` |
 | Default shortcut key ![][osu!mania] | `L` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.12x |
+| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.2x* |
 | Score multiplier ![][osu!mania] | 1.00x |
 | Status | Ranked |
 | Incompatible mods ![][osu!] ![][osu!taiko] ![][osu!catch] | [Fade In (FI)](/wiki/Gameplay/Game_modifier/Fade_In_(lazer)), [Cover (CO)](/wiki/Gameplay/Game_modifier/Cover), [Blinds (BL)](/wiki/Gameplay/Game_modifier/Blinds), [Bloom (BM)](/wiki/Gameplay/Game_modifier/Bloom) |
@@ -36,6 +36,12 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Flashlight** mod restricts visibility of the playfield to a small illuminated area, as if viewed through a flashlight. As the player's combo increases, this visible area progressively shrinks until it reaches a minimum size, which varies depending on the [game mode](/wiki/Game_mode).
+
+*Score multiplier depends on other factors such as mod combinations or mod settings.
+
+- Reduced by 0.02x per 0.1 increase to the "Flashlight size" setting.
+- Reduced to 1.04x if the "Change size based on combo" setting is disabled.
+- Reduced to 1.1x if [Freeze Frame (FR)](/wiki/Gameplay/Game_modifier/Freeze_Frame) is enabled.
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
@@ -37,11 +37,11 @@ tags:
 
 The **Flashlight** mod restricts visibility of the playfield to a small illuminated area, as if viewed through a flashlight. As the player's combo increases, this visible area progressively shrinks until it reaches a minimum size, which varies depending on the [game mode](/wiki/Game_mode).
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
+*Score multiplier depends on other factors such as mod combinations or mod settings:
 
-- Reduced by 0.02x per 0.1 increase to the "Flashlight size" setting.
-- Reduced to 1.04x if the "Change size based on combo" setting is disabled.
-- Reduced to 1.1x if [Freeze Frame (FR)](/wiki/Gameplay/Game_modifier/Freeze_Frame) is enabled.
+- Decreases by 0.02x for every 0.1 increase applied to the `Flashlight size` setting.
+- It is reduced to 1.04x if the `Change size based on combo` setting is disabled.
+- Additionally, the multiplier is reduced to 1.10x if [Freeze Frame (FR)](/wiki/Gameplay/Game_modifier/Freeze_Frame) is enabled.
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Freeze_Frame/en.md
+++ b/wiki/Gameplay/Game_modifier/Freeze_Frame/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | FR |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Transform (TR)](/wiki/Gameplay/Game_modifier/Transform), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Grow/en.md
+++ b/wiki/Gameplay/Game_modifier/Grow/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | GR |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Deflate (DF)](/wiki/Gameplay/Game_modifier/Deflate), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Grow/en.md
+++ b/wiki/Gameplay/Game_modifier/Grow/en.md
@@ -33,6 +33,8 @@ tags:
 
 ## Score multiplier
 
-Score multiplier depends on other factors such as mod combinations or mod settings.
+Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Decreases the [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)) score multiplier by 0.02x if enabled.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
@@ -34,7 +34,9 @@ tags:
 
 The **Half Time** mod decreases the BPM of any beatmap to 75%, increasing the length of the song by 33%. It also can reduce the [approach rate (AR)](/wiki/Beatmap/Approach_rate), [overall difficulty (OD)](/wiki/Beatmap/Overall_difficulty) or both at once depending on the [game mode](/wiki/Game_mode).
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Calculated in steps of 0.05 rate, the final value scales linearly using the formula `rate * 1.4 - 0.5`.
 ### 

--- a/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
@@ -23,7 +23,7 @@ tags:
 | Type | Difficulty Reduction |
 | Default shortcut key | `E` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.30x\* <!-- TODO --> |
+| Score multiplier | 0.55x* <!-- TODO --> |
 | Status | Ranked |
 | Incompatible mods | [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) |
 
@@ -33,6 +33,24 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Half Time** mod decreases the BPM of any beatmap to 75%, increasing the length of the song by 33%. It also can reduce the [approach rate (AR)](/wiki/Beatmap/Approach_rate), [overall difficulty (OD)](/wiki/Beatmap/Overall_difficulty) or both at once depending on the [game mode](/wiki/Game_mode).
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Calculated in steps of 0.05 rate, the final value scales linearly using the formula `rate * 1.4 - 0.5`.
+### 
+| Rate | Before | After |
+| :--- | :---: | :---: |
+| 0.95x | 0.5x | 0.83x |
+| 0.90x | 0.5x | 0.76x |
+| 0.85x | 0.4x | 0.69x |
+| 0.80x | 0.4x | 0.62x |
+| 0.75x | 0.3x | 0.55x |
+| 0.70x | 0.3x | 0.48x |
+| 0.65x | 0.2x | 0.41x |
+| 0.60x | 0.2x | 0.34x |
+| 0.55x | 0.1x | 0.27x |
+| 0.50x | 0.1x | 0.20x |
+- No custom rate penalty applies to this modifier, unlike [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)) and [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)).
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/en.md
@@ -23,7 +23,7 @@ tags:
 | Type | Difficulty Increase |
 | Default shortcut key | `A` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier ![][osu!] ![][osu!taiko] | 1.06x |
+| Score multiplier ![][osu!] ![][osu!taiko] | 1.09x |
 | Score multiplier ![][osu!catch] | 1.12x |
 | Score multiplier ![][osu!mania] | 1.00x |
 | Status ![][osu!] ![][osu!taiko] ![][osu!catch] | Ranked |

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -40,8 +40,8 @@ The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Appr
 
 *Score multiplier depends on other factors such as mod combinations or mod settings.
 
-- Score multiplier goes from 1.04x to 1.02x if "Only fade approach circles" is enabled.
-- It is also reduced by 0.02x if any of the mods below are enabled, since they restore timing information that Hidden removes: 
+- The multiplier decreases from 1.04x to 1.02x if the `Only fade approach circles` setting is enabled.
+- It is further reduced by 0.02x if combined with any mods that restore object visibility or timing information, such as:
   - [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
   - [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)
   - [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate)

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -38,7 +38,7 @@ tags:
 
 The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Approach_circle) and makes the [hit circles](/wiki/Gameplay/Hit_object/Hit_circle) fade out after appearing on the screen.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
+*Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - The multiplier decreases from 1.04x to 1.02x if the `Only fade approach circles` setting is enabled.
 - It is further reduced by 0.02x if combined with any mods that restore object visibility or timing information, such as:

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -40,7 +40,7 @@ The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Appr
 
 *Score multiplier goes from 1.04x to 1.02x if "Only fade approach circles" is enabled. 
 
-It is also reduced to 0.02x if any of the mods are enabled, since they restore timing information that Hidden removes: 
+It is also reduced by 0.02x if any of the mods are enabled, since they restore timing information that Hidden removes: 
 - [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
 - [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)
 - [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate)

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -38,14 +38,15 @@ tags:
 
 The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Approach_circle) and makes the [hit circles](/wiki/Gameplay/Hit_object/Hit_circle) fade out after appearing on the screen.
 
-*Score multiplier goes from 1.04x to 1.02x if "Only fade approach circles" is enabled. 
+*Score multiplier depends on other factors such as mod combinations or mod settings.
 
-It is also reduced by 0.02x if any of the mods are enabled, since they restore timing information that Hidden removes: 
-- [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
-- [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)
-- [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate)
-- [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel)
-- [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth)
+- Score multiplier goes from 1.04x to 1.02x if "Only fade approach circles" is enabled.
+- It is also reduced by 0.02x if any of the mods below are enabled, since they restore timing information that Hidden removes: 
+  - [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
+  - [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)
+  - [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate)
+  - [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel)
+  - [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth)
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -40,7 +40,7 @@ The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Appr
 
 *Score multiplier depends on other factors such as mod combinations or mod settings:
 
-- The multiplier decreases from 1.04x to 1.02x if the `Only fade approach circles` setting is enabled.
+- Decreases from 1.04x to 1.02x if the `Only fade approach circles` setting is enabled.
 - It is further reduced by 0.02x if combined with any mods that restore object visibility or timing information, such as:
   - [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
   - [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -38,7 +38,9 @@ tags:
 
 The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Approach_circle) and makes the [hit circles](/wiki/Gameplay/Hit_object/Hit_circle) fade out after appearing on the screen.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Decreases from 1.04x to 1.02x if the `Only fade approach circles` setting is enabled.
 - It is further reduced by 0.02x if combined with any mods that restore object visibility or timing information, such as:

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -26,10 +26,10 @@ tags:
 | Default shortcut key ![][osu!] ![][osu!taiko] ![][osu!catch] | `H` |
 | Default shortcut key ![][osu!mania] | `J` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.06x |
+| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.04x* |
 | Score multiplier ![][osu!mania] | 1.00x |
 | Status | Ranked |
-| Incompatible mods | [Fade In (FI)](/wiki/Gameplay/Game_modifier/Fade_In_(lazer)), [Cover (CO)](/wiki/Gameplay/Game_modifier/Cover), [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
+| Incompatible mods | [Fade In (FI)](/wiki/Gameplay/Game_modifier/Fade_In_(lazer)), [Cover (CO)](/wiki/Gameplay/Game_modifier/Cover), [Flashlight (FL)](/wiki/Gameplay/Game_modifier/Flashlight_(lazer)), [Blinds (BL)](/wiki/Gameplay/Game_modifier/Blinds), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
 :::
 
@@ -37,6 +37,15 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Hidden** mod removes the [approach circles](/wiki/Gameplay/Hit_object/Approach_circle) and makes the [hit circles](/wiki/Gameplay/Hit_object/Hit_circle) fade out after appearing on the screen.
+
+*Score multiplier goes from 1.04x to 1.02x if "Only fade approach circles" is enabled. 
+
+It is also reduced to 0.02x if any of the mods are enabled, since they restore timing information that Hidden removes: 
+- [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle)
+- [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow)
+- [Deflate (DP)](/wiki/Gameplay/Game_modifier/Deflate)
+- [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel)
+- [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth)
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Magnetised/en.md
+++ b/wiki/Gameplay/Game_modifier/Magnetised/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | MG |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 0.50x |
+| Score multiplier | 0.40x* |
 | Status | Unranked |
 | Incompatible mods | [Autoplay (AT)](/wiki/Gameplay/Game_modifier/Autoplay_(lazer)), [Cinema (CN)](/wiki/Gameplay/Game_modifier/Cinema_(lazer)), [Relax (RX)](/wiki/Gameplay/Game_modifier/Relax_(lazer)), [Autopilot (AP)](/wiki/Gameplay/Game_modifier/Autopilot_(lazer)), [Transform (TR)](/wiki/Gameplay/Game_modifier/Transform), [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle), [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel), [Bubbles (BU)](/wiki/Gameplay/Game_modifier/Bubbles), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
@@ -34,7 +34,9 @@ tags:
 
 The **Nightcore** mod behaves exactly as [Double Time](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)) regarding speed changes and difficulty adjustments. However, it specifically increases the audio frequency by 150% without offering the pitch adjustment options available in customization settings.
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings:
 
 - Calculated in steps of 0.1 rate, the final value scales linearly using the formula `(rate - 1) * 0.46 + 1`.
 ### 

--- a/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
@@ -22,7 +22,7 @@ tags:
 | Type | Difficulty Increase |
 | Default shortcut key | `G` |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.10x\* <!-- TODO --> |
+| Score multiplier ![][osu!] ![][osu!taiko] ![][osu!catch] | 1.23x* <!-- TODO --> |
 | Score multiplier ![][osu!mania] | 1.00x |
 | Status | Ranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) |
@@ -33,6 +33,24 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 The **Nightcore** mod behaves exactly as [Double Time](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)) regarding speed changes and difficulty adjustments. However, it specifically increases the audio frequency by 150% without offering the pitch adjustment options available in customization settings.
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Calculated in steps of 0.1 rate, the final value scales linearly using the formula `(rate - 1) * 0.46 + 1`.
+### 
+| Rate | Before | After |
+| :--- | :---: | :---: |
+| 1.1x | 1.02x | 1.036x |
+| 1.2x | 1.04x | 1.082x |
+| 1.3x | 1.06x | 1.128x |
+| 1.4x | 1.08x | 1.174x |
+| 1.5x | 1.1x | 1.23x |
+| 1.6x | 1.12x | 1.266x |
+| 1.7x | 1.14x | 1.312x |
+| 1.8x | 1.16x | 1.358x |
+| 1.9x | 1.18x | 1.404x |
+| 2.0x | 1.2x | 1.45x |
+- A penalty of 0.01x is added if a custom rate other than the default 1.5x is selected. This ensures that legacy Double Time scores preserve their positions on the leaderboards.
 
 ## Customisation
 

--- a/wiki/Gameplay/Game_modifier/Random_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Random_(lazer)/en.md
@@ -23,7 +23,7 @@ tags:
 | Acronym | RD |
 | Type | Conversion |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!mania] |
-| Score multiplier | 1.00x |
+| Score multiplier | 0.70x |
 | Status | Unranked |
 | Incompatible mods | [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)), [Swap (SW)](/wiki/Gameplay/Game_modifier/Swap) |
 

--- a/wiki/Gameplay/Game_modifier/Repel/en.md
+++ b/wiki/Gameplay/Game_modifier/Repel/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | RP |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Autoplay (AT)](/wiki/Gameplay/Game_modifier/Autoplay_(lazer)), [Cinema (CN)](/wiki/Gameplay/Game_modifier/Cinema_(lazer)), [Autopilot (AP)](/wiki/Gameplay/Game_modifier/Autopilot_(lazer)), [Transform (TR)](/wiki/Gameplay/Game_modifier/Transform), [Wiggle (WG)](/wiki/Gameplay/Game_modifier/Wiggle), [Magnetised (MG)](/wiki/Gameplay/Game_modifier/Magnetised), [Bubbles (BU)](/wiki/Gameplay/Game_modifier/Bubbles), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Repel/en.md
+++ b/wiki/Gameplay/Game_modifier/Repel/en.md
@@ -33,6 +33,8 @@ tags:
 
 ## Score multiplier
 
-Score multiplier depends on other factors such as mod combinations or mod settings.
+Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Decreases the [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)) score multiplier by 0.02x if enabled.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
@@ -23,7 +23,7 @@ tags:
 | Type | Automation |
 | Default shortcut key | `B` |
 | Game modes | ![][osu!] |
-| Score multiplier | 0.90x |
+| Score multiplier | 0.95x |
 | Status | Ranked |
 | Incompatible mods | [Autoplay (AT)](/wiki/Gameplay/Game_modifier/Autoplay_(lazer)), [Cinema (CN)](/wiki/Gameplay/Game_modifier/Cinema_(lazer)), [Autopilot (AP)](/wiki/Gameplay/Game_modifier/Autopilot_(lazer)), [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)) |
 

--- a/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
@@ -34,4 +34,6 @@ tags:
 
 <!-- TODO description and settings -->
 
+**This mod can't be customised through Customisation.**
+
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Synesthesia/en.md
+++ b/wiki/Gameplay/Game_modifier/Synesthesia/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | SY |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 0.80x |
+| Score multiplier | 0.99x |
 | Status | Unranked |
 | Incompatible mods | None |
 

--- a/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/en.md
@@ -22,7 +22,7 @@ tags:
 | Acronym | TP |
 | Type | Conversion |
 | Game modes | ![][osu!] |
-| Score multiplier | 0.10x |
+| Score multiplier | 0.01x |
 | Status | Unranked |
 | Incompatible mods | [Sudden Death (SD)](/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)), [Strict Tracking (ST)](/wiki/Gameplay/Game_modifier/Strict_Tracking), [Spun Out (SO)](/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)), [Random (RD)](/wiki/Gameplay/Game_modifier/Random_(lazer)), [Traceable (TC)](/wiki/Gameplay/Game_modifier/Traceable), [Approach Different (AD)](/wiki/Gameplay/Game_modifier/Approach_Different), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 

--- a/wiki/Gameplay/Game_modifier/Traceable/en.md
+++ b/wiki/Gameplay/Game_modifier/Traceable/en.md
@@ -31,8 +31,10 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings.
-
 **This mod can't be customised through Customisation.**
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Traceable/en.md
+++ b/wiki/Gameplay/Game_modifier/Traceable/en.md
@@ -21,14 +21,18 @@ tags:
 | Acronym | TC |
 | Type | Difficulty Increase |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.02x* |
 | Status | Ranked |
-| Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow), [Deflate (DF)](/wiki/Gameplay/Game_modifier/Deflate) |
+| Incompatible mods | [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)), [Blinds (BL)](/wiki/Gameplay/Game_modifier/Blinds), [Target Practice (TP)](/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)), [Spin In (SI)](/wiki/Gameplay/Game_modifier/Spin_In), [Grow (GR)](/wiki/Gameplay/Game_modifier/Grow), [Deflate (DF)](/wiki/Gameplay/Game_modifier/Deflate), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
 :::
 
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+*Score multiplier depends on other factors such as mod combinations or mod settings.
+
+**This mod can't be customised through Customisation.**
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Wiggle/en.md
+++ b/wiki/Gameplay/Game_modifier/Wiggle/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | WG |
 | Type | Fun |
 | Game modes | ![][osu!] |
-| Score multiplier | 1.00x |
+| Score multiplier | 1.00x* |
 | Status | Unranked |
 | Incompatible mods | [Transform (TR)](/wiki/Gameplay/Game_modifier/Transform), [Magnetised (MG)](/wiki/Gameplay/Game_modifier/Magnetised), [Repel (RP)](/wiki/Gameplay/Game_modifier/Repel), [Depth (DP)](/wiki/Gameplay/Game_modifier/Depth) |
 
@@ -30,5 +30,9 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+## Score multiplier
+
+Score multiplier depends on other factors such as mod combinations or mod settings.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Wiggle/en.md
+++ b/wiki/Gameplay/Game_modifier/Wiggle/en.md
@@ -33,6 +33,8 @@ tags:
 
 ## Score multiplier
 
-Score multiplier depends on other factors such as mod combinations or mod settings.
+Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Decreases the [Hidden (HD)](/wiki/Gameplay/Game_modifier/Hidden_(lazer)) score multiplier by 0.02x if enabled.
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"

--- a/wiki/Gameplay/Game_modifier/Wind_Down/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Down/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | WD |
 | Type | Fun |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.50x |
+| Score multiplier | Variable* |
 | Status | Unranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed) |
 
@@ -30,6 +30,18 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Both Wind Down and [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up) use the same weighted calculation based on the minimum and maximum selected speed rates:
+
+`0.8 * mod_multiplier(minimum) + 0.2 * mod_multiplier(maximum)`.
+####
+| Minimum Rate | Maximum Rate | Multiplier |
+| :---: | :---: | :---: |
+| 1.2x (1.082x) | 1.7x (1.312x) | 1.128x |
+| 0.7x (0.480x) | 0.9x (0.760x) | 0.536x |
+| 0.5x (0.200x) | 0.51x (0.200x) | 0.200x |
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/Wind_Down/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Down/en.md
@@ -31,9 +31,9 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
 
-- Both Wind Down and [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up) use the same weighted calculation based on the minimum and maximum selected speed rates:
+Both Wind Down and [Wind Up (WU)](/wiki/Gameplay/Game_modifier/Wind_Up) use the same weighted calculation based on the minimum and maximum selected speed rates:
 
 `0.8 * mod_multiplier(minimum) + 0.2 * mod_multiplier(maximum)`.
 ####

--- a/wiki/Gameplay/Game_modifier/Wind_Up/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Up/en.md
@@ -21,7 +21,7 @@ tags:
 | Acronym | WU |
 | Type | Fun |
 | Game modes | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| Score multiplier | 0.50x |
+| Score multiplier | Variable* |
 | Status | Unranked |
 | Incompatible mods | [Half Time (HT)](/wiki/Gameplay/Game_modifier/Half_Time_(lazer)), [Daycore (DC)](/wiki/Gameplay/Game_modifier/Daycore), [Double Time (DT)](/wiki/Gameplay/Game_modifier/Double_Time_(lazer)), [Nightcore (NC)](/wiki/Gameplay/Game_modifier/Nightcore_(lazer)), [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down), [Adaptive Speed (AS)](/wiki/Gameplay/Game_modifier/Adaptive_Speed) |
 
@@ -30,6 +30,18 @@ tags:
 *For the full list of all [lazer](/wiki/Client/Release_stream/Lazer) mods, see: [Game modifier (lazer)](/wiki/Gameplay/Game_modifier_(lazer))*
 
 <!-- TODO description and settings -->
+
+*Score multiplier depends on other factors such as mod combinations or mod settings:
+
+- Both Wind Up and [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) use the same weighted calculation based on the minimum and maximum selected speed rates:
+
+`0.8 * mod_multiplier(minimum) + 0.2 * mod_multiplier(maximum)`.
+####
+| Minimum Rate | Maximum Rate | Multiplier |
+| :---: | :---: | :---: |
+| 1.2x (1.082x) | 1.7x (1.312x) | 1.128x |
+| 0.7x (0.480x) | 0.9x (0.760x) | 0.536x |
+| 0.5x (0.200x) | 0.51x (0.200x) | 0.200x |
 
 [osu!]: /wiki/shared/mode/osu.png "osu!"
 [osu!taiko]: /wiki/shared/mode/taiko.png "osu!taiko"

--- a/wiki/Gameplay/Game_modifier/Wind_Up/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Up/en.md
@@ -31,9 +31,9 @@ tags:
 
 <!-- TODO description and settings -->
 
-*Score multiplier depends on other factors such as mod combinations or mod settings:
+## Score multiplier
 
-- Both Wind Up and [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) use the same weighted calculation based on the minimum and maximum selected speed rates:
+Both Wind Up and [Wind Down (WD)](/wiki/Gameplay/Game_modifier/Wind_Down) use the same weighted calculation based on the minimum and maximum selected speed rates:
 
 `0.8 * mod_multiplier(minimum) + 0.2 * mod_multiplier(maximum)`.
 ####


### PR DESCRIPTION
This pull request updates the score multiplier values, fixes some incompatible mods and adds new formulas across several osu!(lazer) game modifiers to align with the latest balance patch.

- Changes only affect the following mods' wiki pages from the news article:

<img width="1266" height="2359" alt="68747470733a2f2f6f73752e7070792e73682f77696b692f696d616765732f7368617265642f6e6577732f323032362d30362d30332d6d6f642d6d756c7469706c696572732d7375727665792d726573756c74732f6d6f642d6d756c7469706c696572732e706e673f32" src="https://github.com/user-attachments/assets/6913006c-7bbb-4481-a5a2-6f2ea2fdc756" />

- A new section called "Score multiplier" has been added for all pages with the "Score multiplier" containing an asterisk:
 
<img width="1072" height="780" alt="hidden" src="https://github.com/user-attachments/assets/433f721a-b7e9-4593-bd65-03d6dd4f4bef" />


