### PR TITLE
Update `Installation on macOS` wiki article to reflect online play status

### DIFF
--- a/wiki/Client/Installation/macOS/en.md
+++ b/wiki/Client/Installation/macOS/en.md
@@ -8,7 +8,7 @@ This page will roughly guide you on installing osu! on your macOS device.
 
 ## Installing osu!
 
-The macOS version of osu! is subject to minor display bugs and less performant gameplay. The game may not function perfectly at first and takes some fine-tuning to get used to. In order to install it, take the following steps:
+The macOS version of osu! is no longer supported for online play, and is subject to minor display bugs and less performant gameplay. The game may not function perfectly at first and takes some fine-tuning to get used to. In order to install it, take the following steps:
 
 1. Go to the [unofficial Wineskin download page](https://osu.ppy.sh/community/forums/topics/1106057), download the latest Wineskin and unzip it.
 2. Download the [unofficial osu!macOS Agent tool](https://osu.ppy.sh/community/forums/topics/1036678) and use it to repair the `osu!.app` file. Alternatively:

--- a/wiki/Client/Installation/macOS/es.md
+++ b/wiki/Client/Installation/macOS/es.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Instalación en macOS
 
 Esta página te guiará de manera sencilla para instalar osu! en tu dispositivo macOS.

--- a/wiki/Client/Installation/macOS/fr.md
+++ b/wiki/Client/Installation/macOS/fr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Installation sur macOS
 
 Cette page vous guidera pour installer osu! sur votre appareil macOS.

--- a/wiki/Client/Installation/macOS/id.md
+++ b/wiki/Client/Installation/macOS/id.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Instalasi pada macOS
 
 Halaman ini akan secara kasar menjelaskan cara untuk memasang osu! pada perangkat macOS milikmu.

--- a/wiki/Client/Installation/macOS/it.md
+++ b/wiki/Client/Installation/macOS/it.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Installazione su macOS
 
 Questa pagina ti guiderà in linea di massima nell'installazione di osu! sul tuo dispositivo macOS.

--- a/wiki/Client/Installation/macOS/ru.md
+++ b/wiki/Client/Installation/macOS/ru.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Установка osu! на macOS
 
 ## Минимальные системные требования

--- a/wiki/Client/Installation/macOS/tr.md
+++ b/wiki/Client/Installation/macOS/tr.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # macOS için kurulum
 
 Bu sayfa size macOS cihazınızda osu!'yu nasıl kuracağınız hakkında size rehberlik edecektir.

--- a/wiki/Client/Installation/macOS/uk.md
+++ b/wiki/Client/Installation/macOS/uk.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Встановлення на macOS
 
 Ця стаття приблизно розкаже вам, як встановити osu! на девайсі під керівництвом macOS.

--- a/wiki/Client/Installation/macOS/vi.md
+++ b/wiki/Client/Installation/macOS/vi.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # Cài đặt trên macOS
 
 Trang này sẽ hướng dẫn bạn đại khái cách cài đặt osu! trên thiết bị macOS của bạn.

--- a/wiki/Client/Installation/macOS/zh-tw.md
+++ b/wiki/Client/Installation/macOS/zh-tw.md
@@ -1,5 +1,6 @@
 ---
-no_native_review: true
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
 ---
 
 # 在 macOS 上安裝

--- a/wiki/Client/Installation/macOS/zh.md
+++ b/wiki/Client/Installation/macOS/zh.md
@@ -1,3 +1,8 @@
+---
+outdated_translation: true
+outdated_since: 54beafba216840adfed39a7224382435c05f119c
+---
+
 # 在 macOS 上安装
 
 这个页面会为你在 macOS 设备上安装 osu! 提供有限的帮助。


### PR DESCRIPTION
As per various user reports online play in osu!(stable) is no longer supported on macOS
this is intentional as per [peppy in the osu!team discord](https://discord.com/channels/90072389919997952/1458129877558497300/1544592275961810994)