### PR TITLE
[DE/FR/ID/IT/RU/ZH] Add missing article links to `Gameplay/Hit object`

### DIFF
--- a/wiki/Gameplay/Hit_object/de.md
+++ b/wiki/Gameplay/Hit_object/de.md
@@ -1,8 +1,6 @@
 ---
 tags:
   - Hit-Objekte
-outdated_translation: true
-outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 ---
 
 # Hit-Objekt
@@ -11,9 +9,9 @@ outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [Hit-Circles](/wiki/Gameplay/Hit_object/Hit_circle) | Hit-Circles | [Fruits](/wiki/Gameplay/Hit_object/Fruit) | Notes |
-| [Slider](/wiki/Gameplay/Hit_object/Slider) | Drumrolls | [Juice Stream](/wiki/Gameplay/Hit_object/Juice_stream) | Hold-Notes |
-| [Spinner](/wiki/Gameplay/Hit_object/Spinner) | Dendens | [Bananen](/wiki/Gameplay/Hit_object/Banana) | x |
+| [Hit-Circles](/wiki/Gameplay/Hit_object/Hit_circle) | [Don & Kat](/wiki/Gameplay/Hit_object/Hit) | [Fruits](/wiki/Gameplay/Hit_object/Fruit) | [Notes](/wiki/Gameplay/Hit_object/Note) |
+| [Slider](/wiki/Gameplay/Hit_object/Slider) | [Drumrolls](/wiki/Gameplay/Hit_object/Drumroll) | [Juice Stream](/wiki/Gameplay/Hit_object/Juice_stream) | [Hold-Notes](/wiki/Gameplay/Hit_object/Hold_note) |
+| [Spinner](/wiki/Gameplay/Hit_object/Spinner) | [Swells](/wiki/Gameplay/Hit_object/Swell) | [Bananen](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [Hyperfruits](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 
 Aus Programmiersicht sind Hold-Notes in osu!mania nicht gleichzusetzen mit Slidern in osu!, auch wenn sie zur Vereinfachung in dieser Tabelle zusammengefasst wurden. Andere Elemente, mit denen während des Spielens nicht interagiert wird, wie z. B. die Gesundheitsleiste oder die Kiai-Sterne, werden entweder als spielverbessernd oder als Teil der Benutzeroberfläche betrachtet.

--- a/wiki/Gameplay/Hit_object/de.md
+++ b/wiki/Gameplay/Hit_object/de.md
@@ -10,7 +10,7 @@ tags:
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
 | [Hit-Circles](/wiki/Gameplay/Hit_object/Hit_circle) | [Don & Kat](/wiki/Gameplay/Hit_object/Hit) | [Fruits](/wiki/Gameplay/Hit_object/Fruit) | [Notes](/wiki/Gameplay/Hit_object/Note) |
-| [Slider](/wiki/Gameplay/Hit_object/Slider) | [Drumrolls](/wiki/Gameplay/Hit_object/Drumroll) | [Juice Stream](/wiki/Gameplay/Hit_object/Juice_stream) | [Hold-Notes](/wiki/Gameplay/Hit_object/Hold_note) |
+| [Slider](/wiki/Gameplay/Hit_object/Slider) | [Drumrolls](/wiki/Gameplay/Hit_object/Drumroll) | [Juice-Stream](/wiki/Gameplay/Hit_object/Juice_stream) | [Hold-Notes](/wiki/Gameplay/Hit_object/Hold_note) |
 | [Spinner](/wiki/Gameplay/Hit_object/Spinner) | [Swells](/wiki/Gameplay/Hit_object/Swell) | [Bananen](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [Hyperfruits](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 

--- a/wiki/Gameplay/Hit_object/fr.md
+++ b/wiki/Gameplay/Hit_object/fr.md
@@ -2,8 +2,6 @@
 tags:
   - hit objects
   - objets
-outdated_translation: true
-outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 ---
 
 # Objets
@@ -12,9 +10,9 @@ Les *objets* sont des éléments avec lesquels les joueurs peuvent intéragir pe
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [cercles](/wiki/Gameplay/Hit_object/Hit_circle) | cercles | [fruits](/wiki/Gameplay/Hit_object/Fruit) | notes |
-| [sliders](/wiki/Gameplay/Hit_object/Slider) | drumrolls | [juice stream](/wiki/Gameplay/Hit_object/Juice_stream) | hold notes |
-| [spinners](/wiki/Gameplay/Hit_object/Spinner) | dendens | [bananas](/wiki/Gameplay/Hit_object/Banana) | x |
+| [cercles](/wiki/Gameplay/Hit_object/Hit_circle) | [Don & Kat](/wiki/Gameplay/Hit_object/Hit) | [fruits](/wiki/Gameplay/Hit_object/Fruit) | [notes](/wiki/Gameplay/Hit_object/Note) |
+| [sliders](/wiki/Gameplay/Hit_object/Slider) | [drumrolls](/wiki/Gameplay/Hit_object/Drumroll) | [juice stream](/wiki/Gameplay/Hit_object/Juice_stream) | [hold notes](/wiki/Gameplay/Hit_object/Hold_note) |
+| [spinners](/wiki/Gameplay/Hit_object/Spinner) | [swells](/wiki/Gameplay/Hit_object/Swell) | [bananas](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [hyperfruits](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 
 Du point de vue de la programmation, les hold notes dans osu!mania ne sont pas équivalentes aux curseurs dans le mode osu!, bien qu'elles aient été regroupées pour simplifier ce tableau. D'autres éléments avec lesquels on n'interagit pas pendant le jeu, comme la barre de santé ou les kiai stars, sont considérés comme améliorant le jeu ou faisant partie de l'interface utilisateur.

--- a/wiki/Gameplay/Hit_object/id.md
+++ b/wiki/Gameplay/Hit_object/id.md
@@ -2,8 +2,6 @@
 tags:
   - hit objects
   - objek ketukan
-outdated_translation: true
-outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 ---
 
 # Hit object
@@ -12,9 +10,9 @@ outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [hit circle](/wiki/Gameplay/Hit_object/Hit_circle) | hit circle | [fruit](/wiki/Gameplay/Hit_object/Fruit) | note |
-| [slider](/wiki/Gameplay/Hit_object/Slider) | drumroll | [juice stream](/wiki/Gameplay/Hit_object/Juice_stream) | hold note |
-| [spinner](/wiki/Gameplay/Hit_object/Spinner) | denden | [banana](/wiki/Gameplay/Hit_object/Banana) | x |
+| [hit circle](/wiki/Gameplay/Hit_object/Hit_circle) | [Don & Kat](/wiki/Gameplay/Hit_object/Hit) | [fruit](/wiki/Gameplay/Hit_object/Fruit) | [note](/wiki/Gameplay/Hit_object/Note) |
+| [slider](/wiki/Gameplay/Hit_object/Slider) | [drumroll](/wiki/Gameplay/Hit_object/Drumroll) | [juice stream](/wiki/Gameplay/Hit_object/Juice_stream) | [hold note](/wiki/Gameplay/Hit_object/Hold_note) |
+| [spinner](/wiki/Gameplay/Hit_object/Spinner) | [swells](/wiki/Gameplay/Hit_object/Swell) | [banana](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [hyperfruit](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 
 Walaupun hold note pada osu!mania pada dasarnya tidak sama dengan slider pada osu! karena perbedaan perilaku antar keduanya, di sini kami mengkategorikan keduanya sebagai hal yang sama untuk menyederhanakan tabel di atas. Adapun elemen-elemen permainan yang tidak bersifat interaktif seperti *health bar* atau *kiai star* dikategorikan sebagai elemen tambahan atau bagian dari *user interface*.

--- a/wiki/Gameplay/Hit_object/it.md
+++ b/wiki/Gameplay/Hit_object/it.md
@@ -1,8 +1,6 @@
 ---
 tags:
   - hit objects
-outdated_translation: true
-outdated_since: d6c7c0584fb357f15e4cb27909721fed36058c8e
 ---
 
 # Note
@@ -11,9 +9,9 @@ Le *note* sono elementi con cui il giocatore può interagire durante una [beatma
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [cerchi](/wiki/Gameplay/Hit_object/Hit_circle) | cerchi | [frutti](/wiki/Gameplay/Hit_object/Fruit) | note |
-| [sliders](/wiki/Gameplay/Hit_object/Slider) | rullo di tamburi | [fiumi di succo](/wiki/Gameplay/Hit_object/Juice_stream) | note lunghe |
-| [spinner](/wiki/Gameplay/Hit_object/Spinner) | dendens | [banane](/wiki/Gameplay/Hit_object/Banana) | x |
+| [cerchi](/wiki/Gameplay/Hit_object/Hit_circle) | [Don & Kat](/wiki/Gameplay/Hit_object/Hit) | [frutti](/wiki/Gameplay/Hit_object/Fruit) | [note](/wiki/Gameplay/Hit_object/Note) |
+| [sliders](/wiki/Gameplay/Hit_object/Slider) | [rullo di tamburi](/wiki/Gameplay/Hit_object/Drumroll) | [fiumi di succo](/wiki/Gameplay/Hit_object/Juice_stream) | [note lunghe](/wiki/Gameplay/Hit_object/Hold_note) |
+| [spinner](/wiki/Gameplay/Hit_object/Spinner) | [swells](/wiki/Gameplay/Hit_object/Swell) | [banane](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [hyperfruits](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 
 Dal punto di vista della programmazione, le note lunghe in osu!mania non sono uguali agli slider su osu!, anche se in questa tabella sono stati raggruppati insieme per semplificare. Altri elementi con cui non si interagisce durante il gioco, come la barra della salute o le stelle kiai, sono considerati elementi che migliorano il gioco o parte dell'interfaccia utente.

--- a/wiki/Gameplay/Hit_object/ru.md
+++ b/wiki/Gameplay/Hit_object/ru.md
@@ -11,7 +11,7 @@ tags:
 | :-: | :-: | :-: | :-: |
 | [Ноты](/wiki/Gameplay/Hit_object/Hit_circle) (hit circles) | [Дон и кат](/wiki/Gameplay/Hit_object/Hit) | [Фрукты](/wiki/Gameplay/Hit_object/Fruit) (fruits) | [Ноты](/wiki/Gameplay/Hit_object/Note) (notes) |
 | [Слайдеры](/wiki/Gameplay/Hit_object/Slider) (sliders) | [Драмроллы](/wiki/Gameplay/Hit_object/Drumroll) (drumrolls) | [Цепочки фруктов](/wiki/Gameplay/Hit_object/Juice_stream) (fruit trails) | [Холд-ноты](/wiki/Gameplay/Hit_object/Hold_note) (hold notes) |
-| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | [TicClick please help](/wiki/Gameplay/Hit_object/Swell) (swells) | [Бананы](/wiki/Gameplay/Hit_object/Banana) (bananas) | x |
+| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | [Свеллы](/wiki/Gameplay/Hit_object/Swell) (swells) | [Бананы](/wiki/Gameplay/Hit_object/Banana) (bananas) | x |
 | x | x | [Гиперфрукты](/wiki/Gameplay/Hit_object/Hyperfruit) (hyperfruits) | x |
 
 С точки зрения программирования, холд-ноты в osu!mania не эквивалентны слайдерам в osu!standart, хотя они и сопоставлены в этой таблице ради упрощения. Другие элементы, с которыми игрок не взаимодействует во время игры, такие как полоса здоровья или киай, считаются либо модификациями игрового процесса, либо частью пользовательского интерфейса.

--- a/wiki/Gameplay/Hit_object/ru.md
+++ b/wiki/Gameplay/Hit_object/ru.md
@@ -1,8 +1,6 @@
 ---
 tags:
   - hit objects
-outdated_translation: true
-outdated_since: ae529c3d01b7067006ddbf21f2e9eadf2bd19192
 ---
 
 # Игровые объекты
@@ -11,9 +9,9 @@ outdated_since: ae529c3d01b7067006ddbf21f2e9eadf2bd19192
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [Ноты](/wiki/Gameplay/Hit_object/Hit_circle) (hit circles) | [Дон и кат](/wiki/Gameplay/Hit_object/Hit) | Фрукты (fruits) | Ноты (notes) |
-| [Слайдеры](/wiki/Gameplay/Hit_object/Slider) (sliders) | Драмроллы (drumrolls) | Цепочки фруктов (fruit trails) | Холд-ноты (hold notes) |
-| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | dendens | Бананы (bananas) | x |
+| [Ноты](/wiki/Gameplay/Hit_object/Hit_circle) (hit circles) | [Дон и кат](/wiki/Gameplay/Hit_object/Hit) | Фрукты (fruits) | [Ноты](/wiki/Gameplay/Hit_object/Note) (notes) |
+| [Слайдеры](/wiki/Gameplay/Hit_object/Slider) (sliders) | [Драмроллы](/wiki/Gameplay/Hit_object/Drumroll) (drumrolls) | Цепочки фруктов (fruit trails) | [Холд-ноты](/wiki/Gameplay/Hit_object/Hold_note) (hold notes) |
+| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | [TicClick please help](/wiki/Gameplay/Hit_object/Swell) (swells) | Бананы (bananas) | x |
 | x | x | Гиперфрукты (hyperfruits) | x |
 
 С точки зрения программирования, холд-ноты в osu!mania не эквивалентны слайдерам в osu!standart, хотя они и сопоставлены в этой таблице ради упрощения. Другие элементы, с которыми игрок не взаимодействует во время игры, такие как полоса здоровья или киай, считаются либо модификациями игрового процесса, либо частью пользовательского интерфейса.

--- a/wiki/Gameplay/Hit_object/ru.md
+++ b/wiki/Gameplay/Hit_object/ru.md
@@ -9,10 +9,10 @@ tags:
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [Ноты](/wiki/Gameplay/Hit_object/Hit_circle) (hit circles) | [Дон и кат](/wiki/Gameplay/Hit_object/Hit) | Фрукты (fruits) | [Ноты](/wiki/Gameplay/Hit_object/Note) (notes) |
-| [Слайдеры](/wiki/Gameplay/Hit_object/Slider) (sliders) | [Драмроллы](/wiki/Gameplay/Hit_object/Drumroll) (drumrolls) | Цепочки фруктов (fruit trails) | [Холд-ноты](/wiki/Gameplay/Hit_object/Hold_note) (hold notes) |
-| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | [TicClick please help](/wiki/Gameplay/Hit_object/Swell) (swells) | Бананы (bananas) | x |
-| x | x | Гиперфрукты (hyperfruits) | x |
+| [Ноты](/wiki/Gameplay/Hit_object/Hit_circle) (hit circles) | [Дон и кат](/wiki/Gameplay/Hit_object/Hit) | [Фрукты](/wiki/Gameplay/Hit_object/Fruit) (fruits) | [Ноты](/wiki/Gameplay/Hit_object/Note) (notes) |
+| [Слайдеры](/wiki/Gameplay/Hit_object/Slider) (sliders) | [Драмроллы](/wiki/Gameplay/Hit_object/Drumroll) (drumrolls) | [Цепочки фруктов](/wiki/Gameplay/Hit_object/Juice_stream) (fruit trails) | [Холд-ноты](/wiki/Gameplay/Hit_object/Hold_note) (hold notes) |
+| [Спиннеры](/wiki/Gameplay/Hit_object/Spinner) (spinners) | [TicClick please help](/wiki/Gameplay/Hit_object/Swell) (swells) | [Бананы](/wiki/Gameplay/Hit_object/Banana) (bananas) | x |
+| x | x | [Гиперфрукты](/wiki/Gameplay/Hit_object/Hyperfruit) (hyperfruits) | x |
 
 С точки зрения программирования, холд-ноты в osu!mania не эквивалентны слайдерам в osu!standart, хотя они и сопоставлены в этой таблице ради упрощения. Другие элементы, с которыми игрок не взаимодействует во время игры, такие как полоса здоровья или киай, считаются либо модификациями игрового процесса, либо частью пользовательского интерфейса.
 

--- a/wiki/Gameplay/Hit_object/zh.md
+++ b/wiki/Gameplay/Hit_object/zh.md
@@ -3,8 +3,6 @@ tags:
   - hit objects
   - 打击物件
 needs_cleanup: true
-outdated_translation: true
-outdated_since: 28c05eafc4957754b0549d2992bb3802f08b59ff
 ---
 
 # 打击物件
@@ -13,8 +11,8 @@ outdated_since: 28c05eafc4957754b0549d2992bb3802f08b59ff
 
 | [osu!](/wiki/Game_mode/osu!) | [osu!taiko](/wiki/Game_mode/osu!taiko) | [osu!catch](/wiki/Game_mode/osu!catch) | [osu!mania](/wiki/Game_mode/osu!mania) |
 | :-: | :-: | :-: | :-: |
-| [圆圈](/wiki/Gameplay/Hit_object/Hit_circle) | [咚和咔](/wiki/Gameplay/Hit_object/Hit) | [水果](/wiki/Gameplay/Hit_object/Fruit) | 单点音符 |
-| [滑条](/wiki/Gameplay/Hit_object/Slider) | [长条](/wiki/Gameplay/Hit_object/Drumroll) | [水果串](/wiki/Gameplay/Hit_object/Juice_stream) | 长按音符 |
+| [圆圈](/wiki/Gameplay/Hit_object/Hit_circle) | [咚和咔](/wiki/Gameplay/Hit_object/Hit) | [水果](/wiki/Gameplay/Hit_object/Fruit) | [单点音符](/wiki/Gameplay/Hit_object/Note) |
+| [滑条](/wiki/Gameplay/Hit_object/Slider) | [长条](/wiki/Gameplay/Hit_object/Drumroll) | [水果串](/wiki/Gameplay/Hit_object/Juice_stream) | [长按音符](/wiki/Gameplay/Hit_object/Hold_note) |
 | [转盘](/wiki/Gameplay/Hit_object/Spinner) | [转盘](/wiki/Gameplay/Hit_object/Swell) | [香蕉](/wiki/Gameplay/Hit_object/Banana) | x |
 | x | x | [红果](/wiki/Gameplay/Hit_object/Hyperfruit) | x |
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

I updated

- `de`, `fr`, `id`, `it` because they are only missing a few links and most hit object's names don't seem to be translated anyway,
- `zh` because only links are missing,
- `ru` because the hit object's names have already been translated (except for `swells`).
  - I also added missing links to the catch articles which aren't shown in the [diff](https://osu.wiki/status/diff/ae529c3d01b7067006ddbf21f2e9eadf2bd19192/wiki/Gameplay/Hit_object/en.md).

I didn't update

- `es` because it's already up to date,
- `ja` and `zh-tw` because I can't read anything and don't know if any words need to be translated,
- `ko` and `pt` because they are missing way more changes than the other languages.

#### Small todo (for @TicClick probably, thanks in advance)

- [x] Translate `swells` in `ru.md` (line 14) if necessary.

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- ~~*(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)~~