### PR TITLE
[JA] Add `Difficulty spread`

### DIFF
--- a/wiki/Beatmap/Difficulty_spread/ja.md
+++ b/wiki/Beatmap/Difficulty_spread/ja.md
@@ -1,0 +1,18 @@
+---
+tags:
+  - difficulty set
+  - progression
+  - 難易度セット
+  - 難易度スプレッド
+  - 難易度構成
+---
+
+# 難易度スプレッド
+
+**難易度スプレッド**とは、1つの[ビートマップ](/wiki/Beatmap)に含まれ、[星評価](/wiki/Beatmap/Star_rating)が一定の範囲内に収まる[難易度](/wiki/Beatmap/Difficulty)の集合です。
+
+[Ranked](/wiki/Beatmap/Category#ranked)に分類されるビートマップの難易度スプレッドは、[ランキング基準](/wiki/Ranking_criteria)で定められた次の要件を満たす必要があります。
+
+- スプレッドの範囲内で必須とされる[難易度レベル](/wiki/Beatmap/Difficulty#難易度レベル)は、すべて含める必要があります。
+- [スプレッドルール](/wiki/Ranking_criteria#rules.1)で定められた必須の最低難易度レベルよりも低い難易度は、任意で追加できます。
+- ビートマップ内で隣り合う2つの難易度の間に、大きな難易度差があってはなりません。


### PR DESCRIPTION
Added the Japanese translation of the Difficulty spread article.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
