### PR TITLE
Make article titles in `History of osu!/...` consistent

### DIFF
--- a/wiki/History_of_osu!/2008/id.md
+++ b/wiki/History_of_osu!/2008/id.md
@@ -1,4 +1,4 @@
-# 2008
+# Sejarah osu! 2008
 
 ![](img/2008.jpg)
 

--- a/wiki/History_of_osu!/2009/id.md
+++ b/wiki/History_of_osu!/2009/id.md
@@ -4,7 +4,7 @@ outdated_translation: true
 outdated_since: 34b7cb6dfd54f38ac8029dedda25de24a78fc30e
 ---
 
-# 2009
+# Sejarah osu! 2009
 
 ## Januari
 

--- a/wiki/History_of_osu!/2010/id.md
+++ b/wiki/History_of_osu!/2010/id.md
@@ -3,4 +3,4 @@ outdated_translation: true
 outdated_since: a5f307a7f4d0c2e9bf5702c0b10298f9c1be8f86
 ---
 
-# 2010
+# Sejarah osu! 2010

--- a/wiki/History_of_osu!/2011/en.md
+++ b/wiki/History_of_osu!/2011/en.md
@@ -2,7 +2,7 @@
 stub: true
 ---
 
-# 2011
+# History of osu! 2011
 
 ## February
 

--- a/wiki/History_of_osu!/2011/id.md
+++ b/wiki/History_of_osu!/2011/id.md
@@ -3,7 +3,7 @@ outdated_translation: true
 outdated_since: 7e141e8221bdddf973c3eb5aabe4c4b2825144c8
 ---
 
-# 2011
+# Sejarah osu! 2011
 
 ## Desember
 

--- a/wiki/History_of_osu!/2011/zh.md
+++ b/wiki/History_of_osu!/2011/zh.md
@@ -3,7 +3,7 @@ no_native_review: true
 stub: true
 ---
 
-# 2011
+# osu! 2011 大事记
 
 ## 二月
 

--- a/wiki/History_of_osu!/2012/id.md
+++ b/wiki/History_of_osu!/2012/id.md
@@ -3,7 +3,7 @@ outdated_translation: true
 outdated_since: fe17f11824c9c95a9ae81ce1cfea1de342428528
 ---
 
-# 2012
+# Sejarah osu! 2012
 
 ## September
 

--- a/wiki/History_of_osu!/2013/id.md
+++ b/wiki/History_of_osu!/2013/id.md
@@ -3,7 +3,7 @@ outdated_translation: true
 outdated_since: d7ceb0a14e3e4b99775b03cedbd0582dd047a3d7
 ---
 
-# 2013
+# Sejarah osu! 2013
 
 ## Januari
 

--- a/wiki/History_of_osu!/2015/id.md
+++ b/wiki/History_of_osu!/2015/id.md
@@ -2,7 +2,7 @@
 outdated_translation: true
 ---
 
-# 2015
+# Sejarah osu! 2015
 
 ## Maret
 

--- a/wiki/History_of_osu!/2023/en.md
+++ b/wiki/History_of_osu!/2023/en.md
@@ -1,4 +1,4 @@
-# 2023
+# History of osu! 2023
 
 ## January
 

--- a/wiki/History_of_osu!/2023/fr.md
+++ b/wiki/History_of_osu!/2023/fr.md
@@ -1,4 +1,4 @@
-# 2023
+# L'histoire d'osu! en 2023
 
 ## Janvier
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

The article title is usually `History of osu! <year>` but for some reason in some years it's just `<year>`. Occasionally, there are also inconsistencies between English and translations.

<img width="684" height="152" alt="image" src="https://github.com/user-attachments/assets/4e7e9281-ad28-4386-bf6d-e7acbb743b59" />

vs.

<img width="686" height="200" alt="image" src="https://github.com/user-attachments/assets/7dfaca5d-6333-49c6-9ae1-adabbd0fa563" />

The first one looks much better to me (and is used is the majority of these articles).

DO_NOT_OUTDATE: *

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
