### PR TITLE
Fix publication timestamp `Community Mentorship Program Fall 2026 Signups Now Open` news post

### DIFF
--- a/news/2026/2026-08-02-community-mentorship-program-fall-2026-signups-now-open.md
+++ b/news/2026/2026-08-02-community-mentorship-program-fall-2026-signups-now-open.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Community Mentorship Program Fall 2026 Signups Now Open
-date: 2026-08-02 21:00:00 +0000
+date: 2026-08-03 21:00:00 +0000
 series: online_events
 ---
 


### PR DESCRIPTION
i.e. redated because it was merged today instead of yesterday. can't fix the url because the post is already out and has comments