### PR TITLE
Fix incorrect number in `Beatmap/Beatmap tags` (again)

### DIFF
--- a/wiki/Beatmap/Beatmap_tags/en.md
+++ b/wiki/Beatmap/Beatmap_tags/en.md
@@ -63,7 +63,7 @@ The tables below list all user tags grouped by category as well as the game mode
 | Tag name | Description | Game mode |
 | :-- | :-- | :-- |
 | [streams/doubles](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fdoubles%22%22) | Patterns requiring consecutively tapping 2 note groups. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Patterns requiring consecutively tapping 2 note groups. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
+| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Patterns requiring consecutively tapping 4 note groups. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/bursts](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fbursts%22%22) | Patterns requiring consecutively tapping 5-9 note groups. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/stamina](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fstamina%22%22) | Tests a player\'s ability to tap dense rhythms over long periods of time. | ![][osu!] ![][osu!taiko] ![][osu!mania] |
 | [streams/speed](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fspeed%22%22) | A map that requires constant tapping at high BPMs. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |

--- a/wiki/Beatmap/Beatmap_tags/es.md
+++ b/wiki/Beatmap/Beatmap_tags/es.md
@@ -63,7 +63,7 @@ Las siguientes tablas muestran todas las etiquetas de los usuarios agrupadas por
 | Nombre de la etiqueta | Descripción | Modo de juego |
 | :-- | :-- | :-- |
 | [streams/doubles](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fdoubles%22%22) | Mapas con patrones que requieren pulsar consecutivamente 2 grupos de notas. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Mapas con patrones que requieren pulsar consecutivamente 2 grupos de notas. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
+| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Mapas con patrones que requieren pulsar consecutivamente 4 grupos de notas. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/bursts](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fbursts%22%22) | Mapas con patrones que requieren pulsar consecutivamente grupos de 5 a 9 notas. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/stamina](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fstamina%22%22) | Mapas que ponen a prueba la habilidad del jugador para pulsar ritmos densos durante largos periodos de tiempo. | ![][osu!] ![][osu!taiko] ![][osu!mania] |
 | [streams/speed](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fspeed%22%22) | Mapas que requieren pulsaciones constantes a un BPM elevado. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |

--- a/wiki/Beatmap/Beatmap_tags/ru.md
+++ b/wiki/Beatmap/Beatmap_tags/ru.md
@@ -63,7 +63,7 @@
 | Название тега | Описание | Режим |
 | :-- | :-- | :-- |
 | [streams/doubles](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fdoubles%22%22) | Паттерны с идущими подряд группами из 2 нот. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Паттерны с идущими подряд группами из 2 нот. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
+| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | Паттерны с идущими подряд группами из 4 нот. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/bursts](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fbursts%22%22) | Паттерны с идущими подряд группами от 5 до 9 нот. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/stamina](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fstamina%22%22) | Проверка умения игрока проходить плотные, насыщенные ритмы в течение долгого времени. | ![][osu!] ![][osu!taiko] ![][osu!mania] |
 | [streams/speed](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fspeed%22%22) | Карты с постоянным таппингом на высоких BPM. | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |

--- a/wiki/Beatmap/Beatmap_tags/zh.md
+++ b/wiki/Beatmap/Beatmap_tags/zh.md
@@ -63,7 +63,7 @@
 | 标签名 | 描述 | 游戏模式 |
 | :-- | :-- | :-- |
 | [streams/doubles](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fdoubles%22%22) | 需要连续点击 2 个物件的分组的排列（二连）。 | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
-| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | 需要连续点击 2 个物件的分组的排列（四连）。 | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
+| [streams/quads](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fquads%22%22) | 需要连续点击 4 个物件的分组的排列（四连）。 | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/bursts](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fbursts%22%22) | 需要连续点击 5-9 个物件的分组的排列（爆发）。 | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |
 | [streams/stamina](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fstamina%22%22) | 考验玩家长时间点击密集节奏的能力（耐力）。 | ![][osu!] ![][osu!taiko] ![][osu!mania] |
 | [streams/speed](https://osu.ppy.sh/beatmapsets?q=tag%3D%22%22streams%2Fspeed%22%22) | 需要在高 BPM 下持续点击的谱面（手速）。 | ![][osu!] ![][osu!taiko] ![][osu!catch] ![][osu!mania] |


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

Sorry @Walavouchey, https://github.com/ppy/osu-wiki/pull/14971 was not correct, as pointed out in https://github.com/ppy/osu-wiki/issues/14970#issuecomment-5010388602, cause now `streams/doubles` and `streams/quads` have the exact same description.

DO_NOT_OUTDATE: Beatmap/Beatmap_tags/pl.md

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
