### PR TITLE
Fix typo in `Tournaments/COE/COE 2025`

### DIFF
--- a/wiki/Tournaments/COE/COE_2025/en.md
+++ b/wiki/Tournaments/COE/COE_2025/en.md
@@ -138,7 +138,7 @@ Friday, 1 August 2025:
 | Bubbleman ::{ flag=GB }:: | 4 | **6** | ::{ flag=US }:: **WindowWife** | [#1](https://osu.ppy.sh/multiplayer/rooms/1534312) |
 | **mrekk** ::{ flag=AU }:: | **6** | 2 | ::{ flag=DE }:: criller | [#1](https://osu.ppy.sh/multiplayer/rooms/1534529) |
 
-Saturday, 2 August 2024:
+Saturday, 2 August 2025:
 
 | Player 1 |  |  | Player 2 | Match link |
 | --: | :-: | :-: | :-- | :-- |


### PR DESCRIPTION
fix incorrect year

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [x] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)
