### PR TITLE
In `Gameplay/Score/ScoreV1/osu!mania`, split `ModMultiplier` and `ModDivider` for clarity

### DIFF
--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -37,12 +37,12 @@ ModDivider = The punishment divider of the selected mods (see below)
 
 | Judgement | HitValue | HitBonusValue | HitBonus | HitPunishment |
 | :-- | --: | --: | --: | --: |
-| MAX | 320 | 32 | 2 | |
-| 300 | 300 | 32 | 1 | |
-| 200 | 200 | 16 | | 8 |
-| 100 | 100 | 8 | | 24 |
-| 50 | 50 | 4 | | 44 |
-| Miss | 0 | 0 | | ∞ |
+| MAX | 320 | 32 | 2 |  |
+| 300 | 300 | 32 | 1 |  |
+| 200 | 200 | 16 |  | 8 |
+| 100 | 100 | 8 |  | 24 |
+| 50 | 50 | 4 |  | 44 |
+| Miss | 0 | 0 |  | ∞ |
 
 ## Mod multipliers
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -65,7 +65,11 @@ With the [ScoreV2](/wiki/Gameplay/Game_modifier/ScoreV2) mod enabled, No Fail no
 
 ## Mod divider
 
-Difficulty increase mods divide `HitPunishment` before it is subtracted from the bonus, making a 200 or below cost less bonus score than it would without mods. This still does not raise the maximum score, because a perfect play keeps the bonus at its maximum either way.
+The mod divider used to be a divisor applied to `HitPunishment` that depended on a combination of selected mods. It is now always equal to 1 and has no effect on score.[^note-mod-divider-0] [^note-mod-divider-1]
+
+### Old usage
+
+Previously, difficulty increase mods divided `HitPunishment` before it was subtracted from the bonus, making a 200 or below cost less bonus score than it would without mods. This did not raise the maximum score, because a perfect play kept the bonus at its maximum either way.
 
 | Mod | `ModDivider` |
 | :-- | --: |
@@ -75,3 +79,8 @@ Difficulty increase mods divide `HitPunishment` before it is subtracted from the
 | [Fade In](/wiki/Gameplay/Game_modifier/Fade_In) | 1.06 |
 | [Hidden](/wiki/Gameplay/Game_modifier/Hidden) | 1.06 |
 | [Flashlight](/wiki/Gameplay/Game_modifier/Flashlight) | 1.06 |
+
+## References
+
+[^note-mod-divider-0]: [Forum thread by Adyrem (2020-05-16) "ModDivider in BonusScore calculation does nothing"](https://osu.ppy.sh/community/forums/topics/1071173)
+[^note-mod-divider-1]: [GitHub comment by AndiTafel (2026-08-11) in "In `Gameplay/Score/ScoreV1/osu!mania`, split `ModMultiplier` and `ModDivider` for clarity #15073"](https://github.com/ppy/osu-wiki/pull/15073#discussion_r3761909692)

--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -2,7 +2,7 @@
 needs_cleanup: true  # https://github.com/ppy/osu-wiki/issues/2026, also, could probably be restructured/reformatted to read like ScoreV1/osu!
 ---
 
-# osu!mania scoring system
+# ScoreV1 (osu!mania)
 
 ::: alert-note
 **See also:** [osu!mania judgement system](/wiki/Gameplay/Judgement/osu!mania)
@@ -19,7 +19,7 @@ The score is given in two parts, base score and bonus score, each contributing 5
   - The better judgement, the more multiplier increase/less punishment.
     - There's an upper limit for the multiplier.
 
-The score given by each note is calculated with the following formula:-
+The score given by each note is calculated with the following formula:
 
 ```
 Score = BaseScore + BonusScore
@@ -31,25 +31,42 @@ Bonus = Bonus before this hit + HitBonus - HitPunishment / ModDivider
 Bonus is limited to [0, 100], initially 100.
 
 MaxScore = 1 000 000
-ModMultiplier = The score multiplier of the selected mods (difficulty reduction and/or nK)
-ModDivider = The punishment divider of the selected mods (difficulty increase)
-
-Judgement  HitValue  HitBonusValue  HitBonus  HitPunishment
-   MAX       320          32            2
-   300       300          32            1
-   200       200          16                        8
-   100       100           8                       24
-    50        50           4                       44
-  Miss         0           0                        ∞
-
-       Mod  ModMultiplier  ModDivider
-      Easy       0.5
-    NoFail       0.5
-  HalfTime       0.5
-  HardRock                    1.08
-DoubleTime                     1.1
- NightCore                     1.1
-    FadeIn                    1.06
-    Hidden                    1.06
-Flashlight                    1.06
+ModMultiplier = The score multiplier of the selected mods (see below)
+ModDivider = The punishment divider of the selected mods (see below)
 ```
+
+| Judgement | HitValue | HitBonusValue | HitBonus | HitPunishment |
+| :-- | --: | --: | --: | --: |
+| MAX | 320 | 32 | 2 | |
+| 300 | 300 | 32 | 1 | |
+| 200 | 200 | 16 | | 8 |
+| 100 | 100 | 8 | | 24 |
+| 50 | 50 | 4 | | 44 |
+| Miss | 0 | 0 | | ∞ |
+
+## Mod multipliers
+
+Difficulty increase mods do not affect the score, so it never exceeds 1,000,000.
+
+| Mod | `ModMultiplier` |
+| :-- | --: |
+| [Easy](/wiki/Gameplay/Game_modifier/Easy) | 0.50x |
+| [No Fail](/wiki/Gameplay/Game_modifier/No_Fail) | 0.50x |
+| [Half Time](/wiki/Gameplay/Game_modifier/Half_Time) | 0.50x |
+
+[Key mods](/wiki/Gameplay/Game_modifier/Summary#xk-mod-score-multipliers), including [Co-op](/wiki/Gameplay/Game_modifier/Co-op), have score multipliers of their own, ranging from 0.66x to 1.00x. They only apply to beatmaps converted from osu!, and give no penalty on osu!mania-specific beatmaps.
+
+With the [ScoreV2](/wiki/Gameplay/Game_modifier/ScoreV2) mod enabled, No Fail no longer halves the score, while Easy and Half Time still do.<!-- reference: https://github.com/ppy/osu/blob/9f227ed28b6c8ba46dfea1f000f778d8b2827ad0/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs#L25-L62. -->
+
+## Mod divider
+
+Difficulty increase mods divide `HitPunishment` before it is subtracted from the bonus, making a 200 or below cost less bonus score than it would without mods. This still does not raise the maximum score, because a perfect play keeps the bonus at its maximum either way.
+
+| Mod | `ModDivider` |
+| :-- | --: |
+| [Hard Rock](/wiki/Gameplay/Game_modifier/Hard_Rock) | 1.08 |
+| [Double Time](/wiki/Gameplay/Game_modifier/Double_Time) | 1.1 |
+| [Nightcore](/wiki/Gameplay/Game_modifier/Nightcore) | 1.1 |
+| [Fade In](/wiki/Gameplay/Game_modifier/Fade_In) | 1.06 |
+| [Hidden](/wiki/Gameplay/Game_modifier/Hidden) | 1.06 |
+| [Flashlight](/wiki/Gameplay/Game_modifier/Flashlight) | 1.06 |

--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -37,14 +37,14 @@ ModDivider = The punishment divider of the selected mods (see below)
 
 | Judgement | HitValue | HitBonusValue | HitBonus | HitPunishment |
 | :-- | --: | --: | --: | --: |
-| MAX | 320 | 32 | 2 |  |
-| 300 | 300 | 32 | 1 |  |
-| 200 | 200 | 16 |  | 8 |
-| 100 | 100 | 8 |  | 24 |
-| 50 | 50 | 4 |  | 44 |
-| Miss | 0 | 0 |  | ∞ |
+| PERFECT | 320 | 32 | 2 |  |
+| GREAT | 300 | 32 | 1 |  |
+| GOOD | 200 | 16 |  | 8 |
+| OK | 100 | 8 |  | 24 |
+| MEH | 50 | 4 |  | 44 |
+| MISS | 0 | 0 |  | ∞ |
 
-## Mod multipliers
+## Mod multiplier
 
 Difficulty increase mods do not affect the score, so it never exceeds 1,000,000.
 
@@ -54,7 +54,7 @@ Difficulty increase mods do not affect the score, so it never exceeds 1,000,000.
 | [No Fail](/wiki/Gameplay/Game_modifier/No_Fail) | 0.50x |
 | [Half Time](/wiki/Gameplay/Game_modifier/Half_Time) | 0.50x |
 
-[Key mods](/wiki/Gameplay/Game_modifier/Summary#xk-mod-score-multipliers), including [Co-op](/wiki/Gameplay/Game_modifier/Co-op), have score multipliers of their own, ranging from 0.66x to 1.00x. They only apply to beatmaps converted from osu!, and give no penalty on osu!mania-specific beatmaps.
+[Key mods](/wiki/Gameplay/Game_modifier/Summary#xk-mod-score-multipliers), including [Co-op](/wiki/Gameplay/Game_modifier/Co-op), have score multipliers of their own, ranging from 0.66x to 1.00x. They only apply to beatmaps [converted from osu!](/wiki/Beatmap/Converts), and give no penalty on osu!mania-specific beatmaps.
 
 With the [ScoreV2](/wiki/Gameplay/Game_modifier/ScoreV2) mod enabled, No Fail no longer halves the score, while Easy and Half Time still do.<!-- reference: https://github.com/ppy/osu/blob/9f227ed28b6c8ba46dfea1f000f778d8b2827ad0/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs#L25-L62. -->
 

--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -69,7 +69,7 @@ The mod divider used to be a divisor applied to `HitPunishment` that depended on
 
 ### Old usage
 
-Previously, difficulty increase mods divided `HitPunishment` before it was subtracted from the bonus, making a 200 or below cost less bonus score than it would without mods. This did not raise the maximum score, because a perfect play kept the bonus at its maximum either way.
+Previously, difficulty increase mods divided `HitPunishment` before it was subtracted from the bonus, making a GOOD or below cost less bonus score than it would without mods. This did not raise the maximum score, because a perfect play kept the bonus at its maximum either way.
 
 | Mod | `ModDivider` |
 | :-- | --: |

--- a/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
+++ b/wiki/Gameplay/Score/ScoreV1/osu!mania/en.md
@@ -13,11 +13,11 @@ In osu!mania, each beatmap has the same maximum total score of 1 million (1,000,
 The score is given in two parts, base score and bonus score, each contributing 50% of total score.
 
 - Base score is based on hit judgement.
-  - A rainbow 300 is worth a bit more than 300.
+  - A PERFECT is worth a bit more than a GREAT.
 - Bonus score is based on hit judgement and a floating bonus multiplier.
-  - The multiplier increases with a rainbow 300 or 300, while it decreases with a 200 or below.
-  - The better judgement, the more multiplier increase/less punishment.
-    - There's an upper limit for the multiplier.
+  - The multiplier increases with a PERFECT or GREAT, while it decreases with a GOOD or below.
+  - The better the judgement, the more the multiplier increases/less punishment.
+    - There is an upper limit for the multiplier.
 
 The score given by each note is calculated with the following formula:
 
@@ -44,6 +44,8 @@ ModDivider = The punishment divider of the selected mods (see below)
 | MEH | 50 | 4 |  | 44 |
 | MISS | 0 | 0 |  | ∞ |
 
+The total score for a play is the sum of scores of all notes in the map, rounded to the nearest integer.
+
 ## Mod multiplier
 
 Difficulty increase mods do not affect the score, so it never exceeds 1,000,000.
@@ -56,7 +58,10 @@ Difficulty increase mods do not affect the score, so it never exceeds 1,000,000.
 
 [Key mods](/wiki/Gameplay/Game_modifier/Summary#xk-mod-score-multipliers), including [Co-op](/wiki/Gameplay/Game_modifier/Co-op), have score multipliers of their own, ranging from 0.66x to 1.00x. They only apply to beatmaps [converted from osu!](/wiki/Beatmap/Converts), and give no penalty on osu!mania-specific beatmaps.
 
+::: alert-notice
+**Notice**
 With the [ScoreV2](/wiki/Gameplay/Game_modifier/ScoreV2) mod enabled, No Fail no longer halves the score, while Easy and Half Time still do.<!-- reference: https://github.com/ppy/osu/blob/9f227ed28b6c8ba46dfea1f000f778d8b2827ad0/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs#L25-L62. -->
+:::
 
 ## Mod divider
 


### PR DESCRIPTION
this does little but makes it more clear that these two are unrelated, and allows us to finally close https://github.com/ppy/osu-wiki/issues/2025 (I think)

two things I would like a bit of help with:
- one confusing thing left is https://osu.ppy.sh/community/forums/posts/7467081 that I found on the forums
- where would the note about ScoreV2 look the best?