### PR TITLE
[DE] Fix some hatnotes not using new syntax

### DIFF
--- a/wiki/Gameplay/Game_modifier/Mod_multiplier/de.md
+++ b/wiki/Gameplay/Game_modifier/Mod_multiplier/de.md
@@ -14,7 +14,10 @@ outdated_since: 6b1c578abe39d6f2eae6a0585e841a7a75c83dc4
 
 # Mod-Multiplikator
 
-*Nicht zu verwechseln mit: [Combo](/wiki/Gameplay/Combo_(score_multiplier))*\
+::: alert-note
+**Anmerkung:** Nicht zu verwechseln mit [Combo](/wiki/Gameplay/Combo_(score_multiplier))
+:::
+
 ::: alert-note
 **Siehe auch:** [Spielmodifikationen](/wiki/Gameplay/Game_modifier)
 :::

--- a/wiki/Gameplay/Score/de.md
+++ b/wiki/Gameplay/Score/de.md
@@ -1,7 +1,7 @@
 # Punktzahl
 
 ::: alert-note
-**Anmerkung:** Siehe auch [Score (Begriffsabgrenzung)](/wiki/Disambiguation/Score).
+**Anmerkung:** [Score (Begriffsabgrenzung)](/wiki/Disambiguation/Score).
 :::
 
 Die Punktzahl eines Spielers nach dem erfolgreichen Abschluss einer [Beatmap](/wiki/Beatmap) hängt von den [Beurteilungen](/wiki/Gameplay/Judgement), die der Spieler bei jedem [Hit-Objekt](/wiki/Gameplay/Hit_object) erzielt, ab. Allgemein gibt es zwei Hauptversionen des Punktesystems.

--- a/wiki/Gameplay/Score/de.md
+++ b/wiki/Gameplay/Score/de.md
@@ -1,6 +1,8 @@
 # Punktzahl
 
-*Siehe auch [Score (Begriffsabgrenzung)](/wiki/Disambiguation/Score).*
+::: alert-note
+**Anmerkung:** Siehe auch [Score (Begriffsabgrenzung)](/wiki/Disambiguation/Score).
+:::
 
 Die Punktzahl eines Spielers nach dem erfolgreichen Abschluss einer [Beatmap](/wiki/Beatmap) hängt von den [Beurteilungen](/wiki/Gameplay/Judgement), die der Spieler bei jedem [Hit-Objekt](/wiki/Gameplay/Hit_object) erzielt, ab. Allgemein gibt es zwei Hauptversionen des Punktesystems.
 


### PR DESCRIPTION
## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~
