### PR TITLE
Add query strings to mod icons in lazer mods articles

### DIFF
--- a/wiki/Gameplay/Game_modifier/Accuracy_Challenge/en.md
+++ b/wiki/Gameplay/Game_modifier/Accuracy_Challenge/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Accuracy Challenge
 
-![Accuracy Challenge mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png)
+![Accuracy Challenge mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png?1)
 
 *Fail if your accuracy drops too low!*
 

--- a/wiki/Gameplay/Game_modifier/Accuracy_Challenge/es.md
+++ b/wiki/Gameplay/Game_modifier/Accuracy_Challenge/es.md
@@ -15,7 +15,7 @@ tags:
 
 #### Accuracy Challenge
 
-![Icono del mod Accuracy Challenge](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png)
+![Icono del mod Accuracy Challenge](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png?1)
 
 *¡Pierdes si tu precisión baja demasiado!*
 

--- a/wiki/Gameplay/Game_modifier/Accuracy_Challenge/zh.md
+++ b/wiki/Gameplay/Game_modifier/Accuracy_Challenge/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Accuracy Challenge
 
-![Accuracy Challenge 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png)
+![Accuracy Challenge 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AC.png?1)
 
 *准度过低即失败！*
 

--- a/wiki/Gameplay/Game_modifier/Adaptive_Speed/en.md
+++ b/wiki/Gameplay/Game_modifier/Adaptive_Speed/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Adaptive Speed
 
-![Adaptive Speed mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png)
+![Adaptive Speed mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png?1)
 
 *Let track speed adapt to you.*
 

--- a/wiki/Gameplay/Game_modifier/Adaptive_Speed/es.md
+++ b/wiki/Gameplay/Game_modifier/Adaptive_Speed/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Adaptive Speed
 
-![Icono del mod Adaptive Speed](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png)
+![Icono del mod Adaptive Speed](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png?1)
 
 *Deja que la velocidad de la pista se adapte a ti.*
 

--- a/wiki/Gameplay/Game_modifier/Adaptive_Speed/zh.md
+++ b/wiki/Gameplay/Game_modifier/Adaptive_Speed/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Adaptive Speed
 
-![Adaptive Speed 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png)
+![Adaptive Speed 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AS.png?1)
 
 *让曲速适应你。*
 

--- a/wiki/Gameplay/Game_modifier/Alternate/en.md
+++ b/wiki/Gameplay/Game_modifier/Alternate/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Alternate
 
-![Alternate mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png)
+![Alternate mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png?1)
 
 *Don't use the same key twice in a row!*
 

--- a/wiki/Gameplay/Game_modifier/Alternate/es.md
+++ b/wiki/Gameplay/Game_modifier/Alternate/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Alternate
 
-![Icono del mod Alternate](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png)
+![Icono del mod Alternate](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png?1)
 
 *¡No uses la misma tecla dos veces seguidas!*
 

--- a/wiki/Gameplay/Game_modifier/Alternate/zh.md
+++ b/wiki/Gameplay/Game_modifier/Alternate/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Alternate
 
-![Alternate 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png)
+![Alternate 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AL.png?1)
 
 *不要连按同一个键！*
 

--- a/wiki/Gameplay/Game_modifier/Approach_Different/en.md
+++ b/wiki/Gameplay/Game_modifier/Approach_Different/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Approach Different
 
-![Approach Different mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png)
+![Approach Different mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png?1)
 
 *Never trust the approach circles...*
 

--- a/wiki/Gameplay/Game_modifier/Approach_Different/es.md
+++ b/wiki/Gameplay/Game_modifier/Approach_Different/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Approach Different
 
-![Icono del mod Approach Different](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png)
+![Icono del mod Approach Different](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png?1)
 
 *No confíes en los círculos de aproximación...*
 

--- a/wiki/Gameplay/Game_modifier/Approach_Different/zh.md
+++ b/wiki/Gameplay/Game_modifier/Approach_Different/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Approach Different
 
-![Approach Different 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png)
+![Approach Different 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AD.png?1)
 
 *永远别相信缩圈...*
 

--- a/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Autopilot
 
-![Autopilot mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png)
+![Autopilot mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png?1)
 
 *Automatic cursor movement - just follow the rhythm.*
 

--- a/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/es.md
@@ -14,7 +14,7 @@ tags:
 
 #### Autopilot
 
-![Icono del mod Autopilot](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png)
+![Icono del mod Autopilot](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png?1)
 
 *Movimiento automático del cursor; solo tienes que seguir el ritmo.*
 

--- a/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Autopilot_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Autopilot
 
-![Autopilot 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png)
+![Autopilot 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AP.png?1)
 
 *光标会自动移动，跟着节奏点就好。*
 

--- a/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/en.md
@@ -14,7 +14,7 @@ tags:
 
 #### Autoplay
 
-![Autoplay mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png)
+![Autoplay mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png?1)
 
 *Watch a perfect automated play through the song.*
 

--- a/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/es.md
@@ -15,7 +15,7 @@ tags:
 
 #### Autoplay
 
-![Icono del mod Autoplay](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png)
+![Icono del mod Autoplay](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png?1)
 
 *Visualiza una jugada automática perfecta de la canción.*
 

--- a/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Autoplay_(lazer)/zh.md
@@ -14,7 +14,7 @@ tags:
 
 #### Autoplay
 
-![Autoplay 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png)
+![Autoplay 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/AT.png?1)
 
 *来看看精彩绝伦的自动表演。*
 

--- a/wiki/Gameplay/Game_modifier/Barrel_Roll/en.md
+++ b/wiki/Gameplay/Game_modifier/Barrel_Roll/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Barrel Roll
 
-![Barrel Roll mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png)
+![Barrel Roll mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png?1)
 
 *The whole playfield is on a wheel!*
 

--- a/wiki/Gameplay/Game_modifier/Barrel_Roll/es.md
+++ b/wiki/Gameplay/Game_modifier/Barrel_Roll/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Barrel Roll
 
-![Icono del mod Barrel Roll](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png)
+![Icono del mod Barrel Roll](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png?1)
 
 *¡Todo el campo de juego está sobre una rueda!*
 

--- a/wiki/Gameplay/Game_modifier/Barrel_Roll/zh.md
+++ b/wiki/Gameplay/Game_modifier/Barrel_Roll/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Barrel Roll
 
-![Barrel Roll 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png)
+![Barrel Roll 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BR.png?1)
 
 *整个游玩区域都转起来了！*
 

--- a/wiki/Gameplay/Game_modifier/Blinds/en.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Blinds
 
-![Blinds mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png)
+![Blinds mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png?1)
 
 *Play with blinds on your screen.*
 

--- a/wiki/Gameplay/Game_modifier/Blinds/es.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Blinds
 
-![Icono del mod Blinds](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png)
+![Icono del mod Blinds](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png?1)
 
 *Juega con persianas en tu pantalla.*
 

--- a/wiki/Gameplay/Game_modifier/Blinds/zh.md
+++ b/wiki/Gameplay/Game_modifier/Blinds/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Blinds
 
-![Blinds 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png)
+![Blinds 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BL.png?1)
 
 *在屏幕上添加盲区。*
 

--- a/wiki/Gameplay/Game_modifier/Bloom/en.md
+++ b/wiki/Gameplay/Game_modifier/Bloom/en.md
@@ -11,7 +11,7 @@ tags:
 
 #### Bloom
 
-![Bloom mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png)
+![Bloom mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png?1)
 
 *The cursor blooms into.. a larger cursor!*
 

--- a/wiki/Gameplay/Game_modifier/Bloom/es.md
+++ b/wiki/Gameplay/Game_modifier/Bloom/es.md
@@ -11,7 +11,7 @@ tags:
 
 #### Bloom
 
-![Icono del mod Bloom](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png)
+![Icono del mod Bloom](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png?1)
 
 *El cursor se convierte en... ¡un cursor más grande!*
 

--- a/wiki/Gameplay/Game_modifier/Bloom/zh.md
+++ b/wiki/Gameplay/Game_modifier/Bloom/zh.md
@@ -11,7 +11,7 @@ tags:
 
 #### Bloom
 
-![Bloom 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png)
+![Bloom 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BM.png?1)
 
 *光标开花了...更大的光标！*
 

--- a/wiki/Gameplay/Game_modifier/Bubbles/en.md
+++ b/wiki/Gameplay/Game_modifier/Bubbles/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Bubbles
 
-![Bubbles mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png)
+![Bubbles mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png?1)
 
 *Don't let their popping distract you!*
 

--- a/wiki/Gameplay/Game_modifier/Bubbles/es.md
+++ b/wiki/Gameplay/Game_modifier/Bubbles/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Bubbles
 
-![Icono del mod Bubbles](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png)
+![Icono del mod Bubbles](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png?1)
 
 *¡No dejes que los estallidos te distraigan!*
 

--- a/wiki/Gameplay/Game_modifier/Bubbles/zh.md
+++ b/wiki/Gameplay/Game_modifier/Bubbles/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Bubbles
 
-![Bubbles 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png)
+![Bubbles 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/BU.png?1)
 
 *别被爆开的它们分了心！*
 

--- a/wiki/Gameplay/Game_modifier/Cinema_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Cinema_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cinema
 
-![Cinema mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png)
+![Cinema mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png?1)
 
 *Watch the video without visual distractions.*
 

--- a/wiki/Gameplay/Game_modifier/Cinema_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Cinema_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cinema
 
-![Icono del mod Cinema](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png)
+![Icono del mod Cinema](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png?1)
 
 *Reproduce el vídeo sin distracciones visuales.*
 

--- a/wiki/Gameplay/Game_modifier/Cinema_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Cinema_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cinema
 
-![Cinema 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png)
+![Cinema 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CN.png?1)
 
 *专心看视频，没有其他东西干扰。*
 

--- a/wiki/Gameplay/Game_modifier/Classic/en.md
+++ b/wiki/Gameplay/Game_modifier/Classic/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Classic
 
-![Classic mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png)
+![Classic mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png?1)
 
 *Feeling nostalgic?*
 

--- a/wiki/Gameplay/Game_modifier/Classic/es.md
+++ b/wiki/Gameplay/Game_modifier/Classic/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Classic
 
-![Icono del mod Classic](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png)
+![Icono del mod Classic](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png?1)
 
 *¿Te sientes nostálgico?*
 

--- a/wiki/Gameplay/Game_modifier/Classic/zh.md
+++ b/wiki/Gameplay/Game_modifier/Classic/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Classic
 
-![Classic 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png)
+![Classic 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CL.png?1)
 
 *想 Stable 了嘛？*
 

--- a/wiki/Gameplay/Game_modifier/Constant_Speed/en.md
+++ b/wiki/Gameplay/Game_modifier/Constant_Speed/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Constant Speed
 
-![Constant Speed mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png)
+![Constant Speed mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png?1)
 
 *No more tricky speed changes!*
 

--- a/wiki/Gameplay/Game_modifier/Constant_Speed/es.md
+++ b/wiki/Gameplay/Game_modifier/Constant_Speed/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Constant Speed
 
-![Icono del mod Constant Speed](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png)
+![Icono del mod Constant Speed](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png?1)
 
 *¡Olvídate de los complicados cambios de velocidad!*
 

--- a/wiki/Gameplay/Game_modifier/Constant_Speed/zh.md
+++ b/wiki/Gameplay/Game_modifier/Constant_Speed/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Constant Speed
 
-![Constant Speed 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png)
+![Constant Speed 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CS.png?1)
 
 *棘手的变速不存在了！*
 

--- a/wiki/Gameplay/Game_modifier/Cover/en.md
+++ b/wiki/Gameplay/Game_modifier/Cover/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cover
 
-![Cover mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png)
+![Cover mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png?1)
 
 *Decrease the playfield's viewing area.*
 

--- a/wiki/Gameplay/Game_modifier/Cover/es.md
+++ b/wiki/Gameplay/Game_modifier/Cover/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cover
 
-![Icono del mod Cover](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png)
+![Icono del mod Cover](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png?1)
 
 *Reduce el área de visión del campo de juego.*
 

--- a/wiki/Gameplay/Game_modifier/Cover/zh.md
+++ b/wiki/Gameplay/Game_modifier/Cover/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Cover
 
-![Cover 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png)
+![Cover 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/CO.png?1)
 
 *缩小游玩区域的可见范围。*
 

--- a/wiki/Gameplay/Game_modifier/Daycore/en.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Daycore
 
-![Daycore mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png)
+![Daycore mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png?1)
 
 *Whoaaaaa...*
 

--- a/wiki/Gameplay/Game_modifier/Daycore/es.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Daycore
 
-![Icono del mod Daycore](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png)
+![Icono del mod Daycore](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png?1)
 
 *Vaya...*
 

--- a/wiki/Gameplay/Game_modifier/Daycore/zh.md
+++ b/wiki/Gameplay/Game_modifier/Daycore/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Daycore
 
-![Daycore 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png)
+![Daycore 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DC.png?1)
 
 *呜啊啊...*
 

--- a/wiki/Gameplay/Game_modifier/Deflate/en.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Deflate
 
-![Deflate mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png)
+![Deflate mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png?1)
 
 *Hit them at the right size!*
 

--- a/wiki/Gameplay/Game_modifier/Deflate/es.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Deflate
 
-![Icono del mod Deflate](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png)
+![Icono del mod Deflate](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png?1)
 
 *¡Dales el tamaño adecuado!*
 

--- a/wiki/Gameplay/Game_modifier/Deflate/zh.md
+++ b/wiki/Gameplay/Game_modifier/Deflate/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Deflate
 
-![Deflate 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png)
+![Deflate 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DF.png?1)
 
 *在大小正好的时候点击它们！*
 

--- a/wiki/Gameplay/Game_modifier/Depth/en.md
+++ b/wiki/Gameplay/Game_modifier/Depth/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Depth
 
-![Depth mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png)
+![Depth mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png?1)
 
 *3D. Almost.*
 

--- a/wiki/Gameplay/Game_modifier/Depth/es.md
+++ b/wiki/Gameplay/Game_modifier/Depth/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Depth
 
-![Icono del mod Depth](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png)
+![Icono del mod Depth](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png?1)
 
 *3D. Casi.*
 

--- a/wiki/Gameplay/Game_modifier/Depth/zh.md
+++ b/wiki/Gameplay/Game_modifier/Depth/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Depth
 
-![Depth 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png)
+![Depth 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DP.png?1)
 
 *3D。基本上如此。*
 

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Difficulty Adjust
 
-![Difficulty Adjust mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png)
+![Difficulty Adjust mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png?1)
 
 *Override a beatmap's difficulty settings.*
 

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/es.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Difficulty Adjust
 
-![Icono del mod Difficulty Adjust](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png)
+![Icono del mod Difficulty Adjust](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png?1)
 
 *Modifica los ajustes de dificultad de un beatmap.*
 

--- a/wiki/Gameplay/Game_modifier/Difficulty_Adjust/zh.md
+++ b/wiki/Gameplay/Game_modifier/Difficulty_Adjust/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Difficulty Adjust
 
-![Difficulty Adjust 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png)
+![Difficulty Adjust 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DA.png?1)
 
 *覆写谱面的难度设定。*
 

--- a/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Double Time
 
-![Double Time mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png)
+![Double Time mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png?1)
 
 *Zoooooooooom...*
 

--- a/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/es.md
@@ -17,7 +17,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Double Time
 
-![Icono del mod Double Time](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png)
+![Icono del mod Double Time](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png?1)
 
 *Zoooooooooom...*
 

--- a/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Double_Time_(lazer)/zh.md
@@ -15,7 +15,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Double Time
 
-![Double Time 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png)
+![Double Time 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DT.png?1)
 
 *加>>>>>>>>>>>速...*
 

--- a/wiki/Gameplay/Game_modifier/Dual_Stages/en.md
+++ b/wiki/Gameplay/Game_modifier/Dual_Stages/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Dual Stages
 
-![Dual Stages mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DS.png)
+![Dual Stages mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DS.png?1)
 
 *Double the stages, double the fun!*
 

--- a/wiki/Gameplay/Game_modifier/Dual_Stages/zh.md
+++ b/wiki/Gameplay/Game_modifier/Dual_Stages/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Dual Stages
 
-![Dual Stages 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DS.png)
+![Dual Stages 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/DS.png?1)
 
 *双重舞台，双倍乐趣！*
 

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Easy
 
-![Easy mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png)
+![Easy mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png?1)
 
 *![][osu!] Larger circles, more forgiving HP drain, less accuracy required, and extra lives!*\
 *![][osu!taiko] Beats move slower, and less accuracy required!*\

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Easy
 
-![Icono del mod Easy](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png)
+![Icono del mod Easy](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png?1)
 
 *![][osu!]: Círculos más grandes, menor drenaje de HP, menor precisión requerida, ¡y vidas extra!*\
 *![][osu!taiko]: ¡Las notas se moverán más despacio y la precisión requerida será menor!*\

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/fr.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/fr.md
@@ -15,7 +15,7 @@ outdated_since: 8845b6ba9a974f01fcbb7dfa9bfa4df092585c48
 
 #### Easy
 
-![Icône du mod Easy](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png)
+![Icône du mod Easy](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png?1)
 
 *![][osu!] Cercles plus larges, barre de vie plus indulgente, moins de précision nécessaire, et deux vies supplémentaires !*\
 *![][osu!taiko] Les notes arrivent plus lentement, et moins de précision nécessaire !*\

--- a/wiki/Gameplay/Game_modifier/Easy_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Easy_(lazer)/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Easy
 
-![Easy 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png)
+![Easy 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/EZ.png?1)
 
 *![][osu!] 更大的圈，掉血更慢，准度要求更低，还有三条命！*\
 *![][osu!taiko] 物件移动变慢，准度要求更低！*\

--- a/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Fade In
 
-![Fade In mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png)
+![Fade In mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png?1)
 
 *Keys appear out of nowhere!*
 

--- a/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/es.md
@@ -14,7 +14,7 @@ tags:
 
 #### Fade In
 
-![Icono del mod Fade In](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png)
+![Icono del mod Fade In](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png?1)
 
 *¡Las notas aparecen de la nada!*
 

--- a/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Fade_In_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Fade In
 
-![Fade In 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png)
+![Fade In 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FI.png?1)
 
 *按键凭空出现！*
 

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Flashlight
 
-![Flashlight mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png)
+![Flashlight mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png?1)
 
 *Restricted view area.*
 

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/es.md
@@ -16,7 +16,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Flashlight
 
-![Icono del mod Flashlight](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png)
+![Icono del mod Flashlight](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png?1)
 
 *Reduce el área de visión.*
 

--- a/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Flashlight_(lazer)/zh.md
@@ -16,7 +16,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Flashlight
 
-![Flashlight 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png)
+![Flashlight 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FL.png?1)
 
 *限制视野。*
 

--- a/wiki/Gameplay/Game_modifier/Floating_Fruits/en.md
+++ b/wiki/Gameplay/Game_modifier/Floating_Fruits/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Floating Fruits
 
-![Floating Fruits mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png)
+![Floating Fruits mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png?1)
 
 *The fruits are... floating?*
 

--- a/wiki/Gameplay/Game_modifier/Floating_Fruits/es.md
+++ b/wiki/Gameplay/Game_modifier/Floating_Fruits/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Floating Fruits
 
-![Icono del mod Floating Fruits](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png)
+![Icono del mod Floating Fruits](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png?1)
 
 *Las frutas están... ¿flotando?*
 

--- a/wiki/Gameplay/Game_modifier/Floating_Fruits/zh.md
+++ b/wiki/Gameplay/Game_modifier/Floating_Fruits/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Floating Fruits
 
-![Floating Fruits 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png)
+![Floating Fruits 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FF.png?1)
 
 *水果在...飘浮？*
 

--- a/wiki/Gameplay/Game_modifier/Freeze_Frame/en.md
+++ b/wiki/Gameplay/Game_modifier/Freeze_Frame/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Freeze Frame
 
-![Freeze Frame mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png)
+![Freeze Frame mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png?1)
 
 *Burn the notes into your memory.*
 

--- a/wiki/Gameplay/Game_modifier/Freeze_Frame/es.md
+++ b/wiki/Gameplay/Game_modifier/Freeze_Frame/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Freeze Frame
 
-![Icono del mod Freeze Frame](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png)
+![Icono del mod Freeze Frame](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png?1)
 
 *Graba las notas en tu memoria.*
 

--- a/wiki/Gameplay/Game_modifier/Freeze_Frame/zh.md
+++ b/wiki/Gameplay/Game_modifier/Freeze_Frame/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Freeze Frame
 
-![Freeze Frame 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png)
+![Freeze Frame 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/FR.png?1)
 
 *牢牢记住这些物件。*
 

--- a/wiki/Gameplay/Game_modifier/Grow/en.md
+++ b/wiki/Gameplay/Game_modifier/Grow/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Grow
 
-![Grow mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png)
+![Grow mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png?1)
 
 *Hit them at the right size!*
 

--- a/wiki/Gameplay/Game_modifier/Grow/es.md
+++ b/wiki/Gameplay/Game_modifier/Grow/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Grow
 
-![Icono del mod Grow](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png)
+![Icono del mod Grow](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png?1)
 
 *¡Pulsa los objetos en el tamaño adecuado!*
 

--- a/wiki/Gameplay/Game_modifier/Grow/zh.md
+++ b/wiki/Gameplay/Game_modifier/Grow/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Grow
 
-![Grow 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png)
+![Grow 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/GR.png?1)
 
 *在大小正好的时候点击它们！*
 

--- a/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Half Time
 
-![Half Time mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png)
+![Half Time mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png?1)
 
 *Less zoom...*
 

--- a/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/es.md
@@ -16,7 +16,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Half Time
 
-![Icono del mod Half Time](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png)
+![Icono del mod Half Time](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png?1)
 
 *Menos zoom...*
 

--- a/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Half_Time_(lazer)/zh.md
@@ -15,7 +15,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Half Time
 
-![Half Time 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png)
+![Half Time 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HT.png?1)
 
 *减<<<<<<速...*
 

--- a/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Hard Rock
 
-![Hard Rock mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png)
+![Hard Rock mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png?1)
 
 *Everything just got a bit harder...*
 

--- a/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### Hard Rock
 
-![Icono del mod Hard Rock](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png)
+![Icono del mod Hard Rock](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png?1)
 
 *Todo se vuelve un poco más difícil...*
 

--- a/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Hard_Rock_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Hard Rock
 
-![Hard Rock 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png)
+![Hard Rock 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HR.png?1)
 
 *各方面的难度都增加一点...*
 

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Hidden
 
-![Hidden mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png)
+![Hidden mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png?1)
 
 *![][osu!] Play with no approach circles and fading circles/sliders.*\
 *![][osu!taiko] Beats fade out before you hit them!*\

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Hidden
 
-![Icono del mod Hidden](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png)
+![Icono del mod Hidden](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png?1)
 
 *![][osu!] Juega sin círculos de aproximación y con círculos/sliders que desaparecen.*\
 *![][osu!taiko] ¡Las notas desaparecen antes de que las pulses!*\

--- a/wiki/Gameplay/Game_modifier/Hidden_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Hidden_(lazer)/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Hidden
 
-![Hidden 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png)
+![Hidden 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HD.png?1)
 
 *![][osu!] 没有缩圈，圆圈与滑条渐隐。*\
 *![][osu!taiko] 物件会在击打之前渐渐隐藏！*\

--- a/wiki/Gameplay/Game_modifier/Hold_Off/en.md
+++ b/wiki/Gameplay/Game_modifier/Hold_Off/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Hold Off
 
-![Hold Off mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png)
+![Hold Off mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png?1)
 
 *Replaces all hold notes with normal notes.*
 

--- a/wiki/Gameplay/Game_modifier/Hold_Off/es.md
+++ b/wiki/Gameplay/Game_modifier/Hold_Off/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Hold Off
 
-![Icono del mod Hold Off](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png)
+![Icono del mod Hold Off](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png?1)
 
 *Reemplaza todas las notas largas por notas normales.*
 

--- a/wiki/Gameplay/Game_modifier/Hold_Off/zh.md
+++ b/wiki/Gameplay/Game_modifier/Hold_Off/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Hold Off
 
-![Hold Off 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png)
+![Hold Off 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/HO.png?1)
 
 *把面条都换成单点音符。*
 

--- a/wiki/Gameplay/Game_modifier/Invert/en.md
+++ b/wiki/Gameplay/Game_modifier/Invert/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Invert
 
-![Invert mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png)
+![Invert mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png?1)
 
 *Hold the keys. To the beat.*
 

--- a/wiki/Gameplay/Game_modifier/Invert/es.md
+++ b/wiki/Gameplay/Game_modifier/Invert/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Invert
 
-![Icono del mod Invert](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png).
+![Icono del mod Invert](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png?1).
 
 *Mantén las notas. Al ritmo de la música.*
 

--- a/wiki/Gameplay/Game_modifier/Invert/zh.md
+++ b/wiki/Gameplay/Game_modifier/Invert/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Invert
 
-![Invert 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png)
+![Invert 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/IN.png?1)
 
 *跟着节拍。按住按键。*
 

--- a/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/en.md
@@ -24,7 +24,7 @@ tags:
 
 #### 1K, 2K, 3K, 4K, 5K, 6K, 7K, 8K, 9K, 10K
 
-![7K mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png)
+![7K mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png?1)
 
 *Play with \[key count\] keys.*
 

--- a/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/es.md
@@ -28,7 +28,7 @@ tags:
 
 #### 1K, 2K, 3K, 4K, 5K, 6K, 7K, 8K, 9K, 10K
 
-![Icono del mod 7K](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png)
+![Icono del mod 7K](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png?1)
 
 *Juega con el \[número de teclas\] que quieras.*
 

--- a/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Key_mods_(lazer)/zh.md
@@ -24,7 +24,7 @@ tags:
 
 #### 1K, 2K, 3K, 4K, 5K, 6K, 7K, 8K, 9K, 10K
 
-![7K 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png)
+![7K 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/7K.png?1)
 
 *用 \[按键数\] 个按键来玩。*
 

--- a/wiki/Gameplay/Game_modifier/Magnetised/en.md
+++ b/wiki/Gameplay/Game_modifier/Magnetised/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Magnetised
 
-![Magnetised mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png)
+![Magnetised mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png?1)
 
 *No need to chase the circles — your cursor is a magnet!*
 

--- a/wiki/Gameplay/Game_modifier/Magnetised/es.md
+++ b/wiki/Gameplay/Game_modifier/Magnetised/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Magnetised
 
-![Icono del mod Magnetised](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png)
+![Icono del mod Magnetised](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png?1)
 
 *No hace falta que persigas a los círculos; ¡tu cursor es un imán!*
 

--- a/wiki/Gameplay/Game_modifier/Magnetised/zh.md
+++ b/wiki/Gameplay/Game_modifier/Magnetised/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Magnetised
 
-![Magnetised 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png)
+![Magnetised 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MG.png?1)
 
 *不必追着圈跑了——你的光标就是磁铁！*
 

--- a/wiki/Gameplay/Game_modifier/Mirror_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Mirror_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Mirror
 
-![Mirror mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png)
+![Mirror mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png?1)
 
 *![][osu!]: Flip objects on the chosen axes.*\
 *![][osu!catch]: Fruits are flipped horizontally.*\

--- a/wiki/Gameplay/Game_modifier/Mirror_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Mirror_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Mirror
 
-![Icono del mod Mirror](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png)
+![Icono del mod Mirror](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png?1)
 
 *![][osu!]: Invierte los objetos en los ejes elegidos.*\
 *![][osu!catch]: Las frutas se invierten horizontalmente.*\

--- a/wiki/Gameplay/Game_modifier/Mirror_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Mirror_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Mirror
 
-![Mirror 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png)
+![Mirror 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MR.png?1)
 
 *![][osu!]: 物件绕所选轴翻转。*\
 *![][osu!catch]: 水果左右翻转。*\

--- a/wiki/Gameplay/Game_modifier/Moving_Fast/en.md
+++ b/wiki/Gameplay/Game_modifier/Moving_Fast/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Moving Fast
 
-![Moving Fast mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MF.png)
+![Moving Fast mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MF.png?1)
 
 *Dashing by default, slow down!*
 

--- a/wiki/Gameplay/Game_modifier/Moving_Fast/zh.md
+++ b/wiki/Gameplay/Game_modifier/Moving_Fast/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Moving Fast
 
-![Moving Fast 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MF.png)
+![Moving Fast 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MF.png?1)
 
 *一直冲也要慢一点！*
 

--- a/wiki/Gameplay/Game_modifier/Muted/en.md
+++ b/wiki/Gameplay/Game_modifier/Muted/en.md
@@ -11,7 +11,7 @@ tags:
 
 #### Muted
 
-![Muted mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png)
+![Muted mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png?1)
 
 *Can you still feel the rhythm without music?*
 

--- a/wiki/Gameplay/Game_modifier/Muted/es.md
+++ b/wiki/Gameplay/Game_modifier/Muted/es.md
@@ -11,7 +11,7 @@ tags:
 
 #### Muted
 
-![Icono del mod Muted](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png)
+![Icono del mod Muted](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png?1)
 
 *¿Puedes mantener el ritmo sin música?*
 

--- a/wiki/Gameplay/Game_modifier/Muted/zh.md
+++ b/wiki/Gameplay/Game_modifier/Muted/zh.md
@@ -11,7 +11,7 @@ tags:
 
 #### Muted
 
-![Muted 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png)
+![Muted 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/MU.png?1)
 
 *没有音乐，你还能感知到节奏吗？*
 

--- a/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Nightcore
 
-![Nightcore mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png)
+![Nightcore mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png?1)
 
 *Uguuuuuuuu...*
 

--- a/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Nightcore
 
-![Icono del mod Nightcore](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png)
+![Icono del mod Nightcore](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png?1)
 
 *Uguuuuuuuu...*
 

--- a/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Nightcore_(lazer)/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Nightcore
 
-![Nightcore 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png)
+![Nightcore 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NC.png?1)
 
 *洞次打次洞次打次...*
 

--- a/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### No Fail
 
-![No Fail mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png)
+![No Fail mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png?1)
 
 *You can't fail, no matter what.*
 

--- a/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### No Fail
 
-![Icono del mod No Fail](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png)
+![Icono del mod No Fail](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png?1)
 
 *No podrás perder, sin importar lo que hagas.*
 

--- a/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/No_Fail_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### No Fail
 
-![No Fail 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png)
+![No Fail 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NF.png?1)
 
 *不管怎么样，你都失败不了。*
 

--- a/wiki/Gameplay/Game_modifier/No_Release/en.md
+++ b/wiki/Gameplay/Game_modifier/No_Release/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Release
 
-![No Release mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png)
+![No Release mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png?1)
 
 *No more timing the end of hold notes.*
 

--- a/wiki/Gameplay/Game_modifier/No_Release/es.md
+++ b/wiki/Gameplay/Game_modifier/No_Release/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Release
 
-![Icono del mod No Release](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png)
+![Icono del mod No Release](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png?1)
 
 *Olvídate de calcular el momento en el que debes soltar las notas largas.*
 

--- a/wiki/Gameplay/Game_modifier/No_Release/zh.md
+++ b/wiki/Gameplay/Game_modifier/No_Release/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Release
 
-![No Release 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png)
+![No Release 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NR.png?1)
 
 *不用再考虑面条松开的时机了。*
 

--- a/wiki/Gameplay/Game_modifier/No_Scope/en.md
+++ b/wiki/Gameplay/Game_modifier/No_Scope/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Scope
 
-![No Scope mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png)
+![No Scope mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png?1)
 
 *![][osu!]: Where's the cursor?*\
 *![][osu!catch]: Where's the catcher?*

--- a/wiki/Gameplay/Game_modifier/No_Scope/es.md
+++ b/wiki/Gameplay/Game_modifier/No_Scope/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Scope
 
-![Icono del mod No Scope](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png)
+![Icono del mod No Scope](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png?1)
 
 *![][osu!]: ¿Dónde está el cursor?*\
 *![][osu!catch]: ¿Dónde está el catcher?*

--- a/wiki/Gameplay/Game_modifier/No_Scope/zh.md
+++ b/wiki/Gameplay/Game_modifier/No_Scope/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### No Scope
 
-![No Scope 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png)
+![No Scope 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/NS.png?1)
 
 *![][osu!]: 光标到哪去了？*\
 *![][osu!catch]: 小人到哪去了？*

--- a/wiki/Gameplay/Game_modifier/Perfect_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Perfect_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Perfect
 
-![Perfect mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png)
+![Perfect mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png?1)
 
 *SS or quit.*
 

--- a/wiki/Gameplay/Game_modifier/Perfect_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Perfect_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Perfect
 
-![Icono del mod Perfect](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png)
+![Icono del mod Perfect](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png?1)
 
 *SS o nada.*
 

--- a/wiki/Gameplay/Game_modifier/Perfect_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Perfect_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Perfect
 
-![Perfect 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png)
+![Perfect 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/PF.png?1)
 
 *不 SS，便失败。*
 

--- a/wiki/Gameplay/Game_modifier/Random_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Random_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Random
 
-![Random mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png)
+![Random mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png?1)
 
 *![][osu!]: It never gets boring!*\
 *![][osu!taiko]: Shuffle around the colours!*\

--- a/wiki/Gameplay/Game_modifier/Random_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Random_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Random
 
-![Icono del mod Random](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png)
+![Icono del mod Random](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png?1)
 
 *![][osu!]: ¡Nunca se hace aburrido!*\
 *![][osu!taiko]: ¡Mezcla los colores!*\

--- a/wiki/Gameplay/Game_modifier/Random_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Random_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Random
 
-![Random 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png)
+![Random 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RD.png?1)
 
 *![][osu!]: 从不会无聊！*\
 *![][osu!taiko]: 随机排布物件颜色！*\

--- a/wiki/Gameplay/Game_modifier/Relax_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Relax_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Relax
 
-![Relax mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png)
+![Relax mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png?1)
 
 *![][osu!]: You don't need to click. Give your clicking/tapping fingers a break from the heat of things.*\
 *![][osu!taiko]: No need to remember which key is correct anymore!*\

--- a/wiki/Gameplay/Game_modifier/Relax_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Relax_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Relax
 
-![Icono del mod Relax](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png)
+![Icono del mod Relax](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png?1)
 
 *![][osu!]: No necesitas hacer clic. Deja que tus dedos descansen un poco.*\
 *![][osu!taiko]: ¡No es necesario recordar qué tecla es la correcta!*\

--- a/wiki/Gameplay/Game_modifier/Relax_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Relax_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Relax
 
-![Relax 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png)
+![Relax 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RX.png?1)
 
 *![][osu!]: 你不用点击，只需移动。让你点击/敲击用的手指放松一下。*\
 *![][osu!taiko]: 不必记住哪个键是对的了！*\

--- a/wiki/Gameplay/Game_modifier/Repel/en.md
+++ b/wiki/Gameplay/Game_modifier/Repel/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Repel
 
-![Repel mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png)
+![Repel mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png?1)
 
 *Hit objects run away!*
 

--- a/wiki/Gameplay/Game_modifier/Repel/es.md
+++ b/wiki/Gameplay/Game_modifier/Repel/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Repel
 
-![Icono del mod Repel](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png)
+![Icono del mod Repel](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png?1)
 
 *¡Los objetos están huyendo!*
 

--- a/wiki/Gameplay/Game_modifier/Repel/zh.md
+++ b/wiki/Gameplay/Game_modifier/Repel/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Repel
 
-![Repel 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png)
+![Repel 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/RP.png?1)
 
 *物件出逃中！*
 

--- a/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Score V2
 
-![Score V2 mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png)
+![Score V2 mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png?1)
 
 *Score set on earlier osu! versions with the V2 scoring algorithm active.*
 

--- a/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Score V2
 
-![Icono del mod Score V2](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png)
+![Icono del mod Score V2](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png?1)
 
 *Puntuaciones establecidas en versiones anteriores de osu! con el algoritmo de puntuación V2 activo.*
 

--- a/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Score_V2_(lazer)/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Score V2
 
-![Score V2 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png)
+![Score V2 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SV2.png?1)
 
 *在早期版本使用 V2 计分算法获得的成绩。*
 

--- a/wiki/Gameplay/Game_modifier/Simplified_Rhythm/en.md
+++ b/wiki/Gameplay/Game_modifier/Simplified_Rhythm/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Simplified Rhythm
 
-![Simplified Rhythm mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SR.png)
+![Simplified Rhythm mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SR.png?1)
 
 *Simplify tricky rhythms!*
 

--- a/wiki/Gameplay/Game_modifier/Simplified_Rhythm/zh.md
+++ b/wiki/Gameplay/Game_modifier/Simplified_Rhythm/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Simplified Rhythm
 
-![Simplified Rhythm 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SR.png)
+![Simplified Rhythm 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SR.png?1)
 
 *简化棘手的节奏！*
 

--- a/wiki/Gameplay/Game_modifier/Single_Tap/en.md
+++ b/wiki/Gameplay/Game_modifier/Single_Tap/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Single Tap
 
-![Single Tap mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png)
+![Single Tap mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png?1)
 
 *![][osu!]: You must only use one key!*\
 *![][osu!taiko]: One key for dons, one key for kats.*

--- a/wiki/Gameplay/Game_modifier/Single_Tap/es.md
+++ b/wiki/Gameplay/Game_modifier/Single_Tap/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### Single Tap
 
-![Icono del mod Single Tap](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png)
+![Icono del mod Single Tap](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png?1)
 
 *![][osu!]: ¡Solo debes usar una tecla!*\
 *![][osu!taiko]: Una tecla para los dons, una tecla para los kats.*

--- a/wiki/Gameplay/Game_modifier/Single_Tap/zh.md
+++ b/wiki/Gameplay/Game_modifier/Single_Tap/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Single Tap
 
-![Single Tap 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png)
+![Single Tap 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SG.png?1)
 
 *![][osu!]: 只能用一个键！*\
 *![][osu!taiko]: 一个键打咚，一个键打咔。*

--- a/wiki/Gameplay/Game_modifier/Spin_In/en.md
+++ b/wiki/Gameplay/Game_modifier/Spin_In/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Spin In
 
-![Spin In mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png)
+![Spin In mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png?1)
 
 *Circles spin in. No approach circles.*
 

--- a/wiki/Gameplay/Game_modifier/Spin_In/es.md
+++ b/wiki/Gameplay/Game_modifier/Spin_In/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Spin In
 
-![Icono del mod Spin In](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png)
+![Icono del mod Spin In](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png?1)
 
 *Círculos girando. No hay círculos de aproximación.*
 

--- a/wiki/Gameplay/Game_modifier/Spin_In/zh.md
+++ b/wiki/Gameplay/Game_modifier/Spin_In/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Spin In
 
-![Spin In 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png)
+![Spin In 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SI.png?1)
 
 *圆圈旋转进入。没有缩圈。*
 

--- a/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Spun Out
 
-![Spun Out mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png)
+![Spun Out mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png?1)
 
 *Spinners will be automatically completed.*
 

--- a/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### Spun Out
 
-![Icono del mod Spun Out](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png)
+![Icono del mod Spun Out](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png?1)
 
 *Los spinners se completarán automáticamente.*
 

--- a/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Spun_Out_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Spun Out
 
-![Spun Out 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png)
+![Spun Out 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SO.png?1)
 
 *转盘会自动完成。*
 

--- a/wiki/Gameplay/Game_modifier/Strict_Tracking/en.md
+++ b/wiki/Gameplay/Game_modifier/Strict_Tracking/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Strict Tracking
 
-![Strict Tracking mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png)
+![Strict Tracking mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png?1)
 
 *Once you start a slider, follow precisely or get a miss.*
 

--- a/wiki/Gameplay/Game_modifier/Strict_Tracking/es.md
+++ b/wiki/Gameplay/Game_modifier/Strict_Tracking/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Strict Tracking
 
-![Icono del mod Strict Tracking](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png)
+![Icono del mod Strict Tracking](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png?1)
 
 *Una vez que inicies un slider, síguelo con precisión o fallarás.*
 

--- a/wiki/Gameplay/Game_modifier/Strict_Tracking/zh.md
+++ b/wiki/Gameplay/Game_modifier/Strict_Tracking/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Strict Tracking
 
-![Strict Tracking 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png)
+![Strict Tracking 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/ST.png?1)
 
 *点击滑条后，没跟上便 Miss。*
 

--- a/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Sudden Death
 
-![Sudden Death mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png)
+![Sudden Death mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png?1)
 
 *Miss and fail.*
 

--- a/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### Sudden Death
 
-![Icono del mod Sudden Death](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png)
+![Icono del mod Sudden Death](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png?1)
 
 *Falla una nota y pierdes.*
 

--- a/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Sudden_Death_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Sudden Death
 
-![Sudden Death 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png)
+![Sudden Death 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SD.png?1)
 
 *不全连，便失败。*
 

--- a/wiki/Gameplay/Game_modifier/Swap/en.md
+++ b/wiki/Gameplay/Game_modifier/Swap/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Swap
 
-![Swap mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png)
+![Swap mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png?1)
 
 *Dons become kats, kats become dons*
 

--- a/wiki/Gameplay/Game_modifier/Swap/es.md
+++ b/wiki/Gameplay/Game_modifier/Swap/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Swap
 
-![Icono del mod Swap](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png)
+![Icono del mod Swap](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png?1)
 
 *Los dons se convierten en kats, los kats se convierten en dons*
 

--- a/wiki/Gameplay/Game_modifier/Swap/zh.md
+++ b/wiki/Gameplay/Game_modifier/Swap/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Swap
 
-![Swap 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png)
+![Swap 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SW.png?1)
 
 *咚变成咔，咔变成咚！*
 

--- a/wiki/Gameplay/Game_modifier/Synesthesia/en.md
+++ b/wiki/Gameplay/Game_modifier/Synesthesia/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Synesthesia
 
-![Synesthesia mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png)
+![Synesthesia mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png?1)
 
 *Colours hit objects based on the rhythm.*
 

--- a/wiki/Gameplay/Game_modifier/Synesthesia/es.md
+++ b/wiki/Gameplay/Game_modifier/Synesthesia/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Synesthesia
 
-![Icono del mod Synesthesia](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png)
+![Icono del mod Synesthesia](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png?1)
 
 *Colorea los objetos según el ritmo.*
 

--- a/wiki/Gameplay/Game_modifier/Synesthesia/zh.md
+++ b/wiki/Gameplay/Game_modifier/Synesthesia/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Synesthesia
 
-![Synesthesia 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png)
+![Synesthesia 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/SY.png?1)
 
 *按节奏给物件上色。*
 

--- a/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/en.md
@@ -13,7 +13,7 @@ tags:
 
 #### Target Practice
 
-![Target Practice mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png)
+![Target Practice mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png?1)
 
 *Practice keeping up with the beat of the song.*
 

--- a/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/es.md
@@ -13,7 +13,7 @@ tags:
 
 #### Target Practice
 
-![Icono del mod Target Practice](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png)
+![Icono del mod Target Practice](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png?1)
 
 *Practica siguiendo el ritmo de la canción.*
 

--- a/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Target_Practice_(lazer)/zh.md
@@ -13,7 +13,7 @@ tags:
 
 #### Target Practice
 
-![Target Practice 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png)
+![Target Practice 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TP.png?1)
 
 *练习跟上歌曲的节拍。*
 

--- a/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/en.md
+++ b/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/en.md
@@ -14,7 +14,7 @@ tags:
 
 #### Touch Device
 
-![Touch Device mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png)
+![Touch Device mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png?1)
 
 *Automatically applied to plays on devices with a touchscreen.*
 

--- a/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/es.md
+++ b/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/es.md
@@ -18,7 +18,7 @@ tags:
 
 #### Touch Device
 
-![Icono del mod Touch Device](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png)
+![Icono del mod Touch Device](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png?1)
 
 *Se aplica automáticamente a las jugadas en dispositivos con pantalla táctil.*
 

--- a/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/zh.md
+++ b/wiki/Gameplay/Game_modifier/Touch_Device_(lazer)/zh.md
@@ -15,7 +15,7 @@ tags:
 
 #### Touch Device
 
-![Touch Device 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png)
+![Touch Device 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TD.png?1)
 
 *使用触摸屏游玩时会自动添加。*
 

--- a/wiki/Gameplay/Game_modifier/Traceable/en.md
+++ b/wiki/Gameplay/Game_modifier/Traceable/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Traceable
 
-![Traceable mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png)
+![Traceable mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png?1)
 
 *Put your faith in the approach circles...*
 

--- a/wiki/Gameplay/Game_modifier/Traceable/es.md
+++ b/wiki/Gameplay/Game_modifier/Traceable/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Traceable
 
-![Icono del mod Traceable](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png)
+![Icono del mod Traceable](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png?1)
 
 *Confía en los círculos de aproximación...*
 

--- a/wiki/Gameplay/Game_modifier/Traceable/zh.md
+++ b/wiki/Gameplay/Game_modifier/Traceable/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Traceable
 
-![Traceable 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png)
+![Traceable 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TC.png?1)
 
 *相信缩圈...*
 

--- a/wiki/Gameplay/Game_modifier/Transform/en.md
+++ b/wiki/Gameplay/Game_modifier/Transform/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Transform
 
-![Transform mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png)
+![Transform mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png?1)
 
 *Everything rotates. EVERYTHING.*
 

--- a/wiki/Gameplay/Game_modifier/Transform/es.md
+++ b/wiki/Gameplay/Game_modifier/Transform/es.md
@@ -12,7 +12,7 @@ tags:
 
 #### Transform
 
-![Icono del mod Transform](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png)
+![Icono del mod Transform](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png?1)
 
 *Todo se mueve. TODO.*
 

--- a/wiki/Gameplay/Game_modifier/Transform/zh.md
+++ b/wiki/Gameplay/Game_modifier/Transform/zh.md
@@ -12,7 +12,7 @@ tags:
 
 #### Transform
 
-![Transform 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png)
+![Transform 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/TR.png?1)
 
 *一切都在转。一切。*
 

--- a/wiki/Gameplay/Game_modifier/Wiggle/en.md
+++ b/wiki/Gameplay/Game_modifier/Wiggle/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Wiggle
 
-![Wiggle mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png)
+![Wiggle mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png?1)
 
 *They just won't stay still...*
 

--- a/wiki/Gameplay/Game_modifier/Wiggle/es.md
+++ b/wiki/Gameplay/Game_modifier/Wiggle/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wiggle
 
-![Icono del mod Wiggle](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png)
+![Icono del mod Wiggle](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png?1)
 
 *No se quedan quietos...*
 

--- a/wiki/Gameplay/Game_modifier/Wiggle/zh.md
+++ b/wiki/Gameplay/Game_modifier/Wiggle/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wiggle
 
-![Wiggle 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png)
+![Wiggle 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WG.png?1)
 
 *它们就是不能定住不动...*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Down/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Down/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Wind Down
 
-![Wind Down mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png)
+![Wind Down mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png?1)
 
 *Sloooow doooown...*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Down/es.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Down/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wind Down
 
-![Icono del mod Wind Down](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png)
+![Icono del mod Wind Down](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png?1)
 
 *Bajando la velocidad...*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Down/zh.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Down/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wind Down
 
-![Wind Down 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png)
+![Wind Down 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WD.png?1)
 
 *慢——下——来...*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Up/en.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Up/en.md
@@ -12,7 +12,7 @@ tags:
 
 #### Wind Up
 
-![Wind Up mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png)
+![Wind Up mod icon](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png?1)
 
 *Can you keep up?*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Up/es.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Up/es.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wind Up
 
-![Icono del mod Wind Up](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png)
+![Icono del mod Wind Up](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png?1)
 
 *¿Puedes seguir el ritmo?*
 

--- a/wiki/Gameplay/Game_modifier/Wind_Up/zh.md
+++ b/wiki/Gameplay/Game_modifier/Wind_Up/zh.md
@@ -14,7 +14,7 @@ outdated_since: 6188363b106ff99cd3ffb64e4116be419d1d798d
 
 #### Wind Up
 
-![Wind Up 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png)
+![Wind Up 模组图标](/wiki/Gameplay/Game_modifier_(lazer)/img/mods/WU.png?1)
 
 *你能跟上吗？*
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->

New mod icons were added in https://github.com/ppy/osu-wiki/pull/14837 (and https://github.com/ppy/osu-wiki/pull/14627) but a lot of them still haven't updated on the website (e.g. [NR](https://osu.ppy.sh/wiki/en/Gameplay/Game_modifier/No_Release), [RX](https://osu.ppy.sh/wiki/en/Gameplay/Game_modifier/Relax_%28lazer%29), [TC](https://osu.ppy.sh/wiki/en/Gameplay/Game_modifier/Traceable)).

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)