### PR TITLE
Fix a typo in `History of osu!/2008`

### DIFF
--- a/wiki/History_of_osu!/2008/en.md
+++ b/wiki/History_of_osu!/2008/en.md
@@ -50,7 +50,7 @@ A new ranked status "![](img/fire.gif) [Approved](/wiki/Beatmap/Category#approve
 
 ![](img/flashlight.png "Flashlight \(v1\)") ![](img/spun_out.png "Spun Out \(v1\)") ![](img/auto.png "Auto \(v1\)")
 
-A slew of new mods were unveiled this month: [Flashlight](/wiki/Gameplay/Game_modifier/Flashlight), [Spun Out](/wiki/Gameplay/Game_modifier/Spun_Out) and [Auto](/wiki/Gameplay/Game_modifier/Auto). Auto scripts an AI player that completed (almost) any beatmap with perfect [accuracy](/wiki/Gameplay/Accuracy), and can also be accessed via the editor test mode. The limits of beatmap design were pushed farther with the addition of more skinnable elements (including [comboburst images](/wiki/Gameplay/Comboburst), the clap sound sample, the ability to assign sound samples to individual slider endpoints and inherited timing sections. The song selection screen also received an overhaul.
+A slew of new mods were unveiled this month: [Flashlight](/wiki/Gameplay/Game_modifier/Flashlight), [Spun Out](/wiki/Gameplay/Game_modifier/Spun_Out) and [Auto](/wiki/Gameplay/Game_modifier/Auto). Auto scripts an AI player that completed (almost) any beatmap with perfect [accuracy](/wiki/Gameplay/Accuracy), and can also be accessed via the editor test mode. The limits of beatmap design were pushed further with the addition of more skinnable elements (including [comboburst images](/wiki/Gameplay/Comboburst), the clap sound sample, the ability to assign sound samples to individual slider endpoints and inherited timing sections. The song selection screen also received an overhaul.
 
 ## October
 


### PR DESCRIPTION
"farther" to "further"

<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)

DO_NOT_OUTDATE: *
